### PR TITLE
Update tag.yml

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -11,14 +11,14 @@ jobs:
       - name: Checkout current code
         uses: actions/checkout@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }} # this allows the push to succeed later
+          token: ${{ secrets.BROADBOT_TOKEN }} # this allows the push to succeed later
           
       - name: Bump the tag to a new version
         # https://github.com/DataBiosphere/github-actions/tree/master/actions/bumper
         uses: databiosphere/github-actions/actions/bumper@bumper-0.0.6
         id: tag
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
           DEFAULT_BUMP: patch
           RELEASE_BRANCHES: main
           VERSION_FILE_PATH: build.gradle


### PR DESCRIPTION
Fixing residual problem from AJ-449:
My theory is that version changes are not being committed because 2 reviewers are required - [See here](https://github.com/DataBiosphere/terra-workspace-data-service/runs/7814628435?check_suite_focus=true#step:4:39) -
I believe using the BROADBOT token instead of GITHUB token should change that.  Was not apparent in testing because the reviews were not required for merging to non-main branch.