### PR TITLE
disable CORS headers for non-local development [AJ-696]

### DIFF
--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -20,3 +20,7 @@ spring.servlet.multipart.max-file-size=5GB
 
 twds.write.batch.size=5000
 twds.streaming.fetch.size=5000
+
+# activate the "local" profile to turn on CORS response headers,
+# which may be necessary for local development.
+# spring.profiles.active=local

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/CorsLiveMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/CorsLiveMockMvcTest.java
@@ -10,40 +10,45 @@ import org.springframework.test.web.servlet.MvcResult;
 
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+/**
+ * This class tests CORS behavior for live deployments. WDS in live deployments sits behind
+ * Azure Relay, and Relay handles CORS headers. Therefore, WDS should *not* reply with CORS
+ * headers, as it will cause a conflict.
+ *
+ * See also CorsLocalMockMvcTest for testing CORS behavior in the "local" Spring profile
+ */
 @SpringBootTest
 @AutoConfigureMockMvc
-class CorsMockMvcTest {
+class CorsLiveMockMvcTest {
 
 	@Autowired
 	MockMvc mockMvc;
 
 	private static final String versionId = "v0.2";
 
-	@ParameterizedTest(name = "CORS response headers for {0} should be correct")
+	@ParameterizedTest(name = "CORS response headers for non-local profile to {0} should be correct")
 	@ValueSource(strings = {"/instances/{version}/{instanceId}", "/{instanceid}/types/{v}",
 			"/{instanceid}/tsv/{v}/{type}", "/{instanceid}/search/{v}/{type}", "/{instanceid}/records/{v}/{type}/{id}"})
 	void testCorsResponseHeaders(String urlTemplate) throws Exception {
 		UUID uuid = UUID.randomUUID();
 
+		// for the non-"local" profile, OPTIONS requests should return 403 and not include
+		// Access-Control-Allow-Origin or Access-Control-Allow-Methods headers.
+
 		MvcResult mvcResult = mockMvc.perform(options(urlTemplate, versionId, uuid, "sometype", "someid")
 				// Access-Control-Request-Method and Origin required to trigger CORS response
 				.header("Access-Control-Request-Method", "POST").header("Origin", "http://www.example.com"))
-				.andExpect(status().isOk()).andReturn();
+				.andExpect(status().isForbidden()).andReturn();
 
 		String actualOrigin = mvcResult.getResponse().getHeader("Access-Control-Allow-Origin");
-		assertNotNull(actualOrigin, "Access-Control-Allow-Origin not present in CORS response for " + urlTemplate);
-		assertEquals("*", actualOrigin, "bad Access-Control-Allow-Origin in CORS response for " + urlTemplate);
+		assertNull(actualOrigin, "Access-Control-Allow-Origin should not be present in CORS response for " + urlTemplate);
 
 		String actualMethods = mvcResult.getResponse().getHeader("Access-Control-Allow-Methods");
-		assertNotNull(actualMethods, "Access-Control-Allow-Methods not present in CORS response for " + urlTemplate);
-		assertEquals("DELETE,GET,HEAD,PATCH,POST,PUT", actualMethods,
-				"bad Access-Control-Allow-Methods in CORS response for " + urlTemplate);
-
+		assertNull(actualMethods, "Access-Control-Allow-Methods should not be present in CORS response for " + urlTemplate);
 	}
 
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/CorsLocalMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/CorsLocalMockMvcTest.java
@@ -1,0 +1,61 @@
+package org.databiosphere.workspacedataservice.controller;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * This class tests CORS behavior for local development. WDS in local development does not sit behind
+ * Azure Relay, and therefore does not inherit Relay's CORS responseheaders. By enabling the "local"
+ * Spring profile, WDS sends its own CORS response headers.
+ *
+ * See also CorsLiveMockMvcTest for testing CORS behavior in live deployments.
+ */
+@ActiveProfiles(profiles = "local")
+@SpringBootTest
+@AutoConfigureMockMvc
+class CorsLocalMockMvcTest {
+
+	@Autowired
+	MockMvc mockMvc;
+
+	private static final String versionId = "v0.2";
+
+	@ParameterizedTest(name = "CORS response headers for the local profile {0} should be correct")
+	@ValueSource(strings = {"/instances/{version}/{instanceId}", "/{instanceid}/types/{v}",
+			"/{instanceid}/tsv/{v}/{type}", "/{instanceid}/search/{v}/{type}", "/{instanceid}/records/{v}/{type}/{id}"})
+	void testCorsResponseHeaders(String urlTemplate) throws Exception {
+		UUID uuid = UUID.randomUUID();
+
+		// for the "local" profile, OPTIONS requests should return 200 and include
+		// Access-Control-Allow-Origin and Access-Control-Allow-Methods headers.
+
+		MvcResult mvcResult = mockMvc.perform(options(urlTemplate, versionId, uuid, "sometype", "someid")
+				// Access-Control-Request-Method and Origin required to trigger CORS response
+				.header("Access-Control-Request-Method", "POST").header("Origin", "http://www.example.com"))
+				.andExpect(status().isOk()).andReturn();
+
+		String actualOrigin = mvcResult.getResponse().getHeader("Access-Control-Allow-Origin");
+		assertNotNull(actualOrigin, "Access-Control-Allow-Origin not present in CORS response for " + urlTemplate);
+		assertEquals("*", actualOrigin, "bad Access-Control-Allow-Origin in CORS response for " + urlTemplate);
+
+		String actualMethods = mvcResult.getResponse().getHeader("Access-Control-Allow-Methods");
+		assertNotNull(actualMethods, "Access-Control-Allow-Methods not present in CORS response for " + urlTemplate);
+		assertEquals("DELETE,GET,HEAD,PATCH,POST,PUT", actualMethods,
+				"bad Access-Control-Allow-Methods in CORS response for " + urlTemplate);
+
+	}
+
+}


### PR DESCRIPTION
When deployed behind Terra's Azure Relay, WDS's CORS responses and the Relay's CORS responses conflict with each other, resulting in CORS errors in the browser. Relay configuration [here](https://github.com/DataBiosphere/terra-azure-relay-listeners/blob/a9576c888e934d51ef9bad486aa69e8c2aa92e4a/service/src/main/java/org/broadinstitute/listener/relay/Utils.java#L34).

This PR changes WDS to _not_ issue CORS responses, unless WDS is running with the "local" Spring profile. That profile is not enabled by default, but engineers can toggle it on if they need to connect to a local WDS from a browser.