### PR TITLE
aj-604 check for null relation

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -412,7 +412,7 @@ public class RecordDao {
 					if (columnName.startsWith(RESERVED_NAME_PREFIX)) {
 						continue;
 					}
-					if (referenceColToTable.size() > 0 && referenceColToTable.containsKey(columnName)) {
+					if (referenceColToTable.size() > 0 && referenceColToTable.containsKey(columnName) && rs.getString(columnName) != null) {
 						attributes.putAttribute(columnName, RelationUtils
 								.createRelationString(referenceColToTable.get(columnName), rs.getString(columnName)));
 					} else {


### PR DESCRIPTION
[Aj-604 Blank relation value displays incomplete relation identifier](https://broadworkbench.atlassian.net/browse/AJ-604)
If a relation attribute is blank, it would show up as simply the terra relation identifier string without a recordId (`terra-wds:/recordType`:
<img width="1397" alt="Screen Shot 2022-10-03 at 4 39 41 PM" src="https://user-images.githubusercontent.com/5884792/193678819-13d1f5fa-f9f7-4b8c-bedf-b4fb155bb8cb.png">

This PR simply checks for null before adding the relation identifier:
<img width="1397" alt="Screen Shot 2022-10-03 at 4 39 15 PM" src="https://user-images.githubusercontent.com/5884792/193678936-9174d4e4-7e6f-44bc-8a1c-01309032face.png">
