### PR TITLE
Sentry via Logback [AJ-763]

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -44,6 +44,7 @@ dependencies {
 	implementation ('bio.terra:terra-common-lib:0.0.77-SNAPSHOT') {
 		exclude group: 'org.broadinstitute.dsde.workbench', module: 'sam-client_2.12'
 	}
+	implementation 'io.sentry:sentry-logback:6.11.0'
 	runtimeOnly 'org.webjars.npm:swagger-ui-dist:4.12.0'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 	implementation 'org.postgresql:postgresql'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.webjars:webjars-locator-core:0.52'
-	implementation 'io.sentry:sentry-logback:6.11.0'
+	implementation 'io.sentry:sentry-logback:6.12.1'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	runtimeOnly 'org.webjars.npm:swagger-ui-dist:4.12.0'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/service/src/main/java/org/databiosphere/workspacedataservice/SentryInitializer.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/SentryInitializer.java
@@ -6,10 +6,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
-import org.springframework.context.annotation.PropertySources;
 
 @Configuration
-@PropertySources({@PropertySource("classpath:git.properties"), @PropertySource("classpath:application.properties")})
+@PropertySource("classpath:git.properties")
+@PropertySource("classpath:application.properties")
 public class SentryInitializer  {
 
 	@Value("${sentry.dsn}")
@@ -29,7 +29,7 @@ public class SentryInitializer  {
 
 	@Bean
 	public SmartInitializingSingleton initialize() {
-		return () -> {
+		return () ->
         Sentry.init(options -> {
 				options.setDsn(dsn);
 				options.setEnvironment(env);
@@ -37,6 +37,5 @@ public class SentryInitializer  {
 				options.setRelease(release);
 				options.setTag("workspaceId", workspaceId);
 			});
-		};
 	}
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/SentryInitializer.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/SentryInitializer.java
@@ -27,8 +27,11 @@ public class SentryInitializer  {
 	@Value("${sentry.samurl}")
 	String samurl;
 
-	@Value("${sentry.servername}")
-	String serverName;
+	@Value("${sentry.releasename}")
+	String releaseName;
+
+	@Value("${sentry.mrg}")
+	String mrg;
 
 	@Bean
 	public SmartInitializingSingleton initialize() {
@@ -36,14 +39,15 @@ public class SentryInitializer  {
         Sentry.init(options -> {
 				options.setDsn(dsn);
 				options.setEnvironment(urlToEnv(samurl));
-				options.setServerName(serverName);
+				options.setServerName(releaseName);
 				options.setRelease(release);
 				options.setTag("workspaceId", workspaceId);
+				options.setTag("mrg", mrg);
 			});
 	}
 
-	private final Pattern SAM_ENV_PATTERN = Pattern.compile("\\.dsde-(\\p{Alnum}+)\\.");
-	private final String DEFAULT_ENV = "unknown";
+	private static final Pattern SAM_ENV_PATTERN = Pattern.compile("\\.dsde-(\\p{Alnum}+)\\.");
+	private static final String DEFAULT_ENV = "unknown";
 
 	/**
 	 * Extracts an environment (e.g. "dev" or "prod") from a Sam url.

--- a/service/src/main/java/org/databiosphere/workspacedataservice/SentryInitializer.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/SentryInitializer.java
@@ -71,8 +71,6 @@ public class SentryInitializer  {
 		boolean found = matcher.find();
 		if (found) {
 			return matcher.group(1);
-		} else if (samUrl.endsWith("bee.envs-terra.bio")) {
-			return samUrl.split("\\.")[1];
 		} else {
 			return DEFAULT_ENV;
 		}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/SentryInitializer.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/SentryInitializer.java
@@ -21,10 +21,10 @@ public class SentryInitializer  {
 	@Value("${git.commit.id.abbrev}")
 	String release;
 
-	@Value("${sentry.env:local}")
-	String env;
+	@Value("${sentry.samurl}")
+	String samurl;
 
-	@Value("${sentry.servername:local-cluster}")
+	@Value("${sentry.servername}")
 	String serverName;
 
 	@Bean
@@ -32,10 +32,22 @@ public class SentryInitializer  {
 		return () ->
         Sentry.init(options -> {
 				options.setDsn(dsn);
-				options.setEnvironment(env);
+				options.setEnvironment(urlToEnv(samurl));
 				options.setServerName(serverName);
 				options.setRelease(release);
 				options.setTag("workspaceId", workspaceId);
 			});
+	}
+
+	String urlToEnv(String samUrl){
+		String env = "dev";
+		if (samUrl != null){
+			int dsde_loc = samUrl.indexOf("dsde-");
+			int broad_loc = samUrl.indexOf(".broad");
+			if (dsde_loc > -1 && broad_loc > -1 && dsde_loc != broad_loc){
+				env = samUrl.substring(dsde_loc+5,broad_loc);
+			}
+		}
+		return env;
 	}
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/SentryInitializer.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/SentryInitializer.java
@@ -1,0 +1,42 @@
+package org.databiosphere.workspacedataservice;
+
+import io.sentry.Sentry;
+import org.springframework.beans.factory.SmartInitializingSingleton;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.context.annotation.PropertySources;
+
+@Configuration
+@PropertySources({@PropertySource("classpath:git.properties"), @PropertySource("classpath:application.properties")})
+public class SentryInitializer  {
+
+	@Value("${sentry.dsn}")
+	String dsn;
+
+	@Value("${twds.instance.workspace-id}")
+	String workspaceId;
+
+	@Value("${git.commit.id.abbrev}")
+	String release;
+
+	@Value("${sentry.env:local}")
+	String env;
+
+	@Value("${sentry.servername:local-cluster}")
+	String serverName;
+
+	@Bean
+	public SmartInitializingSingleton initialize() {
+		return () -> {
+        Sentry.init(options -> {
+				options.setDsn(dsn);
+				options.setEnvironment(env);
+				options.setServerName(serverName);
+				options.setRelease(release);
+				options.setTag("workspaceId", workspaceId);
+			});
+		};
+	}
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/WorkspaceDataServiceApplication.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/WorkspaceDataServiceApplication.java
@@ -10,20 +10,15 @@ import com.fasterxml.jackson.databind.cfg.CoercionInputShape;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.type.LogicalType;
 import com.zaxxer.hikari.HikariDataSource;
-import io.sentry.Sentry;
 import org.databiosphere.workspacedataservice.service.DataTypeInferer;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.cache.annotation.EnableCaching;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Primary;
-import org.springframework.context.annotation.Profile;
+import org.springframework.context.annotation.*;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.lang.NonNull;
 import org.springframework.retry.annotation.EnableRetry;
@@ -33,11 +28,6 @@ import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import javax.sql.DataSource;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Optional;
-import java.util.Properties;
-
 @SpringBootApplication(scanBasePackages = {
 		// this codebase
 		"org.databiosphere.workspacedataservice",
@@ -138,42 +128,7 @@ public class WorkspaceDataServiceApplication {
 		};
 	}
 
-	private static void configureSentry() {
-		ClassLoader classLoader = WorkspaceDataServiceApplication.class.getClassLoader();
-		try (final InputStream appPropsFile = classLoader.getResourceAsStream("application.properties");
-			 final InputStream gitPropsFile = classLoader.getResourceAsStream("git.properties")) {
-
-			// load the application properties file
-			Properties appProps = new Properties();
-			appProps.load(appPropsFile);
-
-			// load the git properties file
-			Properties gitProps = new Properties();
-			gitProps.load(gitPropsFile);
-
-			// get workspace id from env:
-			Optional<String> workspaceId = Optional.ofNullable(System.getenv("WORKSPACE_ID"));
-
-
-			// TODO: read these from config / environment
-			Sentry.init(options -> {
-				options.setDsn("https://e59ecdd940784bd2922f25a0f3197ffd@o54426.ingest.sentry.io/4504299946835968");
-				options.setEnvironment("local-dev"); // read from Leo's env
-				options.setServerName("davidan"); // read from Leo's app name (or short k8s name)
-
-				options.setRelease(gitProps.getProperty("git.commit.id.abbrev"));
-				// options.setTag("workspaceId", appProps.getProperty("twds.instance.workspace-id"));
-				options.setTag("workspaceId", workspaceId.orElse("n/a"));
-
-				options.setSampleRate(1.0); // read from config
-			});
-		} catch (IOException ex) {
-			ex.printStackTrace();
-		}
-	}
-
 	public static void main(String[] args) {
-		configureSentry();
 		SpringApplication.run(WorkspaceDataServiceApplication.class, args);
 	}
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/WorkspaceDataServiceApplication.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/WorkspaceDataServiceApplication.java
@@ -10,11 +10,13 @@ import com.fasterxml.jackson.databind.cfg.CoercionInputShape;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.type.LogicalType;
 import com.zaxxer.hikari.HikariDataSource;
+import io.sentry.Sentry;
 import org.databiosphere.workspacedataservice.service.DataTypeInferer;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.cache.annotation.EnableCaching;
@@ -131,7 +133,25 @@ public class WorkspaceDataServiceApplication {
 		};
 	}
 
+	private static void configureSentry() {
+		// TODO: read these from config / environment
+		Sentry.init(options -> {
+			options.setDsn("https://e59ecdd940784bd2922f25a0f3197ffd@o54426.ingest.sentry.io/4504299946835968");
+			options.setEnvironment("local-dev");
+			options.setServerName("davidan"); // read from Leo's app name (or short k8s name)
+			options.setRelease("54321"); // read from git.commit.id.abbrev in generated git.properties
+//			options.setAttachServerName();
+			options.setSampleRate(1.0); // read from config
+		});
+	}
+
 	public static void main(String[] args) {
-		SpringApplication.run(WorkspaceDataServiceApplication.class, args);
+		configureSentry();
+
+		new SpringApplicationBuilder(WorkspaceDataServiceApplication.class)
+				.initializers()
+				.run(args);
+
+//		SpringApplication.run(WorkspaceDataServiceApplication.class, args);
 	}
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/WorkspaceDataServiceApplication.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/WorkspaceDataServiceApplication.java
@@ -136,7 +136,7 @@ public class WorkspaceDataServiceApplication {
 	private static void configureSentry() {
 		// TODO: read these from config / environment
 		Sentry.init(options -> {
-			options.setDsn("https://e59ecdd940784bd2922f25a0f3197ffd@o54426.ingest.sentry.io/4504299946835968");
+			options.setDsn("add Sentry DSN here");
 			options.setEnvironment("local-dev");
 			options.setServerName("davidan"); // read from Leo's app name (or short k8s name)
 			options.setRelease("54321"); // read from git.commit.id.abbrev in generated git.properties

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -106,11 +106,12 @@ public class RecordDao {
 	}
 
 	public boolean recordTypeExists(UUID instanceId, RecordType recordType) {
-		return Boolean.TRUE.equals(namedTemplate.queryForObject(
-				"select exists(select from pg_tables where schemaname = :instanceId AND tablename  = :recordType)",
-				new MapSqlParameterSource(
-						Map.of(INSTANCE_ID, instanceId.toString(), "recordType", recordType.getName())),
-				Boolean.class));
+		throw new RuntimeException("testing Sentry, unique id: " + UUID.randomUUID().toString());
+//		return Boolean.TRUE.equals(namedTemplate.queryForObject(
+//				"select exists(select from pg_tables where schemaname = :instanceId AND tablename  = :recordType)",
+//				new MapSqlParameterSource(
+//						Map.of(INSTANCE_ID, instanceId.toString(), "recordType", recordType.getName())),
+//				Boolean.class));
 	}
 
 	@SuppressWarnings("squid:S2077")

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -126,7 +126,6 @@ public class RecordDao {
 	}
 
 	public boolean recordTypeExists(UUID instanceId, RecordType recordType) {
-//		throw new RuntimeException("testing Sentry, unique id: " + UUID.randomUUID().toString());
 		return Boolean.TRUE.equals(namedTemplate.queryForObject(
 				"select exists(select from pg_tables where schemaname = :instanceId AND tablename  = :recordType)",
 				new MapSqlParameterSource(

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -106,12 +106,12 @@ public class RecordDao {
 	}
 
 	public boolean recordTypeExists(UUID instanceId, RecordType recordType) {
-		throw new RuntimeException("testing Sentry, unique id: " + UUID.randomUUID().toString());
-//		return Boolean.TRUE.equals(namedTemplate.queryForObject(
-//				"select exists(select from pg_tables where schemaname = :instanceId AND tablename  = :recordType)",
-//				new MapSqlParameterSource(
-//						Map.of(INSTANCE_ID, instanceId.toString(), "recordType", recordType.getName())),
-//				Boolean.class));
+//		throw new RuntimeException("testing Sentry, unique id: " + UUID.randomUUID().toString());
+		return Boolean.TRUE.equals(namedTemplate.queryForObject(
+				"select exists(select from pg_tables where schemaname = :instanceId AND tablename  = :recordType)",
+				new MapSqlParameterSource(
+						Map.of(INSTANCE_ID, instanceId.toString(), "recordType", recordType.getName())),
+				Boolean.class));
 	}
 
 	@SuppressWarnings("squid:S2077")

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -30,7 +30,8 @@ twds.instance.workspace-id=${WORKSPACE_ID:}
 
 sentry.dsn=https://e59ecdd940784bd2922f25a0f3197ffd@o54426.ingest.sentry.io/4504299946835968
 sentry.samurl=${SAM_URL:} 
-sentry.servername=${LZ_MRG:}
+sentry.mrg=${LZ_MRG:}
+sentry.releasename=${RELEASE_NAME:}
 
 # activate the "local" profile to turn on CORS response headers,
 # which may be necessary for local development.

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -28,6 +28,11 @@ twds.streaming.fetch.size=5000
 # Workspace Id for launching instance
 twds.instance.workspace-id=${WORKSPACE_ID:}
 
+sentry.dsn=https://e59ecdd940784bd2922f25a0f3197ffd@o54426.ingest.sentry.io/4504299946835968
+#The name of these two properties will likely change depending on IA-3966
+sentry.env=${ENV:local-dev} 
+sentry.servername=${SERVER_NAME:a_cluster}
+
 # activate the "local" profile to turn on CORS response headers,
 # which may be necessary for local development.
 # spring.profiles.active=local

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -29,9 +29,8 @@ twds.streaming.fetch.size=5000
 twds.instance.workspace-id=${WORKSPACE_ID:}
 
 sentry.dsn=https://e59ecdd940784bd2922f25a0f3197ffd@o54426.ingest.sentry.io/4504299946835968
-#The name of these two properties will likely change depending on IA-3966
-sentry.env=${ENV:local-dev} 
-sentry.servername=${RESOURCE_GROUP:}
+sentry.samurl=${SAM_URL:} 
+sentry.servername=${LZ_MRG:}
 
 # activate the "local" profile to turn on CORS response headers,
 # which may be necessary for local development.

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -31,7 +31,7 @@ twds.instance.workspace-id=${WORKSPACE_ID:}
 sentry.dsn=https://e59ecdd940784bd2922f25a0f3197ffd@o54426.ingest.sentry.io/4504299946835968
 #The name of these two properties will likely change depending on IA-3966
 sentry.env=${ENV:local-dev} 
-sentry.servername=${SERVER_NAME:a_cluster}
+sentry.servername=${RESOURCE_GROUP:}
 
 # activate the "local" profile to turn on CORS response headers,
 # which may be necessary for local development.

--- a/service/src/main/resources/logback-spring.xml
+++ b/service/src/main/resources/logback-spring.xml
@@ -11,10 +11,6 @@
     </appender>
 
     <appender name="Sentry" class="io.sentry.logback.SentryAppender">
-        <options>
-            <!-- can we read this from env? -->
-            <dsn>https://e59ecdd940784bd2922f25a0f3197ffd@o54426.ingest.sentry.io/4504299946835968</dsn>
-        </options>
         <!-- Optionally change minimum Event level. Default for Events is ERROR -->
         <minimumEventLevel>ERROR</minimumEventLevel>
         <!-- Optionally change minimum Breadcrumbs level. Default for Breadcrumbs is INFO -->
@@ -47,6 +43,7 @@
         <root level="info">
             <appender-ref ref="RollingFile" />
             <appender-ref ref="Console" />
+            <appender-ref ref="Sentry" />
         </root>
 
         <!-- log WDS at DEBUG level -->
@@ -65,17 +62,14 @@
     <springProfile name="local">
         <root level="info">
             <appender-ref ref="Console" />
-            <appender-ref ref="Sentry" />
         </root>
 
         <logger name="org.databiosphere.workspacedataservice" level="debug" additivity="false">
             <appender-ref ref="Console" />
-            <appender-ref ref="Sentry" />
         </logger>
 
         <logger name="org.springframework.web" level="debug" additivity="false">
             <appender-ref ref="Console" />
-            <appender-ref ref="Sentry" />
         </logger>
     </springProfile>
 

--- a/service/src/main/resources/logback-spring.xml
+++ b/service/src/main/resources/logback-spring.xml
@@ -10,6 +10,16 @@
         </layout>
     </appender>
 
+    <appender name="Sentry" class="io.sentry.logback.SentryAppender">
+        <options>
+            <!-- can we read this from env? -->
+            <dsn>https://e59ecdd940784bd2922f25a0f3197ffd@o54426.ingest.sentry.io/4504299946835968</dsn>
+        </options>
+        <!-- Optionally change minimum Event level. Default for Events is ERROR -->
+        <minimumEventLevel>ERROR</minimumEventLevel>
+        <!-- Optionally change minimum Breadcrumbs level. Default for Breadcrumbs is INFO -->
+        <minimumBreadcrumbLevel>INFO</minimumBreadcrumbLevel>
+    </appender>
 
     <springProfile name="!local">
         <property name="LOGS" value="./logs" />
@@ -55,14 +65,17 @@
     <springProfile name="local">
         <root level="info">
             <appender-ref ref="Console" />
+            <appender-ref ref="Sentry" />
         </root>
 
         <logger name="org.databiosphere.workspacedataservice" level="debug" additivity="false">
             <appender-ref ref="Console" />
+            <appender-ref ref="Sentry" />
         </logger>
 
         <logger name="org.springframework.web" level="debug" additivity="false">
             <appender-ref ref="Console" />
+            <appender-ref ref="Sentry" />
         </logger>
     </springProfile>
 

--- a/service/src/main/resources/logback-spring.xml
+++ b/service/src/main/resources/logback-spring.xml
@@ -13,7 +13,7 @@
     <appender name="Sentry" class="io.sentry.logback.SentryAppender">
         <options>
             <!-- can we read this from env? -->
-            <dsn>https://e59ecdd940784bd2922f25a0f3197ffd@o54426.ingest.sentry.io/4504299946835968</dsn>
+            <dsn><!-- add Sentry DSN here --></dsn>
         </options>
         <!-- Optionally change minimum Event level. Default for Events is ERROR -->
         <minimumEventLevel>ERROR</minimumEventLevel>

--- a/service/src/main/resources/logback-spring.xml
+++ b/service/src/main/resources/logback-spring.xml
@@ -13,7 +13,7 @@
     <appender name="Sentry" class="io.sentry.logback.SentryAppender">
         <options>
             <!-- can we read this from env? -->
-            <dsn><!-- add Sentry DSN here --></dsn>
+            <dsn>https://e59ecdd940784bd2922f25a0f3197ffd@o54426.ingest.sentry.io/4504299946835968</dsn>
         </options>
         <!-- Optionally change minimum Event level. Default for Events is ERROR -->
         <minimumEventLevel>ERROR</minimumEventLevel>

--- a/service/src/main/resources/logback-spring.xml
+++ b/service/src/main/resources/logback-spring.xml
@@ -50,12 +50,14 @@
         <logger name="org.databiosphere.workspacedataservice" level="debug" additivity="false">
             <appender-ref ref="RollingFile" />
             <appender-ref ref="Console" />
+            <appender-ref ref="Sentry" />
         </logger>
 
         <!-- log org.springframework.web at DEBUG level -->
         <logger name="org.springframework.web" level="debug" additivity="false">
             <appender-ref ref="RollingFile" />
             <appender-ref ref="Console" />
+            <appender-ref ref="Sentry" />
         </logger>
     </springProfile>
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/SentryInitializerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/SentryInitializerTest.java
@@ -20,7 +20,7 @@ class SentryInitializerTest {
                 Arguments.of("https://sam.dsde-staging.broadinstitute.org", "staging"),
                 Arguments.of("https://sam.dsde-alpha.broadinstitute.org", "alpha"),
                 Arguments.of("https://sam.dsde-dev.broadinstitute.org", "dev"),
-                Arguments.of("https://sam.bee-fancy-generated-name.bee.envs-terra.bio", "bee-fancy-generated-name"),
+                Arguments.of("https://sam.bee-fancy-generated-name.bee.envs-terra.bio", "unknown"),
                 Arguments.of("UNDEFINED", "unknown"),
                 Arguments.of("", "unknown"),
                 Arguments.of("null", "unknown"),

--- a/service/src/test/java/org/databiosphere/workspacedataservice/SentryInitializerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/SentryInitializerTest.java
@@ -1,0 +1,38 @@
+package org.databiosphere.workspacedataservice;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+@SpringBootTest
+public class SentryInitializerTest {
+
+    private static Stream<Arguments> provideSamUrls() {
+		/* Arguments are pairs of input Sam URL and expected environment parsed from that URL
+		 */
+        return Stream.of(
+                Arguments.of("https://sam.dsde-prod.broadinstitute.org", "prod"),
+                Arguments.of("https://sam.dsde-staging.broadinstitute.org", "staging"),
+                Arguments.of("https://sam.dsde-alpha.broadinstitute.org", "alpha"),
+                Arguments.of("https://sam.dsde-dev.broadinstitute.org", "dev"),
+                Arguments.of("https://sam.bee-fancy-generated-name.bee.envs-terra.bio", "bee-fancy-generated-name"),
+                Arguments.of("UNDEFINED", "unknown"),
+                Arguments.of("", "unknown"),
+                Arguments.of("null", "unknown"),
+                Arguments.of(null, "unknown")
+        );
+    }
+
+    @ParameterizedTest(name = "SentryInitializer.urlToEnv parsing for value [{0}] should result in [{1}]")
+    @MethodSource("provideSamUrls")
+    void parseProdEnv(String samUrl, String expected) {
+        SentryInitializer sentryInitializer = new SentryInitializer();
+        String actual = sentryInitializer.urlToEnv(samUrl);
+        assertEquals(expected, actual);
+    }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/SentryInitializerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/SentryInitializerTest.java
@@ -10,7 +10,7 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 @SpringBootTest
-public class SentryInitializerTest {
+class SentryInitializerTest {
 
     private static Stream<Arguments> provideSamUrls() {
 		/* Arguments are pairs of input Sam URL and expected environment parsed from that URL


### PR DESCRIPTION
This PR configures [sentry-logback](https://docs.sentry.io/platforms/java/guides/logback/) in WDS. We create a new Sentry-specific logback appender, set some variables on the `Sentry` object, and then magically Sentry finds exceptions in our logs and sends them to the WDS-specific Sentry dashboard.

Using the logback approach for Sentry should make this fully compatible with [Application Insights instrumentation](https://learn.microsoft.com/en-us/azure/azure-monitor/app/java-spring-boot) when we add that in the future.

See the dashboard at https://sentry.io/organizations/broad-institute/projects/wds/?issuesType=all&project=4504299946835968.

The `samurl` and `lz_mrg` environment variables depend on https://github.com/broadinstitute/cromwhelm/pull/172 which in turn (partially) depends on https://github.com/DataBiosphere/leonardo/pull/3114 .  The `releasename` variable depends on https://github.com/broadinstitute/cromwhelm/pull/173.