### PR TITLE
fix create-instance and swagger ui [AJ-619]

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -132,7 +132,7 @@ public class RecordController {
 		}
 	}
 
-	@PostMapping("/{instanceId}/{version}")
+	@PostMapping("/instances/{version}/{instanceId}")
 	public ResponseEntity<String> createInstance(@PathVariable("instanceId") UUID instanceId,
 			@PathVariable("version") String version) {
 		validateVersion(version);

--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -183,7 +183,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BatchResponse'
-  /{instanceid}/{v}:
+  /instances/{v}/{instanceid}:
     post:
       summary: Create an instance (unstable)
       description: Create an instance with the given UUID. This API is liable to change.

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -52,8 +52,8 @@ class RecordControllerMockMvcTest {
 	@Transactional
 	void createInstanceAndTryToCreateAgain() throws Exception {
 		UUID uuid = UUID.randomUUID();
-		mockMvc.perform(post("/{instanceId}/{version}/", uuid, versionId)).andExpect(status().isCreated());
-		mockMvc.perform(post("/{instanceId}/{version}/", uuid, versionId)).andExpect(status().isConflict());
+		mockMvc.perform(post("/instances/{version}/{instanceId}", versionId, uuid)).andExpect(status().isCreated());
+		mockMvc.perform(post("/instances/{version}/{instanceId}", versionId, uuid)).andExpect(status().isConflict());
 	}
 
 	@Test
@@ -502,7 +502,7 @@ class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void batchWriteInsertShouldSucceed() throws Exception {
-		mockMvc.perform(post("/{instanceId}/{version}/", instanceId, versionId));
+		mockMvc.perform(post("/instances/{version}/{instanceId}", versionId, instanceId));
 		String recordId = "foo";
 		String newBatchRecordType = "new-record-type";
 		Record record = new Record(recordId, RecordType.valueOf(newBatchRecordType),


### PR DESCRIPTION
Move the create-instance API to `/instances/{version}/{instanceId}`.

This works around a weird issue in Spring that causes `There was an unexpected error (type=Method Not Allowed, status=405). Request method 'GET' not supported.` errors