### PR TITLE
AJ-728: Identify pk column in schema apis

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -285,7 +285,7 @@ public class RecordController {
 				.map(entry -> createAttributeSchema(entry.getKey(), entry.getValue(), relations.get(entry.getKey())))
 				.toList();
 		int recordCount = recordDao.countRecords(instanceId, recordType);
-		return new RecordTypeSchema(recordType, attrSchema, recordCount);
+		return new RecordTypeSchema(recordType, attrSchema, recordCount, recordDao.getPrimaryKeyColumn(recordType, instanceId));
 	}
 
 	private AttributeSchema createAttributeSchema(String name, DataTypeMapping datatype, RecordType relation) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -618,6 +618,10 @@ public class RecordDao {
 		}
 	}
 
+	public String getPrimaryKeyColumn(RecordType type, UUID instanceId){
+		return cachedQueryDao.getPrimaryKeyColumn(type, instanceId);
+	}
+
 	public boolean recordExists(UUID instanceId, RecordType recordType, String recordId) {
 		return Boolean.TRUE
 				.equals(namedTemplate.queryForObject(

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/RecordTypeSchema.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/RecordTypeSchema.java
@@ -4,5 +4,5 @@ import org.databiosphere.workspacedataservice.shared.model.RecordType;
 
 import java.util.List;
 
-public record RecordTypeSchema(RecordType name, List<AttributeSchema> attributes, int count, String uniqueRowIdentifier) {
+public record RecordTypeSchema(RecordType name, List<AttributeSchema> attributes, int count, String primaryKey) {
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/RecordTypeSchema.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/RecordTypeSchema.java
@@ -4,5 +4,5 @@ import org.databiosphere.workspacedataservice.shared.model.RecordType;
 
 import java.util.List;
 
-public record RecordTypeSchema(RecordType name, List<AttributeSchema> attributes, int count) {
+public record RecordTypeSchema(RecordType name, List<AttributeSchema> attributes, int count, String uniqueRowIdentifier) {
 }

--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -701,7 +701,7 @@ components:
         - name
         - attributes
         - count
-        - uniqueRowIdentifier
+        - primaryKey
       type: object
       properties:
         name:
@@ -714,9 +714,9 @@ components:
         count:
           type: integer
           description: Number of records of this type
-        uniqueRowIdentifier:
+        primaryKey:
           type: string
-          description: Attribute name that contains the value to uniquely identify each record.
+          description: Attribute name that contains the value to uniquely identify each record, defined as a primary key column in the underlying table.
     ErrorResponse:
       required:
         - status

--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -701,6 +701,7 @@ components:
         - name
         - attributes
         - count
+        - uniqueRowIdentifier
       type: object
       properties:
         name:
@@ -713,6 +714,9 @@ components:
         count:
           type: integer
           description: Number of records of this type
+        uniqueRowIdentifier:
+          type: string
+          description: Attribute name that contains the value to uniquely identify each record.
     ErrorResponse:
       required:
         - status

--- a/service/src/test/java/org/databiosphere/workspacedataservice/GeneratedClientTests.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/GeneratedClientTests.java
@@ -95,6 +95,7 @@ class GeneratedClientTests {
         assertThat(schema.getName()).isEqualTo(recordType);
         List<RecordTypeSchema> schemas = schemaApi.describeAllRecordTypes(instanceId.toString(), version);
         assertThat(schemas).hasSize(2);
+        assertThat(schemas.get(0).getUniqueRowIdentifier()).isEqualTo("sys_name");
     }
 
     @Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/GeneratedClientTests.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/GeneratedClientTests.java
@@ -95,7 +95,7 @@ class GeneratedClientTests {
         assertThat(schema.getName()).isEqualTo(recordType);
         List<RecordTypeSchema> schemas = schemaApi.describeAllRecordTypes(instanceId.toString(), version);
         assertThat(schemas).hasSize(2);
-        assertThat(schemas.get(0).getUniqueRowIdentifier()).isEqualTo("sys_name");
+        assertThat(schemas.get(0).getPrimaryKey()).isEqualTo("sys_name");
     }
 
     @Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -42,8 +42,11 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.databiosphere.workspacedataservice.TestUtils.generateRandomAttributes;
-import static org.hamcrest.Matchers.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.databiosphere.workspacedataservice.service.model.ReservedNames.RECORD_ID;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -740,7 +743,7 @@ class RecordControllerMockMvcTest {
 				new AttributeSchema("z-array-of-number-double", "ARRAY_OF_NUMBER", null),
 				new AttributeSchema("z-array-of-number-long", "ARRAY_OF_NUMBER", null), new AttributeSchema("z-array-of-string", "ARRAY_OF_STRING", null));
 
-		RecordTypeSchema expected = new RecordTypeSchema(type, expectedAttributes, 1);
+		RecordTypeSchema expected = new RecordTypeSchema(type, expectedAttributes, 1, RECORD_ID);
 
 		MvcResult mvcResult = mockMvc.perform(get("/{instanceId}/types/{v}/{type}", instanceId, versionId, type))
 				.andExpect(status().isOk()).andReturn();
@@ -796,9 +799,9 @@ class RecordControllerMockMvcTest {
 				new AttributeSchema("z-array-of-number-double", "ARRAY_OF_NUMBER", null),
 				new AttributeSchema("z-array-of-number-long", "ARRAY_OF_NUMBER", null), new AttributeSchema("z-array-of-string", "ARRAY_OF_STRING", null));
 
-		List<RecordTypeSchema> expectedSchemas = Arrays.asList(new RecordTypeSchema(type1, expectedAttributes, 1),
-				new RecordTypeSchema(type2, expectedAttributes, 2),
-				new RecordTypeSchema(type3, expectedAttributes, 10));
+		List<RecordTypeSchema> expectedSchemas = Arrays.asList(new RecordTypeSchema(type1, expectedAttributes, 1, RECORD_ID),
+				new RecordTypeSchema(type2, expectedAttributes, 2, RECORD_ID),
+				new RecordTypeSchema(type3, expectedAttributes, 10, RECORD_ID));
 
 		MvcResult mvcResult = mockMvc.perform(get("/{instanceId}/types/{v}", instanceId, versionId))
 				.andExpect(status().isOk()).andReturn();

--- a/service/src/test/resources/logback-spring.xml
+++ b/service/src/test/resources/logback-spring.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="Console"
+              class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>
+                %green(%d{ISO8601}) %highlight(%-5level) [%blue(%X{requestId})] %yellow(%C{1.}): %msg%n%throwable
+            </Pattern>
+        </layout>
+    </appender>
+
+    <!-- log everything at INFO level -->
+    <root level="info">
+        <appender-ref ref="Console" />
+    </root>
+
+    <!-- log WDS at DEBUG level -->
+    <logger name="org.databiosphere.workspacedataservice" level="debug" additivity="false">
+        <appender-ref ref="Console" />
+    </logger>
+
+    <!-- log org.springframework.web at DEBUG level -->
+    <logger name="org.springframework.web" level="debug" additivity="false">
+        <appender-ref ref="Console" />
+    </logger>
+
+</configuration>


### PR DESCRIPTION
I ran GeneratedClientTests before updating swagger and they passed so I think this change won't break swagger clients.