### PR TITLE
dont autocreate instance in put-record; add delete-instance API [AJ-614, AJ-674]

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -79,6 +79,7 @@ public class RecordController {
 			@PathVariable("version") String version, @PathVariable("recordType") RecordType recordType,
 			@PathVariable("recordId") String recordId, @RequestBody RecordRequest recordRequest) {
 		validateVersion(version);
+		validateInstance(instanceId);
 		checkRecordTypeExists(instanceId, recordType);
 		Record singleRecord = recordDao
 				.getSingleRecord(instanceId, recordType, recordId)
@@ -114,8 +115,8 @@ public class RecordController {
 	public ResponseEntity<TsvUploadResponse> tsvUpload(@PathVariable("instanceId") UUID instanceId,
 			@PathVariable("version") String version, @PathVariable("recordType") RecordType recordType,
 			@RequestParam("records") MultipartFile records) throws IOException {
-		validateInstance(instanceId);
 		validateVersion(version);
+		validateInstance(instanceId);
 		int recordsModified;
 		try (InputStreamReader inputStreamReader = new InputStreamReader(records.getInputStream())) {
 			recordsModified = batchWriteService.uploadTsvStream(inputStreamReader, instanceId, recordType);
@@ -150,7 +151,10 @@ public class RecordController {
 	@PostMapping("/{instanceid}/search/{version}/{recordType}")
 	public RecordQueryResponse queryForEntities(@PathVariable("instanceid") UUID instanceId,
 			@PathVariable("recordType") RecordType recordType,
+			@PathVariable("version") String version,
 			@RequestBody(required = false) SearchRequest searchRequest) {
+		validateVersion(version);
+		validateInstance(instanceId);
 		checkRecordTypeExists(instanceId, recordType);
 		if (null == searchRequest) {
 			searchRequest = new SearchRequest();
@@ -226,9 +230,7 @@ public class RecordController {
 	public ResponseEntity<String> deleteInstance(@PathVariable("instanceId") UUID instanceId,
 												 @PathVariable("version") String version) {
 		validateVersion(version);
-		if (!recordDao.instanceSchemaExists(instanceId)) {
-			throw new ResponseStatusException(HttpStatus.NOT_FOUND, "This instance does not exist");
-		}
+		validateInstance(instanceId);
 		recordDao.dropSchema(instanceId);
 		return new ResponseEntity<>(HttpStatus.OK);
 	}
@@ -238,6 +240,7 @@ public class RecordController {
 			@PathVariable("version") String version, @PathVariable("recordType") RecordType recordType,
 			@PathVariable("recordId") String recordId) {
 		validateVersion(version);
+		validateInstance(instanceId);
 		boolean recordFound = recordDao.deleteSingleRecord(instanceId, recordType, recordId);
 		return recordFound ? new ResponseEntity<>(HttpStatus.NO_CONTENT) : new ResponseEntity<>(HttpStatus.NOT_FOUND);
 	}
@@ -256,6 +259,7 @@ public class RecordController {
 	public ResponseEntity<RecordTypeSchema> describeRecordType(@PathVariable("instanceId") UUID instanceId,
 			@PathVariable("v") String version, @PathVariable("type") RecordType recordType) {
 		validateVersion(version);
+		validateInstance(instanceId);
 		checkRecordTypeExists(instanceId, recordType);
 		RecordTypeSchema result = getSchemaDescription(instanceId, recordType);
 		return new ResponseEntity<>(result, HttpStatus.OK);
@@ -306,6 +310,7 @@ public class RecordController {
 	public ResponseEntity<BatchResponse> streamingWrite(@PathVariable("instanceid") UUID instanceId,
 			@PathVariable("v") String version, @PathVariable("type") RecordType recordType, InputStream is) {
 		validateVersion(version);
+		validateInstance(instanceId);
 		int recordsModified = batchWriteService.consumeWriteStream(is, instanceId, recordType);
 		return new ResponseEntity<>(new BatchResponse(recordsModified, "Huzzah"), HttpStatus.OK);
 	}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -91,6 +91,7 @@ public class RecordDao {
 		namedTemplate.getJdbcTemplate().update("create schema " + quote(instanceId.toString()));
 	}
 
+	@SuppressWarnings("squid:S2077") // since instanceId must be a UUID, it is safe to use inline
 	public void dropSchema(UUID instanceId) {
 		namedTemplate.getJdbcTemplate().update("drop schema " + quote(instanceId.toString()) + " cascade");
 	}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -91,6 +91,10 @@ public class RecordDao {
 		namedTemplate.getJdbcTemplate().update("create schema " + quote(instanceId.toString()));
 	}
 
+	public void dropSchema(UUID instanceId) {
+		namedTemplate.getJdbcTemplate().update("drop schema " + quote(instanceId.toString()) + " cascade");
+	}
+
 	public boolean recordTypeExists(UUID instanceId, RecordType recordType) {
 		return Boolean.TRUE.equals(namedTemplate.queryForObject(
 				"select exists(select from pg_tables where schemaname = :instanceId AND tablename  = :recordType)",

--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -270,7 +270,7 @@ paths:
                 $ref: '#/components/schemas/BatchResponse'
   /instances/{v}/{instanceid}:
     post:
-      summary: Create an instance (unstable)
+      summary: Create an instance
       description: Create an instance with the given UUID. This API is liable to change.
       operationId: createWDSInstance
       tags:
@@ -283,6 +283,27 @@ paths:
           description: Success
         409:
           description: Conflict - schema already exists.
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      summary: Delete an instance
+      description: |
+        Delete the instance with the given UUID. This API is liable to change.
+
+        THIS WILL DELETE ALL DATA WITHIN THE INSTANCE. Be certain this is what you want to do.
+      operationId: deleteWDSInstance
+      tags:
+        - Instances
+      parameters:
+        - $ref: '#/components/parameters/instanceIdPathParam'
+        - $ref: '#/components/parameters/versionPathParam'
+      responses:
+        200:
+          description: Success
+        404:
+          description: Not Found - instance does not exist.
           content:
             'application/json':
               schema:

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
@@ -14,7 +14,9 @@ import org.databiosphere.workspacedataservice.shared.model.RecordResponse;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 import org.databiosphere.workspacedataservice.shared.model.SearchRequest;
 import org.databiosphere.workspacedataservice.shared.model.SortDirection;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -42,6 +44,7 @@ import java.util.function.Supplier;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.databiosphere.workspacedataservice.TestUtils.generateNonRandomAttributes;
 import static org.databiosphere.workspacedataservice.TestUtils.generateRandomAttributes;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * This test spins up a web server and the full Spring Boot web stack. It was
@@ -67,6 +70,22 @@ class FullStackRecordControllerTest {
 		headers = new HttpHeaders();
 		headers.setContentType(MediaType.APPLICATION_JSON);
 		instanceId = UUID.randomUUID();
+	}
+
+	@BeforeEach
+	void beforeEach() {
+		ResponseEntity<String> response = restTemplate.exchange("/instances/{v}/{instanceid}", HttpMethod.POST,
+				new HttpEntity<>("", headers), String.class,
+				versionId, instanceId);
+		assertEquals(HttpStatus.CREATED, response.getStatusCode());
+	}
+
+	@AfterEach
+	void afterEach() {
+		ResponseEntity<String> response = restTemplate.exchange("/instances/{v}/{instanceid}", HttpMethod.DELETE,
+				new HttpEntity<>("", headers), String.class,
+				versionId, instanceId);
+		assertEquals(HttpStatus.OK, response.getStatusCode());
 	}
 
 	@Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -104,23 +104,20 @@ class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void deleteInstanceContainingData() throws Exception {
-		UUID uuid = UUID.randomUUID();
-		// creating the instance should 201
-		mockMvc.perform(post("/instances/{version}/{instanceId}", versionId, uuid)).andExpect(status().isCreated());
 		RecordAttributes attributes = new RecordAttributes(Map.of("foo", "bar", "num", 123));
 		// create "to" record, which will be the target of a relation
-		mockMvc.perform(put("/{instanceId}/records/{version}/{recordType}/{recordId}", uuid, versionId,
+		mockMvc.perform(put("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 						"to", "1").content(mapper.writeValueAsString(new RecordRequest(attributes)))
 						.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isCreated());
 		// create "from" record, with a relation to "to"
 		RecordAttributes attributes2 = new RecordAttributes(Map.of("relation", "terra-wds:/to/1"));
-		mockMvc.perform(put("/{instanceId}/records/{version}/{recordType}/{recordId}", uuid, versionId,
+		mockMvc.perform(put("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 						"from", "2").content(mapper.writeValueAsString(new RecordRequest(attributes2)))
 						.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isCreated());
 		// delete existing instance should 200
-		mockMvc.perform(delete("/instances/{version}/{instanceId}", versionId, uuid)).andExpect(status().isOk());
+		mockMvc.perform(delete("/instances/{version}/{instanceId}", versionId, instanceId)).andExpect(status().isOk());
 	}
 
 	@Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -1,6 +1,5 @@
 package org.databiosphere.workspacedataservice.controller;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.databiosphere.workspacedataservice.TestUtils;
 import org.databiosphere.workspacedataservice.service.RelationUtils;
@@ -19,7 +18,6 @@ import org.databiosphere.workspacedataservice.shared.model.RecordRequest;
 import org.databiosphere.workspacedataservice.shared.model.RecordResponse;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,8 +34,6 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -67,7 +63,8 @@ class RecordControllerMockMvcTest {
 	@BeforeEach
 	void beforeEach() throws Exception {
 		instanceId = UUID.randomUUID();
-		createInstance(instanceId);
+		mockMvc.perform(post("/instances/{v}/{instanceid}",
+				versionId, instanceId).content("")).andExpect(status().isCreated());
 	}
 
 	@AfterEach
@@ -754,15 +751,12 @@ class RecordControllerMockMvcTest {
 	@Test
 	@Transactional
 	void describeAllTypes() throws Exception {
-		// replace instanceId for this test so only these records are found
-		UUID instId = UUID.randomUUID();
-		createInstance(instId);
 		RecordType type1 = RecordType.valueOf("firstType");
-		createSomeRecords(type1, 1, instId);
+		createSomeRecords(type1, 1, instanceId);
 		RecordType type2 = RecordType.valueOf("secondType");
-		createSomeRecords(type2, 2, instId);
+		createSomeRecords(type2, 2, instanceId);
 		RecordType type3 = RecordType.valueOf("thirdType");
-		createSomeRecords(type3, 10, instId);
+		createSomeRecords(type3, 10, instanceId);
 
 		List<AttributeSchema> expectedAttributes = Arrays.asList(new AttributeSchema("array-of-date", "ARRAY_OF_DATE", null),
 				new AttributeSchema("array-of-datetime", "ARRAY_OF_DATE_TIME", null),
@@ -778,7 +772,7 @@ class RecordControllerMockMvcTest {
 				new RecordTypeSchema(type2, expectedAttributes, 2),
 				new RecordTypeSchema(type3, expectedAttributes, 10));
 
-		MvcResult mvcResult = mockMvc.perform(get("/{instanceId}/types/{v}", instId, versionId))
+		MvcResult mvcResult = mockMvc.perform(get("/{instanceId}/types/{v}", instanceId, versionId))
 				.andExpect(status().isOk()).andReturn();
 
 		List<RecordTypeSchema> actual = Arrays
@@ -791,11 +785,6 @@ class RecordControllerMockMvcTest {
 	@Transactional
 	void describeAllTypesNoInstance() throws Exception {
 		mockMvc.perform(get("/{instanceId}/types/{v}", UUID.randomUUID(), versionId)).andExpect(status().isNotFound());
-	}
-
-	private void createInstance(UUID instanceId) throws Exception {
-		mockMvc.perform(post("/instances/{v}/{instanceid}",
-				versionId, instanceId).content("")).andExpect(status().isCreated());
 	}
 
 	private List<Record> createSomeRecords(String recordType, int numRecords) throws Exception {
@@ -911,8 +900,6 @@ class RecordControllerMockMvcTest {
 		// N.B. This test does not assert that the date attribute is saved as a date in
 		// Postgres;
 		// other tests verify that.
-		UUID instanceId = UUID.randomUUID();
-		createInstance(instanceId);
 		RecordType recordType = RecordType.valueOf("test-type");
 		RecordAttributes attributes = RecordAttributes.empty();
 		String dateString = "1911-01-21";
@@ -946,8 +933,6 @@ class RecordControllerMockMvcTest {
 		// N.B. This test does not assert that the datetime attribute is saved as a
 		// timestamp in Postgres;
 		// other tests verify that.
-		UUID instanceId = UUID.randomUUID();
-		createInstance(instanceId);
 		RecordType recordType = RecordType.valueOf("test-type");
 		RecordAttributes attributes = RecordAttributes.empty();
 		String datetimeString = "1911-01-21T13:45:43";


### PR DESCRIPTION
there's some yak-shaving in here.

The ultimate goal is for the `createOrReplaceRecord` PUT single-record API to stop auto-creating instances if the supplied instanceId does not exist. That runtime change was pretty easy.

However, it caused some issues in unit tests. So I updated unit tests to create the relevant instance before each test ran. In `FullStackRecordControllerTest`, this ran into even more issues because the database is persistent, and each create-instance call past the first would fail with a 409 conflict.

So, I also added a delete-instance API (with a couple tests of its own and swagger doc). This isn't the only solution to the testing situation, but it felt like a beneficial addition for debugging and such. If reviewers think the delete-instance API is a bad idea, I can find a different solution for tests.