### PR TITLE
better error message for TSVs that contain duplicate IDs [AJ-721]

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -14,6 +14,7 @@ import org.databiosphere.workspacedataservice.service.model.exception.BatchDelet
 import org.databiosphere.workspacedataservice.service.model.exception.BatchWriteException;
 import org.databiosphere.workspacedataservice.service.model.exception.InvalidRelationException;
 import org.databiosphere.workspacedataservice.service.model.exception.MissingObjectException;
+import org.databiosphere.workspacedataservice.service.model.exception.InvalidTsvException;
 import org.databiosphere.workspacedataservice.shared.model.AttributeComparator;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
@@ -48,6 +49,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -403,6 +405,11 @@ public class RecordDao {
 	}
 
 	private List<Object[]> getInsertBatchArgs(List<Record> records, List<RecordColumn> cols, String recordTypeRowIdentifier) {
+		// validate that the list of records does not contain any duplicate ids
+		boolean areIdsUnique = records.stream().map(Record::getId).allMatch(new HashSet<>()::add);
+		if (!areIdsUnique) {
+			throw new InvalidTsvException("TSVs cannot contain duplicate primary key values");
+		}
 		return records.stream().map(r -> getInsertArgs(r, cols, recordTypeRowIdentifier)).toList();
 	}
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -14,7 +14,6 @@ import org.databiosphere.workspacedataservice.service.model.exception.BatchDelet
 import org.databiosphere.workspacedataservice.service.model.exception.BatchWriteException;
 import org.databiosphere.workspacedataservice.service.model.exception.InvalidRelationException;
 import org.databiosphere.workspacedataservice.service.model.exception.MissingObjectException;
-import org.databiosphere.workspacedataservice.service.model.exception.InvalidTsvException;
 import org.databiosphere.workspacedataservice.shared.model.AttributeComparator;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
@@ -49,7 +48,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -405,11 +405,6 @@ public class RecordDao {
 	}
 
 	private List<Object[]> getInsertBatchArgs(List<Record> records, List<RecordColumn> cols, String recordTypeRowIdentifier) {
-		// validate that the list of records does not contain any duplicate ids
-		boolean areIdsUnique = records.stream().map(Record::getId).allMatch(new HashSet<>()::add);
-		if (!areIdsUnique) {
-			throw new InvalidTsvException("TSVs cannot contain duplicate primary key values");
-		}
 		return records.stream().map(r -> getInsertArgs(r, cols, recordTypeRowIdentifier)).toList();
 	}
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/BatchWriteService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/BatchWriteService.java
@@ -123,7 +123,7 @@ public class BatchWriteService {
 		CSVParser rows = csvFormat.parse(is);
 		String leftMostColumn = rows.getHeaderNames().get(0);
 		List<Record> batch = new ArrayList<>();
-		HashSet<String> recordIds = new HashSet<>();
+		HashSet<String> recordIds = new HashSet<>(); // this set may be slow for very large TSVs
 		boolean firstUpsertBatch = true;
 		Map<String, DataTypeMapping> schema = null;
 		String uniqueIdentifierAsString = primaryKey.orElse(leftMostColumn);
@@ -156,11 +156,6 @@ public class BatchWriteService {
 				}
 				recordDao.batchUpsert(instanceId, recordType, batch, schema);
 				batch.clear();
-				// If we want to enforce that record ids are unique within the entire TSV,
-				// instead of within a batch, simply remove the next line.
-				// This would have performance implications for very large TSVs: the `recordIds` HashSet
-				// would need to hold ALL recordIds, reducing its efficiency.
-				recordIds.clear();
 			}
 		}
 		if (firstUpsertBatch) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/BatchWriteService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/BatchWriteService.java
@@ -156,8 +156,10 @@ public class BatchWriteService {
 				}
 				recordDao.batchUpsert(instanceId, recordType, batch, schema);
 				batch.clear();
-				// remove the following line to enforce that record ids are unique within the entire TSV,
-				// instead of within a batch. This would have performance implications for very large TSVs.
+				// If we want to enforce that record ids are unique within the entire TSV,
+				// instead of within a batch, simply remove the next line.
+				// This would have performance implications for very large TSVs: the `recordIds` HashSet
+				// would need to hold ALL recordIds, reducing its efficiency.
 				recordIds.clear();
 			}
 		}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -272,7 +272,12 @@ class RecordControllerMockMvcTest {
 	@Transactional
 	void tsvWithDuplicateRowIds() throws Exception {
 		MockMultipartFile file = new MockMultipartFile("records", "duplicate_id.tsv", MediaType.TEXT_PLAIN_VALUE,
-				"idcol\tcol2\n1\tfoo\n1\t\bar\n".getBytes());
+				"""
+                   idcol	col2
+                   1	foo
+                   2	bar
+                   1	baz
+                   3	qux""".stripIndent().getBytes());
 
 		MvcResult mvcResult = mockMvc.perform(multipart("/{instanceId}/tsv/{version}/{recordType}", instanceId, versionId, "duplicate-rowids")
 				.file(file)).andExpect(status().isBadRequest()).andReturn();


### PR DESCRIPTION
Uploading a TSV that contains duplicate ids now yields an error message of "TSVs cannot contain duplicate primary key values."

Per refinement, scope of this ticket is to make the error message better. If we want to allow duplicate PKs in a TSV, we'll do that in a future PR/ticket.

# New Error Message:
![Screenshot 12-8-2022 at 05 10 PM](https://user-images.githubusercontent.com/6041577/206578073-d46f8eef-1df4-4e1c-9abc-2910a5198673.png)

# Old Error Message:
![Screenshot 12-8-2022 at 05 14 PM](https://user-images.githubusercontent.com/6041577/206578571-5495d8e8-a088-4775-8a27-a904fa197703.png)
