### PR TITLE
AJ-486

### DIFF
--- a/src/main/java/org/databiosphere/workspacedataservice/controller/EntityController.java
+++ b/src/main/java/org/databiosphere/workspacedataservice/controller/EntityController.java
@@ -36,6 +36,7 @@ public class EntityController {
         }
     }
 
+    @PatchMapping("/")
 
     @PostMapping("/api/workspaces/{workspaceNamespace}/{workspaceName}/entities/batchUpsert")
     public ResponseEntity<String> batchUpsert(@PathVariable("workspaceNamespace") String wsNamespace,

--- a/src/main/java/org/databiosphere/workspacedataservice/shared/model/EntityAttributes.java
+++ b/src/main/java/org/databiosphere/workspacedataservice/shared/model/EntityAttributes.java
@@ -1,0 +1,5 @@
+package org.databiosphere.workspacedataservice.shared.model;
+
+import java.util.Map;
+
+public record EntityAttributes(Map<String, Object> attributes) {}

--- a/src/main/java/org/databiosphere/workspacedataservice/shared/model/EntityId.java
+++ b/src/main/java/org/databiosphere/workspacedataservice/shared/model/EntityId.java
@@ -1,0 +1,3 @@
+package org.databiosphere.workspacedataservice.shared.model;
+
+record EntityId(String entityIdentifier) {}

--- a/src/main/java/org/databiosphere/workspacedataservice/shared/model/EntityMetadata.java
+++ b/src/main/java/org/databiosphere/workspacedataservice/shared/model/EntityMetadata.java
@@ -1,3 +1,4 @@
 package org.databiosphere.workspacedataservice.shared.model;
 
-public record EntityId(String entityIdentifier) {}
+public record EntityMetadata(String provenance) {
+}

--- a/src/main/java/org/databiosphere/workspacedataservice/shared/model/EntityRequest.java
+++ b/src/main/java/org/databiosphere/workspacedataservice/shared/model/EntityRequest.java
@@ -1,0 +1,3 @@
+package org.databiosphere.workspacedataservice.shared.model;
+
+record EntityRequest(EntityId entityId, EntityType entityType, EntityAttributes entityAttributes) {}

--- a/src/main/java/org/databiosphere/workspacedataservice/shared/model/EntityRequest.java
+++ b/src/main/java/org/databiosphere/workspacedataservice/shared/model/EntityRequest.java
@@ -1,3 +1,3 @@
 package org.databiosphere.workspacedataservice.shared.model;
 
-record EntityRequest(EntityId entityId, EntityType entityType, EntityAttributes entityAttributes) {}
+public record EntityRequest(EntityId entityId, EntityType entityType, EntityAttributes entityAttributes) {}

--- a/src/main/java/org/databiosphere/workspacedataservice/shared/model/EntityResponse.java
+++ b/src/main/java/org/databiosphere/workspacedataservice/shared/model/EntityResponse.java
@@ -1,0 +1,3 @@
+package org.databiosphere.workspacedataservice.shared.model;
+
+public record EntityResponse(EntityId entityId, EntityType entityType, EntityAttributes entityAttributes, EntityMetadata entityMetadata) {}

--- a/src/main/java/org/databiosphere/workspacedataservice/shared/model/EntityType.java
+++ b/src/main/java/org/databiosphere/workspacedataservice/shared/model/EntityType.java
@@ -6,6 +6,9 @@ public class EntityType {
         this.name = name;
     }
 
+    public EntityType() {
+    }
+
     private String name;
 
     public String getName() {

--- a/src/test/java/org/databiosphere/workspacedataservice/controller/PatchSingleEntityTest.java
+++ b/src/test/java/org/databiosphere/workspacedataservice/controller/PatchSingleEntityTest.java
@@ -1,0 +1,38 @@
+package org.databiosphere.workspacedataservice.controller;
+
+import org.databiosphere.workspacedataservice.dao.EntityDao;
+import org.databiosphere.workspacedataservice.service.EntityReferenceService;
+import org.databiosphere.workspacedataservice.service.model.EntityReference;
+import org.databiosphere.workspacedataservice.shared.model.*;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.ResponseEntity;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+public class PatchSingleEntityTest {
+
+    @MockBean
+    EntityDao entityDao;
+
+
+    @Test
+    void testPatchSingleEntity(){
+        when(entityDao.getSingleEntity(any(), any(), any())).thenReturn(new Entity("test",
+                new EntityType("test-type"), new HashMap<>(Map.of("created_at", "2022-10-01")), 1L));
+        EntityReferenceService referenceService = new EntityReferenceService(entityDao);
+        EntityController controller = new EntityController(referenceService, entityDao);
+        ResponseEntity<EntityResponse> response = controller.updateSingleEntity(UUID.randomUUID(), "v0.2", new EntityType("sample"), new EntityId("test"),
+                new EntityRequest(new EntityId("test"), new EntityType("sample"), new EntityAttributes(Map.of("foo", "bar"))));
+        assertTrue(response.getBody().entityAttributes().attributes().size() == 2);
+
+    }
+}


### PR DESCRIPTION
`curl -H "Content-type: application/json" -X POST "http://localhost:8080/api/workspaces/default/test/entities/batchUpsert" -d '[{"name": "sample2", "entityType": "sample", "operations": [{"op": "AddUpdateAttribute", "attributeName": "date-collected", "addUpdateAttribute": "2022-06-01"}]}]'`

`curl -H "Content-type: application/json" -X PATCH "http://localhost:8080/15f36863-30a5-4cab-91f7-52be439f1175/entities/v0.2/sample/sample2" -d '{"entityId": {"entityIdentifier": "sample2"}, "entityType": {"name": "sample"}, "entityAttributes": {"attributes": {"date-collected": "2022-07-01"}}}' `

Writing this code raises a few questions for me:

1. I think I was pretty faithful to the swagger, but some of the record classes like `EntityId` seem over-engineered.  I know we don't want to pass strings around everywhere, but it seems like we could have `EntityRequest` but not the classes "below" it.  It's also possible I misinterpreted things and over-engineered on the java side.  I also recognize I approved the swagger PR and I can live with it, but if feels like if the data class is not combining or validating data then the built-in java type we use might be sufficient.
2. This code supports the existing (Rawls) way that we specify references, which is not my favorite.  We can punt and deal with that later, but I want to call that out.
3. The model/data classes are a bit of a hodgepodge and it's probably worth a follow on ticket to clean things up and make them more consistent.
