### PR TITLE
AJ-726: Add Primary Key to JSON response

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -278,7 +278,7 @@ public class RecordController {
 	}
 
 	private RecordTypeSchema getSchemaDescription(UUID instanceId, RecordType recordType) {
-		Map<String, DataTypeMapping> schema = recordDao.getExistingTableSchemaLessPrimaryKey(instanceId, recordType);
+		Map<String, DataTypeMapping> schema = recordDao.getExistingTableSchema(instanceId, recordType);
 		Map<String, RecordType> relations = recordDao.getRelationCols(instanceId, recordType).stream()
 				.collect(Collectors.toMap(Relation::relationColName, Relation::relationRecordType));
 		List<AttributeSchema> attrSchema = schema.entrySet().stream().sorted(Map.Entry.comparingByKey())

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -156,6 +156,22 @@ public class RecordDao {
 		return attributeNames;
 	}
 
+	public Map<String, DataTypeMapping> getExistingTableSchema(UUID instanceId, RecordType recordType) {
+		MapSqlParameterSource params = new MapSqlParameterSource(INSTANCE_ID, instanceId.toString());
+		params.addValue("tableName", recordType.getName());
+		return namedTemplate
+				.query("select column_name, udt_name::regtype as data_type from INFORMATION_SCHEMA.COLUMNS where table_schema = :instanceId "
+						+ "and table_name = :tableName", params, rs -> {
+					Map<String, DataTypeMapping> result = new HashMap<>();
+					while (rs.next()) {
+						result.put(rs.getString("column_name"),
+								DataTypeMapping.fromPostgresType(rs.getString("data_type")));
+					}
+					return result;
+				});
+	}
+
+
 	public Map<String, DataTypeMapping> getExistingTableSchemaLessPrimaryKey(UUID instanceId, RecordType recordType) {
 		MapSqlParameterSource params = new MapSqlParameterSource(INSTANCE_ID, instanceId.toString());
 		params.addValue("tableName", recordType.getName());

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -539,11 +539,12 @@ public class RecordDao {
 		private RecordAttributes getAttributes(ResultSet rs) throws JsonProcessingException {
 			try {
 				ResultSetMetaData metaData = rs.getMetaData();
-				RecordAttributes attributes = RecordAttributes.empty();
+				RecordAttributes attributes = RecordAttributes.empty(primaryKeyColumn);
 
 				for (int j = 1; j <= metaData.getColumnCount(); j++) {
 					String columnName = metaData.getColumnName(j);
 					if (columnName.equals(primaryKeyColumn)) {
+						attributes.putAttribute(primaryKeyColumn, rs.getString(primaryKeyColumn));
 						continue;
 					}
 					if (referenceColToTable.size() > 0 && referenceColToTable.containsKey(columnName)

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -14,6 +14,7 @@ import org.databiosphere.workspacedataservice.service.model.exception.BatchDelet
 import org.databiosphere.workspacedataservice.service.model.exception.BatchWriteException;
 import org.databiosphere.workspacedataservice.service.model.exception.InvalidRelationException;
 import org.databiosphere.workspacedataservice.service.model.exception.MissingObjectException;
+import org.databiosphere.workspacedataservice.shared.model.AttributeComparator;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
 import org.databiosphere.workspacedataservice.shared.model.RecordColumn;
@@ -45,6 +46,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -148,8 +150,10 @@ public class RecordDao {
 	public List<String> getAllAttributeNames(UUID instanceId, RecordType recordType) {
 		MapSqlParameterSource params = new MapSqlParameterSource(INSTANCE_ID, instanceId.toString());
 		params.addValue("tableName", recordType.getName());
-		return namedTemplate.queryForList("select column_name from INFORMATION_SCHEMA.COLUMNS where table_schema = :instanceId "
-						+ "and table_name = :tableName", params, String.class);
+		List<String> attributeNames = namedTemplate.queryForList("select column_name from INFORMATION_SCHEMA.COLUMNS where table_schema = :instanceId "
+				+ "and table_name = :tableName", params, String.class);
+		Collections.sort(attributeNames, new AttributeComparator(cachedQueryDao.getPrimaryKeyColumn(recordType, instanceId)));
+		return attributeNames;
 	}
 
 	public Map<String, DataTypeMapping> getExistingTableSchemaLessPrimaryKey(UUID instanceId, RecordType recordType) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/AttributeComparator.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/AttributeComparator.java
@@ -1,0 +1,19 @@
+package org.databiosphere.workspacedataservice.shared.model;
+
+import java.text.Collator;
+import java.util.Comparator;
+
+public record AttributeComparator(String primaryKey) implements Comparator<String> {
+
+    @Override
+    public int compare(String o1, String o2) {
+        if (o1.equals(primaryKey)) {
+            return -1;
+        }
+        if (o2.equals(primaryKey)) {
+            return 1;
+        }
+        Collator collator = Collator.getInstance();
+        return collator.compare(o1, o2);
+    }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributes.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributes.java
@@ -38,20 +38,6 @@ public class RecordAttributes {
 		this.attributes.putAll(attributes);
 	}
 
-	private record AttributeComparator(String primaryKey) implements Comparator<String> {
-
-		@Override
-		public int compare(String o1, String o2) {
-			if (o1.equals(primaryKey)) {
-				return -1;
-			}
-			if (o2.equals(primaryKey)) {
-				return 1;
-			}
-			Collator collator = Collator.getInstance();
-			return collator.compare(o1, o2);
-		}
-	}
 
 	/**
 	 * creates a RecordAttributes with no keys/values

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributes.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributes.java
@@ -3,8 +3,11 @@ package org.databiosphere.workspacedataservice.shared.model;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-import java.text.Collator;
-import java.util.*;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
 
 /**
  * Represents the attributes of a Record.

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributes.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributes.java
@@ -3,6 +3,7 @@ package org.databiosphere.workspacedataservice.shared.model;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.text.Collator;
 import java.util.*;
 
 /**
@@ -31,6 +32,27 @@ public class RecordAttributes {
 		this.attributes = new TreeMap<>(attributes);
 	}
 
+	public RecordAttributes(Map<String, Object> attributes, String primaryKey) {
+		AttributeComparator comparator = new AttributeComparator(primaryKey);
+		this.attributes = new TreeMap<>(comparator);
+		this.attributes.putAll(attributes);
+	}
+
+	private record AttributeComparator(String primaryKey) implements Comparator<String> {
+
+		@Override
+		public int compare(String o1, String o2) {
+			if (o1.equals(primaryKey)) {
+				return -1;
+			}
+			if (o2.equals(primaryKey)) {
+				return 1;
+			}
+			Collator collator = Collator.getInstance();
+			return collator.compare(o1, o2);
+		}
+	}
+
 	/**
 	 * creates a RecordAttributes with no keys/values
 	 * 
@@ -38,6 +60,10 @@ public class RecordAttributes {
 	 */
 	public static RecordAttributes empty() {
 		return new RecordAttributes(Collections.emptyMap());
+	}
+
+	public static RecordAttributes empty(String primaryKeyColumn) {
+		return new RecordAttributes(Collections.emptyMap(), primaryKeyColumn);
 	}
 
 	// ========== accessors

--- a/service/src/test/java/org/databiosphere/workspacedataservice/TestUtils.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/TestUtils.java
@@ -18,10 +18,10 @@ public class TestUtils {
 	}
 
 	public static String getExpectedAllAttributesJsonText(){
-		return "{\"id\":\"newRecordId\",\"type\":\"all-types\",\"attributes\":{\"array-of-number\":[1,2,3]," +
+		return "{\"id\":\"newRecordId\",\"type\":\"all-types\",\"attributes\":{\"sys_name\":\"newRecordId\"," +
 				"\"array_of_boolean\":[true,false,true,true],\"array_of_date\":[\"2021-11-03\",\"2021-11-04\"]," +
 				"\"array_of_date_time\":[\"2021-11-03T07:30:00\",\"2021-11-03T07:30:00\"]," +
-				"\"array_of_string\":[\"a\",\"b\",\"c\",\"12\"],\"boolean\":false,\"date\":\"2021-11-03\"," +
+				"\"array_of_string\":[\"a\",\"b\",\"c\",\"12\"],\"array-of-number\":[1,2,3],\"boolean\":false,\"date\":\"2021-11-03\"," +
 				"\"date-time\":\"2021-11-03T07:30:00\",\"empty-array\":[],\"json\":{\"age\":22}," +
 				"\"null\":null,\"number\":47,\"string\":\"Broad Institute\"}}";
 	}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -334,18 +334,18 @@ class RecordControllerMockMvcTest {
 		assertEquals("JSON", schema.attributes().get(4).datatype());
 		assertEquals("NUMBER", schema.attributes().get(5).datatype());
 		assertEquals("long", schema.attributes().get(5).name());
-		assertEquals("z_array_of_string", schema.attributes().get(7).name());
-		assertEquals("ARRAY_OF_STRING", schema.attributes().get(7).datatype());
-		assertEquals("z_double_array", schema.attributes().get(8).name());
-		assertEquals("ARRAY_OF_NUMBER", schema.attributes().get(8).datatype());
-		assertEquals("z_long_array", schema.attributes().get(9).name());
+		assertEquals("z_array_of_string", schema.attributes().get(8).name());
+		assertEquals("ARRAY_OF_STRING", schema.attributes().get(8).datatype());
+		assertEquals("z_double_array", schema.attributes().get(9).name());
 		assertEquals("ARRAY_OF_NUMBER", schema.attributes().get(9).datatype());
-		assertEquals("z_z_boolean_array", schema.attributes().get(10).name());
-		assertEquals("ARRAY_OF_BOOLEAN", schema.attributes().get(10).datatype());
-		assertEquals("zz_array_of_date", schema.attributes().get(11).name());
-		assertEquals("ARRAY_OF_DATE", schema.attributes().get(11).datatype());
-		assertEquals("zz_array_of_datetime", schema.attributes().get(12).name());
-		assertEquals("ARRAY_OF_DATE_TIME", schema.attributes().get(12).datatype());
+		assertEquals("z_long_array", schema.attributes().get(10).name());
+		assertEquals("ARRAY_OF_NUMBER", schema.attributes().get(10).datatype());
+		assertEquals("z_z_boolean_array", schema.attributes().get(11).name());
+		assertEquals("ARRAY_OF_BOOLEAN", schema.attributes().get(11).datatype());
+		assertEquals("zz_array_of_date", schema.attributes().get(12).name());
+		assertEquals("ARRAY_OF_DATE", schema.attributes().get(12).datatype());
+		assertEquals("zz_array_of_datetime", schema.attributes().get(13).name());
+		assertEquals("ARRAY_OF_DATE_TIME", schema.attributes().get(13).datatype());
 		MockMultipartFile alter = new MockMultipartFile("records", "change_json_to_text.tsv",
 				MediaType.TEXT_PLAIN_VALUE, "sys_name\tjson\na\tfoo\n".getBytes());
 		mockMvc.perform(
@@ -739,8 +739,8 @@ class RecordControllerMockMvcTest {
 				new AttributeSchema("attr-ref", "RELATION", referencedType),
 				new AttributeSchema("attr1", "STRING", null), new AttributeSchema("attr2", "NUMBER", null),
 				new AttributeSchema("attr3", "DATE", null), new AttributeSchema("attr4", "STRING", null),
-				new AttributeSchema("attr5", "NUMBER", null), new AttributeSchema("z-array-of-boolean", "ARRAY_OF_BOOLEAN", null),
-				new AttributeSchema("z-array-of-number-double", "ARRAY_OF_NUMBER", null),
+				new AttributeSchema("attr5", "NUMBER", null), new AttributeSchema("sys_name", "STRING", null),
+				new AttributeSchema("z-array-of-boolean", "ARRAY_OF_BOOLEAN", null), new AttributeSchema("z-array-of-number-double", "ARRAY_OF_NUMBER", null),
 				new AttributeSchema("z-array-of-number-long", "ARRAY_OF_NUMBER", null), new AttributeSchema("z-array-of-string", "ARRAY_OF_STRING", null));
 
 		RecordTypeSchema expected = new RecordTypeSchema(type, expectedAttributes, 1, RECORD_ID);
@@ -795,7 +795,8 @@ class RecordControllerMockMvcTest {
 				new AttributeSchema("attr-dt", "DATE_TIME", null), new AttributeSchema("attr-json", "JSON", null),
 				new AttributeSchema("attr1", "STRING", null), new AttributeSchema("attr2", "NUMBER", null),
 				new AttributeSchema("attr3", "DATE", null), new AttributeSchema("attr4", "STRING", null),
-				new AttributeSchema("attr5", "NUMBER", null), new AttributeSchema("z-array-of-boolean", "ARRAY_OF_BOOLEAN", null),
+				new AttributeSchema("attr5", "NUMBER", null), new AttributeSchema("sys_name", "STRING", null),
+				new AttributeSchema("z-array-of-boolean", "ARRAY_OF_BOOLEAN", null),
 				new AttributeSchema("z-array-of-number-double", "ARRAY_OF_NUMBER", null),
 				new AttributeSchema("z-array-of-number-long", "ARRAY_OF_NUMBER", null), new AttributeSchema("z-array-of-string", "ARRAY_OF_STRING", null));
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
@@ -66,19 +66,15 @@ class TsvDownloadTest {
 		CSVFormat csvFormat = CSVFormat.DEFAULT.builder().setHeader().setSkipHeaderRecord(true).setDelimiter("\t")
 				.setQuoteMode(QuoteMode.MINIMAL).build();
 		InputStreamReader reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
-		CSVParser parser = new CSVParser(reader, csvFormat);
-		Map<String, Integer> headerMap = parser.getHeaderMap();
-		assertThat(headerMap).isEqualTo(Map.of("sample_id", 0, "attr-1", 1, "col_1", 2, "col_2", 3));
-		Iterator<CSVRecord> iterator = ((Iterable<CSVRecord>) parser).iterator();
+		Iterable<CSVRecord> records = new CSVParser(reader, csvFormat);
+		Iterator<CSVRecord> iterator = records.iterator();
 		CSVRecord rcd = iterator.next();
 		assertThat(rcd.get(primaryKeyName)).isEqualTo(primaryKeyName+"_val");
-		assertThat(rcd.get("attr-1")).isEqualTo("-99");
 		assertThat(rcd.get("col_1")).isEqualTo("Fido");
 		assertThat(rcd.get("col_2")).isEqualTo("Jerry");
 		assertThat(iterator.hasNext()).isFalse();
 		reader.close();
 	}
-
 	@Test
 	void batchWriteFollowedByTsvDownload() throws IOException {
 		RecordType recordType = RecordType.valueOf("tsv-test");

--- a/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributesTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributesTest.java
@@ -9,7 +9,7 @@ import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class RecordAttributesTest {
+class RecordAttributesTest {
 
 
     @Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributesTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributesTest.java
@@ -1,0 +1,26 @@
+package org.databiosphere.workspacedataservice.shared.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RecordAttributesTest {
+
+
+    @Test
+    void verifyAttributeOrdering() {
+        RecordAttributes recordAttributes = RecordAttributes.empty("Z");
+        recordAttributes.putAttribute("a", 11);
+        recordAttributes.putAttribute("A", 17);
+        recordAttributes.putAttribute("B", "hello");
+        recordAttributes.putAttribute("C", LocalDate.of(2022, 11, 21));
+        recordAttributes.putAttribute("Z", "1");
+        List<String> attributeNamesInOrder = recordAttributes.attributeSet().stream().map(Map.Entry::getKey).collect(Collectors.toList());
+        assertThat(attributeNamesInOrder).isEqualTo(List.of("Z", "a", "A", "B", "C"));
+    }
+}


### PR DESCRIPTION
This PR adds the primary key to the attribute map in the JSON response.    I also took the liberty to add code to order the JSON attributes with PK first and all other attributes following in alphabetical order and to order the TSV columns by that same ordering scheme.  When I tested with terra UI, [this code](https://github.com/DataBiosphere/terra-ui/blob/7976a29f882b3814ff7d65a08cbfbcf949257ed0/src/components/data/DataTable.js#L154-L156) led to problems, my fix was to make those lists match on the server side and update the schema API to include the primary key column too as part of this PR.