### PR TITLE
switch google-java-format to eclipse format [AJ-470]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ idea.project.jdkName = '17'
 // Spotless configuration
 spotless {
     java {
-        palantirJavaFormat()
+        eclipse()
         target '**/*.java'
         targetExclude("${buildDir}/**", "**/generated/**")
     }

--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ idea.project.jdkName = '17'
 // Spotless configuration
 spotless {
     java {
-        googleJavaFormat()
+        palantirJavaFormat()
         target '**/*.java'
         targetExclude("${buildDir}/**", "**/generated/**")
     }


### PR DESCRIPTION
Trying to find a better spotless config, this switches from [google-java-format](https://github.com/google/google-java-format/wiki/FAQ#i-just-need-to-configure-it-a-bit-differently-how) to the eclipse predefined format.

This PR *_only_*  changes build.gradle, it does not reformat any existing code. Because of this, `spotlessCheck` will fail on this PR - the current code formatting has spots that are not legal with eclipse format. I've done this so reviewers can pull this branch, run `./gradlew spotlessApply` locally, and see the changes.
