### PR TITLE
AJ-611: don't require trailing slash for create-instance API

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -132,7 +132,7 @@ public class RecordController {
 		}
 	}
 
-	@PostMapping("/{instanceId}/{version}/")
+	@PostMapping("/{instanceId}/{version}")
 	public ResponseEntity<String> createInstance(@PathVariable("instanceId") UUID instanceId,
 			@PathVariable("version") String version) {
 		validateVersion(version);

--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -183,7 +183,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BatchResponse'
-  /{instanceid}/{v}/:
+  /{instanceid}/{v}:
     post:
       summary: Create an instance (unstable)
       description: Create an instance with the given UUID. This API is liable to change.


### PR DESCRIPTION
title.

This was tripping up CBAS integration because us humans were confused by it