### PR TITLE
remove duplicate id and type for PUT/PATCH single record [AJ-538]

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -138,7 +138,8 @@ public class RecordController {
 			RecordResponse response = new RecordResponse(recordId, recordType, recordRequest.recordAttributes(),
 					new RecordMetadata("TODO"));
 			if (!recordDao.recordTypeExists(instanceId, recordTypeName)) {
-				createRecordTypeAndInsertRecords(instanceId, recordRequest, recordTypeName, requestSchema);
+				Record newRecord = new Record(recordId, recordType, recordRequest);
+				createRecordTypeAndInsertRecords(instanceId, newRecord, recordTypeName, requestSchema);
 				return new ResponseEntity(response, HttpStatus.CREATED);
 			} else {
 				Map<String, DataTypeMapping> existingTableSchema = recordDao.getExistingTableSchema(instanceId,
@@ -174,11 +175,9 @@ public class RecordController {
 		Preconditions.checkArgument(version.equals("v0.2"));
 	}
 
-	private void createRecordTypeAndInsertRecords(UUID instanceId, RecordRequest recordRequest, String recordTypeName,
+	private void createRecordTypeAndInsertRecords(UUID instanceId, Record newRecord, String recordTypeName,
 			Map<String, DataTypeMapping> requestSchema) throws InvalidRelation {
 		try {
-			Record newRecord = new Record(recordRequest.recordId(), recordRequest.recordType(),
-					recordRequest.recordAttributes());
 			List<Record> records = Collections.singletonList(newRecord);
 			recordDao.createRecordType(instanceId, requestSchema, recordTypeName, RelationUtils.findRelations(records));
 			recordDao.batchUpsert(instanceId, recordTypeName, records, new LinkedHashMap<>(requestSchema));

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -184,7 +184,7 @@ public class RecordDao {
 		int i = 0;
 		for (String col : colNames) {
 			if (col.equals(RECORD_ID.getColumnName())) {
-				row[i++] = record.getName().getRecordIdentifier();
+				row[i++] = record.getId().getRecordIdentifier();
 			} else {
 				Object attVal = record.getAttributes().getAttributes().get(col);
 				row[i++] = getValueForSql(attVal);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/Record.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/Record.java
@@ -6,14 +6,14 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Record {
 
-	private RecordId name;
+	private RecordId id;
 
 	private RecordType recordType;
 
 	private RecordAttributes attributes;
 
-	public Record(RecordId name, RecordType recordType, RecordAttributes attributes) {
-		this.name = name;
+	public Record(RecordId id, RecordType recordType, RecordAttributes attributes) {
+		this.id = id;
 		this.recordType = recordType;
 		this.attributes = attributes;
 	}
@@ -21,22 +21,22 @@ public class Record {
 	public Record() {
 	}
 
-	public Record(RecordId recordName) {
-		this.name = recordName;
+	public Record(RecordId id) {
+		this.id = id;
 	}
 
-	public Record(RecordRequest request) {
-		this.name = request.recordId();
-		this.recordType = request.recordType();
+	public Record(RecordId id, RecordType type, RecordRequest request) {
+		this.id = id;
+		this.recordType = type;
 		this.attributes = request.recordAttributes();
 	}
 
-	public RecordId getName() {
-		return name;
+	public RecordId getId() {
+		return id;
 	}
 
-	public void setName(RecordId name) {
-		this.name = name;
+	public void setId(RecordId id) {
+		this.id = id;
 	}
 
 	public RecordAttributes getAttributes() {
@@ -63,14 +63,14 @@ public class Record {
 		if (!(o instanceof Record record))
 			return false;
 
-		if (!getName().equals(record.getName()))
+		if (!getId().equals(record.getId()))
 			return false;
 		return getRecordType().equals(record.getRecordType());
 	}
 
 	@Override
 	public int hashCode() {
-		int result = getName().hashCode();
+		int result = getId().hashCode();
 		result = 31 * result + getRecordType().hashCode();
 		return result;
 	}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordRequest.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordRequest.java
@@ -3,7 +3,5 @@ package org.databiosphere.workspacedataservice.shared.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
-@JsonPropertyOrder({"id", "type", "attributes"})
-public record RecordRequest(@JsonProperty("id") RecordId recordId, @JsonProperty("type") RecordType recordType,
-		@JsonProperty("attributes") RecordAttributes recordAttributes) {
+public record RecordRequest(@JsonProperty("attributes") RecordAttributes recordAttributes) {
 }

--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -454,7 +454,7 @@ components:
             $ref: '#/components/schemas/RecordResponse'
   requestBodies:
     RecordRequestBody:
-      description: An record to upload
+      description: A record's attributes to upload
       required: true
       content:
         application/json:
@@ -492,13 +492,29 @@ components:
       type: object
       required:
         - operation
-        - entity
+        - record
       properties:
         operation:
           type: string
           enum: [create, update, replace, delete]
-        entity:
-          $ref: '#/components/schemas/RecordRequest'
+        record:
+          $ref: '#/components/schemas/BatchRecordRequest'
+    BatchRecordRequest:
+      type: object
+      required:
+        - id
+        - type
+        - attributes
+      properties:
+        id:
+          $ref: '#/components/schemas/RecordId'
+          description: Record id
+        type:
+          $ref: '#/components/schemas/RecordType'
+          description: Record type
+        attributes:
+          $ref: '#/components/schemas/RecordAttributes'
+          description: KVPs of record attributes
     BatchResponse:
       type: object
       required:
@@ -524,16 +540,8 @@ components:
     RecordRequest:
       type: object
       required:
-        - id
-        - type
         - attributes
       properties:
-        id:
-          $ref: '#/components/schemas/RecordId'
-          description: Record id
-        type:
-          $ref: '#/components/schemas/RecordType'
-          description: Record type
         attributes:
           $ref: '#/components/schemas/RecordAttributes'
           description: KVPs of record attributes
@@ -560,6 +568,13 @@ components:
     RecordAttributes:
       type: object
       additionalProperties: true
+      example: |
+        {
+          "stringAttr": "string",
+          "numericAttr": 123,
+          "booleanAttr": true,
+          "relationAttr": "terra-wds:/target-type/target-id"
+        }
     RecordAttributeDefinition:
       required:
         - name

--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -55,8 +55,6 @@ paths:
         If the record already exists, its entire set of attributes will be overwritten by
         the attributes in the request body.
         
-        TODO: the type and id are duplicated in the url and the body; change this? Silently ignore the type/id in the body?
-        
         TODO: add a query parameter to allow/disallow overwriting existing records?
       operationId: createOrReplaceRecord
       tags:
@@ -89,8 +87,6 @@ paths:
         Any attributes included in the request body will be created or overwritten.
         Attributes not included in the request body will be untouched in the database.
         No attributes will be deleted. To delete attributes, use the PUT api instead.
-
-        TODO: the type and id are duplicated in the url and the body; change this? Silently ignore the type/id in the body?
       tags:
         - Records
       parameters:

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -87,10 +87,8 @@ public class RecordControllerMockMvcTest {
 		String ref = RelationUtils.createRelationString(referencedType, "record_0");
 		attributes.put("sample-ref", ref);
 		mockMvc.perform(patch("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
-				referringType, "record_0")
-						.contentType(MediaType.APPLICATION_JSON)
-						.content(mapper.writeValueAsString(new RecordRequest(new RecordId("record_0"),
-								new RecordType(referringType), new RecordAttributes(attributes)))))
+				referringType, "record_0").contentType(MediaType.APPLICATION_JSON)
+						.content(mapper.writeValueAsString(new RecordRequest(new RecordAttributes(attributes)))))
 				.andExpect(status().isOk()).andExpect(content().string(containsString(ref)));
 	}
 
@@ -104,10 +102,8 @@ public class RecordControllerMockMvcTest {
 		String ref = RelationUtils.createRelationString(referencedType, "record_0");
 		attributes.put("sample-ref", ref);
 		mockMvc.perform(put("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
-				referringType, "record_0")
-						.contentType(MediaType.APPLICATION_JSON)
-						.content(mapper.writeValueAsString(new RecordRequest(new RecordId("record_0"),
-								new RecordType(referringType), new RecordAttributes(attributes)))))
+				referringType, "record_0").contentType(MediaType.APPLICATION_JSON)
+						.content(mapper.writeValueAsString(new RecordRequest(new RecordAttributes(attributes)))))
 				.andExpect(status().isBadRequest()).andExpect(content().string(containsString(
 						"It looks like you're attempting to assign a relation to a table, missing, that does not exist")));;
 	}
@@ -123,10 +119,8 @@ public class RecordControllerMockMvcTest {
 		String ref = RelationUtils.createRelationString(referencedType, "record_99");
 		attributes.put("sample-ref", ref);
 		mockMvc.perform(put("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
-				referringType, "record_0")
-						.contentType(MediaType.APPLICATION_JSON)
-						.content(mapper.writeValueAsString(new RecordRequest(new RecordId("record_0"),
-								new RecordType(referringType), new RecordAttributes(attributes)))))
+				referringType, "record_0").contentType(MediaType.APPLICATION_JSON)
+						.content(mapper.writeValueAsString(new RecordRequest(new RecordAttributes(attributes)))))
 				.andExpect(status().isBadRequest()).andExpect(content().string(
 						containsString("It looks like you're trying to reference a record that does not exist.")));
 	}
@@ -139,10 +133,8 @@ public class RecordControllerMockMvcTest {
 		Map<String, Object> attributes = new HashMap<>();
 		attributes.put("attr3", "convert this column from date to text");
 		mockMvc.perform(put("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
-				recordType, "record_1")
-						.contentType(MediaType.APPLICATION_JSON)
-						.content(mapper.writeValueAsString(new RecordRequest(new RecordId("record_0"),
-								new RecordType(recordType), new RecordAttributes(attributes)))))
+				recordType, "record_1").contentType(MediaType.APPLICATION_JSON)
+						.content(mapper.writeValueAsString(new RecordRequest(new RecordAttributes(attributes)))))
 				.andExpect(status().isOk());
 	}
 
@@ -156,8 +148,7 @@ public class RecordControllerMockMvcTest {
 		String recordId = "record_missing";
 		mockMvc.perform(patch("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 				recordType, recordId)
-						.content(mapper.writeValueAsString(new RecordRequest(new RecordId(recordId),
-								new RecordType(recordType), new RecordAttributes(attributes))))
+						.content(mapper.writeValueAsString(new RecordRequest(new RecordAttributes(attributes))))
 						.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isNotFound());
 	}
@@ -173,8 +164,7 @@ public class RecordControllerMockMvcTest {
 
 		mockMvc.perform(put("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 				recordType, recordId)
-						.content(mapper.writeValueAsString(new RecordRequest(new RecordId(recordId),
-								new RecordType(recordType), new RecordAttributes(attributes))))
+						.content(mapper.writeValueAsString(new RecordRequest(new RecordAttributes(attributes))))
 						.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isBadRequest())
 				.andExpect(content().string(containsString("assign a relation to a table that does not exist")));
@@ -190,8 +180,7 @@ public class RecordControllerMockMvcTest {
 		attributes.put("attr1", ref);
 		mockMvc.perform(patch("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 				recordType, "record_0")
-						.content(mapper.writeValueAsString(new RecordRequest(new RecordId("record_0"),
-								new RecordType(recordType), new RecordAttributes(attributes))))
+						.content(mapper.writeValueAsString(new RecordRequest(new RecordAttributes(attributes))))
 						.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isConflict())
 				.andExpect(result -> assertTrue(result.getResolvedException().getMessage()
@@ -212,8 +201,7 @@ public class RecordControllerMockMvcTest {
 			attributes.put("attr-boolean", true);
 			mockMvc.perform(put("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 					recordType, recordId)
-							.content(mapper.writeValueAsString(new RecordRequest(new RecordId(recordId),
-									new RecordType(recordType), new RecordAttributes(attributes))))
+							.content(mapper.writeValueAsString(new RecordRequest(new RecordAttributes(attributes))))
 							.contentType(MediaType.APPLICATION_JSON))
 					.andExpect(status().is2xxSuccessful());
 		}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordRequestTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordRequestTest.java
@@ -19,17 +19,13 @@ public class RecordRequestTest {
 
 	@Test
 	void testJsonDeserialization() throws JsonProcessingException {
-		RecordId recordId = new RecordId("test-id");
-		RecordType recordType = new RecordType("test-type");
 		RecordAttributes recordAttributes = new RecordAttributes(
 				Map.of("foo", "bar", "num", 123, "bool", true, "anotherstring", "hello world"));
 
-		RecordRequest expected = new RecordRequest(recordId, recordType, recordAttributes);
+		RecordRequest expected = new RecordRequest(recordAttributes);
 
 		String inputJsonString = """
 				{
-				  "id": "test-id",
-				  "type": "test-type",
 				  "attributes": {
 				    "foo": "bar",
 				    "num": 123,


### PR DESCRIPTION
Removed the confusing duplication of id and type for PUT/PATCH.

Also renamed `Record.name` to `Record.id`, which caused some corresponding changes