### PR TITLE
aj-615 paginated sort by column

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ repositories { mavenCentral() }
 
 subprojects {
     group = 'org.databiosphere'
-    version = '0.1.39-SNAPSHOT'
+    version = '0.1.40-SNAPSHOT'
 
     apply plugin: 'idea'
     apply plugin: 'java'

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -86,14 +86,14 @@ public class RecordController {
 		}
 
 		if(searchRequest.getSortAttribute() != null && !recordDao.getExistingTableSchema(instanceId, recordType).keySet().contains(searchRequest.getSortAttribute())){
-			throw new MissingObjectException("Record attribute");
+			throw new MissingObjectException("Requested sort attribute");
 		}
 		int totalRecords = recordDao.countRecords(instanceId, recordType);
 		if (searchRequest.getOffset() > totalRecords) {
 			return new RecordQueryResponse(searchRequest, Collections.emptyList(), totalRecords);
 		}
 		List<Record> records = recordDao.queryForRecords(recordType, searchRequest.getLimit(),
-				searchRequest.getOffset(), searchRequest.getSort().name().toLowerCase(), instanceId, searchRequest.getSortAttribute());
+				searchRequest.getOffset(), searchRequest.getSort().name().toLowerCase(), searchRequest.getSortAttribute(), instanceId);
 		List<RecordResponse> recordList = records.stream().map(
 				r -> new RecordResponse(r.getId(), r.getRecordType(), r.getAttributes(), new RecordMetadata("UNUSED")))
 				.toList();

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -84,12 +84,16 @@ public class RecordController {
 			throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
 					"Limit must be more than 0 and can't exceed " + MAX_RECORDS + ", and offset must be positive.");
 		}
+
+		if(searchRequest.getSortAttribute() != null && !recordDao.getExistingTableSchema(instanceId, recordType).keySet().contains(searchRequest.getSortAttribute())){
+			throw new MissingObjectException("Record attribute");
+		}
 		int totalRecords = recordDao.countRecords(instanceId, recordType);
 		if (searchRequest.getOffset() > totalRecords) {
 			return new RecordQueryResponse(searchRequest, Collections.emptyList(), totalRecords);
 		}
 		List<Record> records = recordDao.queryForRecords(recordType, searchRequest.getLimit(),
-				searchRequest.getOffset(), searchRequest.getSort().name().toLowerCase(), instanceId);
+				searchRequest.getOffset(), searchRequest.getSort().name().toLowerCase(), instanceId, searchRequest.getSortAttribute());
 		List<RecordResponse> recordList = records.stream().map(
 				r -> new RecordResponse(r.getId(), r.getRecordType(), r.getAttributes(), new RecordMetadata("UNUSED")))
 				.toList();

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -87,7 +87,7 @@ public class RecordDao {
 
 	@SuppressWarnings("squid:S2077")
 	public List<Record> queryForRecords(RecordType recordType, int pageSize, int offset, String sortDirection,
-			UUID instanceId, String sortAttribute) {
+										String sortAttribute, UUID instanceId) {
 		return namedTemplate.getJdbcTemplate().query(
 				"select * from " + getQualifiedTableName(recordType, instanceId) + " order by " + (sortAttribute == null ? RECORD_ID : quote(sortAttribute)) + " "
 						+ sortDirection + " limit " + pageSize + " offset " + offset,

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -87,9 +87,9 @@ public class RecordDao {
 
 	@SuppressWarnings("squid:S2077")
 	public List<Record> queryForRecords(RecordType recordType, int pageSize, int offset, String sortDirection,
-			UUID instanceId) {
+			UUID instanceId, String sortAttribute) {
 		return namedTemplate.getJdbcTemplate().query(
-				"select * from " + getQualifiedTableName(recordType, instanceId) + " order by " + RECORD_ID + " "
+				"select * from " + getQualifiedTableName(recordType, instanceId) + " order by " + (sortAttribute == null ? RECORD_ID : quote(sortAttribute)) + " "
 						+ sortDirection + " limit " + pageSize + " offset " + offset,
 				new RecordRowMapper(recordType, getRelationColumnsByName(getRelationCols(instanceId, recordType))));
 	}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/SearchRequest.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/SearchRequest.java
@@ -5,11 +5,19 @@ public class SearchRequest {
 	private int limit = 10;
 	private int offset = 0;
 	private SortDirection sort = SortDirection.ASC;
+	private String sortAttribute = null;
 
 	public SearchRequest(int limit, int offset, SortDirection sort) {
 		this.limit = limit;
 		this.offset = offset;
 		this.sort = sort;
+	}
+
+	public SearchRequest(int limit, int offset, SortDirection sort, String sortAttribute) {
+		this.limit = limit;
+		this.offset = offset;
+		this.sort = sort;
+		this.sortAttribute = sortAttribute;
 	}
 
 	public SearchRequest() {
@@ -38,4 +46,8 @@ public class SearchRequest {
 	public void setSort(SortDirection sort) {
 		this.sort = sort;
 	}
+
+	public String getSortAttribute() { return sortAttribute; }
+
+	public void setSortAttribute(String sortAttribute) { this.sortAttribute = sortAttribute; }
 }

--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -502,6 +502,8 @@ components:
           $ref: '#/components/schemas/SearchLimit'
         sort:
           $ref: '#/components/schemas/SearchSortDirection'
+        sortAttribute:
+          type: string
     RecordRequest:
       type: object
       required:

--- a/service/src/test/java/org/databiosphere/workspacedataservice/TestUtils.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/TestUtils.java
@@ -4,10 +4,14 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
 
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 public class TestUtils {
 
 	private TestUtils() {
-
 	}
 
 	public static RecordAttributes generateRandomAttributes() {
@@ -16,5 +20,26 @@ public class TestUtils {
 				.putAttribute("attr4", RandomStringUtils.randomNumeric(5)).putAttribute("attr5", RandomUtils.nextLong())
 				.putAttribute("attr-dt", "2022-03-01T12:00:03").putAttribute("attr-json", "{\"foo\":\"bar\"}")
 				.putAttribute("attr-boolean", true);
+	}
+
+	public static RecordAttributes generateNonRandomAttributes(int seed) {
+		return RecordAttributes.empty().putAttribute("attr1", getStringBySeed(seed))
+				.putAttribute("attr2", getFloatBySeed(seed))
+				.putAttribute("attr3", getIntBySeed(seed))
+				.putAttribute("attr-dt", getDateBySeed(seed));
+	}
+
+	private static String getStringBySeed(int seed){
+		return List.of("abc","def","ghi","jkl","mno","pqr","stu","vwx").get(seed%8);
+	}
+	private static int getIntBySeed(int seed){
+		return List.of(3,1,4,15,9,2,6,5).get(seed%8);
+	}
+	private static float getFloatBySeed(int seed){
+		//In order ascending order: 6.626070e-34f, 1.602e-19f, 6.674e-11f, 1.4142f, 1.61803f, 2.7182f, 3.14159f, 2.99792448e8f
+		return List.of(3.14159f, 2.7182f, 1.4142f, 1.61803f, 6.674e-11f, 2.99792448e8f, 6.626070e-34f, 1.602e-19f).get(seed%8);
+	}
+	private static String getDateBySeed(int seed){
+		return List.of("2022-03-01T12:00:01","2019-07-21T12:00:01","1987-01-10T12:00:01","2002-03-23T12:00:01","1999-12-31T12:00:01","2022-04-25T12:00:01","2016-06-06T12:00:01","1991-05-15T12:00:01").get(seed%8);
 	}
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
@@ -16,9 +16,7 @@ import org.springframework.http.*;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
-import java.time.LocalDate;
 import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.function.Supplier;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
@@ -15,14 +15,16 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.*;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.databiosphere.workspacedataservice.TestUtils.generateNonRandomAttributes;
 import static org.databiosphere.workspacedataservice.TestUtils.generateRandomAttributes;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
  * This test spins up a web server and the full Spring Boot web stack. It was
@@ -96,6 +98,43 @@ class FullStackRecordControllerTest {
 
 	@Test
 	@Transactional
+	void testSortedQuerySuccess() throws Exception {
+		RecordType recordType = RecordType.valueOf("sorted_query");
+		createSpecificRecords(recordType, 8);
+		int limit = 5;
+		int offset = 0;
+		SearchRequest sortByAlpha = new SearchRequest(limit, offset, SortDirection.ASC, "attr1");
+		RecordQueryResponse body = executeQuery(recordType, RecordQueryResponse.class, sortByAlpha)
+				.getBody();
+		assertThat(body.records()).hasSize(limit);
+		assertThat(body.records().get(0).recordAttributes().getAttributeValue("attr1")).as("Record with attr1 'abc' should be first record in ascending order")
+				.isEqualTo("abc");
+		assertThat(body.records().get(4).recordAttributes().getAttributeValue("attr1")).isEqualTo("mno");
+		SearchRequest sortByFloat = new SearchRequest(limit, offset, SortDirection.DESC, "attr2");
+		body = executeQuery(recordType, RecordQueryResponse.class, sortByFloat)
+				.getBody();
+		assertThat(body.records()).hasSize(limit);
+		assertThat(body.records().get(0).recordAttributes().getAttributeValue("attr2")).as("Record with attr2 2.99792448e8f should be first record in descending order")
+				.isEqualTo(299792448);
+		assertThat(body.records().get(4).recordAttributes().getAttributeValue("attr2")).isEqualTo(1.4142);
+		SearchRequest sortByInt = new SearchRequest(limit, offset, SortDirection.ASC, "attr3");
+		body = executeQuery(recordType, RecordQueryResponse.class, sortByInt)
+				.getBody();
+		assertThat(body.records().get(0).recordAttributes().getAttributeValue("attr3"))
+				.as("Record with attr3 1 should be first record in ascending order").isEqualTo(1);
+		assertThat(body.records().get(4).recordAttributes().getAttributeValue("attr3")).isEqualTo(5);
+		SearchRequest sortByDate = new SearchRequest(limit, offset, SortDirection.DESC, "attr-dt");
+		body = executeQuery(recordType, RecordQueryResponse.class, sortByDate)
+				.getBody();
+		assertThat(body.records()).hasSize(limit);
+		assertThat(Instant.ofEpochMilli((Long)body.records().get(0).recordAttributes().getAttributeValue("attr-dt")).atZone(ZoneId.systemDefault()).toLocalDate()).as("Record with attr-dt 2022-04-25 should be first record in descending order")
+				.isEqualTo("2022-04-25");
+		assertThat(Instant.ofEpochMilli((Long)body.records().get(4).recordAttributes().getAttributeValue("attr-dt")).atZone(ZoneId.systemDefault()).toLocalDate())
+				.isEqualTo("2002-03-23");
+	}
+
+	@Test
+	@Transactional
 	void testQueryFailures() throws Exception {
 		RecordType recordType = RecordType.valueOf("for_query");
 		int limit = 5;
@@ -104,6 +143,9 @@ class FullStackRecordControllerTest {
 				new SearchRequest(limit, offset, SortDirection.ASC));
 		assertThat(response.getStatusCode()).as("record type doesn't exist").isEqualTo(HttpStatus.NOT_FOUND);
 		createSomeRecords(recordType, 1);
+		response = executeQuery(recordType, ErrorResponse.class,
+				new SearchRequest(limit, offset, SortDirection.ASC, "no-attr"));
+		assertThat(response.getStatusCode()).as("attribute doesn't exist").isEqualTo(HttpStatus.NOT_FOUND);
 		limit = 1001;
 		response = executeQuery(recordType, ErrorResponse.class, new SearchRequest(limit, offset, SortDirection.ASC));
 		assertThat(response.getStatusCode()).as("unsupported limit size").isEqualTo(HttpStatus.BAD_REQUEST);
@@ -204,6 +246,23 @@ class FullStackRecordControllerTest {
 					? "record_" + i
 					: recordIdSupplier[0].get();
 			RecordAttributes attributes = generateRandomAttributes();
+			RecordRequest recordRequest = new RecordRequest(attributes);
+			ResponseEntity<String> response = restTemplate.exchange(
+					"/{instanceId}/records/{version}/{recordType}/{recordId}", HttpMethod.PUT,
+					new HttpEntity<>(mapper.writeValueAsString(recordRequest), headers), String.class,
+					instanceId, versionId, recordType, recordId);
+			assertThat(response.getStatusCode()).isIn(HttpStatus.CREATED, HttpStatus.OK);
+			result.add(new Record(recordId, recordType, recordRequest));
+		}
+		return result;
+	}
+
+	private List<Record> createSpecificRecords(RecordType recordType, int numRecords)
+			throws Exception {
+		List<Record> result = new ArrayList<>();
+		for (int i = 0; i < numRecords; i++) {
+			String recordId = "record_" + i;
+			RecordAttributes attributes = generateNonRandomAttributes(i);
 			RecordRequest recordRequest = new RecordRequest(attributes);
 			ResponseEntity<String> response = restTemplate.exchange(
 					"/{instanceId}/records/{version}/{recordType}/{recordId}", HttpMethod.PUT,


### PR DESCRIPTION
[AJ-615](https://broadworkbench.atlassian.net/browse/AJ-615)
Allows sorting by a given attribute.  Naive implementation of however postgres interprets the sort.  Defaults to RECORD_ID if none given.