### PR TITLE
try postgres 11.17

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,7 +28,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:11.16
+        image: postgres:11.17-alpine
         env:
           POSTGRES_PASSWORD: postgres
         options: >-

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,7 +28,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:13.1
+        image: postgres:11.16
         env:
           POSTGRES_PASSWORD: postgres
         options: >-

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ brew install homebrew/cask-versions/temurin17
 jenv add /Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home
 ```
 
-We are using Postgres 13.1.  You do not need to have postgres installed on your system.
+We are using Postgres 11.16.  You do not need to have postgres installed on your system.
 Instead use the `run_postgres.sh` script to set up a docker container running postgres (see below).
 
 ## Running

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ brew install homebrew/cask-versions/temurin17
 jenv add /Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home
 ```
 
-We are using Postgres 11.16.  You do not need to have postgres installed on your system.
+We are using Postgres 11.17.  You do not need to have postgres installed on your system.
 Instead use the `run_postgres.sh` script to set up a docker container running postgres (see below).
 
 ## Running

--- a/local-dev/run_postgres.sh
+++ b/local-dev/run_postgres.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Start up a postgres container with initial user/database setup.
-POSTGRES_VERSION=11.16
+POSTGRES_VERSION=11.17-alpine
 
 start() {
     echo "attempting to remove old $CONTAINER container..."

--- a/local-dev/run_postgres.sh
+++ b/local-dev/run_postgres.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Start up a postgres container with initial user/database setup.
-POSTGRES_VERSION=13.1
+POSTGRES_VERSION=11.16
 
 start() {
     echo "attempting to remove old $CONTAINER container..."


### PR DESCRIPTION
LZ Postgres is 11, not the 13.1 we've been using.

https://learn.microsoft.com/en-us/azure/postgresql/single-server/concepts-supported-versions says Azure uses postgres 11.17, so I'm using the [postgres:11.17-alpine image](https://hub.docker.com/layers/library/postgres/11.17-alpine/images/sha256-631b874fd499f66ff44a33c1704ede91a8b3a75ee998cfeaba57318be58bcc56?context=explore) where we need one.

This PR and its accompanying test runs show how compatible we are on Postgres 11 vs. 13