### PR TITLE
configure spotless [AJ-470]

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,3 +98,18 @@ docker run -e WDS_DB_HOST='host.docker.internal' -p 8080:8080 wdsdocker
 ```bash
 docker run --network=host -e WDS_DB_HOST='127.0.0.1' -p 8080:8080 wdsdocker
 ```
+
+## Code Formatting
+This repository uses [Spotless](https://github.com/diffplug/spotless) for code formatting.
+
+To check code formatting without making any changes, run:
+```bash
+./gradlew spotlessCheck
+```
+
+To automatically format your code:
+```bash
+./gradlew spotlessApply
+```
+
+See the Spotless documentation for more information.

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'org.liquibase.gradle' version '2.1.0'
     id 'java'
     id 'com.google.cloud.tools.jib' version '3.2.1'
+    id 'com.diffplug.spotless' version '6.8.0'
     id "org.sonarqube" version "3.4.0.2513"
 }
 
@@ -49,6 +50,24 @@ sonarqube {
     }
 }
 
+// Spotless configuration
+spotless {
+    java {
+        googleJavaFormat()
+        targetExclude("${buildDir}/**", "**/generated/**")
+    }
+    format 'misc', {
+        // define the files to apply `misc` to
+        target '*.gradle', '*.md', '.gitignore'
+
+        // N.B. checks for tabs vs. spaces but does not check the number of spaces
+        // https://github.com/diffplug/spotless/issues/794
+        indentWithSpaces()
+        trimTrailingWhitespace()
+        endWithNewline()
+    }
+}
+
 tasks.named('test') {
     useJUnitPlatform()
     testLogging {
@@ -56,4 +75,3 @@ tasks.named('test') {
         exceptionFormat = "full"
     }
 }
-

--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,10 @@ spotless {
         endWithNewline()
     }
 }
+// disable for now. As a developer, re-enable these tasks and then run ./gradlew spotlessCheck
+// to see the results.
+tasks.spotlessJavaCheck.enabled = false
+tasks.spotlessMiscCheck.enabled = false
 
 tasks.named('test') {
     useJUnitPlatform()


### PR DESCRIPTION
This enables Spotless, but does NOT yet enable any auto-formatting of code (e.g. via `build.dependsOn spotlessApply`) nor any linting.

Putting this PR up to give a chance for folks to play with the formatting before we enable anything automatic! My recommendation for enabling Spotless is:

1.  merge this PR
2. merge any other nontrivial outstanding PRs
3. run `spotlessApply` and make a single PR that contains only the formatting changes plus turns on formatting enforcement