### PR TITLE
BW-1346: Make swagger's links relative not absolute

### DIFF
--- a/service/src/main/resources/static/swagger/swagger-ui.html
+++ b/service/src/main/resources/static/swagger/swagger-ui.html
@@ -5,16 +5,16 @@
   <head>
     <meta charset="UTF-8">
     <title>Swagger UI</title>
-    <link rel="stylesheet" type="text/css" href="/webjars/swagger-ui-dist/swagger-ui.css" />
-    <link rel="stylesheet" type="text/css" href="/webjars/swagger-ui-dist/index.css" />
-    <link rel="icon" type="image/png" href="/webjars/swagger-ui-dist/favicon-32x32.png" sizes="32x32" />
-    <link rel="icon" type="image/png" href="webjars/swagger-ui-dist/favicon-16x16.png" sizes="16x16" />
+    <link rel="stylesheet" type="text/css" href="../webjars/swagger-ui-dist/swagger-ui.css" />
+    <link rel="stylesheet" type="text/css" href="../webjars/swagger-ui-dist/index.css" />
+    <link rel="icon" type="image/png" href="../webjars/swagger-ui-dist/favicon-32x32.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="../webjars/swagger-ui-dist/favicon-16x16.png" sizes="16x16" />
   </head>
 
   <body>
     <div id="swagger-ui"></div>
-    <script src="/webjars/swagger-ui-dist/swagger-ui-bundle.js" charset="UTF-8"> </script>
-    <script src="/webjars/swagger-ui-dist/swagger-ui-standalone-preset.js" charset="UTF-8"> </script>
+    <script src="../webjars/swagger-ui-dist/swagger-ui-bundle.js" charset="UTF-8"> </script>
+    <script src="../webjars/swagger-ui-dist/swagger-ui-standalone-preset.js" charset="UTF-8"> </script>
     <!-- start WDS customization -->
     <script>
     const cleanupPlugin = function(system) {


### PR DESCRIPTION
When hosted in a leo app, the path to the swagger page becomes something like: 
- `https://leonardo.dsde-dev.broadinstitute.org/proxy/google/v1/apps/terra-dev-fc995c1b/terra-app-5503bfa7-b1d9-4140-973b-35e0b60e2f24/cromwell-service/wds/swagger/swagger-ui.html` 

and the associated resources are more like (for example): 
- `https://leonardo.dsde-dev.broadinstitute.org/proxy/google/v1/apps/terra-dev-fc995c1b/terra-app-5503bfa7-b1d9-4140-973b-35e0b60e2f24/cromwell-service/wds/webjars/swagger-ui-dist/favicon-32x32.png`

This change makes the references relative not absolute so that they are proxy-safe when loaded in an image deployed as a leo app