### PR TITLE
abandon terra-common-lib [AJ-767]

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -35,15 +35,14 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.retry:spring-retry:1.3.4'
+	implementation 'org.aspectj:aspectjweaver:1.8.9' // required by spring-retry, not used directly by WDS
 	implementation 'org.apache.commons:commons-lang3'
 	implementation 'org.apache.commons:commons-csv:1.9.0'
 	implementation 'com.google.guava:guava:31.1-jre'
 	implementation 'org.postgresql:postgresql'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.webjars:webjars-locator-core:0.52'
-	implementation ('bio.terra:terra-common-lib:0.0.77-SNAPSHOT') {
-		exclude group: 'org.broadinstitute.dsde.workbench', module: 'sam-client_2.12'
-	}
+	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	runtimeOnly 'org.webjars.npm:swagger-ui-dist:4.12.0'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/service/src/main/java/bio/terra/common/README.md
+++ b/service/src/main/java/bio/terra/common/README.md
@@ -1,0 +1,5 @@
+The classes under `bio.terra.common` are copied, as source code, from
+the `terra-common-lib` [github repository](https://github.com/DataBiosphere/terra-common-lib).
+
+We do this because importing `terra-common-lib` as a whole has side effects such as changing
+logging config, but we want the `@ReadTransaction` and `@WriteTransaction` annotation support.

--- a/service/src/main/java/bio/terra/common/db/DatabaseRetryUtils.java
+++ b/service/src/main/java/bio/terra/common/db/DatabaseRetryUtils.java
@@ -1,0 +1,68 @@
+package bio.terra.common.db;
+
+import com.google.common.base.Preconditions;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.RecoverableDataAccessException;
+import org.springframework.dao.TransientDataAccessException;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+/** Utilities to execute database operations with retry support. */
+public final class DatabaseRetryUtils {
+  private static final Logger logger = LoggerFactory.getLogger(DatabaseRetryUtils.class);
+
+  private DatabaseRetryUtils() {}
+
+  /**
+   * Executes a database operation and retries if retryable
+   *
+   * @param execute database operation to execute
+   * @param retrySleep fixed retry sleep interval
+   * @param maxNumAttempts maximum times this operation will be run
+   * @param <T> database operation class
+   * @return database operation class
+   * @throws InterruptedException on thread interruption
+   * @throws DataAccessException throws the last DB operation error if maxNumAttempts is exceeded.
+   */
+  public static <T> T executeAndRetry(
+      DatabaseOperation<T> execute, Duration retrySleep, int maxNumAttempts)
+      throws InterruptedException {
+    Preconditions.checkArgument(maxNumAttempts > 0, "maxNumAttempts must be at least 1");
+    int numAttempts = 1;
+    while (numAttempts <= maxNumAttempts) {
+      try {
+        return execute.execute();
+      } catch (DataAccessException e) {
+        if (!shouldRetryQuery(e) || (numAttempts == maxNumAttempts)) {
+          throw e;
+        }
+        logger.info("Caught exception, retrying DB operation. Attempts so far: {}", numAttempts, e);
+      }
+      ++numAttempts;
+      TimeUnit.MILLISECONDS.sleep(retrySleep.toMillis());
+    }
+    throw new IllegalStateException(
+        "Exceeded maximum number of retries without throwing an exception. This should never happen.");
+  }
+
+  /**
+   * Tests an exception to see if it is retryable.
+   *
+   * @param dataAccessException execption to test
+   * @return {@code true} if that is retryable {@link DataAccessException}.
+   */
+  public static boolean shouldRetryQuery(DataAccessException dataAccessException) {
+    return ExceptionUtils.hasCause(dataAccessException, RecoverableDataAccessException.class)
+        || ExceptionUtils.hasCause(dataAccessException, TransientDataAccessException.class);
+  }
+
+  /** How to execute this database operation. */
+  @FunctionalInterface
+  public interface DatabaseOperation<T> {
+    T execute();
+  }
+}

--- a/service/src/main/java/bio/terra/common/db/ReadTransaction.java
+++ b/service/src/main/java/bio/terra/common/db/ReadTransaction.java
@@ -1,0 +1,26 @@
+package bio.terra.common.db;
+
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation used to demarcate read-only database transaction, specifying correct transaction
+ * semantics and retry. Spring application must use @{@link
+ * org.springframework.retry.annotation.EnableRetry} and @{@link
+ * org.springframework.transaction.annotation.EnableTransactionManagement}.
+ */
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Retryable(interceptor = "transactionRetryInterceptor")
+@Transactional(
+    isolation = Isolation.SERIALIZABLE,
+    propagation = Propagation.REQUIRED,
+    readOnly = true)
+public @interface ReadTransaction {}

--- a/service/src/main/java/bio/terra/common/db/WriteTransaction.java
+++ b/service/src/main/java/bio/terra/common/db/WriteTransaction.java
@@ -1,0 +1,22 @@
+package bio.terra.common.db;
+
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation used to demarcate write database transaction, specifying correct transaction semantics
+ * and retry. Spring application must use @{@link org.springframework.retry.annotation.EnableRetry}
+ * and @{@link org.springframework.transaction.annotation.EnableTransactionManagement}.
+ */
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Retryable(interceptor = "transactionRetryInterceptor")
+@Transactional(isolation = Isolation.SERIALIZABLE, propagation = Propagation.REQUIRED)
+public @interface WriteTransaction {}

--- a/service/src/main/java/bio/terra/common/retry/CompositeBackOffPolicy.java
+++ b/service/src/main/java/bio/terra/common/retry/CompositeBackOffPolicy.java
@@ -1,0 +1,83 @@
+package bio.terra.common.retry;
+
+import bio.terra.common.db.DatabaseRetryUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.classify.BinaryExceptionClassifier;
+import org.springframework.retry.RetryContext;
+import org.springframework.retry.backoff.BackOffContext;
+import org.springframework.retry.backoff.BackOffInterruptedException;
+import org.springframework.retry.backoff.BackOffPolicy;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * BackOffPolicy that delegates to a number of nested BackOffPolicies. The BackOffPolicy chosen is
+ * determined by the exception being handled. If more than one policy matches, the first is used.
+ */
+public class CompositeBackOffPolicy implements BackOffPolicy {
+  private static final Logger logger = LoggerFactory.getLogger(DatabaseRetryUtils.class);
+
+  // LinkedHashMap to ensure consistent behavior when an exception matches more than 1 policy
+  private final LinkedHashMap<BinaryExceptionClassifier, BackOffPolicy> backOffPoliciesByClassifier;
+
+  public CompositeBackOffPolicy(
+      LinkedHashMap<BinaryExceptionClassifier, BackOffPolicy> backOffPoliciesByClassifier) {
+    this.backOffPoliciesByClassifier = backOffPoliciesByClassifier;
+  }
+
+  /**
+   * This method gets called on entry to a @Retryable function to set up the dynamic context for
+   * backing off on a retry. Since we have slow and fast retry, we need to setup context for both
+   * and package that inside a composite BackOffContext subclass.
+   */
+  @Override
+  public BackOffContext start(RetryContext context) {
+    List<Pair<BinaryExceptionClassifier, BackOffContext>> backOffContexts = new ArrayList<>();
+    this.backOffPoliciesByClassifier.forEach(
+        (classifier, policy) -> backOffContexts.add(Pair.of(classifier, policy.start(context))));
+    return new CompositeBackOffContext(context, backOffContexts);
+  }
+
+  @Override
+  public void backOff(BackOffContext backOffContext) throws BackOffInterruptedException {
+    CompositeBackOffContext compositeBackOffContext = (CompositeBackOffContext) backOffContext;
+
+    for (var classifierAndContext : compositeBackOffContext.backOffContexts) {
+      BinaryExceptionClassifier classifier = classifierAndContext.getLeft();
+      if (classifier.classify(compositeBackOffContext.retryContext.getLastThrowable())) {
+        logger.debug(
+            "retrying",
+            Map.of(
+                "exception",
+                compositeBackOffContext.retryContext.getLastThrowable().getClass().getName(),
+                "exceptionMessage",
+                compositeBackOffContext.retryContext.getLastThrowable().getMessage(),
+                "failedTrialCount",
+                compositeBackOffContext.retryContext.getRetryCount()));
+
+        backOffPoliciesByClassifier.get(classifier).backOff(classifierAndContext.getRight());
+        break; // don't back off for any further matching back off policies
+      }
+    }
+  }
+
+  /**
+   * Class to keep track of retry context and a back off context for each nested back off policy.
+   */
+  private static class CompositeBackOffContext implements BackOffContext {
+    private final RetryContext retryContext;
+    private final List<Pair<BinaryExceptionClassifier, BackOffContext>> backOffContexts;
+
+    private CompositeBackOffContext(
+        RetryContext retryContext,
+        List<Pair<BinaryExceptionClassifier, BackOffContext>> backOffContexts) {
+      this.retryContext = retryContext;
+      this.backOffContexts = backOffContexts;
+    }
+  }
+}

--- a/service/src/main/java/bio/terra/common/retry/transaction/TransactionRetryInterceptorConfiguration.java
+++ b/service/src/main/java/bio/terra/common/retry/transaction/TransactionRetryInterceptorConfiguration.java
@@ -1,0 +1,72 @@
+package bio.terra.common.retry.transaction;
+
+import bio.terra.common.retry.CompositeBackOffPolicy;
+import org.aopalliance.intercept.MethodInterceptor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.classify.BinaryExceptionClassifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.RetryPolicy;
+import org.springframework.retry.backoff.BackOffPolicy;
+import org.springframework.retry.backoff.ExponentialBackOffPolicy;
+import org.springframework.retry.backoff.UniformRandomBackOffPolicy;
+import org.springframework.retry.interceptor.RetryInterceptorBuilder;
+import org.springframework.retry.policy.CompositeRetryPolicy;
+import org.springframework.retry.policy.SimpleRetryPolicy;
+
+import java.util.LinkedHashMap;
+
+@Configuration
+@EnableConfigurationProperties(TransactionRetryProperties.class)
+public class TransactionRetryInterceptorConfiguration {
+  /**
+   * Creates an interceptor that can be used in {@link
+   * org.springframework.retry.annotation.Retryable}: <code>
+   * @Retryable(interceptor = "transactionRetryInterceptor")</code>. Be sure to use {@link
+   * org.springframework.retry.annotation.EnableRetry}.
+   */
+  @Bean("transactionRetryInterceptor")
+  public MethodInterceptor getTransactionRetryInterceptor(TransactionRetryProperties config) {
+    return RetryInterceptorBuilder.stateless()
+        .retryPolicy(createTransactionRetryPolicy(config))
+        .backOffPolicy(createTransactionBackOffPolicy(config))
+        .build();
+  }
+
+  /**
+   * Fast retries with random delay between config.getFastRetryMinBackOffPeriod and
+   * config.getFastRetryMaxBackOffPeriod. Slow retries with exponential back off with initial
+   * config.getSlowRetryInitialInterval delay, multiplied by config.getSlowRetryMultiplier each
+   * attempt.
+   */
+  private BackOffPolicy createTransactionBackOffPolicy(TransactionRetryProperties config) {
+    UniformRandomBackOffPolicy fastBackOffPolicy = new UniformRandomBackOffPolicy();
+    fastBackOffPolicy.setMaxBackOffPeriod(config.getFastRetryMaxBackOffPeriod().toMillis());
+    fastBackOffPolicy.setMinBackOffPeriod(config.getFastRetryMinBackOffPeriod().toMillis());
+
+    ExponentialBackOffPolicy slowBackOffPolicy = new ExponentialBackOffPolicy();
+    slowBackOffPolicy.setInitialInterval(config.getSlowRetryInitialInterval().toMillis());
+    slowBackOffPolicy.setMultiplier(config.getSlowRetryMultiplier());
+
+    LinkedHashMap<BinaryExceptionClassifier, BackOffPolicy> backOffPolicies = new LinkedHashMap<>();
+
+    backOffPolicies.put(config.getFastRetryExceptionClassifier(), fastBackOffPolicy);
+    backOffPolicies.put(config.getSlowRetryExceptionClassifier(), slowBackOffPolicy);
+
+    return new CompositeBackOffPolicy(backOffPolicies);
+  }
+
+  /** Policy dictating number of attempts for fast and slow retries. */
+  private RetryPolicy createTransactionRetryPolicy(TransactionRetryProperties config) {
+    CompositeRetryPolicy retryPolicy = new CompositeRetryPolicy();
+    retryPolicy.setOptimistic(true); // retry when any nested policy says to retry
+    retryPolicy.setPolicies(
+        new RetryPolicy[] {
+          new SimpleRetryPolicy(
+              config.getFastRetryMaxAttempts(), config.getFastRetryExceptionClassifier()),
+          new SimpleRetryPolicy(
+              config.getSlowRetryMaxAttempts(), config.getSlowRetryExceptionClassifier())
+        });
+    return retryPolicy;
+  }
+}

--- a/service/src/main/java/bio/terra/common/retry/transaction/TransactionRetryProperties.java
+++ b/service/src/main/java/bio/terra/common/retry/transaction/TransactionRetryProperties.java
@@ -1,0 +1,123 @@
+package bio.terra.common.retry.transaction;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.classify.BinaryExceptionClassifier;
+import org.springframework.dao.RecoverableDataAccessException;
+import org.springframework.dao.TransientDataAccessException;
+import org.springframework.transaction.CannotCreateTransactionException;
+
+import java.time.Duration;
+import java.util.List;
+
+/**
+ * Configuration settings for how database transactions are retried. There are 2 classes of retries,
+ * fast and slow. Fast retries usually measure in milliseconds with a constant retry period (with
+ * some random jitter) and many attempts. Slow retries usually measure in seconds with an
+ * exponential back off and few attempts.
+ */
+@ConfigurationProperties(prefix = "terra.common.retry.transaction")
+public class TransactionRetryProperties implements InitializingBean {
+  private List<Class<? extends Throwable>> fastRetryExceptions =
+      List.of(TransientDataAccessException.class);
+  private Integer fastRetryMaxAttempts = 100;
+  private Duration fastRetryMinBackOffPeriod = Duration.ofMillis(10);
+  private Duration fastRetryMaxBackOffPeriod = Duration.ofMillis(20);
+
+  private List<Class<? extends Throwable>> slowRetryExceptions =
+      List.of(RecoverableDataAccessException.class, CannotCreateTransactionException.class);
+  private Integer slowRetryMaxAttempts = 4;
+  private Duration slowRetryInitialInterval = Duration.ofSeconds(1);
+  private Double slowRetryMultiplier = 2.0;
+
+  private BinaryExceptionClassifier slowRetryExceptionClassifier;
+  private BinaryExceptionClassifier fastRetryExceptionClassifier;
+
+  /** Exceptions to retry FAST */
+  public List<Class<? extends Throwable>> getFastRetryExceptions() {
+    return fastRetryExceptions;
+  }
+
+  public void setFastRetryExceptions(List<Class<? extends Throwable>> fastRetryExceptions) {
+    this.fastRetryExceptions = fastRetryExceptions;
+  }
+
+  /** Max attempts for FAST retries (including initial attempt) */
+  public Integer getFastRetryMaxAttempts() {
+    return fastRetryMaxAttempts;
+  }
+
+  public void setFastRetryMaxAttempts(Integer fastRetryMaxAttempts) {
+    this.fastRetryMaxAttempts = fastRetryMaxAttempts;
+  }
+
+  /** Minimum time to wait before the next FAST retry */
+  public Duration getFastRetryMinBackOffPeriod() {
+    return fastRetryMinBackOffPeriod;
+  }
+
+  public void setFastRetryMinBackOffPeriod(Duration fastRetryMinBackOffPeriod) {
+    this.fastRetryMinBackOffPeriod = fastRetryMinBackOffPeriod;
+  }
+
+  /** Maximum time to wait before the next FAST retry */
+  public Duration getFastRetryMaxBackOffPeriod() {
+    return fastRetryMaxBackOffPeriod;
+  }
+
+  public void setFastRetryMaxBackOffPeriod(Duration fastRetryMaxBackOffPeriod) {
+    this.fastRetryMaxBackOffPeriod = fastRetryMaxBackOffPeriod;
+  }
+
+  /** Exceptions to retry SLOW */
+  public List<Class<? extends Throwable>> getSlowRetryExceptions() {
+    return slowRetryExceptions;
+  }
+
+  public void setSlowRetryExceptions(List<Class<? extends Throwable>> slowRetryExceptions) {
+    this.slowRetryExceptions = slowRetryExceptions;
+  }
+
+  /** Max attempts for SLOW retries (including initial attempt) */
+  public Integer getSlowRetryMaxAttempts() {
+    return slowRetryMaxAttempts;
+  }
+
+  public void setSlowRetryMaxAttempts(Integer slowRetryMaxAttempts) {
+    this.slowRetryMaxAttempts = slowRetryMaxAttempts;
+  }
+
+  /** Interval to wait for the initial SLOW retry */
+  public Duration getSlowRetryInitialInterval() {
+    return slowRetryInitialInterval;
+  }
+
+  public void setSlowRetryInitialInterval(Duration slowRetryInitialInterval) {
+    this.slowRetryInitialInterval = slowRetryInitialInterval;
+  }
+
+  /** Multiplier applied to the last SLOW trial interval */
+  public Double getSlowRetryMultiplier() {
+    return slowRetryMultiplier;
+  }
+
+  public void setSlowRetryMultiplier(Double slowRetryMultiplier) {
+    this.slowRetryMultiplier = slowRetryMultiplier;
+  }
+
+  /** BinaryExceptionClassifier created using slowRetryExceptions */
+  public BinaryExceptionClassifier getSlowRetryExceptionClassifier() {
+    return slowRetryExceptionClassifier;
+  }
+
+  /** BinaryExceptionClassifier created using fastRetryExceptions */
+  public BinaryExceptionClassifier getFastRetryExceptionClassifier() {
+    return fastRetryExceptionClassifier;
+  }
+
+  @Override
+  public void afterPropertiesSet() {
+    this.fastRetryExceptionClassifier = new BinaryExceptionClassifier(this.fastRetryExceptions);
+    this.slowRetryExceptionClassifier = new BinaryExceptionClassifier(this.slowRetryExceptions);
+  }
+}

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -24,10 +24,6 @@ spring.servlet.multipart.max-file-size=5GB
 twds.write.batch.size=5000
 twds.streaming.fetch.size=5000
 
-# terra-common-lib includes liquibase as a transitive dependency.
-# Spring will notice this and attempt a migration; make sure we disable it.
-spring.liquibase.enabled=false
-
 # activate the "local" profile to turn on CORS response headers,
 # which may be necessary for local development.
 # spring.profiles.active=local


### PR DESCRIPTION
followup to #160 .

This PR removes https://github.com/DataBiosphere/terra-common-lib as a dependency, and copies (as source code) just the pieces of TCL we really need. Including TCL as a whole had undesirable side effects such as resetting logging config; we also had to intentionally disable some TCL features such as Liquibase. By copying just the pieces we need, we keep WDS slim and without unpredictable side effects.

The drawback is that the code copied in here will not benefit from TCL fixes/enhancements, if those ever happen. An ideal solution would be to fix/repackage TCL, but that's larger in scope than I'd like to tackle right now.