### PR TITLE
AJ-559 don't create column for invalid relation

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -78,6 +78,8 @@ public class RecordController {
 					referencedRecordType = newRefCols.get(col).get(0).relationRecordType().getName();
 					recordDao.addForeignKeyForReference(recordType, referencedRecordType, instanceId, col);
 				} catch (MissingReferencedTableException e) {
+					//rollback created column
+					recordDao.removeColumn(instanceId, recordType, col);
 					throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
 							"It looks like you're attempting to assign a relation " + "to a table, "
 									+ referencedRecordType + ", that does not exist");

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -70,20 +70,17 @@ public class RecordController {
 		// single column
 		Preconditions.checkArgument(newRefCols.values().stream().filter(l -> l.size() > 1).findAny().isEmpty());
 		for (String col : colsToAdd.keySet()) {
-			recordDao.addColumn(instanceId, recordType, col, colsToAdd.get(col));
-			schema.put(col, colsToAdd.get(col));
+			String referencedRecordType = null;
 			if (newRefCols.containsKey(col)) {
-				String referencedRecordType = null;
-				try {
-					referencedRecordType = newRefCols.get(col).get(0).relationRecordType().getName();
-					recordDao.addForeignKeyForReference(recordType, referencedRecordType, instanceId, col);
-				} catch (MissingReferencedTableException e) {
-					//rollback created column
-					recordDao.removeColumn(instanceId, recordType, col);
-					throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
-							"It looks like you're attempting to assign a relation " + "to a table, "
-									+ referencedRecordType + ", that does not exist");
-				}
+				referencedRecordType = newRefCols.get(col).get(0).relationRecordType().getName();
+			}
+			try {
+				recordDao.addColumn(instanceId, recordType, col, colsToAdd.get(col), referencedRecordType);
+				schema.put(col, colsToAdd.get(col));
+			} catch (MissingReferencedTableException e) {
+				throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+						"It looks like you're attempting to assign a relation " + "to a table, "
+								+ referencedRecordType + ", that does not exist");
 			}
 		}
 		if (!recordDao.getRelationCols(instanceId, recordType).stream().map(Relation::relationColName)

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -176,10 +176,6 @@ public class RecordDao {
 				.collect(Collectors.joining(", \n"));
 	}
 
-	public String getSingleFkSql(Relation relation) {
-		return " references " + relation.relationRecordType().getName() + "(" + RECORD_ID.getColumnName() + ")";
-	}
-
 	public List<Relation> getRelationCols(UUID instanceId, String tableName) {
 		return namedTemplate.query(
 				"SELECT kcu.column_name, ccu.table_name FROM information_schema.table_constraints tc JOIN information_schema.key_column_usage kcu "

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -88,6 +88,11 @@ public class RecordDao {
 				+ " add column " + quote(columnName) + " " + colType.getPostgresType());
 	}
 
+	public void removeColumn(UUID instanceId, String tableName, String columnName) {
+		namedTemplate.getJdbcTemplate().update("alter table " + getQualifiedTableName(tableName, instanceId)
+				+ " drop column " + quote(columnName));
+	}
+
 	public void changeColumn(UUID instanceId, String tableName, String columnName, DataTypeMapping newColType) {
 		namedTemplate.getJdbcTemplate().update("alter table " + getQualifiedTableName(tableName, instanceId)
 				+ " alter column " + quote(columnName) + " TYPE " + newColType.getPostgresType());

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -53,11 +53,10 @@ public class RecordDao {
 			Set<Relation> relations) throws MissingReferencedTableException, InvalidRelation {
 		String columnDefs = genColumnDefs(tableInfo);
 		try {
-			namedTemplate.getJdbcTemplate()
-					.update("create table " + getQualifiedTableName(tableName, instanceId) + "( " + columnDefs +
-							(!relations.isEmpty() ? ", " + getFkSql(relations) : "") + ")");
+			namedTemplate.getJdbcTemplate().update("create table " + getQualifiedTableName(tableName, instanceId) + "( "
+					+ columnDefs + (!relations.isEmpty() ? ", " + getFkSql(relations) : "") + ")");
 		} catch (DataAccessException e) {
-			if (e.getRootCause() instanceof SQLException sqlEx) {
+			if (e.getRootCause()instanceof SQLException sqlEx) {
 				checkForMissingTable(sqlEx);
 			}
 			throw e;
@@ -83,14 +82,26 @@ public class RecordDao {
 						});
 	}
 
-	public void addColumn(UUID instanceId, String tableName, String columnName, DataTypeMapping colType) {
-		namedTemplate.getJdbcTemplate().update("alter table " + getQualifiedTableName(tableName, instanceId)
-				+ " add column " + quote(columnName) + " " + colType.getPostgresType());
+	public void addColumn(UUID instanceId, String tableName, String columnName, DataTypeMapping colType)
+			throws MissingReferencedTableException {
+		addColumn(instanceId, tableName, columnName, colType, null);
 	}
 
-	public void removeColumn(UUID instanceId, String tableName, String columnName) {
-		namedTemplate.getJdbcTemplate().update("alter table " + getQualifiedTableName(tableName, instanceId)
-				+ " drop column " + quote(columnName));
+	public void addColumn(UUID instanceId, String tableName, String columnName, DataTypeMapping colType,
+			String referencedTable) throws MissingReferencedTableException {
+		try {
+			namedTemplate.getJdbcTemplate()
+					.update("alter table " + getQualifiedTableName(tableName, instanceId) + " add column "
+							+ quote(columnName) + " " + colType.getPostgresType()
+							+ (referencedTable != null
+									? " references " + getQualifiedTableName(referencedTable, instanceId)
+									: ""));
+		} catch (DataAccessException e) {
+			if (e.getRootCause()instanceof SQLException sqlEx) {
+				checkForMissingTable(sqlEx);
+			}
+			throw e;
+		}
 	}
 
 	public void changeColumn(UUID instanceId, String tableName, String columnName, DataTypeMapping newColType) {
@@ -107,37 +118,38 @@ public class RecordDao {
 						: "");
 	}
 
-	private String quote(String toQuote){
+	private String quote(String toQuote) {
 		return "\"" + toQuote + "\"";
 	}
 
 	// The expectation is that the record type already matches the schema and
 	// attributes given, as
 	// that's dealt with earlier in the code.
-	public void batchUpsert(UUID instanceId, String recordType, List<Record> records, Map<String, DataTypeMapping> schema) throws InvalidRelation {
+	public void batchUpsert(UUID instanceId, String recordType, List<Record> records,
+			Map<String, DataTypeMapping> schema) throws InvalidRelation {
 		schema.put(RECORD_ID.getColumnName(), DataTypeMapping.STRING);
-		List<RecordColumn> schemaAsList = schema.entrySet().stream().map(e -> new RecordColumn(e.getKey(), e.getValue())).toList();
+		List<RecordColumn> schemaAsList = schema.entrySet().stream()
+				.map(e -> new RecordColumn(e.getKey(), e.getValue())).toList();
 		try {
 			namedTemplate.getJdbcTemplate().batchUpdate(genInsertStatement(instanceId, recordType, schemaAsList),
 					getInsertBatchArgs(records, schemaAsList));
 		} catch (DataAccessException e) {
-			if (e.getRootCause() instanceof SQLException sqlEx){
+			if (e.getRootCause()instanceof SQLException sqlEx) {
 				checkForMissingRecord(sqlEx);
 				throw e;
 			}
 		}
 	}
 
-
 	public void addForeignKeyForReference(String recordType, String referencedRecordType, UUID instanceId,
-										  String relationColName) throws MissingReferencedTableException {
+			String relationColName) throws MissingReferencedTableException {
 		try {
-			String addFk = "alter table " + getQualifiedTableName(recordType, instanceId) + " add foreign key (" +
-					quote(relationColName) + ") " + "references "
+			String addFk = "alter table " + getQualifiedTableName(recordType, instanceId) + " add foreign key ("
+					+ quote(relationColName) + ") " + "references "
 					+ getQualifiedTableName(referencedRecordType, instanceId);
 			namedTemplate.getJdbcTemplate().execute(addFk);
 		} catch (DataAccessException e) {
-			if (e.getRootCause() instanceof SQLException sqlEx) {
+			if (e.getRootCause()instanceof SQLException sqlEx) {
 				checkForMissingTable(sqlEx);
 			}
 			throw e;
@@ -156,11 +168,16 @@ public class RecordDao {
 		}
 	}
 
-
-
 	public String getFkSql(Set<Relation> relations) {
-		return relations.stream().map(r -> "constraint " + quote("fk_" + r.relationColName()) + " foreign key (" + quote(r.relationColName()) + ") references "
-				+ r.relationRecordType().getName() + "(" + RECORD_ID.getColumnName() + ")").collect(Collectors.joining(", \n"));
+		return relations.stream()
+				.map(r -> "constraint " + quote("fk_" + r.relationColName()) + " foreign key ("
+						+ quote(r.relationColName()) + ") references " + r.relationRecordType().getName() + "("
+						+ RECORD_ID.getColumnName() + ")")
+				.collect(Collectors.joining(", \n"));
+	}
+
+	public String getSingleFkSql(Relation relation) {
+		return " references " + relation.relationRecordType().getName() + "(" + RECORD_ID.getColumnName() + ")";
 	}
 
 	public List<Relation> getRelationCols(UUID instanceId, String tableName) {
@@ -183,7 +200,7 @@ public class RecordDao {
 	}
 
 	private Object getValueForSql(Object attVal, DataTypeMapping typeMapping) {
-		if(Objects.isNull(attVal)){
+		if (Objects.isNull(attVal)) {
 			return null;
 		}
 		if (RelationUtils.isRelationValue(attVal)) {
@@ -217,11 +234,8 @@ public class RecordDao {
 		List<String> colNames = schema.stream().map(RecordColumn::colName).toList();
 		List<DataTypeMapping> colTypes = schema.stream().map(RecordColumn::typeMapping).toList();
 		return "insert into " + getQualifiedTableName(recordType, instanceId) + "(" + getInsertColList(colNames)
-				+ ") values (" + getInsertParamList(colTypes) + ") " + "on conflict ("
-				+ RECORD_ID.getColumnName() + ") "
-				+ (schema.size() == 1
-						? "do nothing"
-						: "do update set " + genColUpsertUpdates(colNames));
+				+ ") values (" + getInsertParamList(colTypes) + ") " + "on conflict (" + RECORD_ID.getColumnName()
+				+ ") " + (schema.size() == 1 ? "do nothing" : "do update set " + genColUpsertUpdates(colNames));
 	}
 
 	private String getInsertParamList(List<DataTypeMapping> colTypes) {
@@ -234,40 +248,40 @@ public class RecordDao {
 	}
 
 	private record RecordRowMapper(String recordType,
-								   Map<String, String> referenceColToTable) implements RowMapper<Record> {
+			Map<String, String> referenceColToTable) implements RowMapper<Record> {
 
 		@Override
-			public Record mapRow(ResultSet rs, int rowNum) throws SQLException {
-				return new Record(new RecordId(rs.getString(RECORD_ID.getColumnName())), new RecordType(recordType),
-						new RecordAttributes(getAttributes(rs)));
-			}
+		public Record mapRow(ResultSet rs, int rowNum) throws SQLException {
+			return new Record(new RecordId(rs.getString(RECORD_ID.getColumnName())), new RecordType(recordType),
+					new RecordAttributes(getAttributes(rs)));
+		}
 
-			private Map<String, Object> getAttributes(ResultSet rs) {
-				try {
-					ResultSetMetaData metaData = rs.getMetaData();
-					Map<String, Object> attributes = new HashMap<>();
-					Set<String> systemCols = Arrays.stream(SystemColumn.values()).map(SystemColumn::getColumnName)
-							.collect(Collectors.toSet());
-					for (int j = 1; j <= metaData.getColumnCount(); j++) {
-						String columnName = metaData.getColumnName(j);
-						if (systemCols.contains(columnName)) {
-							continue;
-						}
-						if (referenceColToTable.size() > 0 && referenceColToTable.containsKey(columnName)) {
-							attributes.put(columnName, RelationUtils
-									.createRelationString(referenceColToTable.get(columnName), rs.getString(columnName)));
-						} else {
-							Object object = rs.getObject(columnName);
-							attributes.put(columnName,
-									object instanceof PGobject ? ((PGobject) object).getValue() : object);
-						}
+		private Map<String, Object> getAttributes(ResultSet rs) {
+			try {
+				ResultSetMetaData metaData = rs.getMetaData();
+				Map<String, Object> attributes = new HashMap<>();
+				Set<String> systemCols = Arrays.stream(SystemColumn.values()).map(SystemColumn::getColumnName)
+						.collect(Collectors.toSet());
+				for (int j = 1; j <= metaData.getColumnCount(); j++) {
+					String columnName = metaData.getColumnName(j);
+					if (systemCols.contains(columnName)) {
+						continue;
 					}
-					return attributes;
-				} catch (SQLException e) {
-					throw new RuntimeException(e);
+					if (referenceColToTable.size() > 0 && referenceColToTable.containsKey(columnName)) {
+						attributes.put(columnName, RelationUtils
+								.createRelationString(referenceColToTable.get(columnName), rs.getString(columnName)));
+					} else {
+						Object object = rs.getObject(columnName);
+						attributes.put(columnName,
+								object instanceof PGobject ? ((PGobject) object).getValue() : object);
+					}
 				}
+				return attributes;
+			} catch (SQLException e) {
+				throw new RuntimeException(e);
 			}
 		}
+	}
 
 	public Optional<Record> getSingleRecord(UUID instanceId, RecordType recordType, RecordId recordId,
 			List<Relation> referenceCols) {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
@@ -43,8 +43,7 @@ public class RecordDaoTest {
 		// add record
 		RecordId recordId = new RecordId("testRecord");
 		Record testRecord = new Record(recordId, recordType, new RecordAttributes(new HashMap<>()));
-		recordDao.batchUpsert(instanceId, recordType.getName(), Collections.singletonList(testRecord),
-				new HashMap<>());
+		recordDao.batchUpsert(instanceId, recordType.getName(), Collections.singletonList(testRecord), new HashMap<>());
 
 		// make sure record is fetched
 		Record search = recordDao.getSingleRecord(instanceId, recordType, recordId, Collections.emptyList()).get();
@@ -58,14 +57,13 @@ public class RecordDaoTest {
 
 	@Test
 	@Transactional
-	void testCreateSingleRecord() throws InvalidRelation {
+	void testCreateSingleRecord() throws InvalidRelation, MissingReferencedTableException {
 		recordDao.addColumn(instanceId, recordType.getName(), "foo", DataTypeMapping.STRING);
 
 		// create record with no attributes
 		RecordId recordId = new RecordId("testRecord");
 		Record testRecord = new Record(recordId, recordType, new RecordAttributes(new HashMap<>()));
-		recordDao.batchUpsert(instanceId, recordType.getName(), Collections.singletonList(testRecord),
-				new HashMap<>());
+		recordDao.batchUpsert(instanceId, recordType.getName(), Collections.singletonList(testRecord), new HashMap<>());
 
 		Record search = recordDao.getSingleRecord(instanceId, recordType, recordId, Collections.emptyList()).get();
 		assertEquals(testRecord, search, "Created record should match entered record");


### PR DESCRIPTION
[AJ-559 Inserting relation to non-existent record creates relation attribute](https://broadworkbench.atlassian.net/browse/AJ-559)
If creating relation fails due to the related table not existing, the column for that relation should not be created. Included the foreign key constraint when initially creating column so we can catch the sql error at the same time.
I ran `build` so there's a number of changes that are just whitespace, hopefully it's not too disruptive.