### PR TITLE
BW-1346: Update swagger UI to make calls to relative paths

### DIFF
--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -13,6 +13,9 @@ info:
   license:
     name: BSD
     url: http://opensource.org/licenses/BSD-3-Clause
+servers:
+  - url: ../
+    description: Relative to the current swagger page
 tags:
   - name: Entities
     description: Entity APIs


### PR DESCRIPTION
Changes the swagger server definition to be relative to the hosted swagger page.

- Swagger is hosted at `.../swagger/swagger-ui.html`
- APIs are hosted at `.../<API path>

Therefore the relative server path is `../` to escape the `swagger/` URL segment.