### PR TITLE
Aj 628 python client

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,4 +35,4 @@ jobs:
         #  ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
          # ARTIFACTORY_REPO_KEY: libs-snapshot-local
   python-client-job:
-      uses: DataBiosphere/terra-workspace-data-service/.github/workflows/release-python-client.yaml@main
+      uses: ./.github/workflows/release-python-client.yaml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,8 +25,8 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
         
-      - name: Build all projects without running tests
-        run: ./gradlew --build-cache build -x test
+     # - name: Build all projects without running tests
+      #  run: ./gradlew --build-cache build -x test
 
     #  - name: Publish API client to Artifactory
      #   run: ./gradlew --build-cache :client:artifactoryPublish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,9 +3,6 @@ on:
   create:
       tags:
         - '*'
-  push:
-    branches:
-      - aj-628-python-client
 
 jobs:
   publish-job:
@@ -25,15 +22,15 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
         
-     # - name: Build all projects without running tests
-      #  run: ./gradlew --build-cache build -x test
+      - name: Build all projects without running tests
+        run: ./gradlew --build-cache build -x test
 
-    #  - name: Publish API client to Artifactory
-     #   run: ./gradlew --build-cache :client:artifactoryPublish
-      #  env:
-       #   ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-        #  ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
-         # ARTIFACTORY_REPO_KEY: libs-snapshot-local
+      - name: Publish API client to Artifactory
+        run: ./gradlew --build-cache :client:artifactoryPublish
+        env:
+          ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          ARTIFACTORY_REPO_KEY: libs-snapshot-local
   python-client-job:
       uses: ./.github/workflows/release-python-client.yaml
       secrets:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,9 @@ on:
   create:
       tags:
         - '*'
+  push:
+    branches:
+      - aj-628-python-client
 
 jobs:
   publish-job:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,3 +36,5 @@ jobs:
          # ARTIFACTORY_REPO_KEY: libs-snapshot-local
   python-client-job:
       uses: ./.github/workflows/release-python-client.yaml
+      secrets:
+        PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,9 +3,6 @@ on:
   create:
       tags:
         - '*'
-  push:
-    branches:
-      - aj-628-python-client
 
 jobs:
   publish-job:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,3 +31,5 @@ jobs:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
           ARTIFACTORY_REPO_KEY: libs-snapshot-local
+      - name: Publish Python client
+        uses: DataBiosphere/terra-workspace-data-service/.github/workflows/release-pythonclient.yaml@main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,9 @@ on:
   create:
       tags:
         - '*'
+  push:
+    branches:
+      - aj-628-python-client
 
 jobs:
   publish-job:
@@ -31,5 +34,5 @@ jobs:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
           ARTIFACTORY_REPO_KEY: libs-snapshot-local
-      - name: Publish Python client
-        uses: DataBiosphere/terra-workspace-data-service/.github/workflows/release-pythonclient.yaml@main
+  python-client-job:
+      uses: DataBiosphere/terra-workspace-data-service/.github/workflows/release-pythonclient.yaml@main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,11 +28,11 @@ jobs:
       - name: Build all projects without running tests
         run: ./gradlew --build-cache build -x test
 
-      - name: Publish API client to Artifactory
-        run: ./gradlew --build-cache :client:artifactoryPublish
-        env:
-          ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
-          ARTIFACTORY_REPO_KEY: libs-snapshot-local
+    #  - name: Publish API client to Artifactory
+     #   run: ./gradlew --build-cache :client:artifactoryPublish
+      #  env:
+       #   ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+        #  ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+         # ARTIFACTORY_REPO_KEY: libs-snapshot-local
   python-client-job:
-      uses: DataBiosphere/terra-workspace-data-service/.github/workflows/release-pythonclient.yaml@main
+      uses: DataBiosphere/terra-workspace-data-service/.github/workflows/release-python-client.yaml@main

--- a/.github/workflows/release-python-client.yaml
+++ b/.github/workflows/release-python-client.yaml
@@ -3,8 +3,6 @@ name: Publish Python client to PyPI
 on:
   workflow_call:
     secrets:
-      GITHUB_TOKEN:
-        required: true
       PYPI_API_TOKEN:
         required: true
 jobs:

--- a/.github/workflows/release-python-client.yaml
+++ b/.github/workflows/release-python-client.yaml
@@ -26,9 +26,9 @@ jobs:
       - name: Use Node.js ${{matrix.node-version }}
         uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 18
       - name: Install openapi-generator-cli
-        run: npm install openapitools/openapi-generator-cli@1.0.18-4.3.1 -g
+        run: npm install @openapitools/openapi-generator-cli@1.0.18-4.3.1 -g
       - name: Generate Python client
         run: |
           openapi-generator-cli generate \

--- a/.github/workflows/release-python-client.yaml
+++ b/.github/workflows/release-python-client.yaml
@@ -11,7 +11,10 @@ jobs:
     name: Build and publish Python client to PyPI
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Set up Python 3.7
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/release-python-client.yaml
+++ b/.github/workflows/release-python-client.yaml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: 3.7
-      - name: 'Get Previous tag'
+      - name: Get previous tag
         id: apiprevioustag
         uses: "broadinstitute/github-action-get-previous-tag@master"
         env:

--- a/.github/workflows/release-python-client.yaml
+++ b/.github/workflows/release-python-client.yaml
@@ -2,7 +2,11 @@ name: Publish Python client to PyPI
 
 on:
   workflow_call:
-
+    secrets:
+      GITHUB_TOKEN:
+        required: true
+      PYPI_API_TOKEN:
+        required: true
 jobs:
   build-n-publish:
     name: Build and publish Python client to PyPI

--- a/.github/workflows/release-python-client.yaml
+++ b/.github/workflows/release-python-client.yaml
@@ -44,5 +44,5 @@ jobs:
         uses: broadinstitute/gh-action-pypi-publish@master
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
-          packages_dir: ./data-repo-client/dist
+          packages_dir: ./wds-client/dist
           skip_existing: true

--- a/.github/workflows/release-python-client.yaml
+++ b/.github/workflows/release-python-client.yaml
@@ -30,7 +30,7 @@ jobs:
           -i service/src/main/resources/static/swagger/openapi-docs.yaml \
           -g python \
           -o wds-client \
-          --additional-properties=projectName=wds-client,packageName=wds_client \
+          --additional-properties=projectName=wds-client,packageName=wds_client,packageVersion=${{github.ref}} \
           --skip-validate-spec
       - name: Install pypa/build
         working-directory: ./wds-client

--- a/.github/workflows/release-python-client.yaml
+++ b/.github/workflows/release-python-client.yaml
@@ -40,3 +40,9 @@ jobs:
         working-directory: ./wds-client
         run: >-
           python -m build --sdist --wheel --outdir dist/ .
+      - name: Publish distribution to PyPI
+        uses: broadinstitute/gh-action-pypi-publish@master
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          packages_dir: ./data-repo-client/dist
+          skip_existing: true

--- a/.github/workflows/release-python-client.yaml
+++ b/.github/workflows/release-python-client.yaml
@@ -1,10 +1,7 @@
 name: Publish Python client to PyPI
 
 on:
-  workflow_dispatch: {}
-  push:
-    branches:
-      - main
+  workflow_call:
 
 jobs:
   build-n-publish:

--- a/.github/workflows/release-python-client.yaml
+++ b/.github/workflows/release-python-client.yaml
@@ -1,0 +1,42 @@
+name: Publish Python client to PyPI
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches:
+      - aj-628-python-client
+
+jobs:
+  build-n-publish:
+    name: Build and publish Python client to PyPI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Use Node.js ${{matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+      - name: Install openapi-generator-cli
+        run: npm install @openapitools/openapi-generator-cli -g
+      - name: set version to 4.3.1
+        run: openapi-generator-cli version-manager set 4.3.1
+      - name: Generate Python client
+        run: |
+          openapi-generator-cli generate \
+          -i service/src/main/resources/static/swagger/openapi-docs.yaml \
+          -g python \
+          -o wds-client \
+          --additional-properties=projectName=wds-client,packageName=wds_client \
+          --skip-validate-spec
+      - name: Install pypa/build
+        working-directory: ./wds-client
+        run: >-
+          python -m pip install build --user
+      - name: Build a binary wheel and a source tarball
+        working-directory: ./wds-client
+        run: >-
+          python -m build --sdist --wheel --outdir dist/ .

--- a/.github/workflows/release-python-client.yaml
+++ b/.github/workflows/release-python-client.yaml
@@ -16,6 +16,11 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: 3.7
+      - name: 'Get Previous tag'
+        id: apiprevioustag
+        uses: "broadinstitute/github-action-get-previous-tag@master"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - name: Use Node.js ${{matrix.node-version }}
         uses: actions/setup-node@v2
         with:
@@ -30,7 +35,7 @@ jobs:
           -i service/src/main/resources/static/swagger/openapi-docs.yaml \
           -g python \
           -o wds-client \
-          --additional-properties=projectName=wds-client,packageName=wds_client,packageVersion=$GITHUB_REF_NAME \
+          --additional-properties=projectName=wds-client,packageName=wds_client,packageVersion=${{ steps.apiprevioustag.outputs.tag }} \
           --skip-validate-spec
       - name: Install pypa/build
         working-directory: ./wds-client

--- a/.github/workflows/release-python-client.yaml
+++ b/.github/workflows/release-python-client.yaml
@@ -28,7 +28,9 @@ jobs:
         with:
           node-version: 18
       - name: Install openapi-generator-cli
-        run: npm install @openapitools/openapi-generator-cli@1.0.18-4.3.1 -g
+        run: npm install @openapitools/openapi-generator-cli -g
+      - name: set version to 4.3.1
+        run: openapi-generator-cli version-manager set 4.3.1
       - name: Generate Python client
         run: |
           openapi-generator-cli generate \

--- a/.github/workflows/release-python-client.yaml
+++ b/.github/workflows/release-python-client.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch: {}
   push:
     branches:
-      - aj-628-python-client
+      - main
 
 jobs:
   build-n-publish:

--- a/.github/workflows/release-python-client.yaml
+++ b/.github/workflows/release-python-client.yaml
@@ -28,16 +28,14 @@ jobs:
         with:
           node-version: 14
       - name: Install openapi-generator-cli
-        run: npm install @openapitools/openapi-generator-cli -g
-      - name: set version to 4.3.1
-        run: openapi-generator-cli version-manager set 4.3.1
+        run: npm install openapitools/openapi-generator-cli@1.0.18-4.3.1 -g
       - name: Generate Python client
         run: |
           openapi-generator-cli generate \
           -i service/src/main/resources/static/swagger/openapi-docs.yaml \
           -g python \
           -o wds-client \
-          --additional-properties=projectName=wds-client,packageName=wds_client,packageVersion=${{ steps.apiprevioustag.outputs.tag }} \
+          --additional-properties=projectName=wds-client,packageName=wds_client,packageVersion=${{ steps.apiprevioustag.outputs.tag }}-SNAPSHOT \
           --skip-validate-spec
       - name: Install pypa/build
         working-directory: ./wds-client

--- a/.github/workflows/release-python-client.yaml
+++ b/.github/workflows/release-python-client.yaml
@@ -37,7 +37,7 @@ jobs:
           -i service/src/main/resources/static/swagger/openapi-docs.yaml \
           -g python \
           -o wds-client \
-          --additional-properties=projectName=wds-client,packageName=wds_client,packageVersion=${{ steps.apiprevioustag.outputs.tag }}-SNAPSHOT \
+          --additional-properties=projectName=wds-client,packageName=wds_client,packageVersion=${{ steps.apiprevioustag.outputs.tag }} \
           --skip-validate-spec
       - name: Install pypa/build
         working-directory: ./wds-client

--- a/.github/workflows/release-python-client.yaml
+++ b/.github/workflows/release-python-client.yaml
@@ -30,7 +30,7 @@ jobs:
           -i service/src/main/resources/static/swagger/openapi-docs.yaml \
           -g python \
           -o wds-client \
-          --additional-properties=projectName=wds-client,packageName=wds_client,packageVersion=${{github.ref}} \
+          --additional-properties=projectName=wds-client,packageName=wds_client,packageVersion=$GITHUB_REF_NAME \
           --skip-validate-spec
       - name: Install pypa/build
         working-directory: ./wds-client


### PR DESCRIPTION
This PR will generate a python client and push it to PYPI.
The `python` yaml is called by the `publish` yaml so that it only occurs after the latest tag has been generated and uses that one.