### PR TITLE
AJ-448 first pass at adding swagger codegen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 HELP.md
 .gradle
 build/

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
-generated/
 client/
 
 ### STS ###

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+generated/
+client/
 
 ### STS ###
 .apt_generated

--- a/build.gradle
+++ b/build.gradle
@@ -66,8 +66,8 @@ swaggerSources {
             language = 'java'
             library = "jersey2"
             outputDir = file("$projectDir/client")
-            jvmArgs = ['--add-opens=java.base/java.util=ALL-UNNAMED'] // for Swagger Codegen v3 on Java 16+
-            components = [apis: true, apiTests: false, models: true, modelTests: false]
+            jvmArgs = ['--add-opens=java.base/java.util=ALL-UNNAMED'] // needed for Java 16+
+            components = [apiTests: false]
             additionalProperties = [
                     modelPackage     : "databiosphere.workspacedataservice.model",
                     apiPackage       : "databiosphere.workspacedataservice.api"
@@ -76,6 +76,10 @@ swaggerSources {
             dependsOn validation
         }
     }
+}
+
+clean {
+    delete 'client'
 }
 
 compileJava.dependsOn tasks.generateSwaggerCode

--- a/build.gradle
+++ b/build.gradle
@@ -68,3 +68,10 @@ swaggerSources {
 
 compileJava.dependsOn tasks.generateSwaggerCode
 
+jar {
+    archiveBaseName = "swagger"
+    from "$projectDir/generated/src/main/java"
+    destinationDirectory = file("$projectDir/client")
+}
+
+jar.dependsOn tasks.generateSwaggerCode

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'org.liquibase.gradle' version '2.1.0'
     id 'java'
     id "org.sonarqube" version "3.4.0.2513"
+    id 'org.hidetake.swagger.generator' version '2.19.2'
 }
 
 group = 'org.databiosphere'
@@ -27,6 +28,7 @@ dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'
+    swaggerCodegen 'io.swagger.codegen.v3:swagger-codegen-cli:3.0.34'
 }
 
 sonarqube {
@@ -44,4 +46,19 @@ tasks.named('test') {
         exceptionFormat = "full"
     }
 }
+
+swaggerSources {
+    server {
+        inputFile = file('static/swagger/openapi-docs.yaml')
+        code {
+            language = 'java'
+            jvmArgs = ['--add-opens=java.base/java.util=ALL-UNNAMED'] // for Swagger Codegen v3 on Java 16+
+            components = ['models', 'apis']
+            // Validate YAML before code generation.
+            dependsOn validation
+        }
+    }
+}
+
+compileJava.dependsOn tasks.generateSwaggerCode
 

--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ swaggerSources {
         code {
             language = 'java'
             library = "jersey2"
-            outputDir = file("$projectDir/generated")
+            outputDir = file("$projectDir/client")
             jvmArgs = ['--add-opens=java.base/java.util=ALL-UNNAMED'] // for Swagger Codegen v3 on Java 16+
             components = [apis: true, apiTests: false, models: true, modelTests: false]
             additionalProperties = [
@@ -79,11 +79,3 @@ swaggerSources {
 }
 
 compileJava.dependsOn tasks.generateSwaggerCode
-
-jar {
-    archiveBaseName = "swagger"
-    from "$projectDir/generated/src/main/java"
-    destinationDirectory = file("$projectDir/client")
-}
-
-jar.dependsOn tasks.generateSwaggerCode

--- a/build.gradle
+++ b/build.gradle
@@ -48,12 +48,18 @@ tasks.named('test') {
 }
 
 swaggerSources {
-    server {
+    client {
         inputFile = file('static/swagger/openapi-docs.yaml')
         code {
             language = 'java'
+            library = "jersey2"
+            outputDir = file("$projectDir/generated")
             jvmArgs = ['--add-opens=java.base/java.util=ALL-UNNAMED'] // for Swagger Codegen v3 on Java 16+
-            components = ['models', 'apis']
+            components = [apis: true, apiTests: false, models: true, modelTests: false]
+            additionalProperties = [
+                    modelPackage     : "databiosphere.workspacedataservice.model",
+                    apiPackage       : "databiosphere.workspacedataservice.api"
+                    ]
             // Validate YAML before code generation.
             dependsOn validation
         }

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ tasks.named('test') {
 
 swaggerSources {
     client {
-        inputFile = file('static/swagger/openapi-docs.yaml')
+        inputFile = file('src/main/resources/static/swagger/openapi-docs.yaml')
         code {
             language = 'java'
             library = "jersey2"


### PR DESCRIPTION
Running `./gradlew build` will now generate code from the swagger doc and put it in `/client`.  Note this folder and thus the generated code is .gitignored.  