### PR TITLE
aj-496 replace reference map with string

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/EntityController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/EntityController.java
@@ -49,8 +49,6 @@ public class EntityController {
     allAttrs.putAll(updatedAtts);
 
     Map<String, DataTypeMapping> typeMapping = inferer.inferTypes(updatedAtts);
-    // TODO: remove entityType/entityName JSON object format for references and move to URIs in the
-    // request/response payloads
     Map<String, DataTypeMapping> existingTableSchema =
         entityDao.getExistingTableSchema(instanceId, entityTypeName);
     singleEntity.setAttributes(new EntityAttributes(allAttrs));
@@ -59,7 +57,7 @@ public class EntityController {
         addOrUpdateColumnIfNeeded(
             instanceId, entityType.getName(), typeMapping, existingTableSchema, entities);
     try {
-      entityDao.batchUpsert(
+      convertRefsAndUpsert(
           instanceId, entityTypeName, entities, new LinkedHashMap<>(updatedSchema));
       EntityResponse response =
           new EntityResponse(
@@ -192,7 +190,7 @@ public class EntityController {
         LinkedHashMap<String, DataTypeMapping> combinedSchema =
             new LinkedHashMap<>(existingTableSchema);
         combinedSchema.putAll(requestSchema);
-        entityDao.batchUpsert(instanceId, entityTypeName, entities, combinedSchema);
+        convertRefsAndUpsert(instanceId, entityTypeName, entities, combinedSchema);
         return new ResponseEntity(response, HttpStatus.OK);
       }
     } catch (ResponseStatusException | InvalidEntityReference e) {
@@ -230,7 +228,7 @@ public class EntityController {
       List<Entity> entities = Collections.singletonList(newEntity);
       entityDao.createEntityType(
           instanceId, requestSchema, entityTypeName, RefUtils.findEntityReferences(entities));
-      entityDao.batchUpsert(
+      convertRefsAndUpsert(
           instanceId, entityTypeName, entities, new LinkedHashMap<>(requestSchema));
     } catch (MissingReferencedTableException e) {
       throw new ResponseStatusException(
@@ -239,5 +237,17 @@ public class EntityController {
               + "to a table that does not exist",
           e);
     }
+  }
+
+  private void convertRefsAndUpsert(UUID workspaceId,
+                                    String entityType,
+                                    List<Entity> entities,
+                                    LinkedHashMap<String, DataTypeMapping> schema) throws InvalidEntityReference{
+    for (Entity e: entities){
+      e.setAttributes(new EntityAttributes(e.getAttributes().getAttributes().entrySet().stream()
+              .map(entry -> RefUtils.isReferenceValue(entry.getValue()) ? new AbstractMap.SimpleEntry<>(entry.getKey(), RefUtils.getRefValue(entry.getValue())) : entry)
+              .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))));
+    }
+    entityDao.batchUpsert(workspaceId, entityType, entities, schema);
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/EntityDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/EntityDao.java
@@ -308,9 +308,13 @@ public class EntityDao {
           if (systemCols.contains(columnName)) {
             continue;
           }
-          Object object = rs.getObject(columnName);
-          attributes.put(
-              columnName, object instanceof PGobject ? ((PGobject) object).getValue() : object);
+          if (referenceColToTable.size() > 0 && referenceColToTable.containsKey(columnName)) {
+            attributes.put(columnName, RefUtils.createReferenceString(referenceColToTable.get(columnName), rs.getString(columnName)));
+        } else {
+            Object object = rs.getObject(columnName);
+            attributes.put(
+                    columnName, object instanceof PGobject ? ((PGobject) object).getValue() : object);
+          }
         }
         return attributes;
       } catch (SQLException e) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/EntityDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/EntityDao.java
@@ -1,7 +1,5 @@
 package org.databiosphere.workspacedataservice.dao;
 
-import static org.databiosphere.workspacedataservice.service.model.EntityReference.ENTITY_NAME_KEY;
-import static org.databiosphere.workspacedataservice.service.model.EntityReference.ENTITY_TYPE_KEY;
 import static org.databiosphere.workspacedataservice.service.model.EntitySystemColumn.ENTITY_ID;
 
 import java.sql.ResultSet;
@@ -310,16 +308,9 @@ public class EntityDao {
           if (systemCols.contains(columnName)) {
             continue;
           }
-          if (referenceColToTable.size() > 0 && referenceColToTable.containsKey(columnName)) {
-            Map<String, String> refMap = new HashMap<>();
-            refMap.put(ENTITY_TYPE_KEY, referenceColToTable.get(columnName));
-            refMap.put(ENTITY_NAME_KEY, rs.getString(columnName));
-            attributes.put(columnName, refMap);
-          } else {
-            Object object = rs.getObject(columnName);
-            attributes.put(
-                columnName, object instanceof PGobject ? ((PGobject) object).getValue() : object);
-          }
+          Object object = rs.getObject(columnName);
+          attributes.put(
+              columnName, object instanceof PGobject ? ((PGobject) object).getValue() : object);
         }
         return attributes;
       } catch (SQLException e) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/RefUtils.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/RefUtils.java
@@ -1,8 +1,5 @@
 package org.databiosphere.workspacedataservice.service;
 
-import static org.databiosphere.workspacedataservice.service.model.EntityReference.ENTITY_NAME_KEY;
-import static org.databiosphere.workspacedataservice.service.model.EntityReference.ENTITY_TYPE_KEY;
-
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -13,11 +10,13 @@ import org.databiosphere.workspacedataservice.shared.model.EntityType;
 
 public class RefUtils {
 
+  public static final String REFERENCE_IDENTIFIER = "terra-wds:";
+
   /**
    * Determines if any attributes reference another table
    *
    * @param entities - all entities whose references to check
-   * @return Set of SingleTenantEntityReference for all referencing attributes
+   * @return Set of EntityReference for all referencing attributes
    */
   public static Set<EntityReference> findEntityReferences(List<Entity> entities) {
     Set<EntityReference> result = new HashSet<>();
@@ -33,32 +32,38 @@ public class RefUtils {
   }
 
   public static String getTypeValue(Object obj) {
-    if (obj instanceof Map) {
-      Map map = (Map) obj;
-      return (String) map.get(ENTITY_TYPE_KEY);
+    if (obj != null){
+      String sVal = obj.toString();
+      int index = sVal.indexOf("/");
+      if (index >= 0){
+        return sVal.substring(REFERENCE_IDENTIFIER.length(), index);
+      }
     }
-    throw new IllegalArgumentException("Expected {\"entityType\":<type>, \"entityName\":<name>}");
+    throw new IllegalArgumentException("Expected " + REFERENCE_IDENTIFIER + "<entityType>/<entityName>");
   }
 
   public static String getRefValue(Object obj) {
-    if (obj instanceof Map) {
-      Map map = (Map) obj;
-      return (String) map.get(ENTITY_NAME_KEY);
+    if (obj != null){
+      String sVal = obj.toString();
+      int index = sVal.indexOf("/");
+      if (index >= 0){
+        return sVal.substring(index+1);
+      }
     }
-    throw new IllegalArgumentException("Expected {\"entityType\":<type>, \"entityName\":<name>}");
+    throw new IllegalArgumentException("Expected " + REFERENCE_IDENTIFIER + "<entityType>/<entityName>");
   }
 
   /**
    * Determines whether attribute value matches this expectation
    *
    * @param obj - attribute value to check
-   * @return true if attribute in form of a map with keys "entityType" and "entityName"
+   * @return true if attribute begins with the REFERENCE_IDENTIFIER
    */
   public static boolean isReferenceValue(Object obj) {
-    if (obj instanceof Map) {
-      Map map = (Map) obj;
-      return map.size() == 2 && map.keySet().containsAll(Set.of(ENTITY_TYPE_KEY, ENTITY_NAME_KEY));
-    }
-    return false;
+    return obj != null && obj.toString().startsWith(REFERENCE_IDENTIFIER);
+  }
+
+  public static String createReferenceString(String entityTypeName, String entityId){
+    return REFERENCE_IDENTIFIER + entityTypeName + "/" + entityId;
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/RefUtils.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/RefUtils.java
@@ -4,6 +4,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import com.google.common.base.Preconditions;
 import org.databiosphere.workspacedataservice.service.model.EntityReference;
 import org.databiosphere.workspacedataservice.shared.model.Entity;
 import org.databiosphere.workspacedataservice.shared.model.EntityType;
@@ -32,25 +34,19 @@ public class RefUtils {
   }
 
   public static String getTypeValue(Object obj) {
-    if (obj != null){
-      String sVal = obj.toString();
-      int index = sVal.indexOf("/");
-      if (index >= 0){
-        return sVal.substring(REFERENCE_IDENTIFIER.length(), index);
-      }
-    }
-    throw new IllegalArgumentException("Expected " + REFERENCE_IDENTIFIER + "<entityType>/<entityName>");
+    return splitReferenceString(obj)[0];
+  }
+
+  private static String[] splitReferenceString(Object obj) {
+    String errorMessage = "Expected " + REFERENCE_IDENTIFIER + "<entityType>/<entityName>";
+    Preconditions.checkNotNull(obj, errorMessage);
+    String[] parts = obj.toString().substring(REFERENCE_IDENTIFIER.length()).split("/");
+    Preconditions.checkArgument(parts.length == 2, errorMessage);
+    return parts;
   }
 
   public static String getRefValue(Object obj) {
-    if (obj != null){
-      String sVal = obj.toString();
-      int index = sVal.indexOf("/");
-      if (index >= 0){
-        return sVal.substring(index+1);
-      }
-    }
-    throw new IllegalArgumentException("Expected " + REFERENCE_IDENTIFIER + "<entityType>/<entityName>");
+    return splitReferenceString(obj)[1];
   }
 
   /**

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/RefUtils.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/RefUtils.java
@@ -1,11 +1,10 @@
 package org.databiosphere.workspacedataservice.service;
 
+import com.google.common.base.Preconditions;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import com.google.common.base.Preconditions;
 import org.databiosphere.workspacedataservice.service.model.EntityReference;
 import org.databiosphere.workspacedataservice.shared.model.Entity;
 import org.databiosphere.workspacedataservice.shared.model.EntityType;
@@ -43,7 +42,7 @@ public class RefUtils {
     String errorMessage = "Expected " + REFERENCE_IDENTIFIER + "<entityType>/<entityName>";
     Preconditions.checkNotNull(obj, errorMessage);
     Preconditions.checkArgument(obj instanceof String, errorMessage);
-    String ref = (String)obj;
+    String ref = (String) obj;
 
     // parse the string as a uri
     UriComponents uric = UriComponentsBuilder.fromUriString(ref).build();
@@ -56,8 +55,7 @@ public class RefUtils {
     List<String> pathSegments = uric.getPathSegments();
     Preconditions.checkArgument(pathSegments.size() == 2, errorMessage);
 
-    return pathSegments.toArray(new String[0]); // or have this method return List<String> instead of array
-//    return parts;
+    return pathSegments.toArray(new String[0]);
   }
 
   public static String getRefValue(Object obj) {
@@ -74,7 +72,11 @@ public class RefUtils {
     return obj != null && obj.toString().startsWith(REFERENCE_IDENTIFIER);
   }
 
-  public static String createReferenceString(String entityTypeName, String entityId){
-    return REFERENCE_IDENTIFIER + entityTypeName + "/" + entityId;
+  public static String createReferenceString(String entityTypeName, String entityId) {
+    return UriComponentsBuilder.newInstance()
+        .scheme(REFERENCE_IDENTIFIER)
+        .pathSegment(entityTypeName, entityId)
+        .build()
+        .toUriString();
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/RefUtils.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/RefUtils.java
@@ -9,10 +9,12 @@ import com.google.common.base.Preconditions;
 import org.databiosphere.workspacedataservice.service.model.EntityReference;
 import org.databiosphere.workspacedataservice.shared.model.Entity;
 import org.databiosphere.workspacedataservice.shared.model.EntityType;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
 
 public class RefUtils {
 
-  public static final String REFERENCE_IDENTIFIER = "terra-wds:";
+  public static final String REFERENCE_IDENTIFIER = "terra-wds";
 
   /**
    * Determines if any attributes reference another table
@@ -40,9 +42,22 @@ public class RefUtils {
   private static String[] splitReferenceString(Object obj) {
     String errorMessage = "Expected " + REFERENCE_IDENTIFIER + "<entityType>/<entityName>";
     Preconditions.checkNotNull(obj, errorMessage);
-    String[] parts = obj.toString().substring(REFERENCE_IDENTIFIER.length()).split("/");
-    Preconditions.checkArgument(parts.length == 2, errorMessage);
-    return parts;
+    Preconditions.checkArgument(obj instanceof String, errorMessage);
+    String ref = (String)obj;
+
+    // parse the string as a uri
+    UriComponents uric = UriComponentsBuilder.fromUriString(ref).build();
+
+    // uri scheme should be "terra-wds"
+    Preconditions.checkArgument(REFERENCE_IDENTIFIER.equals(uric.getScheme()), errorMessage);
+
+    // record type is the first segment of the uri path;
+    // record id is the second segment of the uri path
+    List<String> pathSegments = uric.getPathSegments();
+    Preconditions.checkArgument(pathSegments.size() == 2, errorMessage);
+
+    return pathSegments.toArray(new String[0]); // or have this method return List<String> instead of array
+//    return parts;
   }
 
   public static String getRefValue(Object obj) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/EntityReference.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/EntityReference.java
@@ -4,9 +4,6 @@ import org.databiosphere.workspacedataservice.shared.model.EntityType;
 
 public class EntityReference {
 
-  public static final String ENTITY_TYPE_KEY = "entityType";
-  public static final String ENTITY_NAME_KEY = "entityName";
-
   private final String referenceColName;
 
   private final EntityType referencedEntityType;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/EntityControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/EntityControllerMockMvcTest.java
@@ -126,7 +126,7 @@ public class EntityControllerMockMvcTest {
                             new EntityType(referringType),
                             new EntityAttributes(attributes)))))
         .andExpect(status().isOk())
-        .andExpect(content().string(containsString("\"sample-ref\":\"entity_0\"")));
+        .andExpect(content().string(containsString(ref)));
     ;
   }
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/EntityControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/EntityControllerMockMvcTest.java
@@ -1,7 +1,5 @@
 package org.databiosphere.workspacedataservice.controller;
 
-import static org.databiosphere.workspacedataservice.service.model.EntityReference.ENTITY_NAME_KEY;
-import static org.databiosphere.workspacedataservice.service.model.EntityReference.ENTITY_TYPE_KEY;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -14,6 +12,7 @@ import java.util.Map;
 import java.util.UUID;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
+import org.databiosphere.workspacedataservice.service.RefUtils;
 import org.databiosphere.workspacedataservice.shared.model.EntityAttributes;
 import org.databiosphere.workspacedataservice.shared.model.EntityId;
 import org.databiosphere.workspacedataservice.shared.model.EntityRequest;
@@ -109,9 +108,7 @@ public class EntityControllerMockMvcTest {
     createSomeEntities(referencedType, 3);
     createSomeEntities(referringType, 1);
     Map<String, Object> attributes = new HashMap<>();
-    Map<String, Object> ref = new HashMap<>();
-    ref.put(ENTITY_TYPE_KEY, referencedType);
-    ref.put(ENTITY_NAME_KEY, "entity_0");
+    String ref = RefUtils.createReferenceString(referencedType, "entity_0");
     attributes.put("sample-ref", ref);
     mockMvc
         .perform(
@@ -129,7 +126,7 @@ public class EntityControllerMockMvcTest {
                             new EntityType(referringType),
                             new EntityAttributes(attributes)))))
         .andExpect(status().isOk())
-        .andExpect(content().string(containsString("\"" + ENTITY_NAME_KEY + "\":\"entity_0\"")));
+        .andExpect(content().string(containsString("\"sample-ref\":\"entity_0\"")));
     ;
   }
 
@@ -140,9 +137,7 @@ public class EntityControllerMockMvcTest {
     String referringType = "ref_samples-2";
     createSomeEntities(referringType, 1);
     Map<String, Object> attributes = new HashMap<>();
-    Map<String, Object> ref = new HashMap<>();
-    ref.put(ENTITY_TYPE_KEY, referencedType);
-    ref.put(ENTITY_NAME_KEY, "entity_0");
+    String ref = RefUtils.createReferenceString(referencedType, "entity_0");
     attributes.put("sample-ref", ref);
     mockMvc
         .perform(
@@ -176,9 +171,7 @@ public class EntityControllerMockMvcTest {
     createSomeEntities(referencedType, 3);
     createSomeEntities(referringType, 1);
     Map<String, Object> attributes = new HashMap<>();
-    Map<String, Object> ref = new HashMap<>();
-    ref.put(ENTITY_TYPE_KEY, referencedType);
-    ref.put(ENTITY_NAME_KEY, "entity_99");
+    String ref = RefUtils.createReferenceString(referencedType, "entity_99");
     attributes.put("sample-ref", ref);
     mockMvc
         .perform(
@@ -260,9 +253,7 @@ public class EntityControllerMockMvcTest {
     String entityType = "entity-type-missing-table-ref";
     String entityId = "entity_0";
     Map<String, Object> entityAttributes = new HashMap<>();
-    Map<String, Object> ref = new HashMap<>();
-    ref.put(ENTITY_TYPE_KEY, "missing");
-    ref.put(ENTITY_NAME_KEY, "missing_also");
+    String ref = RefUtils.createReferenceString("missing", "missing_also");
     entityAttributes.put("sample-ref", ref);
 
     mockMvc
@@ -291,9 +282,7 @@ public class EntityControllerMockMvcTest {
     String entityType = "ref-alter";
     createSomeEntities(entityType, 1);
     Map<String, Object> entityAttributes = new HashMap<>();
-    Map<String, Object> ref = new HashMap<>();
-    ref.put(ENTITY_TYPE_KEY, "missing");
-    ref.put(ENTITY_NAME_KEY, "missing_also");
+    String ref = RefUtils.createReferenceString("missing", "missing_also");
     entityAttributes.put("attr1", ref);
     mockMvc
         .perform(

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/EntityControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/EntityControllerMockMvcTest.java
@@ -127,7 +127,6 @@ public class EntityControllerMockMvcTest {
                             new EntityAttributes(attributes)))))
         .andExpect(status().isOk())
         .andExpect(content().string(containsString(ref)));
-    ;
   }
 
   @Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/EntityDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/EntityDaoTest.java
@@ -3,6 +3,8 @@ package org.databiosphere.workspacedataservice.dao;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.*;
+
+import org.databiosphere.workspacedataservice.service.RefUtils;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
 import org.databiosphere.workspacedataservice.service.model.EntityReference;
 import org.databiosphere.workspacedataservice.service.model.InvalidEntityReference;
@@ -114,12 +116,7 @@ public class EntityDaoTest {
         new LinkedHashMap<>());
 
     EntityId entityId = new EntityId("testEntity");
-    Map<String, String> reference =
-        Map.of(
-            EntityReference.ENTITY_TYPE_KEY,
-            "testEntityType",
-            EntityReference.ENTITY_NAME_KEY,
-            "referencedEntity");
+    String reference = RefUtils.createReferenceString("testEntityType", "referencedEntity");
     Entity testEntity =
         new Entity(entityId, entityType, new EntityAttributes(Map.of("testEntityType", reference)));
     entityDao.batchUpsert(


### PR DESCRIPTION
[AJ-496](https://broadworkbench.atlassian.net/browse/AJ-496)
Instead of using a map with "entityType" and "entityName" keys, have references be accepted as simply a string beginning with an identifier, with entityType and entityName separated by a /.
Question: Presumably this convention will need to be documented somewhere.  Should that go in the openapi-docs.yaml?  In the README?  Both?  Neither?