### PR TITLE
RecordAttributes model [AJ-507]

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -41,7 +41,7 @@ public class RecordController {
 				.getSingleRecord(instanceId, recordType, recordId, recordDao.getRelationCols(instanceId, recordType))
 				.orElseThrow(() -> new MissingObjectException("Record"));
 		RecordAttributes incomingAtts = recordRequest.recordAttributes();
-		RecordAttributes allAttrs = singleRecord.getAttributes().putAll(incomingAtts);
+		RecordAttributes allAttrs = singleRecord.putAllAttributes(incomingAtts).getAttributes();
 		Map<String, DataTypeMapping> typeMapping = inferer.inferTypes(incomingAtts);
 		Map<String, DataTypeMapping> existingTableSchema = recordDao.getExistingTableSchema(instanceId, recordType);
 		singleRecord.setAttributes(allAttrs);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -40,13 +40,11 @@ public class RecordController {
 		Record singleRecord = recordDao
 				.getSingleRecord(instanceId, recordType, recordId, recordDao.getRelationCols(instanceId, recordType))
 				.orElseThrow(() -> new MissingObjectException("Record"));
-		Map<String, Object> updatedAtts = recordRequest.recordAttributes().getAttributes();
-		Map<String, Object> allAttrs = new HashMap<>(singleRecord.getAttributes().getAttributes());
-		allAttrs.putAll(updatedAtts);
-
-		Map<String, DataTypeMapping> typeMapping = inferer.inferTypes(updatedAtts);
+		RecordAttributes incomingAtts = recordRequest.recordAttributes();
+		RecordAttributes allAttrs = singleRecord.getAttributes().putAll(incomingAtts);
+		Map<String, DataTypeMapping> typeMapping = inferer.inferTypes(incomingAtts);
 		Map<String, DataTypeMapping> existingTableSchema = recordDao.getExistingTableSchema(instanceId, recordType);
-		singleRecord.setAttributes(new RecordAttributes(allAttrs));
+		singleRecord.setAttributes(allAttrs);
 		List<Record> records = Collections.singletonList(singleRecord);
 		Map<String, DataTypeMapping> updatedSchema = addOrUpdateColumnIfNeeded(instanceId, recordType, typeMapping,
 				existingTableSchema, records);
@@ -156,7 +154,7 @@ public class RecordController {
 			@PathVariable("version") String version, @PathVariable("recordType") RecordType recordType,
 			@PathVariable("recordId") String recordId, @RequestBody RecordRequest recordRequest) {
 		validateVersion(version);
-		Map<String, Object> attributesInRequest = recordRequest.recordAttributes().getAttributes();
+		RecordAttributes attributesInRequest = recordRequest.recordAttributes();
 		Map<String, DataTypeMapping> requestSchema = inferer.inferTypes(attributesInRequest);
 		HttpStatus status = HttpStatus.CREATED;
 		if (!recordDao.instanceSchemaExists(instanceId)) {
@@ -182,7 +180,7 @@ public class RecordController {
 			combinedSchema.putAll(requestSchema);
 			recordDao.batchUpsert(instanceId, recordType, records, combinedSchema);
 			RecordResponse response = new RecordResponse(recordId, recordType,
-					new RecordAttributes(attributesInRequest), new RecordMetadata("TODO"));
+					attributesInRequest, new RecordMetadata("TODO"));
 			return new ResponseEntity<>(response, status);
 		}
 	}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -169,7 +169,7 @@ public class RecordController {
 		} else {
 			Map<String, DataTypeMapping> existingTableSchema = recordDao.getExistingTableSchema(instanceId, recordType);
 			// null out any attributes that already exist but aren't in the request
-			existingTableSchema.keySet().forEach(attr -> attributesInRequest.putIfAbsent(attr, null));
+			existingTableSchema.keySet().forEach(attr -> attributesInRequest.putAttributeIfAbsent(attr, null));
 			if (recordDao.recordExists(instanceId, recordType, recordId)) {
 				status = HttpStatus.OK;
 			}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -310,10 +310,10 @@ public class RecordDao {
 		@Override
 		public Record mapRow(ResultSet rs, int rowNum) throws SQLException {
 			return new Record(rs.getString(RECORD_ID), recordType,
-					new RecordAttributes(getAttributes(rs)));
+					getAttributes(rs));
 		}
 
-		private Map<String, Object> getAttributes(ResultSet rs) {
+		private RecordAttributes getAttributes(ResultSet rs) {
 			try {
 				ResultSetMetaData metaData = rs.getMetaData();
 				Map<String, Object> attributes = new HashMap<>();
@@ -331,7 +331,7 @@ public class RecordDao {
 						attributes.put(columnName, object instanceof PGobject pGobject ? pGobject.getValue() : object);
 					}
 				}
-				return attributes;
+				return new RecordAttributes(attributes);
 			} catch (SQLException e) {
 				throw new RuntimeException(e);
 			}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -281,7 +281,7 @@ public class RecordDao {
 			if (colName.equals(RECORD_ID)) {
 				row[i++] = toInsert.getId();
 			} else {
-				row[i++] = getValueForSql(toInsert.getAttributes().getAttributes().get(colName), col.typeMapping());
+				row[i++] = getValueForSql(toInsert.getAttributes().get(colName), col.typeMapping());
 			}
 		}
 		return row;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -281,7 +281,7 @@ public class RecordDao {
 			if (colName.equals(RECORD_ID)) {
 				row[i++] = toInsert.getId();
 			} else {
-				row[i++] = getValueForSql(toInsert.getAttributes().get(colName), col.typeMapping());
+				row[i++] = getValueForSql(toInsert.getAttributes().getAttributeValue(colName), col.typeMapping());
 			}
 		}
 		return row;
@@ -324,11 +324,11 @@ public class RecordDao {
 						continue;
 					}
 					if (referenceColToTable.size() > 0 && referenceColToTable.containsKey(columnName)) {
-						attributes.put(columnName, RelationUtils
+						attributes.putAttribute(columnName, RelationUtils
 								.createRelationString(referenceColToTable.get(columnName), rs.getString(columnName)));
 					} else {
 						Object object = rs.getObject(columnName);
-						attributes.put(columnName, object instanceof PGobject pGobject ? pGobject.getValue() : object);
+						attributes.putAttribute(columnName, object instanceof PGobject pGobject ? pGobject.getValue() : object);
 					}
 				}
 				return attributes;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -281,7 +281,7 @@ public class RecordDao {
 			if (colName.equals(RECORD_ID)) {
 				row[i++] = toInsert.getId();
 			} else {
-				row[i++] = getValueForSql(toInsert.getAttributes().getAttributeValue(colName), col.typeMapping());
+				row[i++] = getValueForSql(toInsert.getAttributeValue(colName), col.typeMapping());
 			}
 		}
 		return row;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -316,7 +316,7 @@ public class RecordDao {
 		private RecordAttributes getAttributes(ResultSet rs) {
 			try {
 				ResultSetMetaData metaData = rs.getMetaData();
-				Map<String, Object> attributes = new HashMap<>();
+				RecordAttributes attributes = RecordAttributes.empty();
 
 				for (int j = 1; j <= metaData.getColumnCount(); j++) {
 					String columnName = metaData.getColumnName(j);
@@ -331,7 +331,7 @@ public class RecordDao {
 						attributes.put(columnName, object instanceof PGobject pGobject ? pGobject.getValue() : object);
 					}
 				}
-				return new RecordAttributes(attributes);
+				return attributes;
 			} catch (SQLException e) {
 				throw new RuntimeException(e);
 			}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/DataTypeInferer.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/DataTypeInferer.java
@@ -19,7 +19,7 @@ public class DataTypeInferer {
 
 	public Map<String, DataTypeMapping> inferTypes(RecordAttributes updatedAtts) {
 		Map<String, DataTypeMapping> result = new HashMap<>();
-		for (Map.Entry<String, Object> entry : updatedAtts.getAttributes().entrySet()) {
+		for (Map.Entry<String, Object> entry : updatedAtts.entrySet()) {
 			result.put(entry.getKey(), inferType(entry.getValue()));
 		}
 		return result;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/DataTypeInferer.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/DataTypeInferer.java
@@ -11,14 +11,15 @@ import java.time.format.DateTimeParseException;
 import java.util.HashMap;
 import java.util.Map;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
+import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
 
 public class DataTypeInferer {
 
 	private ObjectMapper objectMapper = new ObjectMapper();
 
-	public Map<String, DataTypeMapping> inferTypes(Map<String, Object> updatedAtts) {
+	public Map<String, DataTypeMapping> inferTypes(RecordAttributes updatedAtts) {
 		Map<String, DataTypeMapping> result = new HashMap<>();
-		for (Map.Entry<String, Object> entry : updatedAtts.entrySet()) {
+		for (Map.Entry<String, Object> entry : updatedAtts.getAttributes().entrySet()) {
 			result.put(entry.getKey(), inferType(entry.getValue()));
 		}
 		return result;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/DataTypeInferer.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/DataTypeInferer.java
@@ -19,7 +19,7 @@ public class DataTypeInferer {
 
 	public Map<String, DataTypeMapping> inferTypes(RecordAttributes updatedAtts) {
 		Map<String, DataTypeMapping> result = new HashMap<>();
-		for (Map.Entry<String, Object> entry : updatedAtts.entrySet()) {
+		for (Map.Entry<String, Object> entry : updatedAtts.attributeSet()) {
 			result.put(entry.getKey(), inferType(entry.getValue()));
 		}
 		return result;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/RelationUtils.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/RelationUtils.java
@@ -26,10 +26,9 @@ public class RelationUtils {
 	public static Set<Relation> findRelations(List<Record> records) {
 		Set<Relation> result = new HashSet<>();
 		for (Record record : records) {
-			Map<String, Object> attributes = record.getAttributes().getAttributes();
-			for (String attr : attributes.keySet()) {
-				if (isRelationValue(attributes.get(attr))) {
-					result.add(new Relation(attr, getTypeValue(attributes.get(attr))));
+			for (Map.Entry<String, Object> entry : record.getAttributes().entrySet()) {
+				if (isRelationValue(entry.getValue())) {
+					result.add(new Relation(entry.getKey(), getTypeValue(entry.getValue())));
 				}
 			}
 		}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/RelationUtils.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/RelationUtils.java
@@ -26,7 +26,7 @@ public class RelationUtils {
 	public static Set<Relation> findRelations(List<Record> records) {
 		Set<Relation> result = new HashSet<>();
 		for (Record record : records) {
-			for (Map.Entry<String, Object> entry : record.getAttributes().attributeSet()) {
+			for (Map.Entry<String, Object> entry : record.attributeSet()) {
 				if (isRelationValue(entry.getValue())) {
 					result.add(new Relation(entry.getKey(), getTypeValue(entry.getValue())));
 				}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/RelationUtils.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/RelationUtils.java
@@ -26,7 +26,7 @@ public class RelationUtils {
 	public static Set<Relation> findRelations(List<Record> records) {
 		Set<Relation> result = new HashSet<>();
 		for (Record record : records) {
-			for (Map.Entry<String, Object> entry : record.getAttributes().entrySet()) {
+			for (Map.Entry<String, Object> entry : record.getAttributes().attributeSet()) {
 				if (isRelationValue(entry.getValue())) {
 					result.add(new Relation(entry.getKey(), getTypeValue(entry.getValue())));
 				}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/Record.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/Record.java
@@ -66,20 +66,6 @@ public class Record {
 		return this;
 	}
 
-//	public Record putAll(RecordAttributes incoming) {
-//		this.attributes.putAll(incoming);
-//	}
-//
-//	public Record putAttribute(String key, Object value)  {
-//		this.attributes.putAttribute(key, value);
-//	}
-//
-//	public Record putAttributeIfAbsent(String key, Object value) {
-//		this.attributes.putAttributeIfAbsent(key, value);
-//		return this;
-//	}
-
-
 	public RecordType getRecordType() {
 		return recordType;
 	}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/Record.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/Record.java
@@ -4,6 +4,9 @@ import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Map;
+import java.util.Set;
+
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Record {
 
@@ -48,6 +51,34 @@ public class Record {
 	public void setAttributes(RecordAttributes attributes) {
 		this.attributes = attributes;
 	}
+
+	// convenience methods for attribute manipulation
+	public Object getAttributeValue(String attributeName) {
+		return this.attributes.getAttributeValue(attributeName);
+	}
+
+	public Set<Map.Entry<String, Object>> attributeSet() {
+		return this.attributes.attributeSet();
+	}
+
+	public Record putAllAttributes(RecordAttributes incoming) {
+		this.attributes.putAll(incoming);
+		return this;
+	}
+
+//	public Record putAll(RecordAttributes incoming) {
+//		this.attributes.putAll(incoming);
+//	}
+//
+//	public Record putAttribute(String key, Object value)  {
+//		this.attributes.putAttribute(key, value);
+//	}
+//
+//	public Record putAttributeIfAbsent(String key, Object value) {
+//		this.attributes.putAttributeIfAbsent(key, value);
+//		return this;
+//	}
+
 
 	public RecordType getRecordType() {
 		return recordType;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributes.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributes.java
@@ -11,8 +11,7 @@ public class RecordAttributes {
 
 	// TODO: want to use Guava ImmutableMap, or even Java unmodifiable maps, but they don't allow null values
 	// use sorted map internally so getAttributes is automatically sorted
-	final private TreeMap<String, Object> attributes;
-
+	private final TreeMap<String, Object> attributes;
 
 	@JsonCreator
 	public RecordAttributes(Map<String, Object> attributes) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributes.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributes.java
@@ -39,6 +39,7 @@ public class RecordAttributes {
 
 	// when serializing to json, delegate to the internal map.
 	// this is private so callers aren't tempted to use it
+	@SuppressWarnings("unused") // used by JsonValue but nothing else, intentionally
 	@JsonValue
 	private Map<String, Object> getAttributes() {
 		return attributes;
@@ -55,27 +56,26 @@ public class RecordAttributes {
 		return this.attributes.get(attributeName);
 	}
 
-	public boolean containsAttribute(String attributeName) {
-		return this.attributes.containsKey(attributeName);
-	}
-
 	public Set<Map.Entry<String, Object>> attributeSet() {
 		return this.attributes.entrySet();
+	}
+
+	/* not currently used, but could be useful in the future
+
+	public boolean containsAttribute(String attributeName) {
+		return this.attributes.containsKey(attributeName);
 	}
 
 	public Set<String> attributeNameSet() {
 		return this.attributes.keySet();
 	}
+	*/
 
 	// ========== mutators
 
-	private RecordAttributes putAll(Map<String, Object> incoming) {
-		this.attributes.putAll(incoming);
-		return this;
-	}
-
 	public RecordAttributes putAll(RecordAttributes incoming) {
-		return putAll(incoming.attributes);
+		this.attributes.putAll(incoming.attributes);
+		return this;
 	}
 
 	public RecordAttributes putAttribute(String key, Object value)  {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributes.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributes.java
@@ -5,12 +5,16 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 import java.util.*;
 
+/**
+ * Represents the attributes of a Record.
+ */
 public class RecordAttributes {
 
 	// internal representation is a sorted map, so json serialization
 	// is nicely sorted without additional work upon render
 	private final TreeMap<String, Object> attributes;
-	// TODO: want to use Guava ImmutableMap, or even Java unmodifiable maps, but they don't allow null values
+	// want to use Guava ImmutableMap, or even Java unmodifiable maps, but they don't allow null values
+	// and nulls are necessary since we may have them in the db
 
 	// ========== members and constructors
 
@@ -71,7 +75,7 @@ public class RecordAttributes {
 	}
 
 	public RecordAttributes putAll(RecordAttributes incoming) {
-		return putAll(incoming.getAttributes());
+		return putAll(incoming.attributes);
 	}
 
 	public RecordAttributes putAttribute(String key, Object value)  {
@@ -84,7 +88,7 @@ public class RecordAttributes {
 		return this;
 	}
 
-	// ========== util methods
+	// ========== utils
 
 	@Override
 	public String toString() {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributes.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributes.java
@@ -2,24 +2,77 @@ package org.databiosphere.workspacedataservice.shared.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+//import com.google.common.collect.ImmutableMap;
+//import com.google.common.collect.ImmutableSortedMap;
+//import graphql.collect.ImmutableMapWithNullValues;
+
 import java.util.Map;
 import java.util.Objects;
 import java.util.TreeMap;
 
 public class RecordAttributes {
 
-	private Map<String, Object> attributes;
+	// ========== members and constructors
+
+	// private ImmutableSortedMap<String, Object> attributes;
+	// private ImmutableMapWithNullValues<String, Object> attributes;
+	// use sorted map internally so getAttributes is automatically sorted
+	private TreeMap<String, Object> attributes;
+
 
 	@JsonCreator
 	public RecordAttributes(Map<String, Object> attributes) {
-		this.attributes = attributes;
+		this.attributes = new TreeMap<>(attributes);
 	}
+
+	// TODO: assess how this is used
+	// ========== getAttributes
 
 	// when serializing to json, sort attribute keys
 	@JsonValue
 	public Map<String, Object> getAttributes() {
-		return new TreeMap<>(attributes);
+		return attributes;
 	}
+
+	// ========== accessors
+
+	// TODO: implement iterator
+
+	/**
+	 * Retrieve the value for a single named attribute
+	 * 
+	 * @param attributeName
+	 *            name of the attribute to retrieve
+	 * @return the value of the named attribute
+	 */
+	public Object get(String attributeName) {
+		return this.attributes.get(attributeName);
+	}
+
+	/**
+	 * find all relation attributes
+	 */
+	public void getRelations() {
+		// TODO
+	}
+
+	// ========== mutators
+
+	public RecordAttributes putAll(Map<String, Object> incoming) {
+		this.attributes.putAll(incoming);
+		return this;
+	}
+
+	public RecordAttributes putAll(RecordAttributes incoming) {
+		return putAll(incoming.getAttributes());
+	}
+
+	public RecordAttributes putIfAbsent(String key, Object value) {
+		this.attributes.putIfAbsent(key, value);
+		return this;
+	}
+
+	// ========== util methods
 
 	@Override
 	public String toString() {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributes.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributes.java
@@ -2,27 +2,25 @@ package org.databiosphere.workspacedataservice.shared.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-//import com.google.common.collect.ImmutableMap;
-//import com.google.common.collect.ImmutableSortedMap;
-//import graphql.collect.ImmutableMapWithNullValues;
 
-import java.util.Map;
-import java.util.Objects;
-import java.util.TreeMap;
+import java.util.*;
 
 public class RecordAttributes {
 
 	// ========== members and constructors
 
-	// private ImmutableSortedMap<String, Object> attributes;
-	// private ImmutableMapWithNullValues<String, Object> attributes;
+	// TODO: want to use Guava ImmutableMap, or even Java unmodifiable maps, but they don't allow null values
 	// use sorted map internally so getAttributes is automatically sorted
-	private TreeMap<String, Object> attributes;
+	final private TreeMap<String, Object> attributes;
 
 
 	@JsonCreator
 	public RecordAttributes(Map<String, Object> attributes) {
 		this.attributes = new TreeMap<>(attributes);
+	}
+
+	public static RecordAttributes empty() {
+		return new RecordAttributes(Collections.emptyMap());
 	}
 
 	// TODO: assess how this is used
@@ -35,9 +33,6 @@ public class RecordAttributes {
 	}
 
 	// ========== accessors
-
-	// TODO: implement iterator
-
 	/**
 	 * Retrieve the value for a single named attribute
 	 * 
@@ -49,11 +44,8 @@ public class RecordAttributes {
 		return this.attributes.get(attributeName);
 	}
 
-	/**
-	 * find all relation attributes
-	 */
-	public void getRelations() {
-		// TODO
+	public Set<Map.Entry<String, Object>> entrySet() {
+		return this.attributes.entrySet();
 	}
 
 	// ========== mutators
@@ -67,9 +59,12 @@ public class RecordAttributes {
 		return putAll(incoming.getAttributes());
 	}
 
-	public RecordAttributes putIfAbsent(String key, Object value) {
+	public void put(String key, Object value)  {
+		this.attributes.put(key, value);
+	}
+
+	public void putIfAbsent(String key, Object value) {
 		this.attributes.putIfAbsent(key, value);
-		return this;
 	}
 
 	// ========== util methods

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributes.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributes.java
@@ -60,17 +60,6 @@ public class RecordAttributes {
 		return this.attributes.entrySet();
 	}
 
-	/* not currently used, but could be useful in the future
-
-	public boolean containsAttribute(String attributeName) {
-		return this.attributes.containsKey(attributeName);
-	}
-
-	public Set<String> attributeNameSet() {
-		return this.attributes.keySet();
-	}
-	*/
-
 	// ========== mutators
 
 	public RecordAttributes putAll(RecordAttributes incoming) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributes.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributes.java
@@ -7,31 +7,39 @@ import java.util.*;
 
 public class RecordAttributes {
 
+	// internal representation is a sorted map, so json serialization
+	// is nicely sorted without additional work upon render
+	private final TreeMap<String, Object> attributes;
+	// TODO: want to use Guava ImmutableMap, or even Java unmodifiable maps, but they don't allow null values
+
 	// ========== members and constructors
 
-	// TODO: want to use Guava ImmutableMap, or even Java unmodifiable maps, but they don't allow null values
-	// use sorted map internally so getAttributes is automatically sorted
-	private final TreeMap<String, Object> attributes;
-
+	/**
+	 * Generic constructor, also used as the JsonCreator.
+	 * @param attributes the map of attribute names->values to use for this RecordAttributes.
+	 */
 	@JsonCreator
 	public RecordAttributes(Map<String, Object> attributes) {
 		this.attributes = new TreeMap<>(attributes);
 	}
 
+	/**
+	 * creates a RecordAttributes with no keys/values
+	 * @return the empty RecordAttributes object
+	 */
 	public static RecordAttributes empty() {
 		return new RecordAttributes(Collections.emptyMap());
 	}
 
-	// TODO: assess how this is used
-	// ========== getAttributes
+	// ========== accessors
 
-	// when serializing to json, sort attribute keys
+	// when serializing to json, delegate to the internal map.
+	// this is private so callers aren't tempted to use it
 	@JsonValue
-	public Map<String, Object> getAttributes() {
+	private Map<String, Object> getAttributes() {
 		return attributes;
 	}
 
-	// ========== accessors
 	/**
 	 * Retrieve the value for a single named attribute
 	 * 
@@ -39,17 +47,25 @@ public class RecordAttributes {
 	 *            name of the attribute to retrieve
 	 * @return the value of the named attribute
 	 */
-	public Object get(String attributeName) {
+	public Object getAttributeValue(String attributeName) {
 		return this.attributes.get(attributeName);
 	}
 
-	public Set<Map.Entry<String, Object>> entrySet() {
+	public boolean containsAttribute(String attributeName) {
+		return this.attributes.containsKey(attributeName);
+	}
+
+	public Set<Map.Entry<String, Object>> attributeSet() {
 		return this.attributes.entrySet();
+	}
+
+	public Set<String> attributeNameSet() {
+		return this.attributes.keySet();
 	}
 
 	// ========== mutators
 
-	public RecordAttributes putAll(Map<String, Object> incoming) {
+	private RecordAttributes putAll(Map<String, Object> incoming) {
 		this.attributes.putAll(incoming);
 		return this;
 	}
@@ -58,12 +74,14 @@ public class RecordAttributes {
 		return putAll(incoming.getAttributes());
 	}
 
-	public void put(String key, Object value)  {
+	public RecordAttributes putAttribute(String key, Object value)  {
 		this.attributes.put(key, value);
+		return this;
 	}
 
-	public void putIfAbsent(String key, Object value) {
+	public RecordAttributes putAttributeIfAbsent(String key, Object value) {
 		this.attributes.putIfAbsent(key, value);
+		return this;
 	}
 
 	// ========== util methods

--- a/service/src/test/java/org/databiosphere/workspacedataservice/DataTypeInfererTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/DataTypeInfererTest.java
@@ -7,6 +7,7 @@ import java.util.*;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.databiosphere.workspacedataservice.service.DataTypeInferer;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
+import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
 import org.junit.jupiter.api.Test;
 
 class DataTypeInfererTest {
@@ -47,8 +48,9 @@ class DataTypeInfererTest {
 		assertThat(inferer.inferType("[\"12345\"]")).isEqualTo(DataTypeMapping.JSON);
 	}
 
-	private static Map<String, Object> getSomeAttrs() {
-		return Map.of("int_val", new Random().nextInt(), "string_val", RandomStringUtils.random(10), "json_val",
-				"[\"a\", \"b\"]", "date_val", "2001-11-03", "date_time_val", "2001-11-03T10:00:00");
+	private static RecordAttributes getSomeAttrs() {
+		return new RecordAttributes(
+			Map.of("int_val", new Random().nextInt(), "string_val", RandomStringUtils.random(10), "json_val",
+				"[\"a\", \"b\"]", "date_val", "2001-11-03", "date_time_val", "2001-11-03T10:00:00"));
 	}
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/TestUtils.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/TestUtils.java
@@ -4,9 +4,6 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
 
-import java.util.HashMap;
-import java.util.Map;
-
 public class TestUtils {
 
 	private TestUtils() {
@@ -15,14 +12,14 @@ public class TestUtils {
 
 	public static RecordAttributes generateRandomAttributes() {
 		RecordAttributes attributes = RecordAttributes.empty();
-		attributes.put("attr1", RandomStringUtils.randomAlphabetic(6));
-		attributes.put("attr2", RandomUtils.nextFloat());
-		attributes.put("attr3", "2022-11-01");
-		attributes.put("attr4", RandomStringUtils.randomNumeric(5));
-		attributes.put("attr5", RandomUtils.nextLong());
-		attributes.put("attr-dt", "2022-03-01T12:00:03");
-		attributes.put("attr-json", "{\"foo\":\"bar\"}");
-		attributes.put("attr-boolean", true);
+		attributes.putAttribute("attr1", RandomStringUtils.randomAlphabetic(6));
+		attributes.putAttribute("attr2", RandomUtils.nextFloat());
+		attributes.putAttribute("attr3", "2022-11-01");
+		attributes.putAttribute("attr4", RandomStringUtils.randomNumeric(5));
+		attributes.putAttribute("attr5", RandomUtils.nextLong());
+		attributes.putAttribute("attr-dt", "2022-03-01T12:00:03");
+		attributes.putAttribute("attr-json", "{\"foo\":\"bar\"}");
+		attributes.putAttribute("attr-boolean", true);
 		return attributes;
 	}
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/TestUtils.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/TestUtils.java
@@ -2,6 +2,7 @@ package org.databiosphere.workspacedataservice;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
+import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -12,7 +13,7 @@ public class TestUtils {
 
 	}
 
-	public static Map<String, Object> generateRandomAttributes() {
+	public static RecordAttributes generateRandomAttributes() {
 		Map<String, Object> attributes = new HashMap<>();
 		attributes.put("attr1", RandomStringUtils.randomAlphabetic(6));
 		attributes.put("attr2", RandomUtils.nextFloat());
@@ -22,6 +23,6 @@ public class TestUtils {
 		attributes.put("attr-dt", "2022-03-01T12:00:03");
 		attributes.put("attr-json", "{\"foo\":\"bar\"}");
 		attributes.put("attr-boolean", true);
-		return attributes;
+		return new RecordAttributes(attributes);
 	}
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/TestUtils.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/TestUtils.java
@@ -14,7 +14,7 @@ public class TestUtils {
 	}
 
 	public static RecordAttributes generateRandomAttributes() {
-		Map<String, Object> attributes = new HashMap<>();
+		RecordAttributes attributes = RecordAttributes.empty();
 		attributes.put("attr1", RandomStringUtils.randomAlphabetic(6));
 		attributes.put("attr2", RandomUtils.nextFloat());
 		attributes.put("attr3", "2022-11-01");
@@ -23,6 +23,6 @@ public class TestUtils {
 		attributes.put("attr-dt", "2022-03-01T12:00:03");
 		attributes.put("attr-json", "{\"foo\":\"bar\"}");
 		attributes.put("attr-boolean", true);
-		return new RecordAttributes(attributes);
+		return attributes;
 	}
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/TestUtils.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/TestUtils.java
@@ -11,15 +11,14 @@ public class TestUtils {
 	}
 
 	public static RecordAttributes generateRandomAttributes() {
-		RecordAttributes attributes = RecordAttributes.empty();
-		attributes.putAttribute("attr1", RandomStringUtils.randomAlphabetic(6));
-		attributes.putAttribute("attr2", RandomUtils.nextFloat());
-		attributes.putAttribute("attr3", "2022-11-01");
-		attributes.putAttribute("attr4", RandomStringUtils.randomNumeric(5));
-		attributes.putAttribute("attr5", RandomUtils.nextLong());
-		attributes.putAttribute("attr-dt", "2022-03-01T12:00:03");
-		attributes.putAttribute("attr-json", "{\"foo\":\"bar\"}");
-		attributes.putAttribute("attr-boolean", true);
-		return attributes;
+		return RecordAttributes.empty()
+				.putAttribute("attr1", RandomStringUtils.randomAlphabetic(6))
+				.putAttribute("attr2", RandomUtils.nextFloat())
+				.putAttribute("attr3", "2022-11-01")
+				.putAttribute("attr4", RandomStringUtils.randomNumeric(5))
+				.putAttribute("attr5", RandomUtils.nextLong())
+				.putAttribute("attr-dt", "2022-03-01T12:00:03")
+				.putAttribute("attr-json", "{\"foo\":\"bar\"}")
+				.putAttribute("attr-boolean", true);
 	}
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
@@ -120,10 +120,10 @@ class FullStackRecordControllerTest {
 	void testBadAttributeNames() throws JsonProcessingException {
 		List<String> badNames = List.of("create table buttheads(id int)", "samples\n11", "##magic beans!");
 		for (String badName : badNames) {
-			HashMap<String, Object> attributes = new HashMap<>();
+			RecordAttributes attributes = RecordAttributes.empty();
 			attributes.put(badName, "foo");
 			HttpEntity<String> requestEntity = new HttpEntity<>(
-					mapper.writeValueAsString(new RecordRequest(new RecordAttributes(attributes))), headers);
+					mapper.writeValueAsString(new RecordRequest(attributes)), headers);
 			ResponseEntity<ErrorResponse> response = restTemplate.exchange(
 					"/{instanceId}/records/{version}/{recordType}/{recordId}", HttpMethod.PUT, requestEntity,
 					ErrorResponse.class, instanceId, versionId, "sample", "sample_1");
@@ -136,11 +136,11 @@ class FullStackRecordControllerTest {
 	@Test
 	@Transactional
 	void missingReferencedRecordTypeShouldFail() throws JsonProcessingException {
-		Map<String, Object> attrs = new HashMap<>();
+		RecordAttributes attrs = RecordAttributes.empty();
 		attrs.put("attr_ref", RelationUtils.createRelationString(RecordType.valueOf("non_existent"), "recordId"));
 		attrs.put("attr_ref_2", RelationUtils.createRelationString(RecordType.valueOf("non_existent_2"), "recordId"));
 		HttpEntity<String> requestEntity = new HttpEntity<>(
-				mapper.writeValueAsString(new RecordRequest(new RecordAttributes(attrs))), headers);
+				mapper.writeValueAsString(new RecordRequest(attrs)), headers);
 		ResponseEntity<ErrorResponse> response = restTemplate.exchange(
 				"/{instanceId}/records/{version}/{recordType}/{recordId}", HttpMethod.PUT, requestEntity,
 				ErrorResponse.class, instanceId, versionId, "samples-1", "sample_1");
@@ -152,12 +152,12 @@ class FullStackRecordControllerTest {
 	@Test
 	@Transactional
 	void referencingMissingRecordShouldFail() throws Exception {
-		Map<String, Object> attrs = new HashMap<>();
+		RecordAttributes attrs = RecordAttributes.empty();
 		RecordType referencedRecordType = RecordType.valueOf("referenced-type");
 		createSomeRecords(referencedRecordType, 1);
 		attrs.put("attr_ref", RelationUtils.createRelationString(referencedRecordType, "missing-id"));
 		HttpEntity<String> requestEntity = new HttpEntity<>(
-				mapper.writeValueAsString(new RecordRequest(new RecordAttributes(attrs))), headers);
+				mapper.writeValueAsString(new RecordRequest(attrs)), headers);
 		ResponseEntity<ErrorResponse> response = restTemplate.exchange(
 				"/{instanceId}/records/{version}/{recordType}/{recordId}", HttpMethod.PUT, requestEntity,
 				ErrorResponse.class, instanceId, versionId, "samples-2", "sample_1");
@@ -195,10 +195,10 @@ class FullStackRecordControllerTest {
 			String recordId = recordIdSupplier == null || recordIdSupplier.length == 0
 					? "record_" + i
 					: recordIdSupplier[0].get();
-			Map<String, Object> attributes = generateRandomAttributes();
+			RecordAttributes attributes = generateRandomAttributes();
 			ResponseEntity<String> response = restTemplate.exchange(
 					"/{instanceId}/records/{version}/{recordType}/{recordId}", HttpMethod.PUT,
-					new HttpEntity<>(mapper.writeValueAsString(new RecordRequest(new RecordAttributes(attributes))),
+					new HttpEntity<>(mapper.writeValueAsString(new RecordRequest(attributes)),
 							headers),
 					String.class, instanceId, versionId, recordType, recordId);
 			assertThat(response.getStatusCode()).isIn(HttpStatus.CREATED, HttpStatus.OK);

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
@@ -121,7 +121,7 @@ class FullStackRecordControllerTest {
 		List<String> badNames = List.of("create table buttheads(id int)", "samples\n11", "##magic beans!");
 		for (String badName : badNames) {
 			RecordAttributes attributes = RecordAttributes.empty();
-			attributes.put(badName, "foo");
+			attributes.putAttribute(badName, "foo");
 			HttpEntity<String> requestEntity = new HttpEntity<>(
 					mapper.writeValueAsString(new RecordRequest(attributes)), headers);
 			ResponseEntity<ErrorResponse> response = restTemplate.exchange(
@@ -137,8 +137,8 @@ class FullStackRecordControllerTest {
 	@Transactional
 	void missingReferencedRecordTypeShouldFail() throws JsonProcessingException {
 		RecordAttributes attrs = RecordAttributes.empty();
-		attrs.put("attr_ref", RelationUtils.createRelationString(RecordType.valueOf("non_existent"), "recordId"));
-		attrs.put("attr_ref_2", RelationUtils.createRelationString(RecordType.valueOf("non_existent_2"), "recordId"));
+		attrs.putAttribute("attr_ref", RelationUtils.createRelationString(RecordType.valueOf("non_existent"), "recordId"));
+		attrs.putAttribute("attr_ref_2", RelationUtils.createRelationString(RecordType.valueOf("non_existent_2"), "recordId"));
 		HttpEntity<String> requestEntity = new HttpEntity<>(
 				mapper.writeValueAsString(new RecordRequest(attrs)), headers);
 		ResponseEntity<ErrorResponse> response = restTemplate.exchange(
@@ -155,7 +155,7 @@ class FullStackRecordControllerTest {
 		RecordAttributes attrs = RecordAttributes.empty();
 		RecordType referencedRecordType = RecordType.valueOf("referenced-type");
 		createSomeRecords(referencedRecordType, 1);
-		attrs.put("attr_ref", RelationUtils.createRelationString(referencedRecordType, "missing-id"));
+		attrs.putAttribute("attr_ref", RelationUtils.createRelationString(referencedRecordType, "missing-id"));
 		HttpEntity<String> requestEntity = new HttpEntity<>(
 				mapper.writeValueAsString(new RecordRequest(attrs)), headers);
 		ResponseEntity<ErrorResponse> response = restTemplate.exchange(

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
@@ -46,7 +46,7 @@ class FullStackRecordControllerTest {
 	@Transactional
 	void testBadRecordTypeNames() throws JsonProcessingException {
 		HttpEntity<String> requestEntity = new HttpEntity<>(
-				mapper.writeValueAsString(new RecordRequest(new RecordAttributes(new HashMap<>()))), headers);
+				mapper.writeValueAsString(new RecordRequest(RecordAttributes.empty())), headers);
 		List<String> badNames = List.of("); drop table users;", "$$foo.bar", "...", "&Q$(*^@$(*");
 		for (String badName : badNames) {
 			ResponseEntity<ErrorResponse> response = restTemplate.exchange(

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -89,7 +89,7 @@ class RecordControllerMockMvcTest {
 		RecordType recordType1 = RecordType.valueOf("illegalName");
 		createSomeRecords(recordType1, 1);
 		RecordAttributes illegalAttribute = RecordAttributes.empty();
-		illegalAttribute.put("sys_foo", "some_val");
+		illegalAttribute.putAttribute("sys_foo", "some_val");
 		mockMvc.perform(patch("/{instanceId}/records/{versionId}/{recordType}/{recordId}", instanceId, versionId,
 				recordType1, "record_0").contentType(MediaType.APPLICATION_JSON)
 						.content(mapper.writeValueAsString(new RecordRequest(illegalAttribute))))
@@ -127,7 +127,7 @@ class RecordControllerMockMvcTest {
 		RecordType recordType1 = RecordType.valueOf("recordType1");
 		createSomeRecords(recordType1, 1);
 		RecordAttributes newAttributes = RecordAttributes.empty();
-		newAttributes.put("new-attr", "some_val");
+		newAttributes.putAttribute("new-attr", "some_val");
 		mockMvc.perform(put("/{instanceId}/records/{versionId}/{recordType}/{recordId}", instanceId, versionId,
 				recordType1, "record_0").contentType(MediaType.APPLICATION_JSON)
 						.content(mapper.writeValueAsString(new RecordRequest(newAttributes))))
@@ -140,7 +140,7 @@ class RecordControllerMockMvcTest {
 		RecordType recordType1 = RecordType.valueOf("recordType1");
 		createSomeRecords(recordType1, 1);
 		RecordAttributes newAttributes = RecordAttributes.empty();
-		newAttributes.put("new-attr", "some_val");
+		newAttributes.putAttribute("new-attr", "some_val");
 		mockMvc.perform(patch("/{instanceId}/records/{versionId}/{recordType}/{recordId}", instanceId, versionId,
 				recordType1, "record_0").contentType(MediaType.APPLICATION_JSON)
 						.content(mapper.writeValueAsString(new RecordRequest(newAttributes))))
@@ -165,7 +165,7 @@ class RecordControllerMockMvcTest {
 		createSomeRecords(referringType, 1);
 		RecordAttributes attributes = RecordAttributes.empty();
 		String ref = RelationUtils.createRelationString(referencedType, "record_0");
-		attributes.put("sample-ref", ref);
+		attributes.putAttribute("sample-ref", ref);
 		mockMvc.perform(patch("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 				referringType, "record_0").contentType(MediaType.APPLICATION_JSON)
 						.content(mapper.writeValueAsString(new RecordRequest(attributes))))
@@ -180,7 +180,7 @@ class RecordControllerMockMvcTest {
 		createSomeRecords(referringType, 1);
 		RecordAttributes attributes = RecordAttributes.empty();
 		String ref = RelationUtils.createRelationString(referencedType, "record_0");
-		attributes.put("sample-ref", ref);
+		attributes.putAttribute("sample-ref", ref);
 		mockMvc.perform(put("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 				referringType, "record_0").contentType(MediaType.APPLICATION_JSON)
 						.content(mapper.writeValueAsString(new RecordRequest(attributes))))
@@ -197,7 +197,7 @@ class RecordControllerMockMvcTest {
 		createSomeRecords(referringType, 1);
 		RecordAttributes attributes = RecordAttributes.empty();
 		String ref = RelationUtils.createRelationString(referencedType, "record_99");
-		attributes.put("sample-ref", ref);
+		attributes.putAttribute("sample-ref", ref);
 		mockMvc.perform(put("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 				referringType, "record_0").contentType(MediaType.APPLICATION_JSON)
 						.content(mapper.writeValueAsString(new RecordRequest(attributes))))
@@ -212,7 +212,7 @@ class RecordControllerMockMvcTest {
 		createSomeRecords(recordType, 1);
 		RecordAttributes attributes = RecordAttributes.empty();
 		String newTextValue = "convert this column from date to text";
-		attributes.put("attr3", newTextValue);
+		attributes.putAttribute("attr3", newTextValue);
 		mockMvc.perform(put("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 				recordType, "record_1").contentType(MediaType.APPLICATION_JSON)
 						.content(mapper.writeValueAsString(new RecordRequest(attributes))))
@@ -225,7 +225,7 @@ class RecordControllerMockMvcTest {
 		RecordType recordType = RecordType.valueOf("to-patch");
 		createSomeRecords(recordType, 1);
 		RecordAttributes attributes = RecordAttributes.empty();
-		attributes.put("attr-boolean", true);
+		attributes.putAttribute("attr-boolean", true);
 		String recordId = "record_missing";
 		mockMvc.perform(patch("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 				recordType, recordId)
@@ -241,7 +241,7 @@ class RecordControllerMockMvcTest {
 		String recordId = "record_0";
 		RecordAttributes attributes = RecordAttributes.empty();
 		String ref = RelationUtils.createRelationString(RecordType.valueOf("missing"), "missing_also");
-		attributes.put("sample-ref", ref);
+		attributes.putAttribute("sample-ref", ref);
 
 		mockMvc.perform(put("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 				recordType, recordId)
@@ -261,7 +261,7 @@ class RecordControllerMockMvcTest {
 		createSomeRecords(referringType, 1);
 		RecordAttributes attributes = RecordAttributes.empty();
 		String ref = RelationUtils.createRelationString(referencedType, recordId);
-		attributes.put("ref-attr", ref);
+		attributes.putAttribute("ref-attr", ref);
 		// Add referencing attribute to referring_Type
 		mockMvc.perform(patch("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 				referringType, recordId)
@@ -272,7 +272,7 @@ class RecordControllerMockMvcTest {
 		// recordType in the pre-existing referencing attribute
 		RecordAttributes new_attributes = RecordAttributes.empty();
 		String invalid_ref = RelationUtils.createRelationString(RecordType.valueOf("missing"), recordId);
-		new_attributes.put("ref-attr", invalid_ref);
+		new_attributes.putAttribute("ref-attr", invalid_ref);
 
 		mockMvc.perform(put("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 				referringType, "new_record")
@@ -288,7 +288,7 @@ class RecordControllerMockMvcTest {
 		createSomeRecords(recordType, 1);
 		RecordAttributes attributes = RecordAttributes.empty();
 		String ref = RelationUtils.createRelationString(RecordType.valueOf("missing"), "missing_also");
-		attributes.put("attr1", ref);
+		attributes.putAttribute("attr1", ref);
 		mockMvc.perform(patch("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 				recordType, "record_0")
 						.content(mapper.writeValueAsString(new RecordRequest(attributes)))
@@ -327,7 +327,7 @@ class RecordControllerMockMvcTest {
 		createSomeRecords(referringType, 1);
 		RecordAttributes attributes = RecordAttributes.empty();
 		String ref = RelationUtils.createRelationString(referencedType, "record_0");
-		attributes.put("sample-ref", ref);
+		attributes.putAttribute("sample-ref", ref);
 		mockMvc.perform(patch("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 				referringType, "record_0").contentType(MediaType.APPLICATION_JSON)
 						.content(mapper.writeValueAsString(new RecordRequest(attributes))))
@@ -364,7 +364,7 @@ class RecordControllerMockMvcTest {
 		createSomeRecords(referringType, 1);
 		RecordAttributes attributes = RecordAttributes.empty();
 		String ref = RelationUtils.createRelationString(referencedType, "record_0");
-		attributes.put("sample-ref", ref);
+		attributes.putAttribute("sample-ref", ref);
 		mockMvc.perform(patch("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 				referringType, "record_0").contentType(MediaType.APPLICATION_JSON)
 						.content(mapper.writeValueAsString(new RecordRequest(attributes))))
@@ -383,7 +383,7 @@ class RecordControllerMockMvcTest {
 		createSomeRecords(referringType, 1);
 		RecordAttributes attributes = RecordAttributes.empty();
 		String ref = RelationUtils.createRelationString(referencedType, "record_0");
-		attributes.put("sample-ref", ref);
+		attributes.putAttribute("sample-ref", ref);
 		// Create relation column
 		mockMvc.perform(patch("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 				referringType, "record_0").contentType(MediaType.APPLICATION_JSON)
@@ -410,7 +410,7 @@ class RecordControllerMockMvcTest {
 		createSomeRecords(type, 1);
 		RecordAttributes attributes = RecordAttributes.empty();
 		String ref = RelationUtils.createRelationString(referencedType, "record_0");
-		attributes.put("attr-ref", ref);
+		attributes.putAttribute("attr-ref", ref);
 
 		mockMvc.perform(patch("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId, type,
 				"record_0").contentType(MediaType.APPLICATION_JSON)

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -74,10 +74,10 @@ class RecordControllerMockMvcTest {
 	@Transactional
 	void tryCreatingIllegallyNamedRecordType() throws Exception {
 		String recordType = "sys_my_type";
-		Map<String, Object> attributes = new HashMap<>();
+		RecordAttributes attributes = RecordAttributes.empty();
 		mockMvc.perform(put("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 				recordType, "recordId")
-						.content(mapper.writeValueAsString(new RecordRequest(new RecordAttributes(attributes))))
+						.content(mapper.writeValueAsString(new RecordRequest(attributes)))
 						.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isBadRequest())
 				.andExpect(result -> assertTrue(result.getResolvedException() instanceof MethodArgumentTypeMismatchException));
@@ -88,11 +88,11 @@ class RecordControllerMockMvcTest {
 	void updateWithIllegalAttributeName() throws Exception {
 		RecordType recordType1 = RecordType.valueOf("illegalName");
 		createSomeRecords(recordType1, 1);
-		Map<String, Object> illegalAttribute = new HashMap<>();
+		RecordAttributes illegalAttribute = RecordAttributes.empty();
 		illegalAttribute.put("sys_foo", "some_val");
 		mockMvc.perform(patch("/{instanceId}/records/{versionId}/{recordType}/{recordId}", instanceId, versionId,
 				recordType1, "record_0").contentType(MediaType.APPLICATION_JSON)
-						.content(mapper.writeValueAsString(new RecordRequest(new RecordAttributes(illegalAttribute)))))
+						.content(mapper.writeValueAsString(new RecordRequest(illegalAttribute))))
 				.andExpect(status().isBadRequest())
 				.andExpect(result -> assertTrue(result.getResolvedException() instanceof InvalidNameException));
 	}
@@ -126,11 +126,11 @@ class RecordControllerMockMvcTest {
 	void ensurePutShowsNewlyNullFields() throws Exception {
 		RecordType recordType1 = RecordType.valueOf("recordType1");
 		createSomeRecords(recordType1, 1);
-		Map<String, Object> newAttributes = new HashMap<>();
+		RecordAttributes newAttributes = RecordAttributes.empty();
 		newAttributes.put("new-attr", "some_val");
 		mockMvc.perform(put("/{instanceId}/records/{versionId}/{recordType}/{recordId}", instanceId, versionId,
 				recordType1, "record_0").contentType(MediaType.APPLICATION_JSON)
-						.content(mapper.writeValueAsString(new RecordRequest(new RecordAttributes(newAttributes)))))
+						.content(mapper.writeValueAsString(new RecordRequest(newAttributes))))
 				.andExpect(content().string(containsString("\"attr3\":null")))
 				.andExpect(content().string(containsString("\"attr-dt\":null"))).andExpect(status().isOk());
 	}
@@ -139,11 +139,11 @@ class RecordControllerMockMvcTest {
 	void ensurePatchShowsAllFields() throws Exception {
 		RecordType recordType1 = RecordType.valueOf("recordType1");
 		createSomeRecords(recordType1, 1);
-		Map<String, Object> newAttributes = new HashMap<>();
+		RecordAttributes newAttributes = RecordAttributes.empty();
 		newAttributes.put("new-attr", "some_val");
 		mockMvc.perform(patch("/{instanceId}/records/{versionId}/{recordType}/{recordId}", instanceId, versionId,
 				recordType1, "record_0").contentType(MediaType.APPLICATION_JSON)
-						.content(mapper.writeValueAsString(new RecordRequest(new RecordAttributes(newAttributes)))))
+						.content(mapper.writeValueAsString(new RecordRequest(newAttributes))))
 				.andExpect(status().isOk()).andExpect(jsonPath("$.attributes.new-attr", is("some_val")));
 	}
 
@@ -163,12 +163,12 @@ class RecordControllerMockMvcTest {
 		RecordType referringType = RecordType.valueOf("ref_samples");
 		createSomeRecords(referencedType, 3);
 		createSomeRecords(referringType, 1);
-		Map<String, Object> attributes = new HashMap<>();
+		RecordAttributes attributes = RecordAttributes.empty();
 		String ref = RelationUtils.createRelationString(referencedType, "record_0");
 		attributes.put("sample-ref", ref);
 		mockMvc.perform(patch("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 				referringType, "record_0").contentType(MediaType.APPLICATION_JSON)
-						.content(mapper.writeValueAsString(new RecordRequest(new RecordAttributes(attributes)))))
+						.content(mapper.writeValueAsString(new RecordRequest(attributes))))
 				.andExpect(status().isOk()).andExpect(jsonPath("$.attributes.sample-ref", is(ref)));
 	}
 
@@ -178,12 +178,12 @@ class RecordControllerMockMvcTest {
 		RecordType referencedType = RecordType.valueOf("missing");
 		RecordType referringType = RecordType.valueOf("ref_samples-2");
 		createSomeRecords(referringType, 1);
-		Map<String, Object> attributes = new HashMap<>();
+		RecordAttributes attributes = RecordAttributes.empty();
 		String ref = RelationUtils.createRelationString(referencedType, "record_0");
 		attributes.put("sample-ref", ref);
 		mockMvc.perform(put("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 				referringType, "record_0").contentType(MediaType.APPLICATION_JSON)
-						.content(mapper.writeValueAsString(new RecordRequest(new RecordAttributes(attributes)))))
+						.content(mapper.writeValueAsString(new RecordRequest(attributes))))
 				.andExpect(status().isNotFound())
 				.andExpect(result -> assertTrue(result.getResolvedException() instanceof MissingObjectException));
 	}
@@ -195,12 +195,12 @@ class RecordControllerMockMvcTest {
 		RecordType referringType = RecordType.valueOf("ref_samples-3");
 		createSomeRecords(referencedType, 3);
 		createSomeRecords(referringType, 1);
-		Map<String, Object> attributes = new HashMap<>();
+		RecordAttributes attributes = RecordAttributes.empty();
 		String ref = RelationUtils.createRelationString(referencedType, "record_99");
 		attributes.put("sample-ref", ref);
 		mockMvc.perform(put("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 				referringType, "record_0").contentType(MediaType.APPLICATION_JSON)
-						.content(mapper.writeValueAsString(new RecordRequest(new RecordAttributes(attributes)))))
+						.content(mapper.writeValueAsString(new RecordRequest(attributes))))
 				.andExpect(status().isForbidden())
 				.andExpect(result -> assertTrue(result.getResolvedException() instanceof InvalidRelationException));
 	}
@@ -210,12 +210,12 @@ class RecordControllerMockMvcTest {
 	void expandColumnDefForNewData() throws Exception {
 		RecordType recordType = RecordType.valueOf("to-alter");
 		createSomeRecords(recordType, 1);
-		Map<String, Object> attributes = new HashMap<>();
+		RecordAttributes attributes = RecordAttributes.empty();
 		String newTextValue = "convert this column from date to text";
 		attributes.put("attr3", newTextValue);
 		mockMvc.perform(put("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 				recordType, "record_1").contentType(MediaType.APPLICATION_JSON)
-						.content(mapper.writeValueAsString(new RecordRequest(new RecordAttributes(attributes)))))
+						.content(mapper.writeValueAsString(new RecordRequest(attributes))))
 				.andExpect(status().isCreated()).andExpect(jsonPath("$.attributes.attr3", is(newTextValue)));
 	}
 
@@ -224,12 +224,12 @@ class RecordControllerMockMvcTest {
 	void patchMissingRecord() throws Exception {
 		RecordType recordType = RecordType.valueOf("to-patch");
 		createSomeRecords(recordType, 1);
-		Map<String, Object> attributes = new HashMap<>();
+		RecordAttributes attributes = RecordAttributes.empty();
 		attributes.put("attr-boolean", true);
 		String recordId = "record_missing";
 		mockMvc.perform(patch("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 				recordType, recordId)
-						.content(mapper.writeValueAsString(new RecordRequest(new RecordAttributes(attributes))))
+						.content(mapper.writeValueAsString(new RecordRequest(attributes)))
 						.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isNotFound());
 	}
@@ -239,13 +239,13 @@ class RecordControllerMockMvcTest {
 	void putRecordWithMissingTableReference() throws Exception {
 		String recordType = "record-type-missing-table-ref";
 		String recordId = "record_0";
-		Map<String, Object> attributes = new HashMap<>();
+		RecordAttributes attributes = RecordAttributes.empty();
 		String ref = RelationUtils.createRelationString(RecordType.valueOf("missing"), "missing_also");
 		attributes.put("sample-ref", ref);
 
 		mockMvc.perform(put("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 				recordType, recordId)
-						.content(mapper.writeValueAsString(new RecordRequest(new RecordAttributes(attributes))))
+						.content(mapper.writeValueAsString(new RecordRequest(attributes)))
 						.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isNotFound())
 				.andExpect(result -> assertTrue(result.getResolvedException() instanceof MissingObjectException));
@@ -259,24 +259,24 @@ class RecordControllerMockMvcTest {
 		String recordId = "record_0";
 		createSomeRecords(referencedType, 1);
 		createSomeRecords(referringType, 1);
-		Map<String, Object> attributes = new HashMap<>();
+		RecordAttributes attributes = RecordAttributes.empty();
 		String ref = RelationUtils.createRelationString(referencedType, recordId);
 		attributes.put("ref-attr", ref);
 		// Add referencing attribute to referring_Type
 		mockMvc.perform(patch("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 				referringType, recordId)
-						.content(mapper.writeValueAsString(new RecordRequest(new RecordAttributes(attributes))))
+						.content(mapper.writeValueAsString(new RecordRequest(attributes)))
 						.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk());
 		// Create a new referring_Type that puts a reference to a non-existent
 		// recordType in the pre-existing referencing attribute
-		Map<String, Object> new_attributes = new HashMap<>();
+		RecordAttributes new_attributes = RecordAttributes.empty();
 		String invalid_ref = RelationUtils.createRelationString(RecordType.valueOf("missing"), recordId);
 		new_attributes.put("ref-attr", invalid_ref);
 
 		mockMvc.perform(put("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 				referringType, "new_record")
-						.content(mapper.writeValueAsString(new RecordRequest(new RecordAttributes(new_attributes))))
+						.content(mapper.writeValueAsString(new RecordRequest(new_attributes)))
 						.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isBadRequest());
 	}
@@ -286,12 +286,12 @@ class RecordControllerMockMvcTest {
 	void tryToAssignReferenceToNonRefColumn() throws Exception {
 		RecordType recordType = RecordType.valueOf("ref-alter");
 		createSomeRecords(recordType, 1);
-		Map<String, Object> attributes = new HashMap<>();
+		RecordAttributes attributes = RecordAttributes.empty();
 		String ref = RelationUtils.createRelationString(RecordType.valueOf("missing"), "missing_also");
 		attributes.put("attr1", ref);
 		mockMvc.perform(patch("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 				recordType, "record_0")
-						.content(mapper.writeValueAsString(new RecordRequest(new RecordAttributes(attributes))))
+						.content(mapper.writeValueAsString(new RecordRequest(attributes)))
 						.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isForbidden())
 				.andExpect(result -> assertTrue(result.getResolvedException().getMessage()
@@ -325,12 +325,12 @@ class RecordControllerMockMvcTest {
 		RecordType referringType = RecordType.valueOf("ref_samples");
 		createSomeRecords(referencedType, 1);
 		createSomeRecords(referringType, 1);
-		Map<String, Object> attributes = new HashMap<>();
+		RecordAttributes attributes = RecordAttributes.empty();
 		String ref = RelationUtils.createRelationString(referencedType, "record_0");
 		attributes.put("sample-ref", ref);
 		mockMvc.perform(patch("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 				referringType, "record_0").contentType(MediaType.APPLICATION_JSON)
-						.content(mapper.writeValueAsString(new RecordRequest(new RecordAttributes(attributes)))))
+						.content(mapper.writeValueAsString(new RecordRequest(attributes))))
 				.andExpect(status().isOk()).andExpect(content().string(containsString(ref)));
 		mockMvc.perform(delete("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 				referencedType, "record_0")).andExpect(status().isBadRequest());
@@ -362,12 +362,12 @@ class RecordControllerMockMvcTest {
 		RecordType referringType = RecordType.valueOf("ref_samples");
 		createSomeRecords(referencedType, 3);
 		createSomeRecords(referringType, 1);
-		Map<String, Object> attributes = new HashMap<>();
+		RecordAttributes attributes = RecordAttributes.empty();
 		String ref = RelationUtils.createRelationString(referencedType, "record_0");
 		attributes.put("sample-ref", ref);
 		mockMvc.perform(patch("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 				referringType, "record_0").contentType(MediaType.APPLICATION_JSON)
-						.content(mapper.writeValueAsString(new RecordRequest(new RecordAttributes(attributes)))))
+						.content(mapper.writeValueAsString(new RecordRequest(attributes))))
 				.andExpect(status().isOk()).andExpect(content().string(containsString(ref)));
 
 		mockMvc.perform(delete("/{instanceId}/types/{version}/{recordType}", instanceId, versionId, referencedType))
@@ -381,13 +381,13 @@ class RecordControllerMockMvcTest {
 		RecordType referringType = RecordType.valueOf("ref_samples");
 		createSomeRecords(referencedType, 3);
 		createSomeRecords(referringType, 1);
-		Map<String, Object> attributes = new HashMap<>();
+		RecordAttributes attributes = RecordAttributes.empty();
 		String ref = RelationUtils.createRelationString(referencedType, "record_0");
 		attributes.put("sample-ref", ref);
 		// Create relation column
 		mockMvc.perform(patch("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 				referringType, "record_0").contentType(MediaType.APPLICATION_JSON)
-						.content(mapper.writeValueAsString(new RecordRequest(new RecordAttributes(attributes)))))
+						.content(mapper.writeValueAsString(new RecordRequest(attributes))))
 				.andExpect(status().isOk()).andExpect(content().string(containsString(ref)));
 
 		// Delete record from referencing type
@@ -408,13 +408,13 @@ class RecordControllerMockMvcTest {
 		RecordType referencedType = RecordType.valueOf("referencedType");
 		createSomeRecords(referencedType, 1);
 		createSomeRecords(type, 1);
-		Map<String, Object> attributes = new HashMap<>();
+		RecordAttributes attributes = RecordAttributes.empty();
 		String ref = RelationUtils.createRelationString(referencedType, "record_0");
 		attributes.put("attr-ref", ref);
 
 		mockMvc.perform(patch("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId, type,
 				"record_0").contentType(MediaType.APPLICATION_JSON)
-						.content(mapper.writeValueAsString(new RecordRequest(new RecordAttributes(attributes)))))
+						.content(mapper.writeValueAsString(new RecordRequest(attributes))))
 				.andExpect(status().isOk()).andExpect(content().string(containsString(ref)));
 
 		List<AttributeSchema> expectedAttributes = Arrays.asList(new AttributeSchema("attr-boolean", "BOOLEAN", null),
@@ -494,10 +494,10 @@ class RecordControllerMockMvcTest {
 	private void createSomeRecords(RecordType recordType, int numRecords, UUID instId) throws Exception {
 		for (int i = 0; i < numRecords; i++) {
 			String recordId = "record_" + i;
-			Map<String, Object> attributes = generateRandomAttributes();
+			RecordAttributes attributes = generateRandomAttributes();
 			mockMvc.perform(put("/{instanceId}/records/{version}/{recordType}/{recordId}", instId, versionId,
 					recordType, recordId)
-							.content(mapper.writeValueAsString(new RecordRequest(new RecordAttributes(attributes))))
+							.content(mapper.writeValueAsString(new RecordRequest(attributes)))
 							.contentType(MediaType.APPLICATION_JSON))
 					.andExpect(status().is2xxSuccessful());
 		}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
@@ -41,7 +41,7 @@ class RecordDaoTest {
 	void testGetSingleRecord() {
 		// add record
 		String recordId = "testRecord";
-		Record testRecord = new Record(recordId, recordType, new RecordAttributes(new HashMap<>()));
+		Record testRecord = new Record(recordId, recordType, RecordAttributes.empty());
 		recordDao.batchUpsert(instanceId, recordType, Collections.singletonList(testRecord), new HashMap<>());
 
 		// make sure record is fetched
@@ -61,7 +61,7 @@ class RecordDaoTest {
 
 		// create record with no attributes
 		String recordId = "testRecord";
-		Record testRecord = new Record(recordId, recordType, new RecordAttributes(new HashMap<>()));
+		Record testRecord = new Record(recordId, recordType, RecordAttributes.empty());
 		recordDao.batchUpsert(instanceId, recordType, Collections.singletonList(testRecord), new HashMap<>());
 
 		Record search = recordDao.getSingleRecord(instanceId, recordType, recordId, Collections.emptyList()).get();
@@ -119,7 +119,7 @@ class RecordDaoTest {
 	void testDeleteSingleRecord() {
 		// add record
 		String recordId = "testRecord";
-		Record testRecord = new Record(recordId, recordType, new RecordAttributes(new HashMap<>()));
+		Record testRecord = new Record(recordId, recordType, RecordAttributes.empty());
 		recordDao.batchUpsert(instanceId, recordType, Collections.singletonList(testRecord), new HashMap<>());
 
 		recordDao.deleteSingleRecord(instanceId, recordType, "testRecord");
@@ -179,7 +179,7 @@ class RecordDaoTest {
 		// insert records and test the count after each insert
 		for (int i = 0; i < 10; i++) {
 			Record testRecord = new Record("record" + i, recordType,
-					new RecordAttributes(new HashMap<>()));
+					RecordAttributes.empty());
 			recordDao.batchUpsert(instanceId, recordType, Collections.singletonList(testRecord), new HashMap<>());
 			assertEquals(i + 1, recordDao.countRecords(instanceId, recordType),
 					"after inserting " + (i + 1) + " records");
@@ -192,7 +192,7 @@ class RecordDaoTest {
 		assertFalse(recordDao.recordExists(instanceId, recordType, "aRecord"));
 		recordDao.batchUpsert(instanceId, recordType,
 				Collections.singletonList(
-						new Record("aRecord", recordType, new RecordAttributes((new HashMap<>())))),
+						new Record("aRecord", recordType, RecordAttributes.empty())),
 				new HashMap<>());
 		assertTrue(recordDao.recordExists(instanceId, recordType, "aRecord"));
 	}
@@ -217,7 +217,7 @@ class RecordDaoTest {
 		recordDao.addColumn(instanceId, recordTypeName, "relation", DataTypeMapping.STRING, referencedType);
 
 		String refRecordId = "referencedRecord";
-		Record referencedRecord = new Record(refRecordId, referencedType, new RecordAttributes(new HashMap<>()));
+		Record referencedRecord = new Record(refRecordId, referencedType, RecordAttributes.empty());
 		recordDao.batchUpsert(instanceId, referencedType, Collections.singletonList(referencedRecord),
 				new HashMap<>());
 


### PR DESCRIPTION
Philosophically, I am realizing that my motivations for refactoring classes like this are:
* where I'm less confident about the underlying representations - like using `Map<String, Object>` to represent attributes - I want to abstract callers from knowing about those representations
* providing domain objects that include some encapsulated logic, as opposed to pure record classes

---

Highlights of this PR:

1. Calling code is able to call methods directly on `Record` or `RecordAttributes`, instead of retrieving the underlying `Map` of attributes.
[Example](https://github.com/DataBiosphere/terra-workspace-data-service/pull/76/files#diff-6fdffee8355da583e8db9f8b0995789baa890a7fc0b2ba3da10e381f60afee25R284
), using `Record toInsert`:
```java
toInsert.getAttributes().getAttributes().get(colName)
```
becomes
```java
toInsert.getAttributeValue(colName)
```

2. Calling code can add `RecordAttributes` to a `Record` or to a `RecordAttributes` without retrieving the underlying `Map`:
[Example](https://github.com/DataBiosphere/terra-workspace-data-service/pull/76/files#diff-494957a4a881ff0f5307171889be87fc44dd3c1a06618aafcbe18998113cbfb1R43):
```java
Map<String, Object> updatedAtts = recordRequest.recordAttributes().getAttributes();
Map<String, Object> allAttrs = new HashMap<>(singleRecord.getAttributes().getAttributes());
allAttrs.putAll(updatedAtts);
```
becomes:
```java
RecordAttributes incomingAtts = recordRequest.recordAttributes();
RecordAttributes allAttrs = singleRecord.putAllAttributes(incomingAtts).getAttributes();
```

3. Reduce occurrences of getting the underlying attribute `Map`, then constructing a new `RecordAttributes` object from that map

4. The underlying implementation of `Map<String, Object>` for `RecordAttributes` is now mostly abstracted (there are a few non-abstracted places where we iterate over the map entries). I suspect the underlying representation will change in the future, so it's nice to be abstracted from it

5. By moving the mutator methods onto `RecordAttributes`, we can chain them, whereas `Map`'s methods return void and are not changeable. Thus we can change ([example](https://github.com/DataBiosphere/terra-workspace-data-service/pull/76/files#diff-ba2227f2e1675ac7d3e2a73ef90f4babd21833fb5166ea2e399e37c8dbc0dd8cL15)):
```java
	public static Map<String, Object> generateRandomAttributes() {
		Map<String, Object> attributes = new HashMap<>();
		attributes.put("attr1", RandomStringUtils.randomAlphabetic(6));
		attributes.put("attr2", RandomUtils.nextFloat());
		attributes.put("attr3", "2022-11-01");
		attributes.put("attr4", RandomStringUtils.randomNumeric(5));
		attributes.put("attr5", RandomUtils.nextLong());
		attributes.put("attr-dt", "2022-03-01T12:00:03");
		attributes.put("attr-json", "{\"foo\":\"bar\"}");
		attributes.put("attr-boolean", true);
		return attributes;
	}
```
to
```java
	public static RecordAttributes generateRandomAttributes() {
		return RecordAttributes.empty()
				.putAttribute("attr1", RandomStringUtils.randomAlphabetic(6))
				.putAttribute("attr2", RandomUtils.nextFloat())
				.putAttribute("attr3", "2022-11-01")
				.putAttribute("attr4", RandomStringUtils.randomNumeric(5))
				.putAttribute("attr5", RandomUtils.nextLong())
				.putAttribute("attr-dt", "2022-03-01T12:00:03")
				.putAttribute("attr-json", "{\"foo\":\"bar\"}")
				.putAttribute("attr-boolean", true);
	}
```