### PR TITLE
aj-556 add sonar.projectName property

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -40,6 +40,7 @@ dependencies {
 
 sonarqube {
 	properties {
+		property "sonar.projectName", "terra-workspace-data-service"
 		property "sonar.projectKey", "DataBiosphere_workspace-data-service"
 		property "sonar.organization", "broad-databiosphere"
 		property "sonar.host.url", "https://sonarcloud.io"


### PR DESCRIPTION
We have the other sonarqube properties but this one got left out.