### PR TITLE
RecordType wrapper class refactor

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -129,9 +129,9 @@ public class RecordController {
 
 	@PostMapping("/{instanceid}/search/{version}/{recordType}")
 	public RecordQueryResponse queryForEntities(@PathVariable("instanceid") UUID instanceId,
-			@PathVariable("recordType") String recordTypeName,
+			@PathVariable("recordType") RecordType recordType,
 			@RequestBody(required = false) SearchRequest searchRequest) {
-		validateRecordType(instanceId, recordTypeName);
+		checkRecordTypeExists(instanceId, recordType);
 		if (null == searchRequest) {
 			searchRequest = new SearchRequest();
 		}
@@ -139,11 +139,11 @@ public class RecordController {
 			throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
 					"Limit must be more than 0 and can't exceed " + MAX_RECORDS + ", and offset must be positive.");
 		}
-		int totalRecords = recordDao.countRecords(instanceId, recordTypeName);
+		int totalRecords = recordDao.countRecords(instanceId, recordType);
 		if (searchRequest.getOffset() > totalRecords) {
 			return new RecordQueryResponse(searchRequest, Collections.emptyList(), totalRecords);
 		}
-		List<Record> records = recordDao.queryForRecords(recordTypeName, searchRequest.getLimit(),
+		List<Record> records = recordDao.queryForRecords(recordType, searchRequest.getLimit(),
 				searchRequest.getOffset(), searchRequest.getSort().name().toLowerCase(), instanceId);
 		List<RecordResponse> recordList = records.stream().map(
 				r -> new RecordResponse(r.getId(), r.getRecordType(), r.getAttributes(), new RecordMetadata("UNUSED")))

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -131,7 +131,6 @@ public class RecordController {
 			@PathVariable("version") String version, @PathVariable("recordType") RecordType recordType,
 			@PathVariable("recordId") RecordId recordId, @RequestBody RecordRequest recordRequest) {
 		validateVersion(version);
-		// String recordTypeName = recordType;
 		Map<String, Object> attributesInRequest = recordRequest.recordAttributes().getAttributes();
 		Map<String, DataTypeMapping> requestSchema = inferer.inferTypes(attributesInRequest);
 		HttpStatus status = HttpStatus.CREATED;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -221,14 +221,14 @@ public class RecordController {
 				.map(entry -> createAttributeSchema(entry.getKey(), entry.getValue(), relations.get(entry.getKey())))
 				.toList();
 		int recordCount = recordDao.countRecords(instanceId, recordType);
-		return new RecordTypeSchema(recordType.toJsonValue(), attrSchema, recordCount);
+		return new RecordTypeSchema(recordType.getName(), attrSchema, recordCount);
 	}
 
 	private AttributeSchema createAttributeSchema(String name, DataTypeMapping datatype, RecordType relation) {
 		if (relation == null) {
 			return new AttributeSchema(name, datatype.toString(), null);
 		}
-		return new AttributeSchema(name, "RELATION", relation.toJsonValue());
+		return new AttributeSchema(name, "RELATION", relation.getName());
 	}
 
 	private static void validateVersion(String version) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -36,31 +36,29 @@ public class RecordController {
 			@PathVariable("version") String version, @PathVariable("recordType") RecordType recordType,
 			@PathVariable("recordId") RecordId recordId, @RequestBody RecordRequest recordRequest) {
 		validateVersion(version);
-		String recordTypeName = recordType.getName();
-		if (!recordDao.recordTypeExists(instanceId, recordTypeName)) {
+		if (!recordDao.recordTypeExists(instanceId, recordType)) {
 			throw new MissingObjectException("Record type");
 		}
 		Record singleRecord = recordDao
-				.getSingleRecord(instanceId, recordType, recordId,
-						recordDao.getRelationCols(instanceId, recordTypeName))
+				.getSingleRecord(instanceId, recordType, recordId, recordDao.getRelationCols(instanceId, recordType))
 				.orElseThrow(() -> new MissingObjectException("Record"));
 		Map<String, Object> updatedAtts = recordRequest.recordAttributes().getAttributes();
 		Map<String, Object> allAttrs = new HashMap<>(singleRecord.getAttributes().getAttributes());
 		allAttrs.putAll(updatedAtts);
 
 		Map<String, DataTypeMapping> typeMapping = inferer.inferTypes(updatedAtts);
-		Map<String, DataTypeMapping> existingTableSchema = recordDao.getExistingTableSchema(instanceId, recordTypeName);
+		Map<String, DataTypeMapping> existingTableSchema = recordDao.getExistingTableSchema(instanceId, recordType);
 		singleRecord.setAttributes(new RecordAttributes(allAttrs));
 		List<Record> records = Collections.singletonList(singleRecord);
-		Map<String, DataTypeMapping> updatedSchema = addOrUpdateColumnIfNeeded(instanceId, recordType.getName(),
-				typeMapping, existingTableSchema, records);
-		recordDao.batchUpsert(instanceId, recordTypeName, records, updatedSchema);
+		Map<String, DataTypeMapping> updatedSchema = addOrUpdateColumnIfNeeded(instanceId, recordType, typeMapping,
+				existingTableSchema, records);
+		recordDao.batchUpsert(instanceId, recordType, records, updatedSchema);
 		RecordResponse response = new RecordResponse(recordId, recordType, singleRecord.getAttributes(),
 				new RecordMetadata("TODO: SUPERFRESH"));
 		return new ResponseEntity<>(response, HttpStatus.OK);
 	}
 
-	private Map<String, DataTypeMapping> addOrUpdateColumnIfNeeded(UUID instanceId, String recordType,
+	private Map<String, DataTypeMapping> addOrUpdateColumnIfNeeded(UUID instanceId, RecordType recordType,
 			Map<String, DataTypeMapping> schema, Map<String, DataTypeMapping> existingTableSchema,
 			List<Record> records) {
 		MapDifference<String, DataTypeMapping> difference = Maps.difference(existingTableSchema, schema);
@@ -80,15 +78,18 @@ public class RecordController {
 		return schema;
 	}
 
-	private void validateRelationsAndAddColumns(UUID instanceId, String recordType, Map<String, DataTypeMapping> requestSchema,
-												List<Record> records, Map<String, DataTypeMapping> colsToAdd, Map<String, DataTypeMapping> existingSchema) {
+	private void validateRelationsAndAddColumns(UUID instanceId, RecordType recordType,
+			Map<String, DataTypeMapping> requestSchema, List<Record> records, Map<String, DataTypeMapping> colsToAdd,
+			Map<String, DataTypeMapping> existingSchema) {
 		Set<Relation> relations = RelationUtils.findRelations(records);
 		List<Relation> existingRelations = recordDao.getRelationCols(instanceId, recordType);
-		Set<String> existingRelationCols = existingRelations.stream().map(Relation::relationColName).collect(Collectors.toSet());
-		//look for case where requested relation column already exists as a non-relational column
+		Set<String> existingRelationCols = existingRelations.stream().map(Relation::relationColName)
+				.collect(Collectors.toSet());
+		// look for case where requested relation column already exists as a
+		// non-relational column
 		for (Relation relation : relations) {
 			String col = relation.relationColName();
-			if(!existingRelationCols.contains(col) && existingSchema.containsKey(col)){
+			if (!existingRelationCols.contains(col) && existingSchema.containsKey(col)) {
 				throw new InvalidRelationException("It looks like you're attempting to assign a relation "
 						+ "to an existing attribute that was not configured for relations");
 			}
@@ -101,9 +102,9 @@ public class RecordController {
 					"Relation attribute can only be assigned to one record type");
 		}
 		for (String col : colsToAdd.keySet()) {
-			String referencedRecordType = null;
+			RecordType referencedRecordType = null;
 			if (allRefCols.containsKey(col)) {
-				referencedRecordType = allRefCols.get(col).get(0).relationRecordType().getName();
+				referencedRecordType = allRefCols.get(col).get(0).relationRecordType();
 			}
 			recordDao.addColumn(instanceId, recordType, col, colsToAdd.get(col), referencedRecordType);
 			requestSchema.put(col, colsToAdd.get(col));
@@ -118,12 +119,11 @@ public class RecordController {
 		if (!recordDao.instanceSchemaExists(instanceId)) {
 			throw new MissingObjectException("Instance");
 		}
-		if (!recordDao.recordTypeExists(instanceId, recordType.getName())) {
+		if (!recordDao.recordTypeExists(instanceId, recordType)) {
 			throw new MissingObjectException("Record type");
 		}
 		Record result = recordDao
-				.getSingleRecord(instanceId, recordType, recordId,
-						recordDao.getRelationCols(instanceId, recordType.getName()))
+				.getSingleRecord(instanceId, recordType, recordId, recordDao.getRelationCols(instanceId, recordType))
 				.orElseThrow(() -> new MissingObjectException("Record"));
 		RecordResponse response = new RecordResponse(recordId, recordType, result.getAttributes(),
 				new RecordMetadata("TODO: RECORDMETADATA"));
@@ -135,29 +135,28 @@ public class RecordController {
 			@PathVariable("version") String version, @PathVariable("recordType") RecordType recordType,
 			@PathVariable("recordId") RecordId recordId, @RequestBody RecordRequest recordRequest) {
 		validateVersion(version);
-		String recordTypeName = recordType.getName();
+		// String recordTypeName = recordType;
 		Map<String, Object> attributesInRequest = recordRequest.recordAttributes().getAttributes();
 		Map<String, DataTypeMapping> requestSchema = inferer.inferTypes(attributesInRequest);
 		if (!recordDao.instanceSchemaExists(instanceId)) {
 			recordDao.createSchema(instanceId);
 		}
-		if (!recordDao.recordTypeExists(instanceId, recordTypeName)) {
+		if (!recordDao.recordTypeExists(instanceId, recordType)) {
 			RecordResponse response = new RecordResponse(recordId, recordType, recordRequest.recordAttributes(),
 					new RecordMetadata("TODO"));
 			Record newRecord = new Record(recordId, recordType, recordRequest);
-			createRecordTypeAndInsertRecords(instanceId, newRecord, recordTypeName, requestSchema);
+			createRecordTypeAndInsertRecords(instanceId, newRecord, recordType, requestSchema);
 			return new ResponseEntity<>(response, HttpStatus.CREATED);
 		} else {
-			Map<String, DataTypeMapping> existingTableSchema = recordDao.getExistingTableSchema(instanceId,
-					recordTypeName);
+			Map<String, DataTypeMapping> existingTableSchema = recordDao.getExistingTableSchema(instanceId, recordType);
 			// null out any attributes that already exist but aren't in the request
 			existingTableSchema.keySet().forEach(attr -> attributesInRequest.putIfAbsent(attr, null));
 			Record record = new Record(recordId, recordType, recordRequest.recordAttributes());
 			List<Record> records = Collections.singletonList(record);
-			addOrUpdateColumnIfNeeded(instanceId, recordType.getName(), requestSchema, existingTableSchema, records);
+			addOrUpdateColumnIfNeeded(instanceId, recordType, requestSchema, existingTableSchema, records);
 			Map<String, DataTypeMapping> combinedSchema = new HashMap<>(existingTableSchema);
 			combinedSchema.putAll(requestSchema);
-			recordDao.batchUpsert(instanceId, recordTypeName, records, combinedSchema);
+			recordDao.batchUpsert(instanceId, recordType, records, combinedSchema);
 			RecordResponse response = new RecordResponse(recordId, recordType,
 					new RecordAttributes(attributesInRequest), new RecordMetadata("TODO"));
 			return new ResponseEntity<>(response, HttpStatus.OK);
@@ -180,8 +179,7 @@ public class RecordController {
 			@PathVariable("version") String version, @PathVariable("recordType") RecordType recordType,
 			@PathVariable("recordId") RecordId recordId) {
 		validateVersion(version);
-		boolean recordFound = recordDao.deleteSingleRecord(instanceId, recordType.getName(),
-				recordId.getRecordIdentifier());
+		boolean recordFound = recordDao.deleteSingleRecord(instanceId, recordType, recordId.getRecordIdentifier());
 		return recordFound ? new ResponseEntity<>(HttpStatus.NO_CONTENT) : new ResponseEntity<>(HttpStatus.NOT_FOUND);
 	}
 
@@ -191,13 +189,11 @@ public class RecordController {
 		}
 	}
 
-	private void createRecordTypeAndInsertRecords(UUID instanceId, Record newRecord, String recordTypeName,
+	private void createRecordTypeAndInsertRecords(UUID instanceId, Record newRecord, RecordType recordType,
 			Map<String, DataTypeMapping> requestSchema) {
-		if (recordTypeName.startsWith(RESERVED_NAME_PREFIX)) {
-			throw new InvalidNameException("Record type");
-		}
+		recordType.validate();
 		List<Record> records = Collections.singletonList(newRecord);
-		recordDao.createRecordType(instanceId, requestSchema, recordTypeName, RelationUtils.findRelations(records));
-		recordDao.batchUpsert(instanceId, recordTypeName, records, requestSchema);
+		recordDao.createRecordType(instanceId, requestSchema, recordType, RelationUtils.findRelations(records));
+		recordDao.batchUpsert(instanceId, recordType, records, requestSchema);
 	}
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -35,7 +35,7 @@ public class RecordController {
 			@PathVariable("version") String version, @PathVariable("recordType") RecordType recordType,
 			@PathVariable("recordId") RecordId recordId, @RequestBody RecordRequest recordRequest) {
 		validateVersion(version);
-		validateRecordType(instanceId, recordType);
+		checkRecordTypeExists(instanceId, recordType);
 		Record singleRecord = recordDao
 				.getSingleRecord(instanceId, recordType, recordId, recordDao.getRelationCols(instanceId, recordType))
 				.orElseThrow(() -> new MissingObjectException("Record"));
@@ -117,7 +117,7 @@ public class RecordController {
 			@PathVariable("recordId") RecordId recordId) {
 		validateVersion(version);
 		validateInstance(instanceId);
-		validateRecordType(instanceId, recordType);
+		checkRecordTypeExists(instanceId, recordType);
 		Record result = recordDao
 				.getSingleRecord(instanceId, recordType, recordId, recordDao.getRelationCols(instanceId, recordType))
 				.orElseThrow(() -> new MissingObjectException("Record"));
@@ -187,7 +187,7 @@ public class RecordController {
 			@PathVariable("v") String version, @PathVariable("type") RecordType recordType) {
 		validateVersion(version);
 		validateInstance(instanceId);
-		validateRecordType(instanceId, recordType);
+		checkRecordTypeExists(instanceId, recordType);
 		recordDao.deleteRecordType(instanceId, recordType);
 		return new ResponseEntity<>(HttpStatus.NO_CONTENT);
 	}
@@ -196,7 +196,7 @@ public class RecordController {
 	public ResponseEntity<RecordTypeSchema> describeRecordType(@PathVariable("instanceId") UUID instanceId,
 			@PathVariable("v") String version, @PathVariable("type") RecordType recordType) {
 		validateVersion(version);
-		validateRecordType(instanceId, recordType);
+		checkRecordTypeExists(instanceId, recordType);
 		RecordTypeSchema result = getSchemaDescription(instanceId, recordType);
 		return new ResponseEntity<>(result, HttpStatus.OK);
 	}
@@ -236,7 +236,7 @@ public class RecordController {
 		}
 	}
 
-	private void validateRecordType(UUID instanceId, RecordType recordType) {
+	private void checkRecordTypeExists(UUID instanceId, RecordType recordType) {
 		if (!recordDao.recordTypeExists(instanceId, recordType)) {
 			throw new MissingObjectException("Record type");
 		}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -221,14 +221,14 @@ public class RecordController {
 				.map(entry -> createAttributeSchema(entry.getKey(), entry.getValue(), relations.get(entry.getKey())))
 				.toList();
 		int recordCount = recordDao.countRecords(instanceId, recordType);
-		return new RecordTypeSchema(recordType.getName(), attrSchema, recordCount);
+		return new RecordTypeSchema(recordType, attrSchema, recordCount);
 	}
 
 	private AttributeSchema createAttributeSchema(String name, DataTypeMapping datatype, RecordType relation) {
 		if (relation == null) {
 			return new AttributeSchema(name, datatype.toString(), null);
 		}
-		return new AttributeSchema(name, "RELATION", relation.getName());
+		return new AttributeSchema(name, "RELATION", relation);
 	}
 
 	private static void validateVersion(String version) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -250,7 +250,6 @@ public class RecordController {
 
 	private void createRecordTypeAndInsertRecords(UUID instanceId, Record newRecord, RecordType recordType,
 			Map<String, DataTypeMapping> requestSchema) {
-		recordType.validate();
 		List<Record> records = Collections.singletonList(newRecord);
 		recordDao.createRecordType(instanceId, requestSchema, recordType, RelationUtils.findRelations(records));
 		recordDao.batchUpsert(instanceId, recordType, records, requestSchema);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -54,7 +54,7 @@ public class RecordDao {
 		return Boolean.TRUE.equals(namedTemplate.queryForObject(
 				"select exists(select from pg_tables where schemaname = :instanceId AND tablename  = :recordType)",
 				new MapSqlParameterSource(
-						Map.of("instanceId", instanceId.toString(), "recordType", recordType.toSqlTableName())),
+						Map.of("instanceId", instanceId.toString(), "recordType", recordType.getName())),
 				Boolean.class));
 	}
 
@@ -76,7 +76,7 @@ public class RecordDao {
 
 	private String getQualifiedTableName(RecordType recordType, UUID instanceId) {
 		return quote(instanceId.toString()) + "."
-				+ quote(validateName(recordType.toSqlTableName(), InvalidNameException.NameType.RECORD_TYPE));
+				+ quote(validateName(recordType.getName(), InvalidNameException.NameType.RECORD_TYPE));
 	}
 
 	private String validateName(String name, InvalidNameException.NameType nameType) {
@@ -92,7 +92,7 @@ public class RecordDao {
 
 	public Map<String, DataTypeMapping> getExistingTableSchema(UUID instanceId, RecordType recordType) {
 		MapSqlParameterSource params = new MapSqlParameterSource("instanceId", instanceId.toString());
-		params.addValue("tableName", recordType.toSqlTableName());
+		params.addValue("tableName", recordType.getName());
 		params.addValue("recordName", RECORD_ID);
 		return namedTemplate
 				.query("select column_name, data_type from INFORMATION_SCHEMA.COLUMNS where table_schema = :instanceId "
@@ -235,9 +235,9 @@ public class RecordDao {
 						+ "ON tc.constraint_name = kcu.constraint_name AND tc.table_schema = kcu.table_schema "
 						+ "JOIN information_schema.constraint_column_usage ccu ON ccu.constraint_name = tc.constraint_name AND ccu.table_schema = tc.table_schema "
 						+ "WHERE tc.constraint_type = 'FOREIGN KEY' AND tc.table_schema = :workspace AND tc.table_name= :tableName",
-				Map.of("workspace", instanceId.toString(), "tableName", recordType.toSqlTableName()),
+				Map.of("workspace", instanceId.toString(), "tableName", recordType.getName()),
 				(rs, rowNum) -> new Relation(rs.getString("column_name"),
-						RecordType.fromSqlTableName(rs.getString("table_name"))));
+						RecordType.valueOf(rs.getString("table_name"))));
 	}
 
 	public int countRecords(UUID instanceId, RecordType recordType) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -56,6 +56,7 @@ public class RecordDao {
 				Boolean.class));
 	}
 
+	@SuppressWarnings("squid:S2077")
 	public void createRecordType(UUID instanceId, Map<String, DataTypeMapping> tableInfo, RecordType recordType,
 			Set<Relation> relations) {
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -71,6 +71,7 @@ public class RecordDao {
 
 	}
 
+	@SuppressWarnings("squid:S2077")
 	private String getQualifiedTableName(RecordType recordType, UUID instanceId) {
 		// N.B. recordType is sql-validated in its constructor, so we don't need it here
 		return quote(instanceId.toString()) + "." + quote(recordType.getName());

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -75,7 +75,7 @@ public class RecordDao {
 
 	private String getQualifiedTableName(RecordType recordType, UUID instanceId) {
 		// N.B. recordType is sql-validated in its constructor, so we don't need it here
-		return quote(instanceId.toString()) + "." + quote(SqlUtils.validateSqlString(recordType.getName(), RECORD_TYPE);
+		return quote(instanceId.toString()) + "." + quote(SqlUtils.validateSqlString(recordType.getName(), RECORD_TYPE));
 	}
 
 	@SuppressWarnings("squid:S2077")

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -72,8 +72,8 @@ public class RecordDao {
 	}
 
 	private String getQualifiedTableName(RecordType recordType, UUID instanceId) {
-		return quote(instanceId.toString()) + "."
-				+ quote(SqlUtils.validateSqlString(recordType.getName(), InvalidNameException.NameType.RECORD_TYPE));
+		// N.B. recordType is sql-validated in its constructor, so we don't need it here
+		return quote(instanceId.toString()) + "." + quote(recordType.getName());
 	}
 
 	public Map<String, DataTypeMapping> getExistingTableSchema(UUID instanceId, RecordType recordType) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -73,7 +73,7 @@ public class RecordDao {
 
 	private String getQualifiedTableName(RecordType recordType, UUID instanceId) {
 		// N.B. recordType is sql-validated in its constructor, so we don't need it here
-		return quote(instanceId.toString()) + "." + quote(recordType.getSqlValidatedName());
+		return quote(instanceId.toString()) + "." + quote(recordType.getName());
 	}
 
 	@SuppressWarnings("squid:S2077")

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -2,7 +2,6 @@ package org.databiosphere.workspacedataservice.dao;
 
 import org.databiosphere.workspacedataservice.service.RelationUtils;
 import org.databiosphere.workspacedataservice.service.model.*;
-import org.databiosphere.workspacedataservice.service.model.exception.InvalidNameException;
 import org.databiosphere.workspacedataservice.service.model.exception.InvalidRelationException;
 import org.databiosphere.workspacedataservice.service.model.exception.MissingObjectException;
 import org.databiosphere.workspacedataservice.shared.model.Record;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -79,14 +79,14 @@ public class RecordDao {
 				+ quote(validateName(recordType.getName(), InvalidNameException.NameType.RECORD_TYPE));
 	}
 
-	private String validateName(String name, InvalidNameException.NameType nameType) {
+	public static String validateName(String name, InvalidNameException.NameType nameType) {
 		if (containsDisallowedSqlCharacter(name)) {
 			throw new InvalidNameException(nameType);
 		}
 		return name;
 	}
 
-	private boolean containsDisallowedSqlCharacter(String name) {
+	private static boolean containsDisallowedSqlCharacter(String name) {
 		return name == null || DISALLOWED_CHARS_PATTERN.matcher(name).find();
 	}
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -73,7 +73,7 @@ public class RecordDao {
 
 	private String getQualifiedTableName(RecordType recordType, UUID instanceId) {
 		// N.B. recordType is sql-validated in its constructor, so we don't need it here
-		return quote(instanceId.toString()) + "." + quote(recordType.getName());
+		return quote(instanceId.toString()) + "." + quote(recordType.getSqlValidatedName());
 	}
 
 	@SuppressWarnings("squid:S2077")

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -71,7 +71,6 @@ public class RecordDao {
 
 	}
 
-	@SuppressWarnings("squid:S2077")
 	private String getQualifiedTableName(RecordType recordType, UUID instanceId) {
 		// N.B. recordType is sql-validated in its constructor, so we don't need it here
 		return quote(instanceId.toString()) + "." + quote(recordType.getName());

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 
 import static org.databiosphere.workspacedataservice.service.model.ReservedNames.*;
 import static org.databiosphere.workspacedataservice.service.model.exception.InvalidNameException.NameType.ATTRIBUTE;
+import static org.databiosphere.workspacedataservice.service.model.exception.InvalidNameException.NameType.RECORD_TYPE;
 
 @Repository
 public class RecordDao {
@@ -74,7 +75,7 @@ public class RecordDao {
 
 	private String getQualifiedTableName(RecordType recordType, UUID instanceId) {
 		// N.B. recordType is sql-validated in its constructor, so we don't need it here
-		return quote(instanceId.toString()) + "." + quote(recordType.getName());
+		return quote(instanceId.toString()) + "." + quote(SqlUtils.validateSqlString(recordType.getName(), RECORD_TYPE);
 	}
 
 	@SuppressWarnings("squid:S2077")

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/SqlUtils.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/SqlUtils.java
@@ -22,8 +22,4 @@ public class SqlUtils {
         return name;
     }
 
-    public static String sanitizeSqlString(String input) {
-        return DISALLOWED_CHARS_PATTERN.matcher(input).replaceAll("");
-    }
-
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/SqlUtils.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/SqlUtils.java
@@ -22,4 +22,8 @@ public class SqlUtils {
         return name;
     }
 
+    public static String sanitizeSqlString(String input) {
+        return DISALLOWED_CHARS_PATTERN.matcher(input).replaceAll("");
+    }
+
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/SqlUtils.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/SqlUtils.java
@@ -1,0 +1,25 @@
+package org.databiosphere.workspacedataservice.dao;
+
+import org.databiosphere.workspacedataservice.service.model.exception.InvalidNameException;
+
+import java.util.regex.Pattern;
+
+/**
+ * A collection of methods useful for working with SQL.
+ */
+public class SqlUtils {
+
+    private static final Pattern DISALLOWED_CHARS_PATTERN = Pattern.compile("[^a-z0-9\\-_ ]", Pattern.CASE_INSENSITIVE);
+
+    private static boolean containsDisallowedSqlCharacter(String name) {
+        return name == null || DISALLOWED_CHARS_PATTERN.matcher(name).find();
+    }
+
+    public static String validateSqlString(String name, InvalidNameException.NameType nameType) {
+        if (containsDisallowedSqlCharacter(name)) {
+            throw new InvalidNameException(nameType);
+        }
+        return name;
+    }
+
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/SqlUtils.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/SqlUtils.java
@@ -9,17 +9,20 @@ import java.util.regex.Pattern;
  */
 public class SqlUtils {
 
-    private static final Pattern DISALLOWED_CHARS_PATTERN = Pattern.compile("[^a-z0-9\\-_ ]", Pattern.CASE_INSENSITIVE);
+	private SqlUtils() {
+	}
 
-    private static boolean containsDisallowedSqlCharacter(String name) {
-        return name == null || DISALLOWED_CHARS_PATTERN.matcher(name).find();
-    }
+	private static final Pattern DISALLOWED_CHARS_PATTERN = Pattern.compile("[^a-z0-9\\-_ ]", Pattern.CASE_INSENSITIVE);
 
-    public static String validateSqlString(String name, InvalidNameException.NameType nameType) {
-        if (containsDisallowedSqlCharacter(name)) {
-            throw new InvalidNameException(nameType);
-        }
-        return name;
-    }
+	private static boolean containsDisallowedSqlCharacter(String name) {
+		return name == null || DISALLOWED_CHARS_PATTERN.matcher(name).find();
+	}
+
+	public static String validateSqlString(String name, InvalidNameException.NameType nameType) {
+		if (containsDisallowedSqlCharacter(name)) {
+			throw new InvalidNameException(nameType);
+		}
+		return name;
+	}
 
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/RelationUtils.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/RelationUtils.java
@@ -37,7 +37,7 @@ public class RelationUtils {
 	}
 
 	public static RecordType getTypeValue(Object obj) {
-		return new RecordType(splitRelationIdentifier(obj)[0]);
+		return RecordType.fromUriSegment(splitRelationIdentifier(obj)[0]);
 	}
 
 	private static String[] splitRelationIdentifier(Object obj) {
@@ -77,6 +77,6 @@ public class RelationUtils {
 
 	public static String createRelationString(RecordType targetRecordType, String recordId) {
 		return UriComponentsBuilder.newInstance().scheme(RELATION_IDENTIFIER)
-				.pathSegment(targetRecordType.toPathSegment(), recordId).build().toUriString();
+				.pathSegment(targetRecordType.toUriSegment(), recordId).build().toUriString();
 	}
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/RelationUtils.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/RelationUtils.java
@@ -37,7 +37,7 @@ public class RelationUtils {
 	}
 
 	public static RecordType getTypeValue(Object obj) {
-		return RecordType.fromUriSegment(splitRelationIdentifier(obj)[0]);
+		return RecordType.valueOf(splitRelationIdentifier(obj)[0]);
 	}
 
 	private static String[] splitRelationIdentifier(Object obj) {
@@ -77,6 +77,6 @@ public class RelationUtils {
 
 	public static String createRelationString(RecordType targetRecordType, String recordId) {
 		return UriComponentsBuilder.newInstance().scheme(RELATION_IDENTIFIER)
-				.pathSegment(targetRecordType.toUriSegment(), recordId).build().toUriString();
+				.pathSegment(targetRecordType.getName(), recordId).build().toUriString();
 	}
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/RelationUtils.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/RelationUtils.java
@@ -29,15 +29,15 @@ public class RelationUtils {
 			Map<String, Object> attributes = record.getAttributes().getAttributes();
 			for (String attr : attributes.keySet()) {
 				if (isRelationValue(attributes.get(attr))) {
-					result.add(new Relation(attr, new RecordType(getTypeValue(attributes.get(attr)))));
+					result.add(new Relation(attr, getTypeValue(attributes.get(attr))));
 				}
 			}
 		}
 		return result;
 	}
 
-	public static String getTypeValue(Object obj) {
-		return splitRelationIdentifier(obj)[0];
+	public static RecordType getTypeValue(Object obj) {
+		return new RecordType(splitRelationIdentifier(obj)[0]);
 	}
 
 	private static String[] splitRelationIdentifier(Object obj) {
@@ -75,8 +75,8 @@ public class RelationUtils {
 		return obj != null && obj.toString().startsWith(RELATION_IDENTIFIER);
 	}
 
-	public static String createRelationString(String recordTypeName, String recordId) {
-		return UriComponentsBuilder.newInstance().scheme(RELATION_IDENTIFIER).pathSegment(recordTypeName, recordId)
-				.build().toUriString();
+	public static String createRelationString(RecordType targetRecordType, String recordId) {
+		return UriComponentsBuilder.newInstance().scheme(RELATION_IDENTIFIER)
+				.pathSegment(targetRecordType.toPathSegment(), recordId).build().toUriString();
 	}
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/AttributeSchema.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/AttributeSchema.java
@@ -1,7 +1,8 @@
 package org.databiosphere.workspacedataservice.service.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import org.databiosphere.workspacedataservice.shared.model.RecordType;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record AttributeSchema(String name, String datatype, String relatesTo) {
+public record AttributeSchema(String name, String datatype, RecordType relatesTo) {
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/RecordTypeSchema.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/RecordTypeSchema.java
@@ -1,6 +1,8 @@
 package org.databiosphere.workspacedataservice.service.model;
 
+import org.databiosphere.workspacedataservice.shared.model.RecordType;
+
 import java.util.List;
 
-public record RecordTypeSchema(String name, List<AttributeSchema> attributes, int count) {
+public record RecordTypeSchema(RecordType name, List<AttributeSchema> attributes, int count) {
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/InvalidNameException.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/InvalidNameException.java
@@ -12,6 +12,10 @@ public class InvalidNameException extends RuntimeException {
 
 		private final String name;
 
+		public String getName() {
+			return name;
+		}
+
 		NameType(String name) {
 			this.name = name;
 		}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/Record.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/Record.java
@@ -55,7 +55,7 @@ public class Record {
 
 	@JsonGetter("recordType")
 	public String getRecordTypeName() {
-		return recordType.toJsonValue();
+		return recordType.getName();
 	}
 
 	@Override

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/Record.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/Record.java
@@ -2,7 +2,6 @@ package org.databiosphere.workspacedataservice.shared.model;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Record {
@@ -54,7 +53,7 @@ public class Record {
 
 	@JsonGetter("recordType")
 	public String getRecordTypeName() {
-		return recordType.toPathSegment();
+		return recordType.toUriSegment();
 	}
 
 	@Override

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/Record.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/Record.java
@@ -2,12 +2,14 @@ package org.databiosphere.workspacedataservice.shared.model;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Record {
 
 	private RecordId id;
 
+	@JsonProperty("type")
 	private RecordType recordType;
 
 	private RecordAttributes attributes;
@@ -53,7 +55,7 @@ public class Record {
 
 	@JsonGetter("recordType")
 	public String getRecordTypeName() {
-		return recordType.toUriSegment();
+		return recordType.toJsonValue();
 	}
 
 	@Override

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/Record.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/Record.java
@@ -2,6 +2,7 @@ package org.databiosphere.workspacedataservice.shared.model;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Record {
@@ -53,7 +54,7 @@ public class Record {
 
 	@JsonGetter("recordType")
 	public String getRecordTypeName() {
-		return recordType.getName();
+		return recordType.toPathSegment();
 	}
 
 	@Override

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordType.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordType.java
@@ -1,7 +1,7 @@
 package org.databiosphere.workspacedataservice.shared.model;
 
 import com.fasterxml.jackson.annotation.*;
-import org.databiosphere.workspacedataservice.dao.RecordDao;
+import org.databiosphere.workspacedataservice.dao.SqlUtils;
 import org.databiosphere.workspacedataservice.service.model.exception.InvalidNameException;
 
 import java.util.Objects;
@@ -41,7 +41,7 @@ public class RecordType {
 		if (name.startsWith(RESERVED_NAME_PREFIX)) {
 			throw new InvalidNameException(InvalidNameException.NameType.RECORD_TYPE);
 		}
-		RecordDao.validateName(name, InvalidNameException.NameType.RECORD_TYPE);
+		SqlUtils.validateSqlString(name, InvalidNameException.NameType.RECORD_TYPE);
 	}
 
 	/*

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordType.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordType.java
@@ -11,12 +11,18 @@ public class RecordType {
 
 	private final String name;
 
-	@JsonCreator
-	public RecordType(String name) {
+	private RecordType(String name) {
 		this.name = name;
 	}
 
-	public static RecordType forUnitTest(String recordTypeName) {
+	// TODO: probably no need to have all of valueOf(), fromSqlTableName(), fromUriSegment()
+
+	/* the valueOf() method is required since the constructor is private. Spring
+	   uses valueOf() when extracting inbound @PathVariable arguments - which are Strings -
+	   into this class.
+	 */
+	@JsonCreator
+	public static RecordType valueOf(String recordTypeName) {
 		return new RecordType(recordTypeName);
 	}
 
@@ -28,6 +34,7 @@ public class RecordType {
 		return new RecordType(uriSegment);
 	}
 
+	// TODO: probably no need to have all of toSqlTableName(), toJsonValue(), toUriSegment()
 	public String toSqlTableName() {
 		return name;
 	}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordType.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordType.java
@@ -37,6 +37,10 @@ public class RecordType {
 		return name;
 	}
 
+	public String getSqlValidatedName() {
+		return SqlUtils.sanitizeSqlString(name);
+	}
+
 	public void validate() {
 		if (name.startsWith(RESERVED_NAME_PREFIX)) {
 			throw new InvalidNameException(InvalidNameException.NameType.RECORD_TYPE);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordType.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordType.java
@@ -1,6 +1,7 @@
 package org.databiosphere.workspacedataservice.shared.model;
 
 import com.fasterxml.jackson.annotation.*;
+import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.databiosphere.workspacedataservice.service.model.exception.InvalidNameException;
 
 import java.util.Objects;
@@ -13,6 +14,7 @@ public class RecordType {
 
 	private RecordType(String name) {
 		this.name = name;
+		validate();
 	}
 
 	/*
@@ -39,6 +41,7 @@ public class RecordType {
 		if (name.startsWith(RESERVED_NAME_PREFIX)) {
 			throw new InvalidNameException(InvalidNameException.NameType.RECORD_TYPE);
 		}
+		RecordDao.validateName(name, InvalidNameException.NameType.RECORD_TYPE);
 	}
 
 	/*

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordType.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordType.java
@@ -11,20 +11,21 @@ public class RecordType {
 
 	private final String name;
 
+	@JsonCreator
 	public RecordType(String name) {
 		this.name = name;
 	}
 
-	public static RecordType forUnitTest(String tableName) {
-		return new RecordType(tableName);
+	public static RecordType forUnitTest(String recordTypeName) {
+		return new RecordType(recordTypeName);
 	}
 
 	public static RecordType fromSqlTableName(String tableName) {
 		return new RecordType(tableName);
 	}
 
-	public static RecordType fromUriSegment(String tableName) {
-		return new RecordType(tableName);
+	public static RecordType fromUriSegment(String uriSegment) {
+		return new RecordType(uriSegment);
 	}
 
 	public String toSqlTableName() {
@@ -32,6 +33,10 @@ public class RecordType {
 	}
 
 	@JsonValue
+	public String toJsonValue() {
+		return name;
+	}
+
 	public String toUriSegment() {
 		return name;
 	}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordType.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordType.java
@@ -15,39 +15,23 @@ public class RecordType {
 		this.name = name;
 	}
 
-	// TODO: probably no need to have all of valueOf(), fromSqlTableName(),
-	// fromUriSegment()
-
 	/*
-	 * the valueOf() method is required since the constructor is private. Spring
-	 * uses valueOf() when extracting inbound @PathVariable arguments - which are
-	 * Strings - into this class.
+	 * the name "valueOf()" for this factory method is required since the
+	 * constructor is private. Spring uses valueOf() when extracting inbound
+	 * @PathVariable arguments - which are Strings - into this class.
 	 */
 	@JsonCreator
 	public static RecordType valueOf(String recordTypeName) {
 		return new RecordType(recordTypeName);
 	}
 
-	public static RecordType fromSqlTableName(String tableName) {
-		return new RecordType(tableName);
-	}
-
-	public static RecordType fromUriSegment(String uriSegment) {
-		return new RecordType(uriSegment);
-	}
-
-	// TODO: probably no need to have all of toSqlTableName(), toJsonValue(),
-	// toUriSegment()
-	public String toSqlTableName() {
-		return name;
-	}
-
+	/*
+	 * N.B. we have a separate getName() method, even though getName() and toString()
+	 * are currently equivalent. In IntelliJ, it's much easier to find usages of
+	 * getName() than toString(), since toString() is an override.
+	 */
 	@JsonValue
-	public String toJsonValue() {
-		return name;
-	}
-
-	public String toUriSegment() {
+	public String getName() {
 		return name;
 	}
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordType.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordType.java
@@ -15,11 +15,13 @@ public class RecordType {
 		this.name = name;
 	}
 
-	// TODO: probably no need to have all of valueOf(), fromSqlTableName(), fromUriSegment()
+	// TODO: probably no need to have all of valueOf(), fromSqlTableName(),
+	// fromUriSegment()
 
-	/* the valueOf() method is required since the constructor is private. Spring
-	   uses valueOf() when extracting inbound @PathVariable arguments - which are Strings -
-	   into this class.
+	/*
+	 * the valueOf() method is required since the constructor is private. Spring
+	 * uses valueOf() when extracting inbound @PathVariable arguments - which are
+	 * Strings - into this class.
 	 */
 	@JsonCreator
 	public static RecordType valueOf(String recordTypeName) {
@@ -34,7 +36,8 @@ public class RecordType {
 		return new RecordType(uriSegment);
 	}
 
-	// TODO: probably no need to have all of toSqlTableName(), toJsonValue(), toUriSegment()
+	// TODO: probably no need to have all of toSqlTableName(), toJsonValue(),
+	// toUriSegment()
 	public String toSqlTableName() {
 		return name;
 	}
@@ -50,12 +53,13 @@ public class RecordType {
 
 	public void validate() {
 		if (name.startsWith(RESERVED_NAME_PREFIX)) {
-			throw new InvalidNameException("Record type");
+			throw new InvalidNameException(InvalidNameException.NameType.RECORD_TYPE);
 		}
 	}
 
-	/* returning the raw string value allows RecordType to be used directly as an argument to
-		url templates, e.g. within unit tests
+	/*
+	 * returning the raw string value allows RecordType to be used directly as an
+	 * argument to url templates, e.g. within unit tests
 	 */
 	@Override
 	public String toString() {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordType.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordType.java
@@ -1,32 +1,62 @@
 package org.databiosphere.workspacedataservice.shared.model;
 
-import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.databiosphere.workspacedataservice.service.model.exception.InvalidNameException;
+
 import java.util.Objects;
+
+import static org.databiosphere.workspacedataservice.service.model.ReservedNames.RESERVED_NAME_PREFIX;
 
 public class RecordType {
 
+	public static RecordType fromSqlTableName(String tableName) {
+		return new RecordType(tableName);
+	}
+
+//	public static RecordType fromPathSegment(String pathSegment) {
+//		return new RecordType(pathSegment);
+//	}
+
+	@JsonCreator
 	public RecordType(String name) {
 		this.name = name;
 	}
 
-	public RecordType() {
-	}
+	private final String name;
 
-	private String name;
+	// public String getNameXXX() {
+	// return name;
+	// }
+	//
+//	 public void setName(String name) {
+//	 this.name = name;
+//	 }
 
-	@JsonValue
-	public String getName() {
+	public String toSqlTableName() {
 		return name;
 	}
 
-	public void setName(String name) {
-		this.name = name;
+	@JsonValue
+	public String toPathSegment() {
+		return name;
+	}
+
+	// TODO: return void instead?
+	public RecordType validate() {
+		if (name.startsWith(RESERVED_NAME_PREFIX)) {
+			throw new InvalidNameException("Record type");
+		}
+		return this;
 	}
 
 	@Override
 	public String toString() {
-		return "RecordType{" + "name='" + name + '\'' + '}';
+		return name;
 	}
+	// public String toString() {
+//		return "RecordType{" + "name='" + name + '\'' + '}';
+//	}
 
 	@Override
 	public boolean equals(Object o) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordType.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordType.java
@@ -37,10 +37,6 @@ public class RecordType {
 		return name;
 	}
 
-	public String getSqlValidatedName() {
-		return SqlUtils.sanitizeSqlString(name);
-	}
-
 	public void validate() {
 		if (name.startsWith(RESERVED_NAME_PREFIX)) {
 			throw new InvalidNameException(InvalidNameException.NameType.RECORD_TYPE);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordType.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordType.java
@@ -1,7 +1,6 @@
 package org.databiosphere.workspacedataservice.shared.model;
 
 import com.fasterxml.jackson.annotation.*;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.databiosphere.workspacedataservice.service.model.exception.InvalidNameException;
 
 import java.util.Objects;
@@ -10,53 +9,46 @@ import static org.databiosphere.workspacedataservice.service.model.ReservedNames
 
 public class RecordType {
 
-	public static RecordType fromSqlTableName(String tableName) {
-		return new RecordType(tableName);
-	}
+	private final String name;
 
-//	public static RecordType fromPathSegment(String pathSegment) {
-//		return new RecordType(pathSegment);
-//	}
-
-	@JsonCreator
 	public RecordType(String name) {
 		this.name = name;
 	}
 
-	private final String name;
+	public static RecordType forUnitTest(String tableName) {
+		return new RecordType(tableName);
+	}
 
-	// public String getNameXXX() {
-	// return name;
-	// }
-	//
-//	 public void setName(String name) {
-//	 this.name = name;
-//	 }
+	public static RecordType fromSqlTableName(String tableName) {
+		return new RecordType(tableName);
+	}
+
+	public static RecordType fromUriSegment(String tableName) {
+		return new RecordType(tableName);
+	}
 
 	public String toSqlTableName() {
 		return name;
 	}
 
 	@JsonValue
-	public String toPathSegment() {
+	public String toUriSegment() {
 		return name;
 	}
 
-	// TODO: return void instead?
-	public RecordType validate() {
+	public void validate() {
 		if (name.startsWith(RESERVED_NAME_PREFIX)) {
 			throw new InvalidNameException("Record type");
 		}
-		return this;
 	}
 
+	/* returning the raw string value allows RecordType to be used directly as an argument to
+		url templates, e.g. within unit tests
+	 */
 	@Override
 	public String toString() {
 		return name;
 	}
-	// public String toString() {
-//		return "RecordType{" + "name='" + name + '\'' + '}';
-//	}
 
 	@Override
 	public boolean equals(Object o) {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
@@ -53,9 +53,9 @@ class FullStackRecordControllerTest {
 	void missingReferencedRecordTypeShouldFail() throws JsonProcessingException {
 		Map<String, Object> attrs = new HashMap<>();
 		attrs.put("attr_ref",
-				RelationUtils.createRelationString(RecordType.fromSqlTableName("non_existent"), "recordId"));
+				RelationUtils.createRelationString(RecordType.forUnitTest("non_existent"), "recordId"));
 		attrs.put("attr_ref_2",
-				RelationUtils.createRelationString(RecordType.fromSqlTableName("non_existent_2"), "recordId"));
+				RelationUtils.createRelationString(RecordType.forUnitTest("non_existent_2"), "recordId"));
 		HttpEntity<String> requestEntity = new HttpEntity<>(
 				mapper.writeValueAsString(new RecordRequest(new RecordAttributes(attrs))), headers);
 		ResponseEntity<ErrorResponse> response = restTemplate.exchange(
@@ -70,7 +70,7 @@ class FullStackRecordControllerTest {
 	@Transactional
 	void referencingMissingRecordShouldFail() throws Exception {
 		Map<String, Object> attrs = new HashMap<>();
-		RecordType referencedRecordType = RecordType.fromSqlTableName("referenced-type");
+		RecordType referencedRecordType = RecordType.forUnitTest("referenced-type");
 		createSomeRecords(referencedRecordType, 1);
 		attrs.put("attr_ref", RelationUtils.createRelationString(referencedRecordType, "missing-id"));
 		HttpEntity<String> requestEntity = new HttpEntity<>(
@@ -87,7 +87,7 @@ class FullStackRecordControllerTest {
 	@Test
 	@Transactional
 	void retrievingMissingEntityShouldFail() throws Exception {
-		createSomeRecords(RecordType.fromSqlTableName("samples"), 1);
+		createSomeRecords(RecordType.forUnitTest("samples"), 1);
 		HttpEntity<String> requestEntity = new HttpEntity<>(headers);
 		ResponseEntity<ErrorResponse> response = restTemplate.exchange(
 				"/{instanceId}/records/{version}/{recordType}/{recordId}", HttpMethod.GET, requestEntity,

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
@@ -80,10 +80,8 @@ class FullStackRecordControllerTest {
 	@Transactional
 	void missingReferencedRecordTypeShouldFail() throws JsonProcessingException {
 		Map<String, Object> attrs = new HashMap<>();
-		attrs.put("attr_ref",
-				RelationUtils.createRelationString(RecordType.valueOf("non_existent"), "recordId"));
-		attrs.put("attr_ref_2",
-				RelationUtils.createRelationString(RecordType.valueOf("non_existent_2"), "recordId"));
+		attrs.put("attr_ref", RelationUtils.createRelationString(RecordType.valueOf("non_existent"), "recordId"));
+		attrs.put("attr_ref_2", RelationUtils.createRelationString(RecordType.valueOf("non_existent_2"), "recordId"));
 		HttpEntity<String> requestEntity = new HttpEntity<>(
 				mapper.writeValueAsString(new RecordRequest(new RecordAttributes(attrs))), headers);
 		ResponseEntity<ErrorResponse> response = restTemplate.exchange(

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
@@ -2,8 +2,6 @@ package org.databiosphere.workspacedataservice.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.lang3.RandomUtils;
 import org.databiosphere.workspacedata.model.ErrorResponse;
 import org.databiosphere.workspacedataservice.service.RelationUtils;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
@@ -23,7 +21,6 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.in;
 import static org.databiosphere.workspacedataservice.TestUtils.generateRandomAttributes;
 
 /**
@@ -53,9 +50,9 @@ class FullStackRecordControllerTest {
 	void missingReferencedRecordTypeShouldFail() throws JsonProcessingException {
 		Map<String, Object> attrs = new HashMap<>();
 		attrs.put("attr_ref",
-				RelationUtils.createRelationString(RecordType.forUnitTest("non_existent"), "recordId"));
+				RelationUtils.createRelationString(RecordType.valueOf("non_existent"), "recordId"));
 		attrs.put("attr_ref_2",
-				RelationUtils.createRelationString(RecordType.forUnitTest("non_existent_2"), "recordId"));
+				RelationUtils.createRelationString(RecordType.valueOf("non_existent_2"), "recordId"));
 		HttpEntity<String> requestEntity = new HttpEntity<>(
 				mapper.writeValueAsString(new RecordRequest(new RecordAttributes(attrs))), headers);
 		ResponseEntity<ErrorResponse> response = restTemplate.exchange(
@@ -70,7 +67,7 @@ class FullStackRecordControllerTest {
 	@Transactional
 	void referencingMissingRecordShouldFail() throws Exception {
 		Map<String, Object> attrs = new HashMap<>();
-		RecordType referencedRecordType = RecordType.forUnitTest("referenced-type");
+		RecordType referencedRecordType = RecordType.valueOf("referenced-type");
 		createSomeRecords(referencedRecordType, 1);
 		attrs.put("attr_ref", RelationUtils.createRelationString(referencedRecordType, "missing-id"));
 		HttpEntity<String> requestEntity = new HttpEntity<>(
@@ -87,7 +84,7 @@ class FullStackRecordControllerTest {
 	@Test
 	@Transactional
 	void retrievingMissingEntityShouldFail() throws Exception {
-		createSomeRecords(RecordType.forUnitTest("samples"), 1);
+		createSomeRecords(RecordType.valueOf("samples"), 1);
 		HttpEntity<String> requestEntity = new HttpEntity<>(headers);
 		ResponseEntity<ErrorResponse> response = restTemplate.exchange(
 				"/{instanceId}/records/{version}/{recordType}/{recordId}", HttpMethod.GET, requestEntity,

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -27,6 +27,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -79,7 +80,7 @@ public class RecordControllerMockMvcTest {
 						.content(mapper.writeValueAsString(new RecordRequest(new RecordAttributes(attributes))))
 						.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isBadRequest())
-				.andExpect(result -> assertTrue(result.getResolvedException() instanceof InvalidNameException));
+				.andExpect(result -> assertTrue(result.getResolvedException() instanceof MethodArgumentTypeMismatchException));
 	}
 
 	@Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -11,7 +11,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.service.RelationUtils;
-import org.databiosphere.workspacedataservice.service.RelationUtils;
 import org.databiosphere.workspacedataservice.service.model.exception.*;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
 import org.databiosphere.workspacedataservice.shared.model.RecordRequest;
@@ -60,7 +59,7 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void tryFetchingMissingRecord() throws Exception {
-		RecordType recordType1 = RecordType.fromSqlTableName("recordType1");
+		RecordType recordType1 = RecordType.forUnitTest("recordType1");
 		createSomeRecords(recordType1, 1);
 		mockMvc.perform(get("/{instanceId}/records/{versionId}/{recordType}/{recordId}", instanceId, versionId,
 				recordType1, "missing-2")).andExpect(status().isNotFound());
@@ -82,7 +81,7 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void updateWithIllegalAttributeName() throws Exception {
-		RecordType recordType1 = RecordType.fromSqlTableName("illegalName");
+		RecordType recordType1 = RecordType.forUnitTest("illegalName");
 		createSomeRecords(recordType1, 1);
 		Map<String, Object> illegalAttribute = new HashMap<>();
 		illegalAttribute.put("sys_foo", "some_val");
@@ -95,7 +94,7 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void ensurePutShowsNewlyNullFields() throws Exception {
-		RecordType recordType1 = RecordType.fromSqlTableName("recordType1");
+		RecordType recordType1 = RecordType.forUnitTest("recordType1");
 		createSomeRecords(recordType1, 1);
 		Map<String, Object> newAttributes = new HashMap<>();
 		newAttributes.put("new-attr", "some_val");
@@ -108,7 +107,7 @@ public class RecordControllerMockMvcTest {
 
 	@Test
 	void ensurePatchShowsAllFields() throws Exception {
-		RecordType recordType1 = RecordType.fromSqlTableName("recordType1");
+		RecordType recordType1 = RecordType.forUnitTest("recordType1");
 		createSomeRecords(recordType1, 1);
 		Map<String, Object> newAttributes = new HashMap<>();
 		newAttributes.put("new-attr", "some_val");
@@ -121,7 +120,7 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void createAndRetrieveRecord() throws Exception {
-		RecordType recordType = RecordType.fromSqlTableName("samples");
+		RecordType recordType = RecordType.forUnitTest("samples");
 		createSomeRecords(recordType, 1);
 		mockMvc.perform(get("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 				recordType, "record_0")).andExpect(status().isOk()).andExpect(jsonPath("$.id", is("record_0")));
@@ -130,8 +129,8 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void createRecordWithReferences() throws Exception {
-		RecordType referencedType = RecordType.fromSqlTableName("ref_participants");
-		RecordType referringType = RecordType.fromSqlTableName("ref_samples");
+		RecordType referencedType = RecordType.forUnitTest("ref_participants");
+		RecordType referringType = RecordType.forUnitTest("ref_samples");
 		createSomeRecords(referencedType, 3);
 		createSomeRecords(referringType, 1);
 		Map<String, Object> attributes = new HashMap<>();
@@ -146,8 +145,8 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void referencingMissingTableFails() throws Exception {
-		RecordType referencedType = RecordType.fromSqlTableName("missing");
-		RecordType referringType = RecordType.fromSqlTableName("ref_samples-2");
+		RecordType referencedType = RecordType.forUnitTest("missing");
+		RecordType referringType = RecordType.forUnitTest("ref_samples-2");
 		createSomeRecords(referringType, 1);
 		Map<String, Object> attributes = new HashMap<>();
 		String ref = RelationUtils.createRelationString(referencedType, "record_0");
@@ -162,8 +161,8 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void referencingMissingRecordFails() throws Exception {
-		RecordType referencedType = RecordType.fromSqlTableName("ref_participants-2");
-		RecordType referringType = RecordType.fromSqlTableName("ref_samples-3");
+		RecordType referencedType = RecordType.forUnitTest("ref_participants-2");
+		RecordType referringType = RecordType.forUnitTest("ref_samples-3");
 		createSomeRecords(referencedType, 3);
 		createSomeRecords(referringType, 1);
 		Map<String, Object> attributes = new HashMap<>();
@@ -179,7 +178,7 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void expandColumnDefForNewData() throws Exception {
-		RecordType recordType = RecordType.fromSqlTableName("to-alter");
+		RecordType recordType = RecordType.forUnitTest("to-alter");
 		createSomeRecords(recordType, 1);
 		Map<String, Object> attributes = new HashMap<>();
 		String newTextValue = "convert this column from date to text";
@@ -193,7 +192,7 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void patchMissingRecord() throws Exception {
-		RecordType recordType = RecordType.fromSqlTableName("to-patch");
+		RecordType recordType = RecordType.forUnitTest("to-patch");
 		createSomeRecords(recordType, 1);
 		Map<String, Object> attributes = new HashMap<>();
 		attributes.put("attr-boolean", true);
@@ -211,7 +210,7 @@ public class RecordControllerMockMvcTest {
 		String recordType = "record-type-missing-table-ref";
 		String recordId = "record_0";
 		Map<String, Object> attributes = new HashMap<>();
-		String ref = RelationUtils.createRelationString(RecordType.fromSqlTableName("missing"), "missing_also");
+		String ref = RelationUtils.createRelationString(RecordType.forUnitTest("missing"), "missing_also");
 		attributes.put("sample-ref", ref);
 
 		mockMvc.perform(put("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
@@ -225,8 +224,8 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void putRecordWithMismatchedReference() throws Exception {
-		RecordType referencedType = RecordType.fromSqlTableName("referenced_Type");
-		RecordType referringType = RecordType.fromSqlTableName("referring_Type");
+		RecordType referencedType = RecordType.forUnitTest("referenced_Type");
+		RecordType referringType = RecordType.forUnitTest("referring_Type");
 		String recordId = "record_0";
 		createSomeRecords(referencedType, 1);
 		createSomeRecords(referringType, 1);
@@ -242,7 +241,7 @@ public class RecordControllerMockMvcTest {
 		// Create a new referring_Type that puts a reference to a non-existent
 		// recordType in the pre-existing referencing attribute
 		Map<String, Object> new_attributes = new HashMap<>();
-		String invalid_ref = RelationUtils.createRelationString(RecordType.fromSqlTableName("missing"), recordId);
+		String invalid_ref = RelationUtils.createRelationString(RecordType.forUnitTest("missing"), recordId);
 		new_attributes.put("ref-attr", invalid_ref);
 
 		mockMvc.perform(put("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
@@ -255,10 +254,10 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void tryToAssignReferenceToNonRefColumn() throws Exception {
-		RecordType recordType = RecordType.fromSqlTableName("ref-alter");
+		RecordType recordType = RecordType.forUnitTest("ref-alter");
 		createSomeRecords(recordType, 1);
 		Map<String, Object> attributes = new HashMap<>();
-		String ref = RelationUtils.createRelationString(RecordType.fromSqlTableName("missing"), "missing_also");
+		String ref = RelationUtils.createRelationString(RecordType.forUnitTest("missing"), "missing_also");
 		attributes.put("attr1", ref);
 		mockMvc.perform(patch("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 				recordType, "record_0")
@@ -272,7 +271,7 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void deleteRecord() throws Exception {
-		RecordType recordType = RecordType.fromSqlTableName("samples");
+		RecordType recordType = RecordType.forUnitTest("samples");
 		createSomeRecords(recordType, 1);
 		mockMvc.perform(delete("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 				recordType, "record_0")).andExpect(status().isNoContent());
@@ -283,7 +282,7 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void deleteMissingRecord() throws Exception {
-		RecordType recordType = RecordType.fromSqlTableName("samples");
+		RecordType recordType = RecordType.forUnitTest("samples");
 		createSomeRecords(recordType, 1);
 		mockMvc.perform(delete("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 				recordType, "record_1")).andExpect(status().isNotFound());
@@ -292,8 +291,8 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void deleteReferencedRecord() throws Exception {
-		RecordType referencedType = RecordType.fromSqlTableName("ref_participants");
-		RecordType referringType = RecordType.fromSqlTableName("ref_samples");
+		RecordType referencedType = RecordType.forUnitTest("ref_participants");
+		RecordType referringType = RecordType.forUnitTest("ref_samples");
 		createSomeRecords(referencedType, 1);
 		createSomeRecords(referringType, 1);
 		Map<String, Object> attributes = new HashMap<>();
@@ -312,7 +311,7 @@ public class RecordControllerMockMvcTest {
 			String recordId = "record_" + i;
 			Map<String, Object> attributes = generateRandomAttributes();
 			mockMvc.perform(put("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
-					recordType.toPathSegment(), recordId)
+					recordType, recordId)
 							.content(mapper.writeValueAsString(new RecordRequest(new RecordAttributes(attributes))))
 							.contentType(MediaType.APPLICATION_JSON))
 					.andExpect(status().is2xxSuccessful());

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -15,6 +15,7 @@ import org.databiosphere.workspacedataservice.service.RelationUtils;
 import org.databiosphere.workspacedataservice.service.model.exception.*;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
 import org.databiosphere.workspacedataservice.shared.model.RecordRequest;
+import org.databiosphere.workspacedataservice.shared.model.RecordType;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -59,7 +60,7 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void tryFetchingMissingRecord() throws Exception {
-		String recordType1 = "recordType1";
+		RecordType recordType1 = RecordType.fromSqlTableName("recordType1");
 		createSomeRecords(recordType1, 1);
 		mockMvc.perform(get("/{instanceId}/records/{versionId}/{recordType}/{recordId}", instanceId, versionId,
 				recordType1, "missing-2")).andExpect(status().isNotFound());
@@ -81,7 +82,7 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void updateWithIllegalAttributeName() throws Exception {
-		String recordType1 = "illegalName";
+		RecordType recordType1 = RecordType.fromSqlTableName("illegalName");
 		createSomeRecords(recordType1, 1);
 		Map<String, Object> illegalAttribute = new HashMap<>();
 		illegalAttribute.put("sys_foo", "some_val");
@@ -94,7 +95,7 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void ensurePutShowsNewlyNullFields() throws Exception {
-		String recordType1 = "recordType1";
+		RecordType recordType1 = RecordType.fromSqlTableName("recordType1");
 		createSomeRecords(recordType1, 1);
 		Map<String, Object> newAttributes = new HashMap<>();
 		newAttributes.put("new-attr", "some_val");
@@ -107,7 +108,7 @@ public class RecordControllerMockMvcTest {
 
 	@Test
 	void ensurePatchShowsAllFields() throws Exception {
-		String recordType1 = "recordType1";
+		RecordType recordType1 = RecordType.fromSqlTableName("recordType1");
 		createSomeRecords(recordType1, 1);
 		Map<String, Object> newAttributes = new HashMap<>();
 		newAttributes.put("new-attr", "some_val");
@@ -120,7 +121,7 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void createAndRetrieveRecord() throws Exception {
-		String recordType = "samples";
+		RecordType recordType = RecordType.fromSqlTableName("samples");
 		createSomeRecords(recordType, 1);
 		mockMvc.perform(get("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 				recordType, "record_0")).andExpect(status().isOk()).andExpect(jsonPath("$.id", is("record_0")));
@@ -129,8 +130,8 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void createRecordWithReferences() throws Exception {
-		String referencedType = "ref_participants";
-		String referringType = "ref_samples";
+		RecordType referencedType = RecordType.fromSqlTableName("ref_participants");
+		RecordType referringType = RecordType.fromSqlTableName("ref_samples");
 		createSomeRecords(referencedType, 3);
 		createSomeRecords(referringType, 1);
 		Map<String, Object> attributes = new HashMap<>();
@@ -145,8 +146,8 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void referencingMissingTableFails() throws Exception {
-		String referencedType = "missing";
-		String referringType = "ref_samples-2";
+		RecordType referencedType = RecordType.fromSqlTableName("missing");
+		RecordType referringType = RecordType.fromSqlTableName("ref_samples-2");
 		createSomeRecords(referringType, 1);
 		Map<String, Object> attributes = new HashMap<>();
 		String ref = RelationUtils.createRelationString(referencedType, "record_0");
@@ -161,8 +162,8 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void referencingMissingRecordFails() throws Exception {
-		String referencedType = "ref_participants-2";
-		String referringType = "ref_samples-3";
+		RecordType referencedType = RecordType.fromSqlTableName("ref_participants-2");
+		RecordType referringType = RecordType.fromSqlTableName("ref_samples-3");
 		createSomeRecords(referencedType, 3);
 		createSomeRecords(referringType, 1);
 		Map<String, Object> attributes = new HashMap<>();
@@ -178,7 +179,7 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void expandColumnDefForNewData() throws Exception {
-		String recordType = "to-alter";
+		RecordType recordType = RecordType.fromSqlTableName("to-alter");
 		createSomeRecords(recordType, 1);
 		Map<String, Object> attributes = new HashMap<>();
 		String newTextValue = "convert this column from date to text";
@@ -192,7 +193,7 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void patchMissingRecord() throws Exception {
-		String recordType = "to-patch";
+		RecordType recordType = RecordType.fromSqlTableName("to-patch");
 		createSomeRecords(recordType, 1);
 		Map<String, Object> attributes = new HashMap<>();
 		attributes.put("attr-boolean", true);
@@ -210,7 +211,7 @@ public class RecordControllerMockMvcTest {
 		String recordType = "record-type-missing-table-ref";
 		String recordId = "record_0";
 		Map<String, Object> attributes = new HashMap<>();
-		String ref = RelationUtils.createRelationString("missing", "missing_also");
+		String ref = RelationUtils.createRelationString(RecordType.fromSqlTableName("missing"), "missing_also");
 		attributes.put("sample-ref", ref);
 
 		mockMvc.perform(put("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
@@ -224,8 +225,8 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void putRecordWithMismatchedReference() throws Exception {
-		String referencedType = "referenced_Type";
-		String referringType = "referring_Type";
+		RecordType referencedType = RecordType.fromSqlTableName("referenced_Type");
+		RecordType referringType = RecordType.fromSqlTableName("referring_Type");
 		String recordId = "record_0";
 		createSomeRecords(referencedType, 1);
 		createSomeRecords(referringType, 1);
@@ -241,7 +242,7 @@ public class RecordControllerMockMvcTest {
 		// Create a new referring_Type that puts a reference to a non-existent
 		// recordType in the pre-existing referencing attribute
 		Map<String, Object> new_attributes = new HashMap<>();
-		String invalid_ref = RelationUtils.createRelationString("missing", recordId);
+		String invalid_ref = RelationUtils.createRelationString(RecordType.fromSqlTableName("missing"), recordId);
 		new_attributes.put("ref-attr", invalid_ref);
 
 		mockMvc.perform(put("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
@@ -254,10 +255,10 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void tryToAssignReferenceToNonRefColumn() throws Exception {
-		String recordType = "ref-alter";
+		RecordType recordType = RecordType.fromSqlTableName("ref-alter");
 		createSomeRecords(recordType, 1);
 		Map<String, Object> attributes = new HashMap<>();
-		String ref = RelationUtils.createRelationString("missing", "missing_also");
+		String ref = RelationUtils.createRelationString(RecordType.fromSqlTableName("missing"), "missing_also");
 		attributes.put("attr1", ref);
 		mockMvc.perform(patch("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 				recordType, "record_0")
@@ -271,7 +272,7 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void deleteRecord() throws Exception {
-		String recordType = "samples";
+		RecordType recordType = RecordType.fromSqlTableName("samples");
 		createSomeRecords(recordType, 1);
 		mockMvc.perform(delete("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 				recordType, "record_0")).andExpect(status().isNoContent());
@@ -282,7 +283,7 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void deleteMissingRecord() throws Exception {
-		String recordType = "samples";
+		RecordType recordType = RecordType.fromSqlTableName("samples");
 		createSomeRecords(recordType, 1);
 		mockMvc.perform(delete("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 				recordType, "record_1")).andExpect(status().isNotFound());
@@ -291,8 +292,8 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void deleteReferencedRecord() throws Exception {
-		String referencedType = "ref_participants";
-		String referringType = "ref_samples";
+		RecordType referencedType = RecordType.fromSqlTableName("ref_participants");
+		RecordType referringType = RecordType.fromSqlTableName("ref_samples");
 		createSomeRecords(referencedType, 1);
 		createSomeRecords(referringType, 1);
 		Map<String, Object> attributes = new HashMap<>();
@@ -306,12 +307,12 @@ public class RecordControllerMockMvcTest {
 				referencedType, "record_0")).andExpect(status().isBadRequest());
 	}
 
-	private void createSomeRecords(String recordType, int numRecords) throws Exception {
+	private void createSomeRecords(RecordType recordType, int numRecords) throws Exception {
 		for (int i = 0; i < numRecords; i++) {
 			String recordId = "record_" + i;
 			Map<String, Object> attributes = generateRandomAttributes();
 			mockMvc.perform(put("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
-					recordType, recordId)
+					recordType.toPathSegment(), recordId)
 							.content(mapper.writeValueAsString(new RecordRequest(new RecordAttributes(attributes))))
 							.contentType(MediaType.APPLICATION_JSON))
 					.andExpect(status().is2xxSuccessful());

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -418,12 +418,12 @@ public class RecordControllerMockMvcTest {
 
 		List<AttributeSchema> expectedAttributes = Arrays.asList(new AttributeSchema("attr-boolean", "BOOLEAN", null),
 				new AttributeSchema("attr-dt", "DATE_TIME", null), new AttributeSchema("attr-json", "JSON", null),
-				new AttributeSchema("attr-ref", "RELATION", referencedType.getName()),
+				new AttributeSchema("attr-ref", "RELATION", referencedType),
 				new AttributeSchema("attr1", "STRING", null), new AttributeSchema("attr2", "DOUBLE", null),
 				new AttributeSchema("attr3", "DATE", null), new AttributeSchema("attr4", "STRING", null),
 				new AttributeSchema("attr5", "LONG", null));
 
-		RecordTypeSchema expected = new RecordTypeSchema(type.getName(), expectedAttributes, 1);
+		RecordTypeSchema expected = new RecordTypeSchema(type, expectedAttributes, 1);
 
 		MvcResult mvcResult = mockMvc.perform(get("/{instanceId}/types/{v}/{type}", instanceId, versionId, type))
 				.andExpect(status().isOk()).andReturn();
@@ -446,11 +446,11 @@ public class RecordControllerMockMvcTest {
 	void describeAllTypes() throws Exception {
 		// replace instanceId for this test so only these records are found
 		UUID instId = UUID.randomUUID();
-		String type1 = "firstType";
+		RecordType type1 = RecordType.valueOf("firstType");
 		createSomeRecords(type1, 1, instId);
-		String type2 = "secondType";
+		RecordType type2 = RecordType.valueOf("secondType");
 		createSomeRecords(type2, 2, instId);
-		String type3 = "thirdType";
+		RecordType type3 = RecordType.valueOf("thirdType");
 		createSomeRecords(type3, 10, instId);
 
 		List<AttributeSchema> expectedAttributes = Arrays.asList(new AttributeSchema("attr-boolean", "BOOLEAN", null),

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -357,8 +357,8 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void deleteReferencedRecordType() throws Exception {
-		String referencedType = "ref_participants";
-		String referringType = "ref_samples";
+		RecordType referencedType = RecordType.valueOf("ref_participants");
+		RecordType referringType = RecordType.valueOf("ref_samples");
 		createSomeRecords(referencedType, 3);
 		createSomeRecords(referringType, 1);
 		Map<String, Object> attributes = new HashMap<>();
@@ -376,8 +376,8 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void deleteReferencedRecordTypeWithNoRecords() throws Exception {
-		String referencedType = "ref_participants";
-		String referringType = "ref_samples";
+		RecordType referencedType = RecordType.valueOf("ref_participants");
+		RecordType referringType = RecordType.valueOf("ref_samples");
 		createSomeRecords(referencedType, 3);
 		createSomeRecords(referringType, 1);
 		Map<String, Object> attributes = new HashMap<>();
@@ -401,10 +401,10 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void describeType() throws Exception {
-		String type = "recordType";
+		RecordType type = RecordType.valueOf("recordType");
 		createSomeRecords(type, 1);
 
-		String referencedType = "referencedType";
+		RecordType referencedType = RecordType.valueOf("referencedType");
 		createSomeRecords(referencedType, 1);
 		createSomeRecords(type, 1);
 		Map<String, Object> attributes = new HashMap<>();
@@ -418,12 +418,12 @@ public class RecordControllerMockMvcTest {
 
 		List<AttributeSchema> expectedAttributes = Arrays.asList(new AttributeSchema("attr-boolean", "BOOLEAN", null),
 				new AttributeSchema("attr-dt", "DATE_TIME", null), new AttributeSchema("attr-json", "JSON", null),
-				new AttributeSchema("attr-ref", "RELATION", referencedType),
+				new AttributeSchema("attr-ref", "RELATION", referencedType.toJsonValue()),
 				new AttributeSchema("attr1", "STRING", null), new AttributeSchema("attr2", "DOUBLE", null),
 				new AttributeSchema("attr3", "DATE", null), new AttributeSchema("attr4", "STRING", null),
 				new AttributeSchema("attr5", "LONG", null));
 
-		RecordTypeSchema expected = new RecordTypeSchema(type, expectedAttributes, 1);
+		RecordTypeSchema expected = new RecordTypeSchema(type.toJsonValue(), expectedAttributes, 1);
 
 		MvcResult mvcResult = mockMvc.perform(get("/{instanceId}/types/{v}/{type}", instanceId, versionId, type))
 				.andExpect(status().isOk()).andReturn();
@@ -479,10 +479,18 @@ public class RecordControllerMockMvcTest {
 	}
 
 	private void createSomeRecords(String recordType, int numRecords) throws Exception {
+		createSomeRecords(RecordType.valueOf(recordType), numRecords, instanceId);
+	}
+
+	private void createSomeRecords(RecordType recordType, int numRecords) throws Exception {
 		createSomeRecords(recordType, numRecords, instanceId);
 	}
 
 	private void createSomeRecords(String recordType, int numRecords, UUID instId) throws Exception {
+		createSomeRecords(RecordType.valueOf(recordType), numRecords, instId);
+	}
+
+	private void createSomeRecords(RecordType recordType, int numRecords, UUID instId) throws Exception {
 		for (int i = 0; i < numRecords; i++) {
 			String recordId = "record_" + i;
 			Map<String, Object> attributes = generateRandomAttributes();

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -59,7 +59,7 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void tryFetchingMissingRecord() throws Exception {
-		RecordType recordType1 = RecordType.forUnitTest("recordType1");
+		RecordType recordType1 = RecordType.valueOf("recordType1");
 		createSomeRecords(recordType1, 1);
 		mockMvc.perform(get("/{instanceId}/records/{versionId}/{recordType}/{recordId}", instanceId, versionId,
 				recordType1, "missing-2")).andExpect(status().isNotFound());
@@ -81,7 +81,7 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void updateWithIllegalAttributeName() throws Exception {
-		RecordType recordType1 = RecordType.forUnitTest("illegalName");
+		RecordType recordType1 = RecordType.valueOf("illegalName");
 		createSomeRecords(recordType1, 1);
 		Map<String, Object> illegalAttribute = new HashMap<>();
 		illegalAttribute.put("sys_foo", "some_val");
@@ -94,7 +94,7 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void ensurePutShowsNewlyNullFields() throws Exception {
-		RecordType recordType1 = RecordType.forUnitTest("recordType1");
+		RecordType recordType1 = RecordType.valueOf("recordType1");
 		createSomeRecords(recordType1, 1);
 		Map<String, Object> newAttributes = new HashMap<>();
 		newAttributes.put("new-attr", "some_val");
@@ -107,7 +107,7 @@ public class RecordControllerMockMvcTest {
 
 	@Test
 	void ensurePatchShowsAllFields() throws Exception {
-		RecordType recordType1 = RecordType.forUnitTest("recordType1");
+		RecordType recordType1 = RecordType.valueOf("recordType1");
 		createSomeRecords(recordType1, 1);
 		Map<String, Object> newAttributes = new HashMap<>();
 		newAttributes.put("new-attr", "some_val");
@@ -120,7 +120,7 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void createAndRetrieveRecord() throws Exception {
-		RecordType recordType = RecordType.forUnitTest("samples");
+		RecordType recordType = RecordType.valueOf("samples");
 		createSomeRecords(recordType, 1);
 		mockMvc.perform(get("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 				recordType, "record_0")).andExpect(status().isOk()).andExpect(jsonPath("$.id", is("record_0")));
@@ -129,8 +129,8 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void createRecordWithReferences() throws Exception {
-		RecordType referencedType = RecordType.forUnitTest("ref_participants");
-		RecordType referringType = RecordType.forUnitTest("ref_samples");
+		RecordType referencedType = RecordType.valueOf("ref_participants");
+		RecordType referringType = RecordType.valueOf("ref_samples");
 		createSomeRecords(referencedType, 3);
 		createSomeRecords(referringType, 1);
 		Map<String, Object> attributes = new HashMap<>();
@@ -145,8 +145,8 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void referencingMissingTableFails() throws Exception {
-		RecordType referencedType = RecordType.forUnitTest("missing");
-		RecordType referringType = RecordType.forUnitTest("ref_samples-2");
+		RecordType referencedType = RecordType.valueOf("missing");
+		RecordType referringType = RecordType.valueOf("ref_samples-2");
 		createSomeRecords(referringType, 1);
 		Map<String, Object> attributes = new HashMap<>();
 		String ref = RelationUtils.createRelationString(referencedType, "record_0");
@@ -161,8 +161,8 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void referencingMissingRecordFails() throws Exception {
-		RecordType referencedType = RecordType.forUnitTest("ref_participants-2");
-		RecordType referringType = RecordType.forUnitTest("ref_samples-3");
+		RecordType referencedType = RecordType.valueOf("ref_participants-2");
+		RecordType referringType = RecordType.valueOf("ref_samples-3");
 		createSomeRecords(referencedType, 3);
 		createSomeRecords(referringType, 1);
 		Map<String, Object> attributes = new HashMap<>();
@@ -178,7 +178,7 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void expandColumnDefForNewData() throws Exception {
-		RecordType recordType = RecordType.forUnitTest("to-alter");
+		RecordType recordType = RecordType.valueOf("to-alter");
 		createSomeRecords(recordType, 1);
 		Map<String, Object> attributes = new HashMap<>();
 		String newTextValue = "convert this column from date to text";
@@ -192,7 +192,7 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void patchMissingRecord() throws Exception {
-		RecordType recordType = RecordType.forUnitTest("to-patch");
+		RecordType recordType = RecordType.valueOf("to-patch");
 		createSomeRecords(recordType, 1);
 		Map<String, Object> attributes = new HashMap<>();
 		attributes.put("attr-boolean", true);
@@ -210,7 +210,7 @@ public class RecordControllerMockMvcTest {
 		String recordType = "record-type-missing-table-ref";
 		String recordId = "record_0";
 		Map<String, Object> attributes = new HashMap<>();
-		String ref = RelationUtils.createRelationString(RecordType.forUnitTest("missing"), "missing_also");
+		String ref = RelationUtils.createRelationString(RecordType.valueOf("missing"), "missing_also");
 		attributes.put("sample-ref", ref);
 
 		mockMvc.perform(put("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
@@ -224,8 +224,8 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void putRecordWithMismatchedReference() throws Exception {
-		RecordType referencedType = RecordType.forUnitTest("referenced_Type");
-		RecordType referringType = RecordType.forUnitTest("referring_Type");
+		RecordType referencedType = RecordType.valueOf("referenced_Type");
+		RecordType referringType = RecordType.valueOf("referring_Type");
 		String recordId = "record_0";
 		createSomeRecords(referencedType, 1);
 		createSomeRecords(referringType, 1);
@@ -241,7 +241,7 @@ public class RecordControllerMockMvcTest {
 		// Create a new referring_Type that puts a reference to a non-existent
 		// recordType in the pre-existing referencing attribute
 		Map<String, Object> new_attributes = new HashMap<>();
-		String invalid_ref = RelationUtils.createRelationString(RecordType.forUnitTest("missing"), recordId);
+		String invalid_ref = RelationUtils.createRelationString(RecordType.valueOf("missing"), recordId);
 		new_attributes.put("ref-attr", invalid_ref);
 
 		mockMvc.perform(put("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
@@ -254,10 +254,10 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void tryToAssignReferenceToNonRefColumn() throws Exception {
-		RecordType recordType = RecordType.forUnitTest("ref-alter");
+		RecordType recordType = RecordType.valueOf("ref-alter");
 		createSomeRecords(recordType, 1);
 		Map<String, Object> attributes = new HashMap<>();
-		String ref = RelationUtils.createRelationString(RecordType.forUnitTest("missing"), "missing_also");
+		String ref = RelationUtils.createRelationString(RecordType.valueOf("missing"), "missing_also");
 		attributes.put("attr1", ref);
 		mockMvc.perform(patch("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 				recordType, "record_0")
@@ -271,7 +271,7 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void deleteRecord() throws Exception {
-		RecordType recordType = RecordType.forUnitTest("samples");
+		RecordType recordType = RecordType.valueOf("samples");
 		createSomeRecords(recordType, 1);
 		mockMvc.perform(delete("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 				recordType, "record_0")).andExpect(status().isNoContent());
@@ -282,7 +282,7 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void deleteMissingRecord() throws Exception {
-		RecordType recordType = RecordType.forUnitTest("samples");
+		RecordType recordType = RecordType.valueOf("samples");
 		createSomeRecords(recordType, 1);
 		mockMvc.perform(delete("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 				recordType, "record_1")).andExpect(status().isNotFound());
@@ -291,8 +291,8 @@ public class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void deleteReferencedRecord() throws Exception {
-		RecordType referencedType = RecordType.forUnitTest("ref_participants");
-		RecordType referringType = RecordType.forUnitTest("ref_samples");
+		RecordType referencedType = RecordType.valueOf("ref_participants");
+		RecordType referringType = RecordType.valueOf("ref_samples");
 		createSomeRecords(referencedType, 1);
 		createSomeRecords(referringType, 1);
 		Map<String, Object> attributes = new HashMap<>();

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -418,12 +418,12 @@ public class RecordControllerMockMvcTest {
 
 		List<AttributeSchema> expectedAttributes = Arrays.asList(new AttributeSchema("attr-boolean", "BOOLEAN", null),
 				new AttributeSchema("attr-dt", "DATE_TIME", null), new AttributeSchema("attr-json", "JSON", null),
-				new AttributeSchema("attr-ref", "RELATION", referencedType.toJsonValue()),
+				new AttributeSchema("attr-ref", "RELATION", referencedType.getName()),
 				new AttributeSchema("attr1", "STRING", null), new AttributeSchema("attr2", "DOUBLE", null),
 				new AttributeSchema("attr3", "DATE", null), new AttributeSchema("attr4", "STRING", null),
 				new AttributeSchema("attr5", "LONG", null));
 
-		RecordTypeSchema expected = new RecordTypeSchema(type.toJsonValue(), expectedAttributes, 1);
+		RecordTypeSchema expected = new RecordTypeSchema(type.getName(), expectedAttributes, 1);
 
 		MvcResult mvcResult = mockMvc.perform(get("/{instanceId}/types/{v}/{type}", instanceId, versionId, type))
 				.andExpect(status().isOk()).andReturn();

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
@@ -33,7 +33,7 @@ public class RecordDaoTest {
 	@BeforeEach
 	void setUp() {
 		instanceId = UUID.randomUUID();
-		recordType = RecordType.fromSqlTableName("testRecordType");
+		recordType = RecordType.forUnitTest("testRecordType");
 		recordDao.createSchema(instanceId);
 		recordDao.createRecordType(instanceId, Collections.emptyMap(), recordType, Collections.emptySet());
 	}
@@ -94,7 +94,7 @@ public class RecordDaoTest {
 		recordDao.batchUpsert(instanceId, recordType, Collections.singletonList(referencedRecord), new HashMap<>());
 
 		RecordId recordId = new RecordId("testRecord");
-		String reference = RelationUtils.createRelationString(RecordType.fromSqlTableName("testRecordType"),
+		String reference = RelationUtils.createRelationString(RecordType.forUnitTest("testRecordType"),
 				"referencedRecord");
 		Record testRecord = new Record(recordId, recordType, new RecordAttributes(Map.of("testRecordType", reference)));
 		recordDao.batchUpsert(instanceId, recordType, Collections.singletonList(testRecord),
@@ -141,14 +141,14 @@ public class RecordDaoTest {
 		recordDao.addColumn(instanceId, recordType, "foo", DataTypeMapping.STRING);
 
 		recordDao.addColumn(instanceId, recordType, "testRecordType", DataTypeMapping.STRING,
-				RecordType.fromSqlTableName("testRecordType"));
+				RecordType.forUnitTest("testRecordType"));
 
 		RecordId refRecordId = new RecordId("referencedRecord");
 		Record referencedRecord = new Record(refRecordId, recordType, new RecordAttributes(Map.of("foo", "bar")));
 		recordDao.batchUpsert(instanceId, recordType, Collections.singletonList(referencedRecord), new HashMap<>());
 
 		RecordId recordId = new RecordId("testRecord");
-		String reference = RelationUtils.createRelationString(RecordType.fromSqlTableName("testRecordType"),
+		String reference = RelationUtils.createRelationString(RecordType.forUnitTest("testRecordType"),
 				"referencedRecord");
 		Record testRecord = new Record(recordId, recordType, new RecordAttributes(Map.of("testRecordType", reference)));
 		recordDao.batchUpsert(instanceId, recordType, Collections.singletonList(testRecord),

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
@@ -93,8 +93,7 @@ public class RecordDaoTest {
 		recordDao.batchUpsert(instanceId, recordType, Collections.singletonList(referencedRecord), new HashMap<>());
 
 		RecordId recordId = new RecordId("testRecord");
-		String reference = RelationUtils.createRelationString(RecordType.valueOf("testRecordType"),
-				"referencedRecord");
+		String reference = RelationUtils.createRelationString(RecordType.valueOf("testRecordType"), "referencedRecord");
 		Record testRecord = new Record(recordId, recordType, new RecordAttributes(Map.of("testRecordType", reference)));
 		recordDao.batchUpsert(instanceId, recordType, Collections.singletonList(testRecord),
 				new HashMap<>(Map.of("foo", DataTypeMapping.STRING, "testRecordType", DataTypeMapping.STRING)));
@@ -147,8 +146,7 @@ public class RecordDaoTest {
 		recordDao.batchUpsert(instanceId, recordType, Collections.singletonList(referencedRecord), new HashMap<>());
 
 		RecordId recordId = new RecordId("testRecord");
-		String reference = RelationUtils.createRelationString(RecordType.valueOf("testRecordType"),
-				"referencedRecord");
+		String reference = RelationUtils.createRelationString(RecordType.valueOf("testRecordType"), "referencedRecord");
 		Record testRecord = new Record(recordId, recordType, new RecordAttributes(Map.of("testRecordType", reference)));
 		recordDao.batchUpsert(instanceId, recordType, Collections.singletonList(testRecord),
 				new HashMap<>(Map.of("foo", DataTypeMapping.STRING, "testRecordType", DataTypeMapping.STRING)));
@@ -161,16 +159,16 @@ public class RecordDaoTest {
 	@Test
 	@Transactional
 	void testGetAllRecordTypes() {
-		List<String> typesList = recordDao.getAllRecordTypes(instanceId);
+		List<RecordType> typesList = recordDao.getAllRecordTypes(instanceId);
 		assertEquals(1, typesList.size());
-		assertTrue(typesList.contains(recordType.getName()));
+		assertTrue(typesList.contains(recordType));
 
-		String newRecordType = "newRecordType";
+		RecordType newRecordType = RecordType.valueOf("newRecordType");
 		recordDao.createRecordType(instanceId, Collections.emptyMap(), newRecordType, Collections.emptySet());
 
-		List<String> newTypesList = recordDao.getAllRecordTypes(instanceId);
+		List<RecordType> newTypesList = recordDao.getAllRecordTypes(instanceId);
 		assertEquals(2, newTypesList.size());
-		assertTrue(newTypesList.contains(recordType.getName()));
+		assertTrue(newTypesList.contains(recordType));
 		assertTrue(newTypesList.contains(newRecordType));
 	}
 
@@ -178,14 +176,13 @@ public class RecordDaoTest {
 	@Transactional
 	void testCountRecords() {
 		// ensure we start with a count of 0 records
-		assertEquals(0, recordDao.countRecords(instanceId, recordType.getName()));
+		assertEquals(0, recordDao.countRecords(instanceId, recordType));
 		// insert records and test the count after each insert
 		for (int i = 0; i < 10; i++) {
 			Record testRecord = new Record(new RecordId("record" + i), recordType,
 					new RecordAttributes(new HashMap<>()));
-			recordDao.batchUpsert(instanceId, recordType.getName(), Collections.singletonList(testRecord),
-					new HashMap<>());
-			assertEquals(i + 1, recordDao.countRecords(instanceId, recordType.getName()),
+			recordDao.batchUpsert(instanceId, recordType, Collections.singletonList(testRecord), new HashMap<>());
+			assertEquals(i + 1, recordDao.countRecords(instanceId, recordType),
 					"after inserting " + (i + 1) + " records");
 		}
 	}
@@ -193,48 +190,47 @@ public class RecordDaoTest {
 	@Test
 	@Transactional
 	void testRecordExists() {
-		assertFalse(recordDao.recordExists(instanceId, recordType.getName(), "aRecord"));
-		recordDao.batchUpsert(instanceId, recordType.getName(),
+		assertFalse(recordDao.recordExists(instanceId, recordType, "aRecord"));
+		recordDao.batchUpsert(instanceId, recordType,
 				Collections.singletonList(
 						new Record(new RecordId("aRecord"), recordType, new RecordAttributes((new HashMap<>())))),
 				new HashMap<>());
-		assertTrue(recordDao.recordExists(instanceId, recordType.getName(), "aRecord"));
+		assertTrue(recordDao.recordExists(instanceId, recordType, "aRecord"));
 	}
 
 	@Test
 	@Transactional
 	void testDeleteRecordType() {
 		// make sure type already exists
-		assertTrue(recordDao.recordTypeExists(instanceId, recordType.getName()));
-		recordDao.deleteRecordType(instanceId, recordType.getName());
+		assertTrue(recordDao.recordTypeExists(instanceId, recordType));
+		recordDao.deleteRecordType(instanceId, recordType);
 		// make sure type no longer exists
-		assertFalse(recordDao.recordTypeExists(instanceId, recordType.getName()));
+		assertFalse(recordDao.recordTypeExists(instanceId, recordType));
 	}
 
 	@Test
 	@Transactional
 	void testDeleteRecordTypeWithRelation() {
-		String recordTypeName = recordType.getName();
-		String referencedTypeName = "referencedType";
-		RecordType referencedType = new RecordType(referencedTypeName);
-		recordDao.createRecordType(instanceId, Collections.emptyMap(), referencedTypeName, Collections.emptySet());
+		RecordType recordTypeName = recordType;
+		RecordType referencedType = RecordType.valueOf("referencedType");
+		recordDao.createRecordType(instanceId, Collections.emptyMap(), referencedType, Collections.emptySet());
 
-		recordDao.addColumn(instanceId, recordTypeName, "relation", DataTypeMapping.STRING, referencedTypeName);
+		recordDao.addColumn(instanceId, recordTypeName, "relation", DataTypeMapping.STRING, referencedType);
 
 		RecordId refRecordId = new RecordId("referencedRecord");
 		Record referencedRecord = new Record(refRecordId, referencedType, new RecordAttributes(new HashMap<>()));
-		recordDao.batchUpsert(instanceId, referencedTypeName, Collections.singletonList(referencedRecord),
+		recordDao.batchUpsert(instanceId, referencedType, Collections.singletonList(referencedRecord),
 				new HashMap<>());
 
 		RecordId recordId = new RecordId("testRecord");
-		String reference = RelationUtils.createRelationString(referencedTypeName, refRecordId.getRecordIdentifier());
+		String reference = RelationUtils.createRelationString(referencedType, refRecordId.getRecordIdentifier());
 		Record testRecord = new Record(recordId, recordType, new RecordAttributes(Map.of("relation", reference)));
 		recordDao.batchUpsert(instanceId, recordTypeName, Collections.singletonList(testRecord),
 				new HashMap<>(Map.of("relation", DataTypeMapping.STRING)));
 
 		// Should throw an error
 		assertThrows(ResponseStatusException.class, () -> {
-			recordDao.deleteRecordType(instanceId, referencedTypeName);
+			recordDao.deleteRecordType(instanceId, referencedType);
 		}, "Exception should be thrown when attempting to delete record type with relation");
 	}
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
@@ -33,7 +33,7 @@ public class RecordDaoTest {
 	@BeforeEach
 	void setUp() {
 		instanceId = UUID.randomUUID();
-		recordType = RecordType.forUnitTest("testRecordType");
+		recordType = RecordType.valueOf("testRecordType");
 		recordDao.createSchema(instanceId);
 		recordDao.createRecordType(instanceId, Collections.emptyMap(), recordType, Collections.emptySet());
 	}
@@ -94,7 +94,7 @@ public class RecordDaoTest {
 		recordDao.batchUpsert(instanceId, recordType, Collections.singletonList(referencedRecord), new HashMap<>());
 
 		RecordId recordId = new RecordId("testRecord");
-		String reference = RelationUtils.createRelationString(RecordType.forUnitTest("testRecordType"),
+		String reference = RelationUtils.createRelationString(RecordType.valueOf("testRecordType"),
 				"referencedRecord");
 		Record testRecord = new Record(recordId, recordType, new RecordAttributes(Map.of("testRecordType", reference)));
 		recordDao.batchUpsert(instanceId, recordType, Collections.singletonList(testRecord),
@@ -141,14 +141,14 @@ public class RecordDaoTest {
 		recordDao.addColumn(instanceId, recordType, "foo", DataTypeMapping.STRING);
 
 		recordDao.addColumn(instanceId, recordType, "testRecordType", DataTypeMapping.STRING,
-				RecordType.forUnitTest("testRecordType"));
+				RecordType.valueOf("testRecordType"));
 
 		RecordId refRecordId = new RecordId("referencedRecord");
 		Record referencedRecord = new Record(refRecordId, recordType, new RecordAttributes(Map.of("foo", "bar")));
 		recordDao.batchUpsert(instanceId, recordType, Collections.singletonList(referencedRecord), new HashMap<>());
 
 		RecordId recordId = new RecordId("testRecord");
-		String reference = RelationUtils.createRelationString(RecordType.forUnitTest("testRecordType"),
+		String reference = RelationUtils.createRelationString(RecordType.valueOf("testRecordType"),
 				"referencedRecord");
 		Record testRecord = new Record(recordId, recordType, new RecordAttributes(Map.of("testRecordType", reference)));
 		recordDao.batchUpsert(instanceId, recordType, Collections.singletonList(testRecord),

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/SqlUtilsTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/SqlUtilsTest.java
@@ -1,0 +1,49 @@
+package org.databiosphere.workspacedataservice.dao;
+
+import org.databiosphere.workspacedataservice.service.model.exception.InvalidNameException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class SqlUtilsTest {
+
+    @Test
+    void testValidateSqlStringFailures() {
+        List<String> badStrings = List.of(
+                "); drop table users;",
+                "$$foo.bar",
+                "...",
+                "&Q$(*^@$(*",
+                "\\u0027\\u003b\\u0020\\u006f\\u0072\\u0020\\u0031\\u003d\\u0031\\u0020\\u0027\\u0027"
+                );
+        for (String badString : badStrings) {
+            assertThrows(InvalidNameException.class, () -> {
+                SqlUtils.validateSqlString(badString, InvalidNameException.NameType.RECORD_TYPE);
+            }, "for input '" + badString + "'");
+        }
+    }
+
+    @Test
+    void testValidateSqlStringSuccesses() {
+        List<String> goodStrings = List.of(
+                "droptable",
+                "where",
+                "sleep",
+                "in"
+        );
+        for (String goodString : goodStrings) {
+            assertDoesNotThrow(() -> {
+                SqlUtils.validateSqlString(goodString, InvalidNameException.NameType.RECORD_TYPE);
+            }, "for input '" + goodString + "'");
+        }
+    }
+
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/SqlUtilsTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/SqlUtilsTest.java
@@ -13,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class SqlUtilsTest {
+class SqlUtilsTest {
 
     @Test
     void testValidateSqlStringFailures() {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordResponseTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordResponseTest.java
@@ -21,7 +21,7 @@ public class RecordResponseTest {
 	@Test
 	void testJsonSerialization() throws JsonProcessingException {
 		RecordId recordId = new RecordId("test-id");
-		RecordType recordType = RecordType.fromSqlTableName("test-type");
+		RecordType recordType = RecordType.forUnitTest("test-type");
 		RecordAttributes recordAttributes = new RecordAttributes(
 				Map.of("foo", "bar", "num", 123, "bool", true, "anotherstring", "hello world"));
 		RecordMetadata recordMetadata = new RecordMetadata("test-provenance");

--- a/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordResponseTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordResponseTest.java
@@ -21,7 +21,7 @@ public class RecordResponseTest {
 	@Test
 	void testJsonSerialization() throws JsonProcessingException {
 		RecordId recordId = new RecordId("test-id");
-		RecordType recordType = new RecordType("test-type");
+		RecordType recordType = RecordType.fromSqlTableName("test-type");
 		RecordAttributes recordAttributes = new RecordAttributes(
 				Map.of("foo", "bar", "num", 123, "bool", true, "anotherstring", "hello world"));
 		RecordMetadata recordMetadata = new RecordMetadata("test-provenance");

--- a/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordResponseTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordResponseTest.java
@@ -21,7 +21,7 @@ public class RecordResponseTest {
 	@Test
 	void testJsonSerialization() throws JsonProcessingException {
 		RecordId recordId = new RecordId("test-id");
-		RecordType recordType = RecordType.forUnitTest("test-type");
+		RecordType recordType = RecordType.valueOf("test-type");
 		RecordAttributes recordAttributes = new RecordAttributes(
 				Map.of("foo", "bar", "num", 123, "bool", true, "anotherstring", "hello world"));
 		RecordMetadata recordMetadata = new RecordMetadata("test-provenance");

--- a/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordTest.java
@@ -33,7 +33,7 @@ public class RecordTest {
 	void testRecordTypeDeserialization() throws JsonProcessingException {
 		String input = "\"my-record-type\"";
 
-		RecordType expected = RecordType.forUnitTest("my-record-type");
+		RecordType expected = RecordType.valueOf("my-record-type");
 
 		RecordType actual = jacksonObjectMapper.readValue(input, RecordType.class);
 
@@ -63,7 +63,7 @@ public class RecordTest {
 		RecordAttributes recordAttributes = new RecordAttributes(
 				Map.of("foo", "bar", "num", 123, "bool", true, "anotherstring", "hello world"));
 
-		RecordType recordType = RecordType.forUnitTest("mytype");
+		RecordType recordType = RecordType.valueOf("mytype");
 		RecordId recordId = new RecordId("my-id");
 
 		Record expected = new Record(recordId, recordType, recordAttributes);

--- a/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordTest.java
@@ -1,0 +1,89 @@
+package org.databiosphere.workspacedataservice.shared.model;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class RecordTest {
+
+	@Autowired
+	private ObjectMapper jacksonObjectMapper;
+
+	@Test
+	void testRecordIdDeserialization() throws JsonProcessingException {
+		String input = "\"my-fancy-id\"";
+
+		RecordId expected = new RecordId("my-fancy-id");
+
+		RecordId actual = jacksonObjectMapper.readValue(input, RecordId.class);
+
+		assertEquals(expected, actual);
+	}
+
+	@Test
+	void testRecordTypeDeserialization() throws JsonProcessingException {
+		String input = "\"my-record-type\"";
+
+		RecordType expected = RecordType.forUnitTest("my-record-type");
+
+		RecordType actual = jacksonObjectMapper.readValue(input, RecordType.class);
+
+		assertEquals(expected, actual);
+	}
+
+	@Test
+	void testRecordAttributesDeserialization() throws JsonProcessingException {
+		RecordAttributes expected = new RecordAttributes(
+				Map.of("foo", "bar", "num", 123, "bool", true, "anotherstring", "hello world"));
+
+		String inputJsonString = """
+				{
+					"foo": "bar",
+					"num": 123,
+					"bool": true,
+					"anotherstring": "hello world"
+				}""";
+
+		RecordAttributes actual = jacksonObjectMapper.readValue(inputJsonString, RecordAttributes.class);
+
+		assertEquals(expected, actual, "Record attributes did not match.");
+	}
+
+	@Test
+	void testRecordDeserialization() throws JsonProcessingException {
+		RecordAttributes recordAttributes = new RecordAttributes(
+				Map.of("foo", "bar", "num", 123, "bool", true, "anotherstring", "hello world"));
+
+		RecordType recordType = RecordType.forUnitTest("mytype");
+		RecordId recordId = new RecordId("my-id");
+
+		Record expected = new Record(recordId, recordType, recordAttributes);
+
+		String inputJsonString = """
+				{
+				  "id": "my-id",
+				  "type": "mytype",
+				  "attributes": {
+				    "foo": "bar",
+				    "num": 123,
+				    "bool": true,
+				    "anotherstring": "hello world"
+				  }
+				}""";
+
+		Record actual = jacksonObjectMapper.readValue(inputJsonString, Record.class);
+
+		assertEquals(expected.getId(), actual.getId(), "Record ids did not match.");
+		assertEquals(expected.getAttributes(), actual.getAttributes(), "Record attributes did not match.");
+		assertEquals(expected.getRecordType(), actual.getRecordType(), "Record types did not match.");
+	}
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordTest.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class RecordTest {
+class RecordTest {
 
 	@Autowired
 	private ObjectMapper jacksonObjectMapper;


### PR DESCRIPTION
Highlights of this refactor:
* `RecordType` class is now immutable
* we perform validation in the RecordType constructor (starts with "sys_", is sql-legal)
* all methods that accept a record type as argument now accept RecordType instead of String, and we pass around RecordType instead of repeatedly transforming it to and from String
* we only translate RecordType to a String value where absolutely necessary, such as when using in a sql statement
* `toString` for RecordType now returns just the name value, making it easy to use a RecordType directly in url templates (such as inside unit tests)

There's a lot of lines of code that changed due to the pervasiveness of RecordType

After this PR merges, I'll make follow-on PRs:
- [ ] eliminate `RecordId` and replace with a plain `String`
- [ ] proposal to simplify `RecordAttributes`

