### PR TITLE
AJ-596: TSV Streaming Download

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.apache.commons:commons-lang3'
-	implementation 'org.apache.commons:commons-csv:1.9.0'
+	implementation 'com.univocity:univocity-parsers:2.9.1'
 	implementation 'com.google.guava:guava:31.1-jre'
 	implementation 'org.postgresql:postgresql'
 	implementation 'org.webjars:webjars-locator-core:0.52'

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.apache.commons:commons-lang3'
+	implementation 'org.apache.commons:commons-csv:1.9.0'
 	implementation 'com.google.guava:guava:31.1-jre'
 	implementation 'org.postgresql:postgresql'
 	implementation 'org.webjars:webjars-locator-core:0.52'

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.apache.commons:commons-lang3'
-	implementation 'com.univocity:univocity-parsers:2.9.1'
+	implementation 'org.apache.commons:commons-csv:1.9.0'
 	implementation 'com.google.guava:guava:31.1-jre'
 	implementation 'org.postgresql:postgresql'
 	implementation 'org.webjars:webjars-locator-core:0.52'

--- a/service/src/main/java/org/databiosphere/workspacedataservice/WorkspaceDataServiceApplication.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/WorkspaceDataServiceApplication.java
@@ -15,6 +15,9 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
 import javax.sql.DataSource;
+
+import org.springframework.lang.NonNull;
+import org.springframework.web.servlet.config.annotation.AsyncSupportConfigurer;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -66,8 +69,13 @@ public class WorkspaceDataServiceApplication {
 	public WebMvcConfigurer corsConfigurer() {
 		return new WebMvcConfigurer() {
 			@Override
-			public void addCorsMappings(CorsRegistry registry) {
+			public void addCorsMappings(@NonNull CorsRegistry registry) {
 				registry.addMapping("/**").allowedOrigins("*");
+			}
+
+			@Override
+			public void configureAsyncSupport(@NonNull AsyncSupportConfigurer configurer) {
+				configurer.setDefaultTimeout(-1);
 			}
 		};
 	}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/WorkspaceDataServiceApplication.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/WorkspaceDataServiceApplication.java
@@ -11,6 +11,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
 import javax.sql.DataSource;
@@ -34,6 +35,19 @@ public class WorkspaceDataServiceApplication {
 		//https://jdbc.postgresql.org/documentation/head/query.html#query-with-cursor
 		hikariDataSource.setAutoCommit(false);
 		return hikariDataSource;
+	}
+
+	@Bean
+	@Primary
+	@ConfigurationProperties("spring.datasource")
+	public DataSource mainDb(){
+		return DataSourceBuilder.create().build();
+	}
+
+	@Bean
+	@Primary
+	public NamedParameterJdbcTemplate namedParameterJdbcTemplate(){
+		return new NamedParameterJdbcTemplate(mainDb());
 	}
 
 	@Bean

--- a/service/src/main/java/org/databiosphere/workspacedataservice/WorkspaceDataServiceApplication.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/WorkspaceDataServiceApplication.java
@@ -35,7 +35,7 @@ public class WorkspaceDataServiceApplication {
 	public DataSource streamingDs(){
 		DataSource ds = DataSourceBuilder.create().build();
 		HikariDataSource hikariDataSource = (HikariDataSource) ds;
-		//https://jdbc.postgresql.org/documentation/head/query.html#query-with-cursor
+		//https://jdbc.postgresql.org/documentation/query/#getting-results-based-on-a-cursor
 		hikariDataSource.setAutoCommit(false);
 		return hikariDataSource;
 	}
@@ -58,7 +58,7 @@ public class WorkspaceDataServiceApplication {
 	public NamedParameterJdbcTemplate templateForStreaming(@Qualifier("streamingDs") DataSource ds,
 														   @Value("${twds.streaming.fetch.size:50}") int fetchSize){
 		NamedParameterJdbcTemplate jdbcTemplate = new NamedParameterJdbcTemplate(ds);
-		//https://jdbc.postgresql.org/documentation/head/query.html#query-with-cursor
+		//https://jdbc.postgresql.org/documentation/query/#getting-results-based-on-a-cursor
 		jdbcTemplate.getJdbcTemplate().setFetchSize(fetchSize);
 		return jdbcTemplate;
 	}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/WorkspaceDataServiceApplication.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/WorkspaceDataServiceApplication.java
@@ -3,9 +3,17 @@ package org.databiosphere.workspacedataservice;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.zaxxer.hikari.HikariDataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.context.annotation.Bean;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+import javax.sql.DataSource;
 
 @SpringBootApplication
 public class WorkspaceDataServiceApplication {
@@ -14,6 +22,28 @@ public class WorkspaceDataServiceApplication {
 	public ObjectMapper objectMapper() {
 		return JsonMapper.builder().enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS).build();
 	}
+
+	@Bean
+	@Qualifier("streamingDs")
+	@ConfigurationProperties("streaming.query")
+	public DataSource streamingDs(){
+		DataSource ds = DataSourceBuilder.create().build();
+		HikariDataSource hikariDataSource = (HikariDataSource) ds;
+		//https://jdbc.postgresql.org/documentation/head/query.html#query-with-cursor
+		hikariDataSource.setAutoCommit(false);
+		return hikariDataSource;
+	}
+
+	@Bean
+	@Qualifier("streamingDs")
+	public NamedParameterJdbcTemplate templateForStreaming(@Qualifier("streamingDs") DataSource ds,
+														   @Value("${twds.streaming.fetch.size:50}") int fetchSize){
+		NamedParameterJdbcTemplate jdbcTemplate = new NamedParameterJdbcTemplate(ds);
+		//https://jdbc.postgresql.org/documentation/head/query.html#query-with-cursor
+		jdbcTemplate.getJdbcTemplate().setFetchSize(fetchSize);
+		return jdbcTemplate;
+	}
+
 	public static void main(String[] args) {
 		SpringApplication.run(WorkspaceDataServiceApplication.class, args);
 	}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/WorkspaceDataServiceApplication.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/WorkspaceDataServiceApplication.java
@@ -56,7 +56,7 @@ public class WorkspaceDataServiceApplication {
 	@Bean
 	@Qualifier("streamingDs")
 	public NamedParameterJdbcTemplate templateForStreaming(@Qualifier("streamingDs") DataSource ds,
-			@Value("${twds.streaming.fetch.size:50}") int fetchSize) {
+			@Value("${twds.streaming.fetch.size:5000}") int fetchSize) {
 		NamedParameterJdbcTemplate jdbcTemplate = new NamedParameterJdbcTemplate(ds);
 		// https://jdbc.postgresql.org/documentation/query/#getting-results-based-on-a-cursor
 		jdbcTemplate.getJdbcTemplate().setFetchSize(fetchSize);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/WorkspaceDataServiceApplication.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/WorkspaceDataServiceApplication.java
@@ -32,10 +32,10 @@ public class WorkspaceDataServiceApplication {
 	@Bean
 	@Qualifier("streamingDs")
 	@ConfigurationProperties("streaming.query")
-	public DataSource streamingDs(){
+	public DataSource streamingDs() {
 		DataSource ds = DataSourceBuilder.create().build();
 		HikariDataSource hikariDataSource = (HikariDataSource) ds;
-		//https://jdbc.postgresql.org/documentation/query/#getting-results-based-on-a-cursor
+		// https://jdbc.postgresql.org/documentation/query/#getting-results-based-on-a-cursor
 		hikariDataSource.setAutoCommit(false);
 		return hikariDataSource;
 	}
@@ -43,26 +43,25 @@ public class WorkspaceDataServiceApplication {
 	@Bean
 	@Primary
 	@ConfigurationProperties("spring.datasource")
-	public DataSource mainDb(){
+	public DataSource mainDb() {
 		return DataSourceBuilder.create().build();
 	}
 
 	@Bean
 	@Primary
-	public NamedParameterJdbcTemplate namedParameterJdbcTemplate(){
+	public NamedParameterJdbcTemplate namedParameterJdbcTemplate() {
 		return new NamedParameterJdbcTemplate(mainDb());
 	}
 
 	@Bean
 	@Qualifier("streamingDs")
 	public NamedParameterJdbcTemplate templateForStreaming(@Qualifier("streamingDs") DataSource ds,
-														   @Value("${twds.streaming.fetch.size:50}") int fetchSize){
+			@Value("${twds.streaming.fetch.size:50}") int fetchSize) {
 		NamedParameterJdbcTemplate jdbcTemplate = new NamedParameterJdbcTemplate(ds);
-		//https://jdbc.postgresql.org/documentation/query/#getting-results-based-on-a-cursor
+		// https://jdbc.postgresql.org/documentation/query/#getting-results-based-on-a-cursor
 		jdbcTemplate.getJdbcTemplate().setFetchSize(fetchSize);
 		return jdbcTemplate;
 	}
-
 
 	// CORS: allow Ajax requests from anywhere for all endpoints.
 	@Bean

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -76,7 +76,7 @@ public class RecordController {
 		return new ResponseEntity<>(response, HttpStatus.OK);
 	}
 
-	@GetMapping("{instanceId}/records/{version}/{recordType}")
+	@GetMapping("{instanceId}/tsv/{version}/{recordType}")
 	public ResponseEntity<StreamingResponseBody> streamAllEntities(@PathVariable("instanceId") UUID instanceId,
 																   @PathVariable("version") String version,
 																   @PathVariable("recordType") RecordType recordType) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -77,8 +77,7 @@ public class RecordController {
 
 	@GetMapping("{instanceId}/tsv/{version}/{recordType}")
 	public ResponseEntity<StreamingResponseBody> streamAllEntities(@PathVariable("instanceId") UUID instanceId,
-																   @PathVariable("version") String version,
-																   @PathVariable("recordType") RecordType recordType) {
+			@PathVariable("version") String version, @PathVariable("recordType") RecordType recordType) {
 		validateVersion(version);
 		validateInstance(instanceId);
 		checkRecordTypeExists(instanceId, recordType);
@@ -87,14 +86,16 @@ public class RecordController {
 		Stream<Record> allRecords = recordDao.streamAllRecordsForType(instanceId, recordType);
 
 		StreamingResponseBody responseBody = httpResponseOutputStream -> {
-			try (CSVPrinter writer = TsvSupport.getOutputFormat(headers).print(new OutputStreamWriter(httpResponseOutputStream))) {
-				TsvSupport.RecordEmitter recordEmitter = new TsvSupport.RecordEmitter(writer, headers.subList(1, headers.size()));
+			try (CSVPrinter writer = TsvSupport.getOutputFormat(headers)
+					.print(new OutputStreamWriter(httpResponseOutputStream))) {
+				TsvSupport.RecordEmitter recordEmitter = new TsvSupport.RecordEmitter(writer,
+						headers.subList(1, headers.size()));
 				allRecords.forEach(recordEmitter);
 			}
 		};
-		return ResponseEntity.status(HttpStatus.OK).contentType(new MediaType("text", "csv")).body(responseBody);
+		return ResponseEntity.status(HttpStatus.OK).contentType(new MediaType("text", "tab-separated-values"))
+				.body(responseBody);
 	}
-
 
 	@PostMapping("/{instanceid}/search/{version}/{recordType}")
 	public RecordQueryResponse queryForEntities(@PathVariable("instanceid") UUID instanceId,
@@ -146,7 +147,8 @@ public class RecordController {
 			}
 			Record newRecord = new Record(recordId, recordType, recordRequest.recordAttributes());
 			List<Record> records = Collections.singletonList(newRecord);
-			batchWriteService.addOrUpdateColumnIfNeeded(instanceId, recordType, requestSchema, existingTableSchema, records);
+			batchWriteService.addOrUpdateColumnIfNeeded(instanceId, recordType, requestSchema, existingTableSchema,
+					records);
 			Map<String, DataTypeMapping> combinedSchema = new HashMap<>(existingTableSchema);
 			combinedSchema.putAll(requestSchema);
 			recordDao.batchUpsert(instanceId, recordType, records, combinedSchema);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -89,10 +89,10 @@ public class RecordController {
 		TsvWriterSettings tsvSettings = TsvSupport.getTsvSettings();
 		StreamingResponseBody responseBody = httpResponseOutputStream -> {
 			TsvWriter writer = null;
-			try {
-				writer = new TsvWriter(new OutputStreamWriter(httpResponseOutputStream), tsvSettings);
-				writer.writeHeaders(headers);
+			try (OutputStreamWriter outputStreamWriter = new OutputStreamWriter(httpResponseOutputStream)){
+				writer = new TsvWriter(outputStreamWriter, tsvSettings);
 				TsvSupport.RecordEmitter recordEmitter = new TsvSupport.RecordEmitter(writer, headers.subList(1, headers.size()));
+				writer.writeHeaders(headers);
 				allRecords.forEach(recordEmitter);
 			} finally {
 				writer.close();

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -171,8 +171,8 @@ public class RecordDao {
 		} catch (DataAccessException e) {
 			if (e.getRootCause()instanceof SQLException sqlEx) {
 				checkForMissingRecord(sqlEx);
-				throw e;
 			}
+			throw e;
 		}
 	}
 
@@ -195,6 +195,7 @@ public class RecordDao {
 					throw new BatchWriteException(rowErrors);
 				}
 			}
+			throw e;
 		}
 	}
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -45,7 +45,8 @@ public class RecordDao {
 	private final NamedParameterJdbcTemplate namedTemplate;
 
 	private final NamedParameterJdbcTemplate templateForStreaming;
-	public RecordDao(NamedParameterJdbcTemplate namedTemplate, @Qualifier("streamingDs") NamedParameterJdbcTemplate templateForStreaming) {
+	public RecordDao(NamedParameterJdbcTemplate namedTemplate,
+			@Qualifier("streamingDs") NamedParameterJdbcTemplate templateForStreaming) {
 		this.namedTemplate = namedTemplate;
 		this.templateForStreaming = templateForStreaming;
 	}
@@ -178,8 +179,7 @@ public class RecordDao {
 
 	private List<RecordColumn> getSchemaWithRowId(Map<String, DataTypeMapping> schema) {
 		schema.put(RECORD_ID, DataTypeMapping.STRING);
-		return schema.entrySet().stream()
-				.map(e -> new RecordColumn(e.getKey(), e.getValue())).toList();
+		return schema.entrySet().stream().map(e -> new RecordColumn(e.getKey(), e.getValue())).toList();
 	}
 
 	public void batchUpsertWithErrorCapture(UUID instanceId, RecordType recordType, List<Record> records,
@@ -217,15 +217,14 @@ public class RecordDao {
 	private String convertSchemaDiffToErrorMessage(
 			Map<String, MapDifference.ValueDifference<DataTypeMapping>> differenceMap, Record rcd) {
 		return differenceMap.keySet().stream()
-				.map(attr -> rcd.getId() + "." + attr + " is a "
-						+ differenceMap.get(attr).leftValue() + " in the request but is defined as "
-						+ differenceMap.get(attr).rightValue() + " in the record type definition for " + rcd.getRecordType())
+				.map(attr -> rcd.getId() + "." + attr + " is a " + differenceMap.get(attr).leftValue()
+						+ " in the request but is defined as " + differenceMap.get(attr).rightValue()
+						+ " in the record type definition for " + rcd.getRecordType())
 				.collect(Collectors.joining("\n"));
 	}
 
 	private boolean isDataMismatchException(DataAccessException e) {
-		return e.getRootCause() instanceof SQLException sqlException
-				&& sqlException.getSQLState().equals("42804");
+		return e.getRootCause()instanceof SQLException sqlException && sqlException.getSQLState().equals("42804");
 	}
 
 	public boolean deleteSingleRecord(UUID instanceId, RecordType recordType, String recordId) {
@@ -281,8 +280,9 @@ public class RecordDao {
 		}
 	}
 
-	public Stream<Record> streamAllRecordsForType(UUID instanceId, RecordType recordType){
-		return templateForStreaming.getJdbcTemplate().queryForStream("select * from " + getQualifiedTableName(recordType, instanceId),
+	public Stream<Record> streamAllRecordsForType(UUID instanceId, RecordType recordType) {
+		return templateForStreaming.getJdbcTemplate().queryForStream(
+				"select * from " + getQualifiedTableName(recordType, instanceId) + " order by " + RECORD_ID,
 				new RecordRowMapper(recordType, getRelationColumnsByName(getRelationCols(instanceId, recordType))));
 	}
 
@@ -389,21 +389,20 @@ public class RecordDao {
 					});
 			List<String> recordErrors = new ArrayList<>();
 			for (int i = 0; i < rowCounts.length; i++) {
-				if(rowCounts[i] != 1){
+				if (rowCounts[i] != 1) {
 					recordErrors.add("record id " + recordIds.get(i) + " does not exist in " + recordType.getName());
 				}
 			}
-			if(!recordErrors.isEmpty()){
+			if (!recordErrors.isEmpty()) {
 				throw new BatchDeleteException(recordErrors);
 			}
 		} catch (DataIntegrityViolationException e) {
-			if (e.getRootCause() instanceof SQLException sqlEx) {
+			if (e.getRootCause()instanceof SQLException sqlEx) {
 				checkForTableRelation(sqlEx);
 			}
 			throw e;
 		}
 	}
-
 
 	private record RecordRowMapper(RecordType recordType,
 			Map<String, RecordType> referenceColToTable) implements RowMapper<Record> {
@@ -423,7 +422,8 @@ public class RecordDao {
 					if (columnName.startsWith(RESERVED_NAME_PREFIX)) {
 						continue;
 					}
-					if (referenceColToTable.size() > 0 && referenceColToTable.containsKey(columnName) && rs.getString(columnName) != null) {
+					if (referenceColToTable.size() > 0 && referenceColToTable.containsKey(columnName)
+							&& rs.getString(columnName) != null) {
 						attributes.putAttribute(columnName, RelationUtils
 								.createRelationString(referenceColToTable.get(columnName), rs.getString(columnName)));
 					} else {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/BatchWriteService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/BatchWriteService.java
@@ -99,7 +99,9 @@ public class BatchWriteService {
 	}
 
 	/**
-	 * All or nothing, write all the operations successfully in the InputStream or write none.
+	 * All or nothing, write all the operations successfully in the InputStream or
+	 * write none.
+	 * 
 	 * @param is
 	 * @param instanceId
 	 * @param recordType
@@ -128,10 +130,10 @@ public class BatchWriteService {
 		return recordsAffected;
 	}
 
-	private Map<String, DataTypeMapping> createOrModifyRecordType(UUID instanceId, RecordType recordType, Map<String, DataTypeMapping> schema, List<Record> records) {
+	private Map<String, DataTypeMapping> createOrModifyRecordType(UUID instanceId, RecordType recordType,
+			Map<String, DataTypeMapping> schema, List<Record> records) {
 		if (!recordDao.recordTypeExists(instanceId, recordType)) {
-			recordDao.createRecordType(instanceId, schema, recordType,
-					RelationUtils.findRelations(records));
+			recordDao.createRecordType(instanceId, schema, recordType, RelationUtils.findRelations(records));
 		} else {
 			return addOrUpdateColumnIfNeeded(instanceId, recordType, schema,
 					recordDao.getExistingTableSchema(instanceId, recordType), records);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/TsvSupport.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/TsvSupport.java
@@ -11,6 +11,9 @@ import java.util.function.Consumer;
 
 public class TsvSupport {
 
+    private TsvSupport() {
+    }
+
     public static CSVFormat getOutputFormat(List<String> headers) {
          return CSVFormat.DEFAULT.builder().setDelimiter('\t')
                 .setQuoteMode(QuoteMode.MINIMAL)
@@ -29,11 +32,11 @@ public class TsvSupport {
         }
 
         @Override
-        public void accept(Record record) {
+        public void accept(Record rcd) {
             try {
-                csvPrinter.print(record.getId());
+                csvPrinter.print(rcd.getId());
                 for (String attributeName : attributeNames) {
-                    csvPrinter.print(record.getAttributeValue(attributeName));
+                    csvPrinter.print(rcd.getAttributeValue(attributeName));
                 }
                 csvPrinter.println();
             } catch (IOException e) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/TsvSupport.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/TsvSupport.java
@@ -11,37 +11,35 @@ import java.util.function.Consumer;
 
 public class TsvSupport {
 
-    private TsvSupport() {
-    }
+	private TsvSupport() {
+	}
 
-    public static CSVFormat getOutputFormat(List<String> headers) {
-         return CSVFormat.DEFAULT.builder().setDelimiter('\t')
-                .setQuoteMode(QuoteMode.MINIMAL)
-                 .setRecordSeparator("\n")
-                 .setHeader(headers.toArray(new String[0])).build();
-    }
+	public static CSVFormat getOutputFormat(List<String> headers) {
+		return CSVFormat.DEFAULT.builder().setDelimiter('\t').setQuoteMode(QuoteMode.MINIMAL).setRecordSeparator("\n")
+				.setHeader(headers.toArray(new String[0])).build();
+	}
 
-    public static class RecordEmitter implements Consumer<Record> {
+	public static class RecordEmitter implements Consumer<Record> {
 
-        private final CSVPrinter csvPrinter;
-        private final List<String> attributeNames;
+		private final CSVPrinter csvPrinter;
+		private final List<String> attributeNames;
 
-        public RecordEmitter(CSVPrinter csvPrinter, List<String> attributeNames) {
-            this.csvPrinter = csvPrinter;
-            this.attributeNames = attributeNames;
-        }
+		public RecordEmitter(CSVPrinter csvPrinter, List<String> attributeNames) {
+			this.csvPrinter = csvPrinter;
+			this.attributeNames = attributeNames;
+		}
 
-        @Override
-        public void accept(Record rcd) {
-            try {
-                csvPrinter.print(rcd.getId());
-                for (String attributeName : attributeNames) {
-                    csvPrinter.print(rcd.getAttributeValue(attributeName));
-                }
-                csvPrinter.println();
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        }
-    }
+		@Override
+		public void accept(Record rcd) {
+			try {
+				csvPrinter.print(rcd.getId());
+				for (String attributeName : attributeNames) {
+					csvPrinter.print(rcd.getAttributeValue(attributeName));
+				}
+				csvPrinter.println();
+			} catch (IOException e) {
+				throw new RuntimeException(e);
+			}
+		}
+	}
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/TsvSupport.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/TsvSupport.java
@@ -1,0 +1,40 @@
+package org.databiosphere.workspacedataservice.service;
+
+import com.univocity.parsers.tsv.TsvWriter;
+import com.univocity.parsers.tsv.TsvWriterSettings;
+import org.databiosphere.workspacedataservice.shared.model.Record;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+public class TsvSupport {
+
+
+    public static TsvWriterSettings getTsvSettings(){
+        TsvWriterSettings settings = new TsvWriterSettings();
+        settings.getFormat().setLineSeparator("\n");
+        return settings;
+    }
+
+    public static class RecordEmitter implements Consumer<Record> {
+
+        private final TsvWriter tsvWriter;
+        private final List<String> attributeNames;
+
+        public RecordEmitter(TsvWriter writer, List<String> attributeNames) {
+            this.tsvWriter = writer;
+            this.attributeNames = attributeNames;
+        }
+
+        @Override
+        public void accept(Record record) {
+            List<Object> attributeValues = new ArrayList<>();
+            attributeValues.add(record.getId());
+            for (String attributeName : attributeNames) {
+                attributeValues.add(record.getAttributeValue(attributeName));
+            }
+            tsvWriter.writeRow(attributeValues);
+        }
+    }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/TsvSupport.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/TsvSupport.java
@@ -1,44 +1,44 @@
 package org.databiosphere.workspacedataservice.service;
 
-import com.univocity.parsers.tsv.TsvWriter;
-import com.univocity.parsers.tsv.TsvWriterSettings;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import org.apache.commons.csv.QuoteMode;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 
-import java.util.ArrayList;
+import java.io.IOException;
 import java.util.List;
 import java.util.function.Consumer;
 
 public class TsvSupport {
 
-    private TsvSupport (){
-
-    }
-
-
-    public static TsvWriterSettings getTsvSettings(){
-        TsvWriterSettings settings = new TsvWriterSettings();
-        settings.getFormat().setLineSeparator("\n");
-        return settings;
+    public static CSVFormat getOutputFormat(List<String> headers) {
+         return CSVFormat.DEFAULT.builder().setDelimiter('\t')
+                .setQuoteMode(QuoteMode.MINIMAL)
+                 .setRecordSeparator("\n")
+                 .setHeader(headers.toArray(new String[0])).build();
     }
 
     public static class RecordEmitter implements Consumer<Record> {
 
-        private final TsvWriter tsvWriter;
+        private final CSVPrinter csvPrinter;
         private final List<String> attributeNames;
 
-        public RecordEmitter(TsvWriter writer, List<String> attributeNames) {
-            this.tsvWriter = writer;
+        public RecordEmitter(CSVPrinter csvPrinter, List<String> attributeNames) {
+            this.csvPrinter = csvPrinter;
             this.attributeNames = attributeNames;
         }
 
         @Override
-        public void accept(Record rcd) {
-            List<Object> attributeValues = new ArrayList<>();
-            attributeValues.add(rcd.getId());
-            for (String attributeName : attributeNames) {
-                attributeValues.add(rcd.getAttributeValue(attributeName));
+        public void accept(Record record) {
+            try {
+                csvPrinter.print(record.getId());
+                for (String attributeName : attributeNames) {
+                    csvPrinter.print(record.getAttributeValue(attributeName));
+                }
+                csvPrinter.println();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
             }
-            tsvWriter.writeRow(attributeValues);
         }
     }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/TsvSupport.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/TsvSupport.java
@@ -10,6 +10,10 @@ import java.util.function.Consumer;
 
 public class TsvSupport {
 
+    private TsvSupport (){
+
+    }
+
 
     public static TsvWriterSettings getTsvSettings(){
         TsvWriterSettings settings = new TsvWriterSettings();
@@ -28,11 +32,11 @@ public class TsvSupport {
         }
 
         @Override
-        public void accept(Record record) {
+        public void accept(Record rcd) {
             List<Object> attributeValues = new ArrayList<>();
-            attributeValues.add(record.getId());
+            attributeValues.add(rcd.getId());
             for (String attributeName : attributeNames) {
-                attributeValues.add(record.getAttributeValue(attributeName));
+                attributeValues.add(rcd.getAttributeValue(attributeName));
             }
             tsvWriter.writeRow(attributeValues);
         }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/BatchDeleteException.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/BatchDeleteException.java
@@ -9,8 +9,8 @@ import java.util.List;
 public class BatchDeleteException extends IllegalArgumentException {
 
 	public BatchDeleteException(List<String> errorInfo) {
-		super("We could not find some of the records you specified for deletion in your request. This list may not be exhaustive. " +
-				"Be sure to look for similar errors. Here's a sampling of records we could not find: "
+		super("We could not find some of the records you specified for deletion in your request. This list may not be exhaustive. "
+				+ "Be sure to look for similar errors. Here's a sampling of records we could not find: "
 				+ errorInfo.subList(0, Math.min(errorInfo.size(), 100)));
 	}
 

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -1,5 +1,4 @@
-spring.datasource.driver-class-name=org.postgresql.Driver
-spring.datasource.url=jdbc:postgresql://${WDS_DB_HOST:localhost}:${WDS_DB_PORT:5432}/wds?reWriteBatchedInserts=true
+spring.datasource.jdbc-url=jdbc:postgresql://${WDS_DB_HOST:localhost}:${WDS_DB_PORT:5432}/wds?reWriteBatchedInserts=true
 spring.datasource.username=${WDS_DB_USER:wds}
 spring.datasource.password=${WDS_DB_PASSWORD:wds}
 

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -10,3 +10,4 @@ server.error.include-stacktrace=never
 server.error.include-message=always
 
 twds.write.batch.size=5000
+twds.streaming.fetch.size=5000

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -3,5 +3,9 @@ spring.datasource.url=jdbc:postgresql://${WDS_DB_HOST:localhost}:${WDS_DB_PORT:5
 spring.datasource.username=${WDS_DB_USER:wds}
 spring.datasource.password=${WDS_DB_PASSWORD:wds}
 
+streaming.query.jdbc-url=jdbc:postgresql://${WDS_DB_HOST:localhost}:${WDS_DB_PORT:5432}/wds
+streaming.query.username=${WDS_DB_USER:wds}
+streaming.query.password=${WDS_DB_PASSWORD:wds}
+
 server.error.include-stacktrace=never
 server.error.include-message=always

--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -178,7 +178,7 @@ paths:
         200:
           description: Records in tsv format
           content:
-            text/plain:
+            text/tab-separated-values:
               schema:
                 type: string
                 format: binary

--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -163,6 +163,31 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /{instanceid}/tsv/{v}/{type}:
+    get:
+      summary: Retrieve all records in record type as tsv.
+      operationId: getRecordsAsTsv
+      description: Streams all records in a record type to a tsv format.
+      tags:
+        - Records
+      parameters:
+        - $ref: '#/components/parameters/instanceIdPathParam'
+        - $ref: '#/components/parameters/versionPathParam'
+        - $ref: '#/components/parameters/recordTypePathParam'
+      responses:
+        200:
+          description: Records in tsv format
+          content:
+            text/plain:
+              schema:
+                type: string
+                format: binary
+        404:
+          description: Instance or Record type not found
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /{instanceid}/batch/{v}/{type}:
     post:
       summary: Batch write records

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
@@ -20,9 +20,6 @@ import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.databiosphere.workspacedataservice.TestUtils.generateRandomAttributes;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
  * This test spins up a web server and the full Spring Boot web stack. It was

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
@@ -28,7 +28,8 @@ import static org.databiosphere.workspacedataservice.TestUtils.generateRandomAtt
  * https://github.com/spring-projects/spring-framework/issues/17290 As a result,
  * this test suite is currently focused on validating expected error handling
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {"spring.main.allow-bean-definition-overriding=true"})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
+		"spring.main.allow-bean-definition-overriding=true"})
 @Import(SmallBatchWriteTestConfig.class)
 class FullStackRecordControllerTest {
 	@Autowired
@@ -204,8 +205,8 @@ class FullStackRecordControllerTest {
 			RecordRequest recordRequest = new RecordRequest(attributes);
 			ResponseEntity<String> response = restTemplate.exchange(
 					"/{instanceId}/records/{version}/{recordType}/{recordId}", HttpMethod.PUT,
-					new HttpEntity<>(mapper.writeValueAsString(recordRequest), headers), String.class,
-					instanceId, versionId, recordType, recordId);
+					new HttpEntity<>(mapper.writeValueAsString(recordRequest), headers), String.class, instanceId,
+					versionId, recordType, recordId);
 			assertThat(response.getStatusCode()).isIn(HttpStatus.CREATED, HttpStatus.OK);
 			result.add(new Record(recordId, recordType, recordRequest));
 		}
@@ -217,13 +218,19 @@ class FullStackRecordControllerTest {
 	void dataTypeMismatchShouldFailBatchWrite() throws Exception {
 		RecordType recordType = RecordType.valueOf("bw-test");
 		List<Record> someRecords = createSomeRecords(recordType, 2);
-		List<BatchOperation> operations = someRecords.stream().map(r -> new BatchOperation(new Record(r.getId(), r.getRecordType(), r.getAttributes()), OperationType.UPSERT)).toList();
+		List<BatchOperation> operations = someRecords.stream()
+				.map(r -> new BatchOperation(new Record(r.getId(), r.getRecordType(), r.getAttributes()),
+						OperationType.UPSERT))
+				.toList();
 		operations.get(1).getRecord().getAttributes().putAttribute("attr2", "not a float, this should fail");
-		ResponseEntity<ErrorResponse> response = restTemplate.exchange("/{instanceid}/batch/{v}/{type}", HttpMethod.POST, new HttpEntity<>(mapper.writeValueAsString(operations), headers),
-				ErrorResponse.class, instanceId, versionId, recordType);
+		ResponseEntity<ErrorResponse> response = restTemplate.exchange("/{instanceid}/batch/{v}/{type}",
+				HttpMethod.POST, new HttpEntity<>(mapper.writeValueAsString(operations), headers), ErrorResponse.class,
+				instanceId, versionId, recordType);
 		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-		assertThat(response.getBody().getMessage()).contains("Some of the records in your request don't have the proper data for the record type");
-		assertThat(response.getBody().getMessage()).contains("is a STRING in the request but is defined as DOUBLE in the record type definition for bw-test");
+		assertThat(response.getBody().getMessage())
+				.contains("Some of the records in your request don't have the proper data for the record type");
+		assertThat(response.getBody().getMessage()).contains(
+				"is a STRING in the request but is defined as DOUBLE in the record type definition for bw-test");
 	}
 
 	@Test
@@ -232,16 +239,24 @@ class FullStackRecordControllerTest {
 		RecordType referencedRT = RecordType.valueOf("batch-delete-test-referenced");
 		List<Record> someRecords = createSomeRecords(referencedRT, 2);
 		RecordType referencerRT = RecordType.valueOf("referencer");
-		List<BatchOperation> ops = List.of(new BatchOperation(new Record("referencer-1", referencerRT,
-				new RecordAttributes(Map.of("attr-ref", RelationUtils.createRelationString(referencedRT, "record_0")))), OperationType.UPSERT));
-		restTemplate.exchange("/{instanceid}/batch/{v}/{type}", HttpMethod.POST, new HttpEntity<>(mapper.writeValueAsString(ops), headers),
-				String.class, instanceId, versionId, referencerRT);
-		List<BatchOperation> deleteOps = List.of(new BatchOperation(someRecords.get(1), OperationType.DELETE), new BatchOperation(someRecords.get(0), OperationType.DELETE));
-		ResponseEntity<ErrorResponse> error = restTemplate.exchange("/{instanceid}/batch/{v}/{type}", HttpMethod.POST, new HttpEntity<>(mapper.writeValueAsString(deleteOps), headers),
-				ErrorResponse.class, instanceId, versionId, referencedRT);
+		List<BatchOperation> ops = List
+				.of(new BatchOperation(
+						new Record("referencer-1", referencerRT,
+								new RecordAttributes(Map.of("attr-ref",
+										RelationUtils.createRelationString(referencedRT, "record_0")))),
+						OperationType.UPSERT));
+		restTemplate.exchange("/{instanceid}/batch/{v}/{type}", HttpMethod.POST,
+				new HttpEntity<>(mapper.writeValueAsString(ops), headers), String.class, instanceId, versionId,
+				referencerRT);
+		List<BatchOperation> deleteOps = List.of(new BatchOperation(someRecords.get(1), OperationType.DELETE),
+				new BatchOperation(someRecords.get(0), OperationType.DELETE));
+		ResponseEntity<ErrorResponse> error = restTemplate.exchange("/{instanceid}/batch/{v}/{type}", HttpMethod.POST,
+				new HttpEntity<>(mapper.writeValueAsString(deleteOps), headers), ErrorResponse.class, instanceId,
+				versionId, referencedRT);
 		assertThat(error.getBody().getMessage()).contains("because another record has a relation to it");
-		ResponseEntity<RecordResponse> stillPresentNonReferencedRecord = restTemplate.exchange("/{instanceId}/records/{version}/{recordType}/{recordId}",
-				HttpMethod.GET, new HttpEntity<>(headers), RecordResponse.class, instanceId, versionId, referencedRT, "record_1");
+		ResponseEntity<RecordResponse> stillPresentNonReferencedRecord = restTemplate.exchange(
+				"/{instanceId}/records/{version}/{recordType}/{recordId}", HttpMethod.GET, new HttpEntity<>(headers),
+				RecordResponse.class, instanceId, versionId, referencedRT, "record_1");
 		assertThat(stillPresentNonReferencedRecord.getBody().recordId()).isEqualTo("record_1");
 	}
 
@@ -251,13 +266,17 @@ class FullStackRecordControllerTest {
 		RecordType recordType = RecordType.valueOf("forBatchDelete");
 		createSomeRecords(recordType, 3);
 		RecordAttributes emptyAtts = new RecordAttributes(new HashMap<>());
-		List<BatchOperation> batchOperations = List.of(new BatchOperation(new Record("record_0", recordType, emptyAtts), OperationType.DELETE),
+		List<BatchOperation> batchOperations = List.of(
+				new BatchOperation(new Record("record_0", recordType, emptyAtts), OperationType.DELETE),
 				new BatchOperation(new Record("missing", recordType, emptyAtts), OperationType.DELETE));
-		ResponseEntity<ErrorResponse> error = restTemplate.exchange("/{instanceid}/batch/{v}/{type}", HttpMethod.POST, new HttpEntity<>(mapper.writeValueAsString(batchOperations), headers),
-				ErrorResponse.class, instanceId, versionId, recordType);
+		ResponseEntity<ErrorResponse> error = restTemplate.exchange("/{instanceid}/batch/{v}/{type}", HttpMethod.POST,
+				new HttpEntity<>(mapper.writeValueAsString(batchOperations), headers), ErrorResponse.class, instanceId,
+				versionId, recordType);
 		assertThat(error.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
-		//record_0 should still be present since the above deletion is transactional and should fail upon 'missing'
-		ResponseEntity<RecordResponse> rresponse = restTemplate.exchange("/{instanceId}/records/{version}/{recordType}/{recordId}", HttpMethod.GET, new HttpEntity<>(headers),
+		// record_0 should still be present since the above deletion is transactional
+		// and should fail upon 'missing'
+		ResponseEntity<RecordResponse> rresponse = restTemplate.exchange(
+				"/{instanceId}/records/{version}/{recordType}/{recordId}", HttpMethod.GET, new HttpEntity<>(headers),
 				RecordResponse.class, instanceId, versionId, recordType, "record_0");
 		assertThat(rresponse.getBody().recordId()).isEqualTo("record_0");
 	}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -10,7 +10,6 @@ import org.databiosphere.workspacedataservice.service.model.exception.MissingObj
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.*;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -482,7 +482,6 @@ class RecordControllerMockMvcTest {
 		return createSomeRecords(recordType, numRecords, instanceId);
 	}
 
-
 	private List<Record> createSomeRecords(RecordType recordType, int numRecords, UUID instId) throws Exception {
 		List<Record> result = new ArrayList<>();
 		for (int i = 0; i < numRecords; i++) {
@@ -510,28 +509,36 @@ class RecordControllerMockMvcTest {
 				new RecordAttributes(Map.of("attr1", "attr-val")));
 		BatchOperation op = new BatchOperation(record, OperationType.UPSERT);
 		mockMvc.perform(post("/{instanceid}/batch/{v}/{type}", instanceId, versionId, newBatchRecordType)
-						.content(mapper.writeValueAsString(List.of(op, new BatchOperation(record2, OperationType.UPSERT)))).contentType(MediaType.APPLICATION_JSON))
-						.andExpect(jsonPath("$.recordsModified", is(2)))
-						.andExpect(jsonPath("$.message", is("Huzzah")))
-				.andExpect(status().isOk());
-		mockMvc.perform(get("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId, newBatchRecordType, recordId)
-				.contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk());
+				.content(mapper.writeValueAsString(List.of(op, new BatchOperation(record2, OperationType.UPSERT))))
+				.contentType(MediaType.APPLICATION_JSON)).andExpect(jsonPath("$.recordsModified", is(2)))
+				.andExpect(jsonPath("$.message", is("Huzzah"))).andExpect(status().isOk());
+		mockMvc.perform(get("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
+				newBatchRecordType, recordId).contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk());
 		mockMvc.perform(post("/{instanceid}/batch/{v}/{type}", instanceId, versionId, newBatchRecordType)
-						.content(mapper.writeValueAsString(List.of(new BatchOperation(record, OperationType.DELETE)))).contentType(MediaType.APPLICATION_JSON))
-				.andExpect(status().isOk());
-		mockMvc.perform(get("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId, newBatchRecordType, recordId)
-				.contentType(MediaType.APPLICATION_JSON)).andExpect(status().isNotFound());
+				.content(mapper.writeValueAsString(List.of(new BatchOperation(record, OperationType.DELETE))))
+				.contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk());
+		mockMvc.perform(get("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
+				newBatchRecordType, recordId).contentType(MediaType.APPLICATION_JSON)).andExpect(status().isNotFound());
 	}
 
 	@Test
 	@Transactional
 	void batchInsertShouldFailWithInvalidRelation() throws Exception {
 		RecordType recordType = RecordType.valueOf("relationBatchInsert");
-		List<BatchOperation> batchOperations = List.of(new BatchOperation(new Record("record_0", recordType,
-						new RecordAttributes(Map.of("attr-relation", RelationUtils.createRelationString(RecordType.valueOf("missing"), "A")))), OperationType.UPSERT),
-				new BatchOperation(new Record("record_1", recordType, new RecordAttributes(Map.of("attr-relation", RelationUtils.createRelationString(RecordType.valueOf("missing"), "A")))), OperationType.UPSERT));
+		List<BatchOperation> batchOperations = List.of(
+				new BatchOperation(
+						new Record("record_0", recordType,
+								new RecordAttributes(Map.of("attr-relation",
+										RelationUtils.createRelationString(RecordType.valueOf("missing"), "A")))),
+						OperationType.UPSERT),
+				new BatchOperation(
+						new Record("record_1", recordType,
+								new RecordAttributes(Map.of("attr-relation",
+										RelationUtils.createRelationString(RecordType.valueOf("missing"), "A")))),
+						OperationType.UPSERT));
 		mockMvc.perform(post("/{instanceid}/batch/{v}/{type}", instanceId, versionId, recordType)
-				.content(mapper.writeValueAsString(batchOperations)).contentType(MediaType.APPLICATION_JSON)).andExpect(status().isNotFound());
+				.content(mapper.writeValueAsString(batchOperations)).contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isNotFound());
 	}
 
 	@Test
@@ -539,11 +546,20 @@ class RecordControllerMockMvcTest {
 	void batchInsertShouldFailWithInvalidRelationExistingRecordType() throws Exception {
 		RecordType recordType = RecordType.valueOf("relationBatchInsert");
 		createSomeRecords(recordType, 2);
-		List<BatchOperation> batchOperations = List.of(new BatchOperation(new Record("record_0", recordType,
-						new RecordAttributes(Map.of("attr-relation", RelationUtils.createRelationString(RecordType.valueOf("missing"), "A")))), OperationType.UPSERT),
-				new BatchOperation(new Record("record_1", recordType, new RecordAttributes(Map.of("attr-relation", RelationUtils.createRelationString(RecordType.valueOf("missing"), "A")))), OperationType.UPSERT));
+		List<BatchOperation> batchOperations = List.of(
+				new BatchOperation(
+						new Record("record_0", recordType,
+								new RecordAttributes(Map.of("attr-relation",
+										RelationUtils.createRelationString(RecordType.valueOf("missing"), "A")))),
+						OperationType.UPSERT),
+				new BatchOperation(
+						new Record("record_1", recordType,
+								new RecordAttributes(Map.of("attr-relation",
+										RelationUtils.createRelationString(RecordType.valueOf("missing"), "A")))),
+						OperationType.UPSERT));
 		mockMvc.perform(post("/{instanceid}/batch/{v}/{type}", instanceId, versionId, recordType)
-				.content(mapper.writeValueAsString(batchOperations)).contentType(MediaType.APPLICATION_JSON)).andExpect(status().isNotFound());
+				.content(mapper.writeValueAsString(batchOperations)).contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isNotFound());
 	}
 
 	@Test
@@ -553,14 +569,17 @@ class RecordControllerMockMvcTest {
 		List<Record> records = createSomeRecords(recordType, 2);
 		Record upsertRcd = records.get(1);
 		upsertRcd.getAttributes().putAttribute("new-col", "new value!!");
-		List<BatchOperation> ops = List.of(new BatchOperation(records.get(0), OperationType.DELETE), new BatchOperation(upsertRcd, OperationType.UPSERT));
+		List<BatchOperation> ops = List.of(new BatchOperation(records.get(0), OperationType.DELETE),
+				new BatchOperation(upsertRcd, OperationType.UPSERT));
 		mockMvc.perform(post("/{instanceid}/batch/{v}/{type}", instanceId, versionId, recordType)
-				.content(mapper.writeValueAsString(ops)).contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk());
-		mockMvc.perform(get("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId, recordType, records.get(0).getId())
-				.contentType(MediaType.APPLICATION_JSON)).andExpect(status().isNotFound());
-		mockMvc.perform(get("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId, recordType, upsertRcd.getId())
-				.contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk()).andExpect(jsonPath("$.attributes.new-col", is("new value!!")));
+				.content(mapper.writeValueAsString(ops)).contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk());
+		mockMvc.perform(get("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
+				recordType, records.get(0).getId()).contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isNotFound());
+		mockMvc.perform(get("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
+				recordType, upsertRcd.getId()).contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+				.andExpect(jsonPath("$.attributes.new-col", is("new value!!")));
 	}
-
 
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/SmallBatchWriteTestConfig.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/SmallBatchWriteTestConfig.java
@@ -12,8 +12,8 @@ import org.springframework.context.annotation.Bean;
 @TestConfiguration
 public class SmallBatchWriteTestConfig {
 
-    @Bean
-    public BatchWriteService batchWriteService(RecordDao recordDao){
-        return new BatchWriteService(recordDao, 1);
-    }
+	@Bean
+	public BatchWriteService batchWriteService(RecordDao recordDao) {
+		return new BatchWriteService(recordDao, 1);
+	}
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
@@ -38,7 +38,7 @@ class TsvDownloadTest {
         String version = "v0.2";
         UUID instanceId = UUID.randomUUID();
         recordController.createInstance(instanceId, version);
-        InputStream is = FullStackRecordControllerTest.class.getResourceAsStream("/batch_write_tsv_data.json");
+        InputStream is = TsvDownloadTest.class.getResourceAsStream("/batch_write_tsv_data.json");
         ResponseEntity<BatchResponse> response = recordController.streamingWrite(instanceId, version, recordType, is);
         is.close();
         assertThat(response.getStatusCodeValue()).isEqualTo(200);

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
@@ -10,6 +10,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.core.io.Resource;
 import org.springframework.http.*;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -50,6 +51,6 @@ public class TsvDownloadTest {
         assertThat(result.size()).isEqualTo(3);
         assertThat(result.get(0)).isEqualTo(new String[]{"sys_name", "createdAt", "description", "location", "jsonObj", "jsonArray"});
         assertThat(result.get(1)).isEqualTo(new String[]{"1", "2021-10-11", "Embedded\tTab", "Portland, OR", "{\"age\": 22, \"foo\": \"bar\"}", null});
-        assertThat(result.get(2)).isEqualTo(new String[]{"2", null, "\n,Weird\n String", "Cambridge, MA", null, "[1, 3, 9, \"puppies\"]"});
+        assertThat(result.get(2)).isEqualTo(new String[]{"2", null, ",Weird\n String", "Cambridge, MA", null, "[1, 3, 9, \"puppies\"]"});
     }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
@@ -29,6 +29,7 @@ public class TsvDownloadTest {
     private RecordController recordController;
 
     @Test
+    @Transactional
     void batchWriteFollowedByTsvDownload() throws IOException {
         RecordType recordType = RecordType.valueOf("tsv-test");
         String version = "v0.2";

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
@@ -56,6 +56,7 @@ class TsvDownloadTest {
         rcd = iterator.next();
         assertThat(rcd.get("description")).isEqualTo("\n,Weird\n String");
         assertThat(rcd.get("location")).isEqualTo("Cambridge, \"MA\"");
+        assertThat(rcd.get("unicodeData")).isEqualTo("\uD83D\uDCA9\u0207");
         assertThat(iterator.hasNext()).isFalse();
         reader.close();
     }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
@@ -10,7 +10,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.core.io.Resource;
 import org.springframework.http.*;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -29,12 +29,10 @@ public class TsvDownloadTest {
     private RecordController recordController;
 
     @Test
-    @Transactional
     void batchWriteFollowedByTsvDownload() throws IOException {
         RecordType recordType = RecordType.valueOf("tsv-test");
         String version = "v0.2";
         UUID instanceId = UUID.randomUUID();
-        System.out.println(instanceId);
         recordController.createInstance(instanceId, version);
         InputStream is = FullStackRecordControllerTest.class.getResourceAsStream("/batch_write_tsv_data.json");
         ResponseEntity<BatchResponse> response = recordController.streamingWrite(instanceId, version, recordType, is);
@@ -42,7 +40,7 @@ public class TsvDownloadTest {
         assertThat(response.getStatusCodeValue()).isEqualTo(200);
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
-        ResponseEntity<Resource> stream = restTemplate.exchange("/{instanceId}/records/{version}/{recordType}",
+        ResponseEntity<Resource> stream = restTemplate.exchange("/{instanceId}/tsv/{version}/{recordType}",
                 HttpMethod.GET, new HttpEntity<>(headers), Resource.class, instanceId, version, recordType);
         InputStream inputStream = stream.getBody().getInputStream();
         TsvParserSettings tsvParserSettings = new TsvParserSettings();

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
@@ -1,0 +1,55 @@
+package org.databiosphere.workspacedataservice.controller;
+
+import com.univocity.parsers.tsv.TsvParser;
+import com.univocity.parsers.tsv.TsvParserSettings;
+import org.databiosphere.workspacedataservice.shared.model.BatchResponse;
+import org.databiosphere.workspacedataservice.shared.model.RecordType;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.io.Resource;
+import org.springframework.http.*;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class TsvDownloadTest {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private RecordController recordController;
+
+    @Test
+    void batchWriteFollowedByTsvDownload() throws IOException {
+        RecordType recordType = RecordType.valueOf("tsv-test");
+        String version = "v0.2";
+        UUID instanceId = UUID.randomUUID();
+        System.out.println(instanceId);
+        recordController.createInstance(instanceId, version);
+        InputStream is = FullStackRecordControllerTest.class.getResourceAsStream("/batch_write_tsv_data.json");
+        ResponseEntity<BatchResponse> response = recordController.streamingWrite(instanceId, version, recordType, is);
+        is.close();
+        assertThat(response.getStatusCodeValue()).isEqualTo(200);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        ResponseEntity<Resource> stream = restTemplate.exchange("/{instanceId}/records/{version}/{recordType}",
+                HttpMethod.GET, new HttpEntity<>(headers), Resource.class, instanceId, version, recordType);
+        InputStream inputStream = stream.getBody().getInputStream();
+        TsvParserSettings tsvParserSettings = new TsvParserSettings();
+        tsvParserSettings.getFormat().setLineSeparator("\n");
+        TsvParser tsvParser = new TsvParser(tsvParserSettings);
+        List<String[]> result = tsvParser.parseAll(inputStream);
+        assertThat(result.size()).isEqualTo(3);
+        assertThat(result.get(0)).isEqualTo(new String[]{"sys_name", "createdAt", "description", "location", "jsonObj", "jsonArray"});
+        assertThat(result.get(1)).isEqualTo(new String[]{"1", "2021-10-11", "Embedded\tTab", "Portland, OR", "{\"age\": 22, \"foo\": \"bar\"}", null});
+        assertThat(result.get(2)).isEqualTo(new String[]{"2", null, "\n,Weird\n String", "Cambridge, MA", null, "[1, 3, 9, \"puppies\"]"});
+    }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
@@ -10,17 +10,17 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.core.io.Resource;
 import org.springframework.http.*;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.UUID;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-public class TsvDownloadTest {
+class TsvDownloadTest {
 
     @Autowired
     private TestRestTemplate restTemplate;
@@ -47,7 +47,7 @@ public class TsvDownloadTest {
         tsvParserSettings.getFormat().setLineSeparator("\n");
         TsvParser tsvParser = new TsvParser(tsvParserSettings);
         List<String[]> result = tsvParser.parseAll(inputStream);
-        assertThat(result.size()).isEqualTo(3);
+        assertThat(result).hasSize(3);
         assertThat(result.get(0)).isEqualTo(new String[]{"sys_name", "createdAt", "description", "location", "jsonObj", "jsonArray"});
         assertThat(result.get(1)).isEqualTo(new String[]{"1", "2021-10-11", "Embedded\tTab", "Portland, OR", "{\"age\": 22, \"foo\": \"bar\"}", null});
         assertThat(result.get(2)).isEqualTo(new String[]{"2", null, ",Weird\n String", "Cambridge, MA", null, "[1, 3, 9, \"puppies\"]"});

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
@@ -40,7 +40,6 @@ class TsvDownloadTest {
         recordController.createInstance(instanceId, version);
         InputStream is = TsvDownloadTest.class.getResourceAsStream("/batch_write_tsv_data.json");
         ResponseEntity<BatchResponse> response = recordController.streamingWrite(instanceId, version, recordType, is);
-        is.close();
         assertThat(response.getStatusCodeValue()).isEqualTo(200);
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
@@ -22,41 +22,40 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class TsvDownloadTest {
 
-    @Autowired
-    private TestRestTemplate restTemplate;
+	@Autowired
+	private TestRestTemplate restTemplate;
 
-    @Autowired
-    private RecordController recordController;
+	@Autowired
+	private RecordController recordController;
 
-    @Test
-    void batchWriteFollowedByTsvDownload() throws IOException {
-        RecordType recordType = RecordType.valueOf("tsv-test");
-        String version = "v0.2";
-        UUID instanceId = UUID.randomUUID();
-        recordController.createInstance(instanceId, version);
-        InputStream is = TsvDownloadTest.class.getResourceAsStream("/batch_write_tsv_data.json");
-        ResponseEntity<BatchResponse> response = recordController.streamingWrite(instanceId, version, recordType, is);
-        assertThat(response.getStatusCodeValue()).isEqualTo(200);
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-        ResponseEntity<Resource> stream = restTemplate.exchange("/{instanceId}/tsv/{version}/{recordType}",
-                HttpMethod.GET, new HttpEntity<>(headers), Resource.class, instanceId, version, recordType);
-        InputStream inputStream = stream.getBody().getInputStream();
-        CSVFormat csvFormat = CSVFormat.DEFAULT.builder().setHeader().setSkipHeaderRecord(true).setDelimiter("\t").setQuoteMode(QuoteMode.MINIMAL).build();
-        InputStreamReader reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
-        Iterable<CSVRecord> records = new CSVParser(reader, csvFormat);
-        Iterator<CSVRecord> iterator = records.iterator();
-        CSVRecord rcd = iterator.next();
-        assertThat(rcd.get("description")).isEqualTo("Embedded\tTab");
-        rcd = iterator.next();
-        assertThat(rcd.get("description")).isEqualTo("\n,Weird\n String");
-        assertThat(rcd.get("location")).isEqualTo("Cambridge, \"MA\"");
-        assertThat(rcd.get("unicodeData")).isEqualTo("\uD83D\uDCA9\u0207");
-        assertThat(iterator.hasNext()).isFalse();
-        reader.close();
-    }
+	@Test
+	void batchWriteFollowedByTsvDownload() throws IOException {
+		RecordType recordType = RecordType.valueOf("tsv-test");
+		String version = "v0.2";
+		UUID instanceId = UUID.randomUUID();
+		recordController.createInstance(instanceId, version);
+		InputStream is = TsvDownloadTest.class.getResourceAsStream("/batch_write_tsv_data.json");
+		ResponseEntity<BatchResponse> response = recordController.streamingWrite(instanceId, version, recordType, is);
+		assertThat(response.getStatusCodeValue()).isEqualTo(200);
+		HttpHeaders headers = new HttpHeaders();
+		ResponseEntity<Resource> stream = restTemplate.exchange("/{instanceId}/tsv/{version}/{recordType}",
+				HttpMethod.GET, new HttpEntity<>(headers), Resource.class, instanceId, version, recordType);
+		InputStream inputStream = stream.getBody().getInputStream();
+		CSVFormat csvFormat = CSVFormat.DEFAULT.builder().setHeader().setSkipHeaderRecord(true).setDelimiter("\t")
+				.setQuoteMode(QuoteMode.MINIMAL).build();
+		InputStreamReader reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
+		Iterable<CSVRecord> records = new CSVParser(reader, csvFormat);
+		Iterator<CSVRecord> iterator = records.iterator();
+		CSVRecord rcd = iterator.next();
+		assertThat(rcd.get("description")).isEqualTo("Embedded\tTab");
+		rcd = iterator.next();
+		assertThat(rcd.get("description")).isEqualTo("\n,Weird\n String");
+		assertThat(rcd.get("location")).isEqualTo("Cambridge, \"MA\"");
+		assertThat(rcd.get("unicodeData")).isEqualTo("\uD83D\uDCA9\u0207");
+		assertThat(iterator.hasNext()).isFalse();
+		reader.close();
+	}
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
@@ -56,7 +56,8 @@ class RecordDaoTest {
 	@Test
 	@Transactional
 	void testGetRecordsWithRelations() {
-		//Create two records of the same type, one with a value for a relation attribute, the other without
+		// Create two records of the same type, one with a value for a relation
+		// attribute, the other without
 		recordDao.addColumn(instanceId, recordType, "foo", DataTypeMapping.STRING);
 		recordDao.addColumn(instanceId, recordType, "relationAttr", DataTypeMapping.STRING);
 		recordDao.addForeignKeyForReference(recordType, recordType, instanceId, "relationAttr");
@@ -75,11 +76,13 @@ class RecordDaoTest {
 		List<Relation> relations = recordDao.getRelationCols(instanceId, recordType);
 
 		Record testRecordFetched = recordDao.getSingleRecord(instanceId, recordType, recordId, relations).get();
-		//Relation attribute should be in the form of "terra-wds:/recordType/recordId"
-		assertEquals(RelationUtils.createRelationString(recordType, refRecordId), testRecordFetched.getAttributeValue("relationAttr").toString());
+		// Relation attribute should be in the form of "terra-wds:/recordType/recordId"
+		assertEquals(RelationUtils.createRelationString(recordType, refRecordId),
+				testRecordFetched.getAttributeValue("relationAttr").toString());
 
-		Record referencedRecordFetched = recordDao.getSingleRecord(instanceId, recordType, refRecordId, relations).get();
-		//Null relation attribute should be null
+		Record referencedRecordFetched = recordDao.getSingleRecord(instanceId, recordType, refRecordId, relations)
+				.get();
+		// Null relation attribute should be null
 		assertNull(referencedRecordFetched.getAttributeValue("relationAttr"));
 	}
 

--- a/service/src/test/resources/batch_write_tsv_data.json
+++ b/service/src/test/resources/batch_write_tsv_data.json
@@ -1,0 +1,4 @@
+[
+  {"operation":  "upsert", "record":  {"id":  "1", "type": "bar", "attributes":  {"location":  "Portland, OR", "description": "Embedded\tTab", "jsonObj":  "{\"foo\":  \"bar\", \"age\":  22}", "createdAt":  "2021-10-11"}}},
+  {"operation":  "upsert", "record":  {"id":  "2", "type": "bar", "attributes":  {"location":  "Cambridge, MA", "description": ",Weird\n String", "jsonArray": "[1, 3, 9, \"puppies\"]"}}}
+]

--- a/service/src/test/resources/batch_write_tsv_data.json
+++ b/service/src/test/resources/batch_write_tsv_data.json
@@ -1,4 +1,4 @@
 [
   {"operation":  "upsert", "record":  {"id":  "1", "type": "bar", "attributes":  {"location":  "Portland, OR", "description": "Embedded\tTab", "jsonObj":  "{\"foo\":  \"bar\", \"age\":  22}", "createdAt":  "2021-10-11"}}},
-  {"operation":  "upsert", "record":  {"id":  "2", "type": "bar", "attributes":  {"location":  "Cambridge, MA", "description": ",Weird\n String", "jsonArray": "[1, 3, 9, \"puppies\"]"}}}
+  {"operation":  "upsert", "record":  {"id":  "2", "type": "bar", "attributes":  {"location":  "Cambridge, \"MA\"", "description": "\n,Weird\n String", "jsonArray": "[1, 3, 9, \"puppies\"]"}}}
 ]

--- a/service/src/test/resources/batch_write_tsv_data.json
+++ b/service/src/test/resources/batch_write_tsv_data.json
@@ -1,4 +1,4 @@
 [
   {"operation":  "upsert", "record":  {"id":  "1", "type": "bar", "attributes":  {"location":  "Portland, OR", "description": "Embedded\tTab", "jsonObj":  "{\"foo\":  \"bar\", \"age\":  22}", "createdAt":  "2021-10-11"}}},
-  {"operation":  "upsert", "record":  {"id":  "2", "type": "bar", "attributes":  {"location":  "Cambridge, \"MA\"", "description": "\n,Weird\n String", "jsonArray": "[1, 3, 9, \"puppies\"]"}}}
+  {"operation":  "upsert", "record":  {"id":  "2", "type": "bar", "attributes":  {"location":  "Cambridge, \"MA\"", "description": "\n,Weird\n String", "jsonArray": "[1, 3, 9, \"puppies\"]", "unicodeData":  "\uD83D\uDCA9\u0207"}}}
 ]


### PR DESCRIPTION
I've tested this with a record type larger than 1gb and confirmed that it works even on a 100mb heap.  Changes are in place to make sure we stream from db to java.sql.Resultset, from Resultset to intermediate domain object, and from domain object to http response.  I can share a large json file you can use as input to the batch write API if you'd like to test for yourself. 