### PR TITLE
[AJ-767] transaction support 

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -34,12 +34,16 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter'
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.retry:spring-retry:1.3.4'
 	implementation 'org.apache.commons:commons-lang3'
 	implementation 'org.apache.commons:commons-csv:1.9.0'
 	implementation 'com.google.guava:guava:31.1-jre'
 	implementation 'org.postgresql:postgresql'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.webjars:webjars-locator-core:0.52'
+	implementation ('bio.terra:terra-common-lib:0.0.77-SNAPSHOT') {
+		exclude group: 'org.broadinstitute.dsde.workbench', module: 'sam-client_2.12'
+	}
 	runtimeOnly 'org.webjars.npm:swagger-ui-dist:4.12.0'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/service/src/main/java/org/databiosphere/workspacedataservice/WorkspaceDataServiceApplication.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/WorkspaceDataServiceApplication.java
@@ -32,8 +32,9 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import javax.sql.DataSource;
 
 @SpringBootApplication(scanBasePackages = {
+		// this codebase
 		"org.databiosphere.workspacedataservice",
-		// Transaction management and DB retry configuration
+		// terra-common-lib transaction management and DB retry configuration
 		"bio.terra.common.retry.transaction"
 })
 @EnableRetry

--- a/service/src/main/java/org/databiosphere/workspacedataservice/WorkspaceDataServiceApplication.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/WorkspaceDataServiceApplication.java
@@ -23,13 +23,21 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.lang.NonNull;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.web.servlet.config.annotation.AsyncSupportConfigurer;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import javax.sql.DataSource;
 
-@SpringBootApplication
+@SpringBootApplication(scanBasePackages = {
+		"org.databiosphere.workspacedataservice",
+		// Transaction management and DB retry configuration
+		"bio.terra.common.retry.transaction"
+})
+@EnableRetry
+@EnableTransactionManagement
 @EnableCaching
 public class WorkspaceDataServiceApplication {
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -1,5 +1,7 @@
 package org.databiosphere.workspacedataservice.controller;
 
+import bio.terra.common.db.ReadTransaction;
+import bio.terra.common.db.WriteTransaction;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.csv.CSVPrinter;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
@@ -65,6 +67,7 @@ public class RecordController {
 	}
 
 	@PatchMapping("/{instanceId}/records/{version}/{recordType}/{recordId}")
+	@WriteTransaction
 	public ResponseEntity<RecordResponse> updateSingleRecord(@PathVariable("instanceId") UUID instanceId,
 			@PathVariable("version") String version, @PathVariable("recordType") RecordType recordType,
 			@PathVariable("recordId") String recordId, @RequestBody RecordRequest recordRequest) {
@@ -88,6 +91,7 @@ public class RecordController {
 	}
 
 	@GetMapping("/{instanceId}/records/{version}/{recordType}/{recordId}")
+	@ReadTransaction
 	public ResponseEntity<RecordResponse> getSingleRecord(@PathVariable("instanceId") UUID instanceId,
 			@PathVariable("version") String version, @PathVariable("recordType") RecordType recordType,
 			@PathVariable("recordId") String recordId) {
@@ -100,6 +104,7 @@ public class RecordController {
 	}
 
 	@PostMapping( "/{instanceId}/tsv/{version}/{recordType}")
+//	@WriteTransaction
 	public ResponseEntity<TsvUploadResponse> tsvUpload(@PathVariable("instanceId") UUID instanceId,
 			   @PathVariable("version") String version, @PathVariable("recordType") RecordType recordType,
 			   @RequestParam(name= "primaryKey", required = false) Optional<String> primaryKey,
@@ -118,6 +123,7 @@ public class RecordController {
 	}
 
 	@GetMapping("/{instanceId}/tsv/{version}/{recordType}")
+//	@ReadTransaction
 	public ResponseEntity<StreamingResponseBody> streamAllEntities(@PathVariable("instanceId") UUID instanceId,
 			@PathVariable("version") String version, @PathVariable("recordType") RecordType recordType) {
 		validateVersion(version);
@@ -140,6 +146,7 @@ public class RecordController {
 	}
 
 	@PostMapping("/{instanceid}/search/{version}/{recordType}")
+	@ReadTransaction
 	public RecordQueryResponse queryForRecords(@PathVariable("instanceid") UUID instanceId,
 			@PathVariable("recordType") RecordType recordType,
 			@PathVariable("version") String version,
@@ -173,6 +180,7 @@ public class RecordController {
 	}
 
 	@PutMapping("/{instanceId}/records/{version}/{recordType}/{recordId}")
+	@WriteTransaction
 	public ResponseEntity<RecordResponse> upsertSingleRecord(@PathVariable("instanceId") UUID instanceId,
 			@PathVariable("version") String version, @PathVariable("recordType") RecordType recordType,
 			@PathVariable("recordId") String recordId, @RequestParam(name= "primaryKey", required = false) Optional<String> primaryKey,
@@ -214,6 +222,7 @@ public class RecordController {
 	}
 
 	@PostMapping("/instances/{version}/{instanceId}")
+	@WriteTransaction
 	public ResponseEntity<String> createInstance(@PathVariable("instanceId") UUID instanceId,
 			@PathVariable("version") String version) {
 		validateVersion(version);
@@ -225,6 +234,7 @@ public class RecordController {
 	}
 
 	@DeleteMapping("/instances/{version}/{instanceId}")
+	@WriteTransaction
 	public ResponseEntity<String> deleteInstance(@PathVariable("instanceId") UUID instanceId,
 												 @PathVariable("version") String version) {
 		validateVersion(version);
@@ -234,6 +244,7 @@ public class RecordController {
 	}
 
 	@DeleteMapping("/{instanceId}/records/{version}/{recordType}/{recordId}")
+	@WriteTransaction
 	public ResponseEntity<Void> deleteSingleRecord(@PathVariable("instanceId") UUID instanceId,
 			@PathVariable("version") String version, @PathVariable("recordType") RecordType recordType,
 			@PathVariable("recordId") String recordId) {
@@ -245,6 +256,7 @@ public class RecordController {
 	}
 
 	@DeleteMapping("/{instanceId}/types/{v}/{type}")
+	@WriteTransaction
 	public ResponseEntity<Void> deleteRecordType(@PathVariable("instanceId") UUID instanceId,
 			@PathVariable("v") String version, @PathVariable("type") RecordType recordType) {
 		validateVersion(version);
@@ -255,6 +267,7 @@ public class RecordController {
 	}
 
 	@GetMapping("/{instanceId}/types/{v}/{type}")
+	@ReadTransaction
 	public ResponseEntity<RecordTypeSchema> describeRecordType(@PathVariable("instanceId") UUID instanceId,
 			@PathVariable("v") String version, @PathVariable("type") RecordType recordType) {
 		validateVersion(version);
@@ -265,6 +278,7 @@ public class RecordController {
 	}
 
 	@GetMapping("/{instanceId}/types/{v}")
+	@ReadTransaction
 	public ResponseEntity<List<RecordTypeSchema>> describeAllRecordTypes(@PathVariable("instanceId") UUID instanceId,
 			@PathVariable("v") String version) {
 		validateVersion(version);
@@ -306,6 +320,7 @@ public class RecordController {
 	}
 
 	@PostMapping("/{instanceid}/batch/{v}/{type}")
+//	@WriteTransaction
 	public ResponseEntity<BatchResponse> streamingWrite(@PathVariable("instanceid") UUID instanceId,
 			@PathVariable("v") String version, @PathVariable("type") RecordType recordType,
 			@RequestParam(name= "primaryKey", required = false) Optional<String> primaryKey, InputStream is) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -104,7 +104,7 @@ public class RecordController {
 	}
 
 	@PostMapping( "/{instanceId}/tsv/{version}/{recordType}")
-//	@WriteTransaction
+	// TODO: enable write transaction
 	public ResponseEntity<TsvUploadResponse> tsvUpload(@PathVariable("instanceId") UUID instanceId,
 			   @PathVariable("version") String version, @PathVariable("recordType") RecordType recordType,
 			   @RequestParam(name= "primaryKey", required = false) Optional<String> primaryKey,
@@ -123,7 +123,7 @@ public class RecordController {
 	}
 
 	@GetMapping("/{instanceId}/tsv/{version}/{recordType}")
-//	@ReadTransaction
+	// TODO: enable read transaction
 	public ResponseEntity<StreamingResponseBody> streamAllEntities(@PathVariable("instanceId") UUID instanceId,
 			@PathVariable("version") String version, @PathVariable("recordType") RecordType recordType) {
 		validateVersion(version);
@@ -320,7 +320,7 @@ public class RecordController {
 	}
 
 	@PostMapping("/{instanceid}/batch/{v}/{type}")
-//	@WriteTransaction
+	// TODO: enable write transaction
 	public ResponseEntity<BatchResponse> streamingWrite(@PathVariable("instanceid") UUID instanceId,
 			@PathVariable("v") String version, @PathVariable("type") RecordType recordType,
 			@RequestParam(name= "primaryKey", required = false) Optional<String> primaryKey, InputStream is) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -104,7 +104,7 @@ public class RecordController {
 	}
 
 	@PostMapping( "/{instanceId}/tsv/{version}/{recordType}")
-	// TODO: enable write transaction
+	// N.B. transaction annotated in batchWriteService.uploadTsvStream
 	public ResponseEntity<TsvUploadResponse> tsvUpload(@PathVariable("instanceId") UUID instanceId,
 			   @PathVariable("version") String version, @PathVariable("recordType") RecordType recordType,
 			   @RequestParam(name= "primaryKey", required = false) Optional<String> primaryKey,
@@ -320,7 +320,7 @@ public class RecordController {
 	}
 
 	@PostMapping("/{instanceid}/batch/{v}/{type}")
-	// TODO: enable write transaction
+	// N.B. transaction annotated in batchWriteService.consumeWriteStream
 	public ResponseEntity<BatchResponse> streamingWrite(@PathVariable("instanceid") UUID instanceId,
 			@PathVariable("v") String version, @PathVariable("type") RecordType recordType,
 			@RequestParam(name= "primaryKey", required = false) Optional<String> primaryKey, InputStream is) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -33,7 +33,6 @@ import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.math.BigDecimal;
@@ -115,7 +114,6 @@ public class RecordDao {
 	}
 
 	@SuppressWarnings("squid:S2077")
-	@Transactional
 	public void createRecordType(UUID instanceId, Map<String, DataTypeMapping> tableInfo, RecordType recordType,
 			RelationCollection relations, String recordTypePrimaryKey) {
 		//this handles the case where the user incorrectly includes the primary key data in the attributes

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/BatchWriteService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/BatchWriteService.java
@@ -140,6 +140,7 @@ public class BatchWriteService {
 		}
 	}
 
+	@WriteTransaction
 	public int uploadTsvStream(InputStreamReader is, UUID instanceId, RecordType recordType, Optional<String> primaryKey) throws IOException {
 		CSVFormat csvFormat = TsvSupport.getUploadFormat();
 		CSVParser rows = csvFormat.parse(is);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/BatchWriteService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/BatchWriteService.java
@@ -1,5 +1,6 @@
 package org.databiosphere.workspacedataservice.service;
 
+import bio.terra.common.db.WriteTransaction;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.MapDifference;
 import com.google.common.collect.Maps;
@@ -219,6 +220,7 @@ public class BatchWriteService {
 	 * @param primaryKey
 	 * @return number of records updated
 	 */
+	@WriteTransaction
 	public int consumeWriteStream(InputStream is, UUID instanceId, RecordType recordType, Optional<String> primaryKey) {
 		int recordsAffected = 0;
 		try (StreamingWriteHandler streamingWriteHandler = new StreamingWriteHandler(is, objectMapper)) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/BatchWriteService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/BatchWriteService.java
@@ -24,7 +24,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.io.IOException;
@@ -140,7 +139,6 @@ public class BatchWriteService {
 		}
 	}
 
-	@Transactional
 	public int uploadTsvStream(InputStreamReader is, UUID instanceId, RecordType recordType, Optional<String> primaryKey) throws IOException {
 		CSVFormat csvFormat = TsvSupport.getUploadFormat();
 		CSVParser rows = csvFormat.parse(is);
@@ -221,7 +219,6 @@ public class BatchWriteService {
 	 * @param primaryKey
 	 * @return number of records updated
 	 */
-	@Transactional
 	public int consumeWriteStream(InputStream is, UUID instanceId, RecordType recordType, Optional<String> primaryKey) {
 		int recordsAffected = 0;
 		try (StreamingWriteHandler streamingWriteHandler = new StreamingWriteHandler(is, objectMapper)) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordService.java
@@ -12,7 +12,6 @@ import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.SQLException;
 import java.util.*;
@@ -30,7 +29,6 @@ public class RecordService {
         this.inferer = inferer;
     }
 
-    @Transactional
     public void prepareAndUpsert(UUID instanceId, RecordType recordType, List<Record> records,
                              Map<String, DataTypeMapping> requestSchema, String primaryKey) {
         //Identify relation arrays

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -24,6 +24,10 @@ spring.servlet.multipart.max-file-size=5GB
 twds.write.batch.size=5000
 twds.streaming.fetch.size=5000
 
+# terra-common-lib includes liquibase as a transitive dependency.
+# Spring will notice this and attempt a migration; make sure we disable it.
+spring.liquibase.enabled=false
+
 # activate the "local" profile to turn on CORS response headers,
 # which may be necessary for local development.
 # spring.profiles.active=local


### PR DESCRIPTION
* bring in terra-common-lib (TCL) for its retryable-transaction annotations
* annotate most APIs with a transaction, right in `RecordController`
* annotate the streaming-write APIs at a lower level in `BatchWriteService`
* remove `@Transactional` from any other runtime code in deference to the TCL transactions

In a future PR I'd like to make the transactions less broad - for instance, don't include the http response itself inside the transaction - but this will require a fair bit of refactoring of `RecordController`. So for now, the transactions are wide and long
