### PR TITLE
AJ-528: Add quoting function, Return Optional instead of null, Show All Attributes with PUT update path, New tables include FKs in create

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -34,10 +34,8 @@ public class RecordController {
 		validateVersion(version);
 		String recordTypeName = recordType.getName();
 		Record singleRecord = recordDao.getSingleRecord(instanceId, recordType, recordId,
-				recordDao.getRelationCols(instanceId, recordTypeName));
-		if (singleRecord == null) {
-			throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Record not found");
-		}
+				recordDao.getRelationCols(instanceId, recordTypeName))
+				.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Record not found"));
 		Map<String, Object> updatedAtts = recordRequest.recordAttributes().getAttributes();
 		Map<String, Object> allAttrs = new HashMap<>(singleRecord.getAttributes().getAttributes());
 		allAttrs.putAll(updatedAtts);
@@ -113,20 +111,17 @@ public class RecordController {
 			throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Instance or table don't exist");
 		}
 		Record result = recordDao.getSingleRecord(instanceId, recordType, recordId,
-				recordDao.getRelationCols(instanceId, recordType.getName()));
-		if (result == null) {
-			// TODO: standard exception classes
-			throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Record not found");
-		}
+				recordDao.getRelationCols(instanceId, recordType.getName())).
+				orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Record not found"));
 		RecordResponse response = new RecordResponse(recordId, recordType, result.getAttributes(),
 				new RecordMetadata("TODO: RECORDMETADATA"));
 		return new ResponseEntity<>(response, HttpStatus.OK);
 	}
 
 	@PutMapping("/{instanceId}/records/{version}/{recordType}/{recordId}")
-	public ResponseEntity<RecordResponse> putSingleRecord(@PathVariable("instanceId") UUID instanceId,
-			@PathVariable("version") String version, @PathVariable("recordType") RecordType recordType,
-			@PathVariable("recordId") RecordId recordId, @RequestBody RecordRequest recordRequest) {
+	public ResponseEntity<RecordResponse> upsertSingleRecord(@PathVariable("instanceId") UUID instanceId,
+															 @PathVariable("version") String version, @PathVariable("recordType") RecordType recordType,
+															 @PathVariable("recordId") RecordId recordId, @RequestBody RecordRequest recordRequest) {
 		validateVersion(version);
 		String recordTypeName = recordType.getName();
 		Map<String, Object> attributesInRequest = recordRequest.recordAttributes().getAttributes();
@@ -135,9 +130,9 @@ public class RecordController {
 			recordDao.createSchema(instanceId);
 		}
 		try {
-			RecordResponse response = new RecordResponse(recordId, recordType, recordRequest.recordAttributes(),
-					new RecordMetadata("TODO"));
 			if (!recordDao.recordTypeExists(instanceId, recordTypeName)) {
+				RecordResponse response = new RecordResponse(recordId, recordType, recordRequest.recordAttributes(),
+						new RecordMetadata("TODO"));
 				Record newRecord = new Record(recordId, recordType, recordRequest);
 				createRecordTypeAndInsertRecords(instanceId, newRecord, recordTypeName, requestSchema);
 				return new ResponseEntity(response, HttpStatus.CREATED);
@@ -152,6 +147,8 @@ public class RecordController {
 				Map<String, DataTypeMapping> combinedSchema = new HashMap<>(existingTableSchema);
 				combinedSchema.putAll(requestSchema);
 				recordDao.batchUpsert(instanceId, recordTypeName, records, combinedSchema);
+				RecordResponse response = new RecordResponse(recordId, recordType, new RecordAttributes(attributesInRequest),
+						new RecordMetadata("TODO"));
 				return new ResponseEntity(response, HttpStatus.OK);
 			}
 		} catch (ResponseStatusException | InvalidRelation e) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -179,7 +179,7 @@ public class RecordController {
 			recordDao.batchUpsert(instanceId, recordTypeName, records, requestSchema);
 		} catch (MissingReferencedTableException e) {
 			throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
-					"It looks like you're attempting to assign a relation " + "to a table that does not exist", e);
+					"It looks like you're attempting to assign a relation to a table that does not exist", e);
 		}
 	}
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -55,7 +55,7 @@ public class RecordDao {
 		try {
 			namedTemplate.getJdbcTemplate()
 					.update("create table " + getQualifiedTableName(tableName, instanceId) + "( " + columnDefs +
-							(relations.size() > 0 ? ", " + getFkSql(relations) : "") + ")");
+							(!relations.isEmpty() ? ", " + getFkSql(relations) : "") + ")");
 		} catch (DataAccessException e) {
 			convertToInvalidRelationEx(e);
 		}
@@ -118,14 +118,12 @@ public class RecordDao {
 	}
 
 	private static void convertToInvalidRelationEx(DataAccessException e) throws InvalidRelation {
-		if (e.getRootCause() instanceof SQLException sqlEx) {
-			if (sqlEx.getSQLState() != null) {
-				if(sqlEx.getSQLState().equals("23503")){
-					throw new InvalidRelation("It looks like you're trying to reference a record that does not exist.");
-				}
-				if(sqlEx.getSQLState().equals("42P01")){
-					throw new InvalidRelation("It looks like you're trying to assign a relation to a table that does not exist.");
-				}
+		if (e.getRootCause() instanceof SQLException sqlEx && sqlEx.getSQLState() != null) {
+			if (sqlEx.getSQLState().equals("23503")) {
+				throw new InvalidRelation("It looks like you're trying to reference a record that does not exist.");
+			}
+			if (sqlEx.getSQLState().equals("42P01")) {
+				throw new InvalidRelation("It looks like you're trying to assign a relation to a table that does not exist.");
 			}
 		}
 		throw e;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -45,7 +45,7 @@ public class RecordControllerMockMvcTest {
 
 	@Test
 	@Transactional
-	public void createInstanceAndTryToCreateAgain() throws Exception {
+	void createInstanceAndTryToCreateAgain() throws Exception {
 		UUID uuid = UUID.randomUUID();
 		mockMvc.perform(post("/{instanceId}/{version}/", uuid, versionId)).andExpect(status().isCreated());
 		mockMvc.perform(post("/{instanceId}/{version}/", uuid, versionId)).andExpect(status().isConflict());
@@ -53,14 +53,14 @@ public class RecordControllerMockMvcTest {
 
 	@Test
 	@Transactional
-	public void tryFetchingMissingRecordType() throws Exception {
+	void tryFetchingMissingRecordType() throws Exception {
 		mockMvc.perform(get("/{instanceId}/records/{versionId}/{recordType}/{recordId}", instanceId, versionId,
 				"missing", "missing-2")).andExpect(status().isNotFound());
 	}
 
 	@Test
 	@Transactional
-	public void tryFetchingMissingRecord() throws Exception {
+	void tryFetchingMissingRecord() throws Exception {
 		String recordType1 = "recordType1";
 		createSomeRecords(recordType1, 1);
 		mockMvc.perform(get("/{instanceId}/records/{versionId}/{recordType}/{recordId}", instanceId, versionId,
@@ -68,7 +68,7 @@ public class RecordControllerMockMvcTest {
 	}
 
 	@Test
-	public void ensurePutShowsNewlyNullFields() throws Exception {
+	void ensurePutShowsNewlyNullFields() throws Exception {
 		String recordType1 = "recordType1";
 		createSomeRecords(recordType1, 1);
 		Map<String, Object> newAttributes = new HashMap<>();
@@ -83,7 +83,7 @@ public class RecordControllerMockMvcTest {
 	}
 
 	@Test
-	public void ensurePatchShowsAllFields() throws Exception {
+	void ensurePatchShowsAllFields() throws Exception {
 		String recordType1 = "recordType1";
 		createSomeRecords(recordType1, 1);
 		Map<String, Object> newAttributes = new HashMap<>();
@@ -100,7 +100,7 @@ public class RecordControllerMockMvcTest {
 
 	@Test
 	@Transactional
-	public void createAndRetrieveRecord() throws Exception {
+	void createAndRetrieveRecord() throws Exception {
 		String recordType = "samples";
 		createSomeRecords(recordType, 1);
 		mockMvc.perform(get("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
@@ -109,7 +109,7 @@ public class RecordControllerMockMvcTest {
 
 	@Test
 	@Transactional
-	public void createRecordWithReferences() throws Exception {
+	void createRecordWithReferences() throws Exception {
 		String referencedType = "ref_participants";
 		String referringType = "ref_samples";
 		createSomeRecords(referencedType, 3);
@@ -125,7 +125,7 @@ public class RecordControllerMockMvcTest {
 
 	@Test
 	@Transactional
-	public void referencingMissingTableFails() throws Exception {
+	void referencingMissingTableFails() throws Exception {
 		String referencedType = "missing";
 		String referringType = "ref_samples-2";
 		createSomeRecords(referringType, 1);
@@ -141,7 +141,7 @@ public class RecordControllerMockMvcTest {
 
 	@Test
 	@Transactional
-	public void referencingMissingRecordFails() throws Exception {
+	void referencingMissingRecordFails() throws Exception {
 		String referencedType = "ref_participants-2";
 		String referringType = "ref_samples-3";
 		createSomeRecords(referencedType, 3);
@@ -158,7 +158,7 @@ public class RecordControllerMockMvcTest {
 
 	@Test
 	@Transactional
-	public void expandColumnDefForNewData() throws Exception {
+	void expandColumnDefForNewData() throws Exception {
 		String recordType = "to-alter";
 		createSomeRecords(recordType, 1);
 		Map<String, Object> attributes = new HashMap<>();
@@ -171,7 +171,7 @@ public class RecordControllerMockMvcTest {
 
 	@Test
 	@Transactional
-	public void patchMissingRecord() throws Exception {
+	void patchMissingRecord() throws Exception {
 		String recordType = "to-patch";
 		createSomeRecords(recordType, 1);
 		Map<String, Object> attributes = new HashMap<>();
@@ -186,7 +186,7 @@ public class RecordControllerMockMvcTest {
 
 	@Test
 	@Transactional
-	public void putRecordWithMissingTableReference() throws Exception {
+	void putRecordWithMissingTableReference() throws Exception {
 		String recordType = "record-type-missing-table-ref";
 		String recordId = "record_0";
 		Map<String, Object> attributes = new HashMap<>();
@@ -194,7 +194,7 @@ public class RecordControllerMockMvcTest {
 		attributes.put("sample-ref", ref);
 
 		mockMvc.perform(put("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
-				recordType, recordId)
+						recordType, recordId)
 						.content(mapper.writeValueAsString(new RecordRequest(new RecordAttributes(attributes))))
 						.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isBadRequest())
@@ -203,7 +203,7 @@ public class RecordControllerMockMvcTest {
 
 	@Test
 	@Transactional
-	public void tryToAssignReferenceToNonRefColumn() throws Exception {
+	void tryToAssignReferenceToNonRefColumn() throws Exception {
 		String recordType = "ref-alter";
 		createSomeRecords(recordType, 1);
 		Map<String, Object> attributes = new HashMap<>();

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -68,6 +68,37 @@ public class RecordControllerMockMvcTest {
 	}
 
 	@Test
+	public void ensurePutShowsNewlyNullFields() throws Exception {
+		String recordType1 = "recordType1";
+		createSomeRecords(recordType1, 1);
+		Map<String, Object> newAttributes = new HashMap<>();
+		newAttributes.put("new-attr", "some_val");
+		mockMvc.perform(put("/{instanceId}/records/{versionId}/{recordType}/{recordId}", instanceId, versionId,
+				recordType1, "record_0")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(mapper.writeValueAsString(new RecordRequest(new RecordAttributes(newAttributes)))))
+				.andExpect(content().string(containsString("\"attr3\":null")))
+				.andExpect(content().string(containsString("\"attr-dt\":null")))
+				.andExpect(status().isOk());
+	}
+
+	@Test
+	public void ensurePatchShowsAllFields() throws Exception {
+		String recordType1 = "recordType1";
+		createSomeRecords(recordType1, 1);
+		Map<String, Object> newAttributes = new HashMap<>();
+		newAttributes.put("new-attr", "some_val");
+		mockMvc.perform(patch("/{instanceId}/records/{versionId}/{recordType}/{recordId}", instanceId, versionId,
+						recordType1, "record_0")
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(mapper.writeValueAsString(new RecordRequest(new RecordAttributes(newAttributes)))))
+				.andExpect(content().string(containsString("\"attr3\"")))
+				.andExpect(content().string(containsString("\"attr-dt\"")))
+				.andExpect(content().string(containsString("\"new-attr\":\"some_val\"")))
+				.andExpect(status().isOk());
+	}
+
+	@Test
 	@Transactional
 	public void createAndRetrieveRecord() throws Exception {
 		String recordType = "samples";

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
@@ -1,14 +1,10 @@
 package org.databiosphere.workspacedataservice.dao;
 
-import static org.junit.jupiter.api.Assertions.*;
-
-import java.util.*;
-
 import org.databiosphere.workspacedataservice.service.RelationUtils;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
-import org.databiosphere.workspacedataservice.service.model.Relation;
 import org.databiosphere.workspacedataservice.service.model.InvalidRelation;
 import org.databiosphere.workspacedataservice.service.model.MissingReferencedTableException;
+import org.databiosphere.workspacedataservice.service.model.Relation;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
 import org.databiosphere.workspacedataservice.shared.model.RecordId;
@@ -19,6 +15,10 @@ import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -47,13 +47,13 @@ public class RecordDaoTest {
 				new HashMap<>());
 
 		// make sure record is fetched
-		Record search = recordDao.getSingleRecord(instanceId, recordType, recordId, Collections.emptyList());
+		Record search = recordDao.getSingleRecord(instanceId, recordType, recordId, Collections.emptyList()).get();
 		assertEquals(testRecord, search);
 
 		// nonexistent record should be null
-		Record none = recordDao.getSingleRecord(instanceId, recordType, new RecordId("noRecord"),
+		Optional<Record> none = recordDao.getSingleRecord(instanceId, recordType, new RecordId("noRecord"),
 				Collections.emptyList());
-		assertNull(none);
+		assertEquals(none, Optional.empty());
 	}
 
 	@Test
@@ -67,7 +67,7 @@ public class RecordDaoTest {
 		recordDao.batchUpsert(instanceId, recordType.getName(), Collections.singletonList(testRecord),
 				new HashMap<>());
 
-		Record search = recordDao.getSingleRecord(instanceId, recordType, recordId, Collections.emptyList());
+		Record search = recordDao.getSingleRecord(instanceId, recordType, recordId, Collections.emptyList()).get();
 		assertEquals(testRecord, search, "Created record should match entered record");
 
 		// create record with attributes
@@ -76,7 +76,7 @@ public class RecordDaoTest {
 		recordDao.batchUpsert(instanceId, recordType.getName(), Collections.singletonList(recordWithAttr),
 				new HashMap<>(Map.of("foo", DataTypeMapping.STRING)));
 
-		search = recordDao.getSingleRecord(instanceId, recordType, attrId, Collections.emptyList());
+		search = recordDao.getSingleRecord(instanceId, recordType, attrId, Collections.emptyList()).get();
 		assertEquals(recordWithAttr, search, "Created record with attributes should match entered record");
 	}
 
@@ -102,7 +102,7 @@ public class RecordDaoTest {
 				new HashMap<>(Map.of("foo", DataTypeMapping.STRING, "testRecordType", DataTypeMapping.STRING)));
 
 		Record search = recordDao.getSingleRecord(instanceId, recordType, recordId,
-				recordDao.getRelationCols(instanceId, recordType.getName()));
+				recordDao.getRelationCols(instanceId, recordType.getName())).get();
 		assertEquals(testRecord, search, "Created record with references should match entered record");
 	}
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
@@ -30,7 +30,7 @@ public class RecordDaoTest {
 	RecordType recordType;
 
 	@BeforeEach
-	void setUp() throws MissingReferencedTableException {
+	void setUp() throws MissingReferencedTableException, InvalidRelation {
 		instanceId = UUID.randomUUID();
 		recordType = new RecordType("testRecordType");
 		recordDao.createSchema(instanceId);


### PR DESCRIPTION
- In `RecordDao` Convert inline quoting of table and column names to method calls
- `RecordDao.getSingleRecord()` now returns an Optional
- PUT single record previously didn't include any nulled out attributes in its response payload (i.e. if PUT was used to update an existing record any existing attributes not included in the request payload would not show up in the PUT response body) This change should make the PUT response consistent with GET for the same Record, which seems correct to me, but let me know if I've misunderstood things.
- When creating a new record type, create foreign keys for references at table creation time.
- Sonar squawking about public test methods.