### PR TITLE
use postgres 13 in GHA [AJ-467]

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -67,7 +67,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:14.4
+        image: postgres:13.1
         env:
           POSTGRES_PASSWORD: postgres
         options: >-


### PR DESCRIPTION
Use the same version of Postgres during unit tests that we use for local development.

Choose Postgres 13 over 14, even though 14 is latest. We [may use Azure Managed PostreSQL Flexible Server](https://docs.google.com/document/d/1IumfzEXSE-uEZPRcVFmj4sgx63so9ILizyU70hn5Llo/edit#) in production, and that currently only supports 13, so let's stay on 13 for now until we're certain … it's easier to upgrade than downgrade in the future.

