### PR TITLE
AJ-567: Sanitize user input for table and column names to remediate SQL injection risk

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ curl -H "Content-type: application/json" -X PATCH "http://localhost:8080/<instan
 }
 }'
 ```
+Note that attribute and record type names are subject to the logic in [validateName](https://github.com/DataBiosphere/terra-workspace-data-service/blob/5375c8c846ad163e38a5540c4487ea05fb292f45/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java#L80)
 
 When done, stop postgres:
 ```bash

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -66,12 +66,13 @@ public class RecordController {
 		MapDifference<String, DataTypeMapping> difference = Maps.difference(existingTableSchema, schema);
 		Map<String, DataTypeMapping> colsToAdd = difference.entriesOnlyOnRight();
 		colsToAdd.keySet().stream().filter(s -> s.startsWith(RESERVED_NAME_PREFIX)).findAny().ifPresent(s -> {
-			throw new InvalidNameException("Attribute");
+			throw new InvalidNameException(InvalidNameException.NameType.ATTRIBUTE);
 		});
 		validateRelationsAndAddColumns(instanceId, recordType, schema, records, colsToAdd, existingTableSchema);
 		Map<String, MapDifference.ValueDifference<DataTypeMapping>> differenceMap = difference.entriesDiffering();
-		for (String column : differenceMap.keySet()) {
-			MapDifference.ValueDifference<DataTypeMapping> valueDifference = differenceMap.get(column);
+		for (Map.Entry<String, MapDifference.ValueDifference<DataTypeMapping>> entry : differenceMap.entrySet()) {
+			String column = entry.getKey();
+			MapDifference.ValueDifference<DataTypeMapping> valueDifference = entry.getValue();
 			DataTypeMapping updatedColType = inferer.selectBestType(valueDifference.leftValue(),
 					valueDifference.rightValue());
 			recordDao.changeColumn(instanceId, recordType, column, updatedColType);
@@ -100,13 +101,15 @@ public class RecordController {
 			throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
 					"Relation attribute can only be assigned to one record type");
 		}
-		for (String col : colsToAdd.keySet()) {
+		for (Map.Entry<String, DataTypeMapping> entry : colsToAdd.entrySet()) {
 			String referencedRecordType = null;
+			String col = entry.getKey();
+			DataTypeMapping dataType = entry.getValue();
 			if (allRefCols.containsKey(col)) {
 				referencedRecordType = allRefCols.get(col).get(0).relationRecordType().getName();
 			}
-			recordDao.addColumn(instanceId, recordType, col, colsToAdd.get(col), referencedRecordType);
-			requestSchema.put(col, colsToAdd.get(col));
+			recordDao.addColumn(instanceId, recordType, col, dataType, referencedRecordType);
+			requestSchema.put(col, dataType);
 		}
 	}
 
@@ -152,8 +155,8 @@ public class RecordController {
 					recordTypeName);
 			// null out any attributes that already exist but aren't in the request
 			existingTableSchema.keySet().forEach(attr -> attributesInRequest.putIfAbsent(attr, null));
-			Record record = new Record(recordId, recordType, recordRequest.recordAttributes());
-			List<Record> records = Collections.singletonList(record);
+			Record newRecord = new Record(recordId, recordType, recordRequest.recordAttributes());
+			List<Record> records = Collections.singletonList(newRecord);
 			addOrUpdateColumnIfNeeded(instanceId, recordType.getName(), requestSchema, existingTableSchema, records);
 			Map<String, DataTypeMapping> combinedSchema = new HashMap<>(existingTableSchema);
 			combinedSchema.putAll(requestSchema);
@@ -176,7 +179,7 @@ public class RecordController {
 	}
 
 	@DeleteMapping("/{instanceId}/records/{version}/{recordType}/{recordId}")
-	public ResponseEntity deleteSingleRecord(@PathVariable("instanceId") UUID instanceId,
+	public ResponseEntity<Void> deleteSingleRecord(@PathVariable("instanceId") UUID instanceId,
 			@PathVariable("version") String version, @PathVariable("recordType") RecordType recordType,
 			@PathVariable("recordId") RecordId recordId) {
 		validateVersion(version);
@@ -194,7 +197,7 @@ public class RecordController {
 	private void createRecordTypeAndInsertRecords(UUID instanceId, Record newRecord, String recordTypeName,
 			Map<String, DataTypeMapping> requestSchema) {
 		if (recordTypeName.startsWith(RESERVED_NAME_PREFIX)) {
-			throw new InvalidNameException("Record type");
+			throw new InvalidNameException(InvalidNameException.NameType.RECORD_TYPE);
 		}
 		List<Record> records = Collections.singletonList(newRecord);
 		recordDao.createRecordType(instanceId, requestSchema, recordTypeName, RelationUtils.findRelations(records));

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -58,6 +58,7 @@ public class RecordDao {
 
 	public void createRecordType(UUID instanceId, Map<String, DataTypeMapping> tableInfo, String tableName,
 			Set<Relation> relations) {
+
 		String columnDefs = genColumnDefs(tableInfo);
 		try {
 			namedTemplate.getJdbcTemplate().update("create table " + getQualifiedTableName(tableName, instanceId) + "( "
@@ -68,12 +69,13 @@ public class RecordDao {
 			}
 			throw e;
 		}
+
 	}
 
 	private String getQualifiedTableName(String recordType, UUID instanceId) {
-//		if(containsDisallowedSqlCharacter(recordType)){
-//			throw new IllegalArgumentException("Your argument is no good");
-//		}
+		if(containsDisallowedSqlCharacter(recordType)){
+			throw new IllegalArgumentException("Your argument is no good");
+		}
 		return quote(instanceId.toString()) + "." + quote(recordType);
 	}
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -34,7 +34,7 @@ import static org.databiosphere.workspacedataservice.service.model.ReservedNames
 public class RecordDao {
 
 	private final NamedParameterJdbcTemplate namedTemplate;
-	private static final Pattern DISALLOWED_CHARS_PATTERN = Pattern.compile("[^a-z0-9\\-_\\s]", Pattern.CASE_INSENSITIVE);
+	private static final Pattern DISALLOWED_CHARS_PATTERN = Pattern.compile("[^a-z0-9\\-_ ]", Pattern.CASE_INSENSITIVE);
 
 	public RecordDao(NamedParameterJdbcTemplate namedTemplate) {
 		this.namedTemplate = namedTemplate;
@@ -80,9 +80,8 @@ public class RecordDao {
 	private String validateName(String name, InvalidNameException.NameType nameType){
 		if(containsDisallowedSqlCharacter(name)){
 			throw new InvalidNameException(nameType);
-		} else {
-			return name;
 		}
+		return name;
 	}
 
 	private boolean containsDisallowedSqlCharacter(String name) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -71,9 +71,9 @@ public class RecordDao {
 	}
 
 	private String getQualifiedTableName(String recordType, UUID instanceId) {
-		if(containsDisallowedSqlCharacter(recordType)){
-			throw new IllegalArgumentException("Your argument is no good");
-		}
+//		if(containsDisallowedSqlCharacter(recordType)){
+//			throw new IllegalArgumentException("Your argument is no good");
+//		}
 		return quote(instanceId.toString()) + "." + quote(recordType);
 	}
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -24,6 +24,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.databiosphere.workspacedataservice.service.model.ReservedNames.*;
@@ -32,6 +33,7 @@ import static org.databiosphere.workspacedataservice.service.model.ReservedNames
 public class RecordDao {
 
 	private final NamedParameterJdbcTemplate namedTemplate;
+	private static final Pattern DISALLOWED_CHARS_PATTERN = Pattern.compile("[^a-z0-9\\-_\\s]", Pattern.CASE_INSENSITIVE);
 
 	public RecordDao(NamedParameterJdbcTemplate namedTemplate) {
 		this.namedTemplate = namedTemplate;
@@ -69,7 +71,14 @@ public class RecordDao {
 	}
 
 	private String getQualifiedTableName(String recordType, UUID instanceId) {
+		if(containsDisallowedSqlCharacter(recordType)){
+			throw new IllegalArgumentException("Your argument is no good");
+		}
 		return quote(instanceId.toString()) + "." + quote(recordType);
+	}
+
+	private boolean containsDisallowedSqlCharacter(String name) {
+		return name == null || DISALLOWED_CHARS_PATTERN.matcher(name).find();
 	}
 
 	public Map<String, DataTypeMapping> getExistingTableSchema(UUID instanceId, String tableName) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -73,9 +73,6 @@ public class RecordDao {
 	}
 
 	private String getQualifiedTableName(String recordType, UUID instanceId) {
-		if(containsDisallowedSqlCharacter(recordType)){
-			throw new IllegalArgumentException("Your argument is no good");
-		}
 		return quote(instanceId.toString()) + "." + quote(recordType);
 	}
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/InvalidNameException.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/InvalidNameException.java
@@ -6,7 +6,18 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 
 @ResponseStatus(code = HttpStatus.BAD_REQUEST)
 public class InvalidNameException extends RuntimeException {
-	public InvalidNameException(String objectType) {
-		super(objectType + " names can't start with " + ReservedNames.RESERVED_NAME_PREFIX);
+
+	public enum NameType {
+		ATTRIBUTE("Attribute"), RECORD_TYPE("Record Type");
+
+		private final String name;
+
+		NameType(String name) {
+			this.name = name;
+		}
+	}
+	public InvalidNameException(NameType nameType) {
+		super(nameType.name + " names can't start with " + ReservedNames.RESERVED_NAME_PREFIX +
+				" or contain characters besides letters, numbers, spaces, dashes or underscores.");
 	}
 }

--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -561,7 +561,7 @@ components:
       properties:
         attributes:
           $ref: '#/components/schemas/RecordAttributes'
-          description: KVPs of record attributes
+          description: KVPs of record attributes, valid characters for attribute names are limited to letters, numbers, spaces, dashes, and underscores.
     RecordResponse:
       required:
         - id
@@ -616,7 +616,7 @@ components:
       properties:
         name:
           type: string
-          description: Record type name
+          description: Record type name, valid characters for record type names are limited to letters, numbers, spaces, dashes, and underscores.
         attributes:
           type: array
           items:

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
@@ -2,8 +2,6 @@ package org.databiosphere.workspacedataservice.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.lang3.RandomUtils;
 import org.databiosphere.workspacedata.model.ErrorResponse;
 import org.databiosphere.workspacedataservice.service.RelationUtils;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
@@ -19,7 +17,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.in;
 import static org.databiosphere.workspacedataservice.TestUtils.generateRandomAttributes;
 
 /**

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
@@ -46,7 +46,7 @@ class FullStackRecordControllerTest {
 	void testBadRecordTypeNames() throws JsonProcessingException {
 		HttpEntity<String> requestEntity = new HttpEntity<>(
 				mapper.writeValueAsString(new RecordRequest(new RecordAttributes(new HashMap<>()))), headers);
-		List<String> badNames = List.of("); drop table users;", "$$foo.bar", "samples.11", "##magic beans!");
+		List<String> badNames = List.of("); drop table users;", "$$foo.bar", "...", "&Q$(*^@$(*");
 		for (String badName : badNames) {
 			ResponseEntity<ErrorResponse> response = restTemplate.exchange(
 					"/{instanceId}/records/{version}/{recordType}/{recordId}", HttpMethod.PUT, requestEntity,
@@ -60,7 +60,7 @@ class FullStackRecordControllerTest {
 	@Test
 	@Transactional
 	void testBadAttributeNames() throws JsonProcessingException {
-		List<String> badNames = List.of("); drop table users;", "$$foo.bar", "samples.11", "##magic beans!");
+		List<String> badNames = List.of("create table buttheads(id int)", "samples.11", "##magic beans!");
 		for (String badName : badNames) {
 			HashMap<String, Object> attributes = new HashMap<>();
 			attributes.put(badName, "foo");

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
@@ -60,7 +60,7 @@ class FullStackRecordControllerTest {
 	@Test
 	@Transactional
 	void testBadAttributeNames() throws JsonProcessingException {
-		List<String> badNames = List.of("create table buttheads(id int)", "samples.11", "##magic beans!");
+		List<String> badNames = List.of("create table buttheads(id int)", "samples\n11", "##magic beans!");
 		for (String badName : badNames) {
 			HashMap<String, Object> attributes = new HashMap<>();
 			attributes.put(badName, "foo");


### PR DESCRIPTION
I threw in a few small sonar fixes in addition to disallowing characters for record type names and attribute names.