### PR TITLE
AJ-754: Don't fail with a SQL Error when passing list data to a STRING attribute

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ repositories { mavenCentral() }
 
 subprojects {
     group = 'org.databiosphere'
-    version = '0.2.10-SNAPSHOT'
+    version = '0.2.11-SNAPSHOT'
 
     apply plugin: 'idea'
     apply plugin: 'java'

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -457,7 +457,7 @@ public class RecordDao {
 		if (Objects.isNull(attVal)) {
 			return null;
 		}
-		if (RelationUtils.isRelationValue(attVal) && typeMapping == DataTypeMapping.STRING) {
+		if (RelationUtils.isRelationValue(attVal) && typeMapping == DataTypeMapping.RELATION) {
 			return RelationUtils.getRelationValue(attVal);
 		}
 		if (attVal instanceof String sVal) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -400,7 +400,7 @@ public class RecordDao {
 		if (Objects.isNull(attVal)) {
 			return null;
 		}
-		if (RelationUtils.isRelationValue(attVal)) {
+		if (RelationUtils.isRelationValue(attVal) && typeMapping == DataTypeMapping.STRING) {
 			return RelationUtils.getRelationValue(attVal);
 		}
 		if (attVal instanceof String sVal) {
@@ -427,6 +427,9 @@ public class RecordDao {
 		}
 		if(typeMapping.isArrayType()){
 			return getArrayValues(attVal, typeMapping);
+		}
+		if(attVal instanceof List<?> list && typeMapping == DataTypeMapping.STRING){
+			return list.stream().map(Object::toString).collect(Collectors.joining(","));
 		}
 		return attVal;
 	}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -439,7 +439,7 @@ public class RecordDao {
 			return getArrayValues(attVal, typeMapping);
 		}
 		if(attVal instanceof List<?> list && typeMapping == DataTypeMapping.STRING){
-			return list.stream().map(Object::toString).collect(Collectors.joining(","));
+			return "{"+ list.stream().map(Object::toString).collect(Collectors.joining(",")) +"}";
 		}
 		return attVal;
 	}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -303,6 +303,29 @@ class RecordControllerMockMvcTest {
 
 	@Test
 	@Transactional
+	void scalarFollowedByArray() throws Exception {
+		String type = "scalar-followed-by-array";
+		String id = "my-id";
+		String attrName = "my-attr";
+
+		RecordAttributes firstPayload = new RecordAttributes(Map.of(attrName, "simple string"));
+		RecordAttributes secondPayload = new RecordAttributes(Map.of(attrName, List.of("array", "of", "strings")));
+
+		// upload the scalar string, should be success
+		mockMvc.perform(put("/{instanceId}/records/{version}/{recordType}/{id}", instanceId, versionId, type, id)
+						.content(mapper.writeValueAsString(new RecordRequest(firstPayload)))
+						.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().is2xxSuccessful());
+
+		// upload the string array into the same attribute, should also be success
+		mockMvc.perform(put("/{instanceId}/records/{version}/{recordType}/{id}", instanceId, versionId, type, id)
+						.content(mapper.writeValueAsString(new RecordRequest(secondPayload)))
+						.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().is2xxSuccessful());
+	}
+
+	@Test
+	@Transactional
 	void tsvWithMissingRelationShouldFail() throws Exception {
 		MockMultipartFile file = new MockMultipartFile("records", "simple_bad_relation.tsv", MediaType.TEXT_PLAIN_VALUE,
 				("sys_name\trelation\na\t" + RelationUtils.createRelationString(RecordType.valueOf("missing"), "QQ")

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -302,7 +302,6 @@ class RecordControllerMockMvcTest {
 	}
 
 	@Test
-	@Transactional
 	void scalarFollowedByArray() throws Exception {
 		String type = "scalar-followed-by-array";
 		String id = "my-id";

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -446,11 +446,21 @@ class RecordControllerMockMvcTest {
 						.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is2xxSuccessful());
 
+		MvcResult firstResult = mockMvc.perform(get("/{instanceId}/records/{version}/{recordType}/{id}", instanceId, versionId, type, id))
+						.andReturn();
+		RecordResponse firstRecord = mapper.readValue(firstResult.getResponse().getContentAsString(), RecordResponse.class);
+		assertEquals("simple string", firstRecord.recordAttributes().getAttributeValue(attrName));
+
 		// upload the string array into the same attribute, should also be success
 		mockMvc.perform(put("/{instanceId}/records/{version}/{recordType}/{id}", instanceId, versionId, type, id)
 						.content(mapper.writeValueAsString(new RecordRequest(secondPayload)))
 						.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is2xxSuccessful());
+
+		MvcResult secondResult = mockMvc.perform(get("/{instanceId}/records/{version}/{recordType}/{id}", instanceId, versionId, type, id))
+				.andReturn();
+		RecordResponse secondRecord = mapper.readValue(secondResult.getResponse().getContentAsString(), RecordResponse.class);
+		assertEquals("{array,of,strings}", secondRecord.recordAttributes().getAttributeValue(attrName));
 	}
 
 	@Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -69,15 +69,7 @@ class RecordControllerMockMvcTest {
 				versionId, instanceId).content("")).andExpect(status().isCreated());
 	}
 
-	@AfterEach
-	void afterEach() throws Exception {
-		try {
-			mockMvc.perform(delete("/instances/{v}/{instanceid}",
-					versionId, instanceId).content("")).andExpect(status().isOk());
-		} catch (Throwable t)  {
-			 // noop - if we fail to delete the instance, don't fail the test
-		}
-	}
+
 
 	@Test
 	@Transactional

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -69,7 +69,15 @@ class RecordControllerMockMvcTest {
 				versionId, instanceId).content("")).andExpect(status().isCreated());
 	}
 
-
+	@AfterEach
+	void afterEach() throws Exception {
+		try {
+			mockMvc.perform(delete("/instances/{v}/{instanceid}",
+					versionId, instanceId).content("")).andExpect(status().isOk());
+		} catch (Throwable t)  {
+			 // noop - if we fail to delete the instance, don't fail the test
+		}
+	}
 
 	@Test
 	@Transactional
@@ -294,6 +302,7 @@ class RecordControllerMockMvcTest {
 	}
 
 	@Test
+	@Transactional
 	void scalarFollowedByArray() throws Exception {
 		String type = "scalar-followed-by-array";
 		String id = "my-id";

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
@@ -85,7 +85,7 @@ class RecordDaoTest {
 		String sample_id = "Sample ID";
 		String recordId = "1199";
 		Record testRecord = new Record(recordId, referencedRt, RecordAttributes.empty());
-		Map<String, DataTypeMapping> schema = Map.of("attr1", DataTypeMapping.STRING);
+		Map<String, DataTypeMapping> schema = Map.of("attr1", DataTypeMapping.RELATION);
 		recordDao.createRecordType(instanceId, schema, referencedRt, new RelationCollection(Collections.emptySet(),Collections.emptySet()), sample_id);
 		recordDao.batchUpsert(instanceId, referencedRt, Collections.singletonList(testRecord), Collections.emptyMap(), sample_id);
 		RecordType referencer = RecordType.valueOf("referencer");
@@ -105,7 +105,7 @@ class RecordDaoTest {
 		// Create two records of the same type, one with a value for a relation
 		// attribute, the other without
 		recordDao.addColumn(instanceId, recordType, "foo", DataTypeMapping.STRING);
-		recordDao.addColumn(instanceId, recordType, "relationAttr", DataTypeMapping.STRING);
+		recordDao.addColumn(instanceId, recordType, "relationAttr", DataTypeMapping.RELATION);
 		recordDao.addForeignKeyForReference(recordType, recordType, instanceId, "relationAttr");
 
 		String refRecordId = "referencedRecord";
@@ -117,7 +117,7 @@ class RecordDaoTest {
 
 		recordDao.batchUpsert(instanceId, recordType, Collections.singletonList(referencedRecord), new HashMap<>());
 		recordDao.batchUpsert(instanceId, recordType, List.of(referencedRecord, testRecord),
-				new HashMap<>(Map.of("foo", DataTypeMapping.STRING, "relationAttr", DataTypeMapping.STRING)));
+				new HashMap<>(Map.of("foo", DataTypeMapping.STRING, "relationAttr", DataTypeMapping.RELATION)));
 
 		List<Relation> relations = recordDao.getRelationCols(instanceId, recordType);
 
@@ -162,7 +162,7 @@ class RecordDaoTest {
 		// get to the dao
 		recordDao.addColumn(instanceId, recordType, "foo", DataTypeMapping.STRING);
 
-		recordDao.addColumn(instanceId, recordType, "testRecordType", DataTypeMapping.STRING);
+		recordDao.addColumn(instanceId, recordType, "testRecordType", DataTypeMapping.RELATION);
 		recordDao.addForeignKeyForReference(recordType, recordType, instanceId, "testRecordType");
 
 		String refRecordId = "referencedRecord";
@@ -173,7 +173,7 @@ class RecordDaoTest {
 		String reference = RelationUtils.createRelationString(RecordType.valueOf("testRecordType"), "referencedRecord");
 		Record testRecord = new Record(recordId, recordType, new RecordAttributes(Map.of("testRecordType", reference)));
 		recordDao.batchUpsert(instanceId, recordType, Collections.singletonList(testRecord),
-				new HashMap<>(Map.of("foo", DataTypeMapping.STRING, "testRecordType", DataTypeMapping.STRING)));
+				new HashMap<>(Map.of("foo", DataTypeMapping.STRING, "testRecordType", DataTypeMapping.RELATION)));
 
 		Record search = recordDao
 				.getSingleRecord(instanceId, recordType, recordId)
@@ -213,7 +213,7 @@ class RecordDaoTest {
 		// get to the dao
 		recordDao.addColumn(instanceId, recordType, "foo", DataTypeMapping.STRING);
 
-		recordDao.addColumn(instanceId, recordType, "testRecordType", DataTypeMapping.STRING,
+		recordDao.addColumn(instanceId, recordType, "testRecordType", DataTypeMapping.RELATION,
 				RecordType.valueOf("testRecordType"));
 
 		String refRecordId = "referencedRecord";
@@ -224,7 +224,7 @@ class RecordDaoTest {
 		String reference = RelationUtils.createRelationString(RecordType.valueOf("testRecordType"), "referencedRecord");
 		Record testRecord = new Record(recordId, recordType, new RecordAttributes(Map.of("testRecordType", reference)));
 		recordDao.batchUpsert(instanceId, recordType, Collections.singletonList(testRecord),
-				new HashMap<>(Map.of("foo", DataTypeMapping.STRING, "testRecordType", DataTypeMapping.STRING)));
+				new HashMap<>(Map.of("foo", DataTypeMapping.STRING, "testRecordType", DataTypeMapping.RELATION)));
 
 		// Should throw an error
 		assertThrows(ResponseStatusException.class, () -> {
@@ -305,7 +305,7 @@ class RecordDaoTest {
 		RecordType referencedType = RecordType.valueOf("referencedType");
 		recordDao.createRecordType(instanceId, Collections.emptyMap(), referencedType, new RelationCollection(Collections.emptySet(), Collections.emptySet()), RECORD_ID);
 
-		recordDao.addColumn(instanceId, recordTypeName, "relation", DataTypeMapping.STRING, referencedType);
+		recordDao.addColumn(instanceId, recordTypeName, "relation", DataTypeMapping.RELATION, referencedType);
 
 		String refRecordId = "referencedRecord";
 		Record referencedRecord = new Record(refRecordId, referencedType, RecordAttributes.empty());
@@ -315,7 +315,7 @@ class RecordDaoTest {
 		String reference = RelationUtils.createRelationString(referencedType, refRecordId);
 		Record testRecord = new Record(recordId, recordType, new RecordAttributes(Map.of("relation", reference)));
 		recordDao.batchUpsert(instanceId, recordTypeName, Collections.singletonList(testRecord),
-				new HashMap<>(Map.of("relation", DataTypeMapping.STRING)));
+				new HashMap<>(Map.of("relation", DataTypeMapping.RELATION)));
 
 		// Should throw an error
 		assertThrows(ResponseStatusException.class, () -> {


### PR DESCRIPTION
[AJ-754](https://broadworkbench.atlassian.net/browse/AJ-754)

## Note

This PR eliminates the error described below. If you upload an array of strings into a column that is a scalar string, your array of strings will be serialized into a scalar. For instance, if you upload `["array","of","strings"]` into a scalar column, you will end up with a scalar value `"{array,of,strings}"`.

I am not convinced this is the final behavior we want. However, I consider this PR as a strict improvement over throwing an error, so I suggest we merge it as-is while we debate what the functionality should be.

### Steps to reproduce

1. Create a new WDS instance
2. use the PUT single-record API to create a record with a single attribute whose value is a scalar string
3. use the PUT single-record API to replace that record, this time specifying the same single attribute as an array of strings

### Expected

All requests are 2xx successful.

### Actual

Step 3 - the attempt to upload the array - fails with:
> ```PreparedStatementCallback; bad SQL grammar [insert into \"f482df36-bada-4e19-a534-05f39c8b0f18\".\"thing\"(\"sys_name\", \"foo\") values (?, ?) on conflict (\"sys_name\") do update set \"foo\" = excluded.\"foo\"]; nested exception is org.postgresql.util.PSQLException: Can't infer the SQL type to use for an instance of java.util.ArrayList. Use setObject() with an explicit Types value to specify the type to use.```



