### PR TITLE
Include primary key in record attributes and list it first

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -539,11 +539,12 @@ public class RecordDao {
 		private RecordAttributes getAttributes(ResultSet rs) throws JsonProcessingException {
 			try {
 				ResultSetMetaData metaData = rs.getMetaData();
-				RecordAttributes attributes = RecordAttributes.empty();
+				RecordAttributes attributes = RecordAttributes.empty(primaryKeyColumn);
 
 				for (int j = 1; j <= metaData.getColumnCount(); j++) {
 					String columnName = metaData.getColumnName(j);
 					if (columnName.equals(primaryKeyColumn)) {
+						attributes.putAttribute(primaryKeyColumn, rs.getString(primaryKeyColumn));
 						continue;
 					}
 					if (referenceColToTable.size() > 0 && referenceColToTable.containsKey(columnName)

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/AttributeComparator.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/AttributeComparator.java
@@ -1,0 +1,19 @@
+package org.databiosphere.workspacedataservice.shared.model;
+
+import java.text.Collator;
+import java.util.Comparator;
+
+public record AttributeComparator(String primaryKey) implements Comparator<String> {
+
+    @Override
+    public int compare(String o1, String o2) {
+        if (o1.equals(primaryKey)) {
+            return -1;
+        }
+        if (o2.equals(primaryKey)) {
+            return 1;
+        }
+        Collator collator = Collator.getInstance();
+        return collator.compare(o1, o2);
+    }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributes.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributes.java
@@ -38,20 +38,6 @@ public class RecordAttributes {
 		this.attributes.putAll(attributes);
 	}
 
-	private record AttributeComparator(String primaryKey) implements Comparator<String> {
-
-		@Override
-		public int compare(String o1, String o2) {
-			if (o1.equals(primaryKey)) {
-				return -1;
-			}
-			if (o2.equals(primaryKey)) {
-				return 1;
-			}
-			Collator collator = Collator.getInstance();
-			return collator.compare(o1, o2);
-		}
-	}
 
 	/**
 	 * creates a RecordAttributes with no keys/values

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributes.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributes.java
@@ -3,6 +3,7 @@ package org.databiosphere.workspacedataservice.shared.model;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.text.Collator;
 import java.util.*;
 
 /**
@@ -31,6 +32,27 @@ public class RecordAttributes {
 		this.attributes = new TreeMap<>(attributes);
 	}
 
+	public RecordAttributes(Map<String, Object> attributes, String primaryKey) {
+		AttributeComparator comparator = new AttributeComparator(primaryKey);
+		this.attributes = new TreeMap<>(comparator);
+		this.attributes.putAll(attributes);
+	}
+
+	private record AttributeComparator(String primaryKey) implements Comparator<String> {
+
+		@Override
+		public int compare(String o1, String o2) {
+			if (o1.equals(primaryKey)) {
+				return -1;
+			}
+			if (o2.equals(primaryKey)) {
+				return 1;
+			}
+			Collator collator = Collator.getInstance();
+			return collator.compare(o1, o2);
+		}
+	}
+
 	/**
 	 * creates a RecordAttributes with no keys/values
 	 * 
@@ -38,6 +60,10 @@ public class RecordAttributes {
 	 */
 	public static RecordAttributes empty() {
 		return new RecordAttributes(Collections.emptyMap());
+	}
+
+	public static RecordAttributes empty(String primaryKeyColumn) {
+		return new RecordAttributes(Collections.emptyMap(), primaryKeyColumn);
 	}
 
 	// ========== accessors

--- a/service/src/test/java/org/databiosphere/workspacedataservice/TestUtils.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/TestUtils.java
@@ -18,10 +18,10 @@ public class TestUtils {
 	}
 
 	public static String getExpectedAllAttributesJsonText(){
-		return "{\"id\":\"newRecordId\",\"type\":\"all-types\",\"attributes\":{\"array-of-number\":[1,2,3]," +
+		return "{\"id\":\"newRecordId\",\"type\":\"all-types\",\"attributes\":{\"sys_name\":\"newRecordId\"," +
 				"\"array_of_boolean\":[true,false,true,true],\"array_of_date\":[\"2021-11-03\",\"2021-11-04\"]," +
 				"\"array_of_date_time\":[\"2021-11-03T07:30:00\",\"2021-11-03T07:30:00\"]," +
-				"\"array_of_string\":[\"a\",\"b\",\"c\",\"12\"],\"boolean\":false,\"date\":\"2021-11-03\"," +
+				"\"array_of_string\":[\"a\",\"b\",\"c\",\"12\"],\"array-of-number\":[1,2,3],\"boolean\":false,\"date\":\"2021-11-03\"," +
 				"\"date-time\":\"2021-11-03T07:30:00\",\"empty-array\":[],\"json\":{\"age\":22}," +
 				"\"null\":null,\"number\":47,\"string\":\"Broad Institute\"}}";
 	}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributesTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributesTest.java
@@ -1,0 +1,26 @@
+package org.databiosphere.workspacedataservice.shared.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RecordAttributesTest {
+
+
+    @Test
+    void verifyAttributeOrdering() {
+        RecordAttributes recordAttributes = RecordAttributes.empty("Z");
+        recordAttributes.putAttribute("a", 11);
+        recordAttributes.putAttribute("A", 17);
+        recordAttributes.putAttribute("B", "hello");
+        recordAttributes.putAttribute("C", LocalDate.of(2022, 11, 21));
+        recordAttributes.putAttribute("Z", "1");
+        List<String> attributeNamesInOrder = recordAttributes.attributeSet().stream().map(Map.Entry::getKey).collect(Collectors.toList());
+        assertThat(attributeNamesInOrder).isEqualTo(List.of("Z", "a", "A", "B", "C"));
+    }
+}


### PR DESCRIPTION
- order attributes with primary key column first
- refactoring AttributeComparator for better reuse
