### PR TITLE
Aj 735 delete array of relations

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -741,10 +741,8 @@ public class RecordDao {
 	@CacheEvict(value = PRIMARY_KEY_COLUMN_CACHE, key = "{ #recordType.name, #instanceId.toString()}")
 	public void deleteRecordType(UUID instanceId, RecordType recordType) {
 		List<Relation> relationArrayCols = getRelationArrayCols(instanceId, recordType);
-		if (!relationArrayCols.isEmpty()){
-			for (Relation rel : relationArrayCols){
-				namedTemplate.getJdbcTemplate().update("drop table " + getQualifiedJoinTableName(instanceId, rel.relationColName(), recordType));
-			}
+		for (Relation rel : relationArrayCols){
+			namedTemplate.getJdbcTemplate().update("drop table " + getQualifiedJoinTableName(instanceId, rel.relationColName(), recordType));
 		}
 		try {
 			namedTemplate.getJdbcTemplate().update("drop table " + getQualifiedTableName(recordType, instanceId));

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -139,21 +139,21 @@ public class RecordDao {
 		}
 	}
 
-	private String getJoinTableName(String relationColumnName, RecordType fromTable){
+	public String getJoinTableName(String relationColumnName, RecordType fromTable){
 		//Use RESERVED_NAME_PREFIX to ensure no collision with user-named tables.
 		//RecordType name has already been sql-validated
 		return quote(RESERVED_NAME_PREFIX + fromTable.getName() + "_" + SqlUtils.validateSqlString(relationColumnName, ATTRIBUTE));
 	}
 
-	private String getQualifiedJoinTableName(UUID instanceId, String relationColumnName, RecordType fromTable){
+	public String getQualifiedJoinTableName(UUID instanceId, String relationColumnName, RecordType fromTable){
 		return quote(instanceId.toString()) + "." + getJoinTableName(relationColumnName, fromTable);
 	}
 
-	private String getFromColumnName(RecordType referringRecordType){
+	public String getFromColumnName(RecordType referringRecordType){
 		return "from_" + referringRecordType.getName() + "_key";
 	}
 
-	private String getToColumnName(RecordType referencedRecordType){
+	public String getToColumnName(RecordType referencedRecordType){
 		return "to_" + referencedRecordType.getName() + "_key";
 
 	}
@@ -164,11 +164,9 @@ public class RecordDao {
 		String fromCol = getFromColumnName(referringRecordType);
 		String toCol = getToColumnName(referencedRecordType);
 		String columnDefs =  quote(fromCol) + " text, " + quote(toCol) + " text";
-		//Possibly temporary fake relations to make existing methods work for this situation
-		Set<Relation> relations = Set.of(new Relation(fromCol, referringRecordType), new Relation(toCol, referencedRecordType));
 		try {
 			namedTemplate.getJdbcTemplate().update("create table " + getQualifiedJoinTableName(instanceId, tableName, referringRecordType) +
-					"( " + columnDefs + ", " + getFkSql(relations, instanceId) + ")");
+					"( " + columnDefs + ", " + getFkSqlForJoin(new Relation(fromCol, referringRecordType), new Relation(toCol, referencedRecordType), instanceId) + ")");
 		} catch (DataAccessException e) {
 			if (e.getRootCause()instanceof SQLException sqlEx) {
 				checkForMissingTable(sqlEx);
@@ -327,14 +325,6 @@ public class RecordDao {
 
 	public boolean deleteSingleRecord(UUID instanceId, RecordType recordType, String recordId) {
 		String recordTypePrimaryKey = cachedQueryDao.getPrimaryKeyColumn(recordType, instanceId);
-		List<Relation> relationArrayCols = getRelationArrayCols(instanceId, recordType);
-		if (!relationArrayCols.isEmpty()){
-			//Remove values from join table first
-			for (Relation rel : relationArrayCols){
-				namedTemplate.update("delete from " + getQualifiedJoinTableName(instanceId, rel.relationColName(), recordType) + " where "
-						+ quote(getFromColumnName(recordType)) + " = :recordId", new MapSqlParameterSource(RECORD_ID_PARAM, recordId));
-			}
-		}
 		try {
 			return namedTemplate.update("delete from " + getQualifiedTableName(recordType, instanceId) + " where "
 					+ quote(recordTypePrimaryKey) + " = :recordId", new MapSqlParameterSource(RECORD_ID_PARAM, recordId)) == 1;
@@ -394,13 +384,19 @@ public class RecordDao {
 	}
 
 	public String getFkSql(Set<Relation> relations, UUID instanceId) {
-
 		return relations.stream()
-				.map(r -> "constraint " + quote("fk_" + SqlUtils.validateSqlString(r.relationColName(), ATTRIBUTE))
+				.map(r -> getFkSql(r, instanceId, false))
+				.collect(Collectors.joining(", \n"));
+	}
+
+	public String getFkSql(Relation r, UUID instanceId, boolean cascade) {
+		return "constraint " + quote("fk_" + SqlUtils.validateSqlString(r.relationColName(), ATTRIBUTE))
 						+ " foreign key (" + quote(SqlUtils.validateSqlString(r.relationColName(), ATTRIBUTE))
 						+ ") references " + getQualifiedTableName(r.relationRecordType(), instanceId) + "(" + quote(cachedQueryDao.getPrimaryKeyColumn(r.relationRecordType(), instanceId))
-						+ ")")
-				.collect(Collectors.joining(", \n"));
+						+ ")" + (cascade ? " on delete cascade" : "");
+	}
+	public String getFkSqlForJoin(Relation fromRelation, Relation toRelation, UUID instanceId) {
+		return getFkSql(fromRelation, instanceId, true) + ", \n" + getFkSql(toRelation, instanceId, false);
 	}
 
 	public List<Relation> getRelationCols(UUID instanceId, RecordType recordType) {
@@ -573,26 +569,6 @@ public class RecordDao {
 	public void batchDelete(UUID instanceId, RecordType recordType, List<Record> records) {
 		List<String> recordIds = records.stream().map(Record::getId).toList();
 		try {
-			List<Relation> relationArrayCols = getRelationArrayCols(instanceId, recordType);
-			if (!relationArrayCols.isEmpty()){
-				//Remove values from join table first
-				for (Relation rel : relationArrayCols) {
-					namedTemplate.getJdbcTemplate().batchUpdate(
-							"delete from" + getQualifiedJoinTableName(instanceId, rel.relationColName(), recordType) + " where " + quote(getFromColumnName(recordType)) + " = ?",
-							new BatchPreparedStatementSetter() {
-								@Override
-								public void setValues(PreparedStatement ps, int i) throws SQLException {
-									ps.setString(1, recordIds.get(i));
-								}
-
-								@Override
-								public int getBatchSize() {
-									return recordIds.size();
-								}
-							});
-				}
-			}
-
 			int[] rowCounts = namedTemplate.getJdbcTemplate().batchUpdate(
 					"delete from" + getQualifiedTableName(recordType, instanceId) + " where " + quote(cachedQueryDao.getPrimaryKeyColumn(recordType, instanceId)) + " = ?",
 					new BatchPreparedStatementSetter() {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -898,6 +898,27 @@ class RecordControllerMockMvcTest {
 
 	@Test
 	@Transactional
+	void deleteRecordWithRelationArray() throws Exception {
+		RecordType referencedType = RecordType.valueOf("ref_participants");
+		RecordType referringType = RecordType.valueOf("ref_samples");
+		createSomeRecords(referencedType, 3);
+		RecordAttributes attributes = RecordAttributes.empty();
+		List<String> relArr = IntStream.range(0,3).mapToObj(Integer::toString).map(i -> RelationUtils.createRelationString(referencedType, "record_" + i)).collect(Collectors.toList());
+		attributes.putAttribute("rel-arr", relArr);
+		mockMvc.perform(put("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
+						referringType, "record_0").contentType(MediaType.APPLICATION_JSON)
+						.content(mapper.writeValueAsString(new RecordRequest(attributes))))
+				.andExpect(status().isCreated()).andExpect(jsonPath("$.attributes.rel-arr", is(relArr)));
+
+
+		mockMvc.perform(delete("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
+				referringType, "record_0")).andExpect(status().isNoContent());
+		mockMvc.perform(get("/{instanceId}/records/{versionId}/{recordType}/{recordId}", instanceId, versionId,
+				referringType, "missing-2")).andExpect(status().isNotFound());
+	}
+
+	@Test
+	@Transactional
 	void deleteRecordType() throws Exception {
 		String recordType = "recordType";
 		createSomeRecords(recordType, 3);
@@ -932,6 +953,26 @@ class RecordControllerMockMvcTest {
 
 		mockMvc.perform(delete("/{instanceId}/types/{version}/{recordType}", instanceId, versionId, referencedType))
 				.andExpect(status().isConflict());
+	}
+
+	@Test
+	@Transactional
+	void deleteRecordTypeWithRelationArray() throws Exception {
+		RecordType referencedType = RecordType.valueOf("ref_participants");
+		RecordType referringType = RecordType.valueOf("ref_samples");
+		createSomeRecords(referencedType, 3);
+		RecordAttributes attributes = RecordAttributes.empty();
+		List<String> relArr = IntStream.range(0,3).mapToObj(Integer::toString).map(i -> RelationUtils.createRelationString(referencedType, "record_" + i)).collect(Collectors.toList());
+		attributes.putAttribute("rel-arr", relArr);
+		mockMvc.perform(put("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
+						referringType, "record_0").contentType(MediaType.APPLICATION_JSON)
+						.content(mapper.writeValueAsString(new RecordRequest(attributes))))
+				.andExpect(status().isCreated()).andExpect(jsonPath("$.attributes.rel-arr", is(relArr)));
+
+		mockMvc.perform(delete("/{instanceId}/types/{v}/{type}", instanceId, versionId, referringType))
+				.andExpect(status().isNoContent());
+		mockMvc.perform(get("/{instanceId}/types/{version}/{type}", instanceId, versionId, referringType))
+				.andExpect(status().isNotFound());
 	}
 
 	@Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
@@ -231,6 +231,31 @@ class RecordDaoTest {
 			recordDao.deleteSingleRecord(instanceId, recordType, "referencedRecord");
 		}, "Exception should be thrown when attempting to delete related record");
 	}
+
+	@Test
+	void testDeleteRelationArrayRecord() {
+		// make sure columns are in recordType, as this will be taken care of before we
+		// get to the dao
+		recordDao.addColumn(instanceId, recordType, "foo", DataTypeMapping.STRING);
+
+		recordDao.addColumn(instanceId, recordType, "testRecordType", DataTypeMapping.STRING,
+				RecordType.valueOf("testRecordType"));
+
+		String refRecordId = "referencedRecord";
+		Record referencedRecord = new Record(refRecordId, recordType, new RecordAttributes(Map.of("foo", "bar")));
+		recordDao.batchUpsert(instanceId, recordType, Collections.singletonList(referencedRecord), new HashMap<>());
+
+		String recordId = "testRecord";
+		String reference = RelationUtils.createRelationString(RecordType.valueOf("testRecordType"), "referencedRecord");
+		Record testRecord = new Record(recordId, recordType, new RecordAttributes(Map.of("testRecordType", reference)));
+		recordDao.batchUpsert(instanceId, recordType, Collections.singletonList(testRecord),
+				new HashMap<>(Map.of("foo", DataTypeMapping.STRING, "testRecordType", DataTypeMapping.STRING)));
+
+		// Should throw an error
+		assertThrows(ResponseStatusException.class, () -> {
+			recordDao.deleteSingleRecord(instanceId, recordType, "referencedRecord");
+		}, "Exception should be thrown when attempting to delete related record");
+	}
 	@Test
 	@Transactional
 	void testGetAllRecordTypes() {


### PR DESCRIPTION
[AJ-735: Delete arrays of relations](https://broadworkbench.atlassian.net/browse/AJ-735)
Deleting a record should remove the values from the relation-array table; deleting a record type should drop the join table altogether.

[AJ-735]: https://broadworkbench.atlassian.net/browse/AJ-735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AJ-735]: https://broadworkbench.atlassian.net/browse/AJ-735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ