### PR TITLE
AJ-528: don't depend on LinkedHashMap to guarantee stable iteration, use a list instead

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -49,7 +49,7 @@ public class RecordController {
 		Map<String, DataTypeMapping> updatedSchema = addOrUpdateColumnIfNeeded(instanceId, recordType.getName(),
 				typeMapping, existingTableSchema, records);
 		try {
-			recordDao.batchUpsert(instanceId, recordTypeName, records, new LinkedHashMap<>(updatedSchema));
+			recordDao.batchUpsert(instanceId, recordTypeName, records, updatedSchema);
 			RecordResponse response = new RecordResponse(recordId, recordType, singleRecord.getAttributes(),
 					new RecordMetadata("TODO: SUPERFRESH"));
 			return new ResponseEntity<>(response, HttpStatus.OK);
@@ -148,9 +148,8 @@ public class RecordController {
 				existingTableSchema.keySet().forEach(attr -> attributesInRequest.putIfAbsent(attr, null));
 				Record record = new Record(recordId, recordType, recordRequest.recordAttributes());
 				List<Record> records = Collections.singletonList(record);
-				addOrUpdateColumnIfNeeded(instanceId, recordType.getName(), requestSchema, existingTableSchema,
-						records);
-				LinkedHashMap<String, DataTypeMapping> combinedSchema = new LinkedHashMap<>(existingTableSchema);
+				addOrUpdateColumnIfNeeded(instanceId, recordType.getName(), requestSchema, existingTableSchema, records);
+				Map<String, DataTypeMapping> combinedSchema = new HashMap<>(existingTableSchema);
 				combinedSchema.putAll(requestSchema);
 				recordDao.batchUpsert(instanceId, recordTypeName, records, combinedSchema);
 				return new ResponseEntity(response, HttpStatus.OK);
@@ -180,7 +179,7 @@ public class RecordController {
 		try {
 			List<Record> records = Collections.singletonList(newRecord);
 			recordDao.createRecordType(instanceId, requestSchema, recordTypeName, RelationUtils.findRelations(records));
-			recordDao.batchUpsert(instanceId, recordTypeName, records, new LinkedHashMap<>(requestSchema));
+			recordDao.batchUpsert(instanceId, recordTypeName, records, requestSchema);
 		} catch (MissingReferencedTableException e) {
 			throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
 					"It looks like you're attempting to assign a relation " + "to a table that does not exist", e);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -155,6 +155,9 @@ public class RecordDao {
 	}
 
 	private Object getValueForSql(Object attVal, DataTypeMapping typeMapping) {
+		if(Objects.isNull(attVal)){
+			return null;
+		}
 		if (RelationUtils.isRelationValue(attVal)) {
 			return RelationUtils.getRelationValue(attVal);
 		}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordColumn.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordColumn.java
@@ -1,0 +1,22 @@
+package org.databiosphere.workspacedataservice.shared.model;
+
+import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
+
+public record RecordColumn(String colName, DataTypeMapping typeMapping) {
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof RecordColumn that)) return false;
+
+        if (!colName.equals(that.colName)) return false;
+        return typeMapping == that.typeMapping;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = colName.hashCode();
+        result = 31 * result + typeMapping.hashCode();
+        return result;
+    }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
@@ -44,7 +44,7 @@ public class RecordDaoTest {
 		RecordId recordId = new RecordId("testRecord");
 		Record testRecord = new Record(recordId, recordType, new RecordAttributes(new HashMap<>()));
 		recordDao.batchUpsert(instanceId, recordType.getName(), Collections.singletonList(testRecord),
-				new LinkedHashMap<>());
+				new HashMap<>());
 
 		// make sure record is fetched
 		Record search = recordDao.getSingleRecord(instanceId, recordType, recordId, Collections.emptyList());
@@ -65,7 +65,7 @@ public class RecordDaoTest {
 		RecordId recordId = new RecordId("testRecord");
 		Record testRecord = new Record(recordId, recordType, new RecordAttributes(new HashMap<>()));
 		recordDao.batchUpsert(instanceId, recordType.getName(), Collections.singletonList(testRecord),
-				new LinkedHashMap<>());
+				new HashMap<>());
 
 		Record search = recordDao.getSingleRecord(instanceId, recordType, recordId, Collections.emptyList());
 		assertEquals(testRecord, search, "Created record should match entered record");
@@ -74,7 +74,7 @@ public class RecordDaoTest {
 		RecordId attrId = new RecordId("recordWithAttr");
 		Record recordWithAttr = new Record(attrId, recordType, new RecordAttributes(Map.of("foo", "bar")));
 		recordDao.batchUpsert(instanceId, recordType.getName(), Collections.singletonList(recordWithAttr),
-				new LinkedHashMap<>(Map.of("foo", DataTypeMapping.STRING)));
+				new HashMap<>(Map.of("foo", DataTypeMapping.STRING)));
 
 		search = recordDao.getSingleRecord(instanceId, recordType, attrId, Collections.emptyList());
 		assertEquals(recordWithAttr, search, "Created record with attributes should match entered record");
@@ -93,13 +93,13 @@ public class RecordDaoTest {
 		RecordId refRecordId = new RecordId("referencedRecord");
 		Record referencedRecord = new Record(refRecordId, recordType, new RecordAttributes(Map.of("foo", "bar")));
 		recordDao.batchUpsert(instanceId, recordType.getName(), Collections.singletonList(referencedRecord),
-				new LinkedHashMap<>());
+				new HashMap<>());
 
 		RecordId recordId = new RecordId("testRecord");
 		String reference = RelationUtils.createRelationString("testRecordType", "referencedRecord");
 		Record testRecord = new Record(recordId, recordType, new RecordAttributes(Map.of("testRecordType", reference)));
 		recordDao.batchUpsert(instanceId, recordType.getName(), Collections.singletonList(testRecord),
-				new LinkedHashMap<>(Map.of("foo", DataTypeMapping.STRING, "testRecordType", DataTypeMapping.STRING)));
+				new HashMap<>(Map.of("foo", DataTypeMapping.STRING, "testRecordType", DataTypeMapping.STRING)));
 
 		Record search = recordDao.getSingleRecord(instanceId, recordType, recordId,
 				recordDao.getRelationCols(instanceId, recordType.getName()));


### PR DESCRIPTION
I'm dividing AJ-528 into smaller PRs.  With this PR, I originally intended to start using named sql parameters since those are usually easier to look at and reason about, but unfortunately there are a number of [constraints](https://stackoverflow.com/questions/422369/are-there-any-illegal-characters-when-using-named-parameters-in-jdbc) that spring jdbc imposes on named sql parameters that led me to abandon that effort.  I think we may want to consider limiting what we allow for record type and column names sooner rather than later or at least evaluate whether the same level of naming flexibility that we offer in Rawls is required.  

Anyhow, what was left in this PR was then switching away from using LinkedHashMap as a parameter type for the RecordDao#batchUpsert() method.  It's not exactly the most essential change, but it's good practice to use the collection interfaces rather than their implementations for methods.  I think we could eventually use List<RecordColumn> in place of Map<String, DataTypeMapping> elsewhere in the code, but for now I'm keeping things localized. 