### PR TITLE
dates and timestamps should be human-readable [AJ-620]

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/WorkspaceDataServiceApplication.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/WorkspaceDataServiceApplication.java
@@ -2,6 +2,7 @@ package org.databiosphere.workspacedataservice;
 
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -14,7 +15,8 @@ public class WorkspaceDataServiceApplication {
 
 	@Bean
 	public ObjectMapper objectMapper() {
-		return JsonMapper.builder().enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS).build();
+		return JsonMapper.builder().enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
+				.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false).findAndAddModules().build();
 	}
 
 	// CORS: allow Ajax requests from anywhere for all endpoints.

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -419,9 +419,9 @@ public class RecordDao {
 						Object object = rs.getObject(columnName);
 
 						if (object instanceof java.sql.Date date) {
-							object = date.toString();
+							object = date.toLocalDate();
 						} else if (object instanceof java.sql.Timestamp ts) {
-							object = ts.toString();
+							object = ts.toLocalDateTime();
 						} else if (object instanceof PGobject pGobject) {
 							object = pGobject.getValue();
 						}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -417,8 +417,16 @@ public class RecordDao {
 								.createRelationString(referenceColToTable.get(columnName), rs.getString(columnName)));
 					} else {
 						Object object = rs.getObject(columnName);
-						attributes.putAttribute(columnName,
-								object instanceof PGobject pGobject ? pGobject.getValue() : object);
+
+						if (object instanceof java.sql.Date date) {
+							object = date.toString();
+						} else if (object instanceof java.sql.Timestamp ts) {
+							object = ts.toString();
+						} else if (object instanceof PGobject pGobject) {
+							object = pGobject.getValue();
+						}
+
+						attributes.putAttribute(columnName, object);
 					}
 				}
 				return attributes;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
@@ -16,6 +16,7 @@ import org.springframework.http.*;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.*;
 import java.util.function.Supplier;
@@ -126,10 +127,12 @@ class FullStackRecordControllerTest {
 		body = executeQuery(recordType, RecordQueryResponse.class, sortByDate)
 				.getBody();
 		assertThat(body.records()).hasSize(limit);
-		assertThat(Instant.ofEpochMilli((Long)body.records().get(0).recordAttributes().getAttributeValue("attr-dt")).atZone(ZoneId.systemDefault()).toLocalDate()).as("Record with attr-dt 2022-04-25 should be first record in descending order")
-				.isEqualTo("2022-04-25");
-		assertThat(Instant.ofEpochMilli((Long)body.records().get(4).recordAttributes().getAttributeValue("attr-dt")).atZone(ZoneId.systemDefault()).toLocalDate())
-				.isEqualTo("2002-03-23");
+
+		assertThat(body.records().get(0).recordAttributes().getAttributeValue("attr-dt"))
+				.as("Record with attr-dt 2022-04-25 should be first record in descending order")
+				.isEqualTo("2022-04-25T12:00:01");
+		assertThat(body.records().get(4).recordAttributes().getAttributeValue("attr-dt"))
+				.isEqualTo("2002-03-23T12:00:01");
 	}
 
 	@Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -582,4 +582,72 @@ class RecordControllerMockMvcTest {
 				.andExpect(jsonPath("$.attributes.new-col", is("new value!!")));
 	}
 
+	@Test
+	@Transactional
+	void dateAttributeShouldBeHumanReadable() throws Exception {
+		// N.B. This test does not assert that the date attribute is saved as a date in
+		// Postgres;
+		// other tests verify that.
+		UUID instanceId = UUID.randomUUID();
+		RecordType recordType = RecordType.valueOf("test-type");
+		RecordAttributes attributes = RecordAttributes.empty();
+		String dateString = "1911-01-21";
+		attributes.putAttribute("dateAttr", dateString);
+		// create record in db
+		mockMvc.perform(put("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
+				recordType, "recordId").content(mapper.writeValueAsString(new RecordRequest(attributes)))
+						.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isCreated());
+		// retrieve as single record
+		MvcResult mvcSingleResult = mockMvc.perform(get("/{instanceId}/records/{version}/{recordType}/{recordId}",
+				instanceId, versionId, recordType, "recordId")).andExpect(status().isOk()).andReturn();
+		// assert single-record response is human-readable
+		RecordResponse actualSingle = mapper.readValue(mvcSingleResult.getResponse().getContentAsString(),
+				RecordResponse.class);
+		assertEquals(dateString, actualSingle.recordAttributes().getAttributeValue("dateAttr"));
+
+		// retrieve as a page of records
+		MvcResult mvcMultiResult = mockMvc
+				.perform(post("/{instanceId}/search/{version}/{recordType}", instanceId, versionId, recordType))
+				.andExpect(status().isOk()).andReturn();
+
+		RecordQueryResponse actualMulti = mapper.readValue(mvcMultiResult.getResponse().getContentAsString(),
+				RecordQueryResponse.class);
+		assertEquals(dateString, actualMulti.records().get(0).recordAttributes().getAttributeValue("dateAttr"));
+	}
+
+	@Test
+	@Transactional
+	void datetimeAttributeShouldBeHumanReadable() throws Exception {
+		// N.B. This test does not assert that the datetime attribute is saved as a
+		// timestamp in Postgres;
+		// other tests verify that.
+		UUID instanceId = UUID.randomUUID();
+		RecordType recordType = RecordType.valueOf("test-type");
+		RecordAttributes attributes = RecordAttributes.empty();
+		String datetimeString = "1911-01-21T13:45:43";
+		attributes.putAttribute("datetimeAttr", datetimeString);
+		// create record in db
+		mockMvc.perform(put("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
+				recordType, "recordId").content(mapper.writeValueAsString(new RecordRequest(attributes)))
+						.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isCreated());
+		// retrieve as single record
+		MvcResult mvcSingleResult = mockMvc.perform(get("/{instanceId}/records/{version}/{recordType}/{recordId}",
+				instanceId, versionId, recordType, "recordId")).andExpect(status().isOk()).andReturn();
+		// assert single-record response is human-readable
+		RecordResponse actualSingle = mapper.readValue(mvcSingleResult.getResponse().getContentAsString(),
+				RecordResponse.class);
+		assertEquals(datetimeString, actualSingle.recordAttributes().getAttributeValue("datetimeAttr"));
+
+		// retrieve as a page of records
+		MvcResult mvcMultiResult = mockMvc
+				.perform(post("/{instanceId}/search/{version}/{recordType}", instanceId, versionId, recordType))
+				.andExpect(status().isOk()).andReturn();
+
+		RecordQueryResponse actualMulti = mapper.readValue(mvcMultiResult.getResponse().getContentAsString(),
+				RecordQueryResponse.class);
+		assertEquals(datetimeString, actualMulti.records().get(0).recordAttributes().getAttributeValue("datetimeAttr"));
+	}
+
 }


### PR DESCRIPTION
* Datetime attributes now serialize to e.g. `2022-04-25T12:00:01`
* Date attributes now serialize to e.g. `2022-04-25`
* The `RecordAttributes` underlying `Map` now contains `LocalDate` and `LocalDateTime` values

