### PR TITLE
AJ-719 update

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -36,7 +36,7 @@ jobs:
         id: find-jira-id
         run: |
           set +e
-          JIRA_ID=$(echo '${{ github.event.head_commit.message }}' | grep -iEo 'AJ-[0-9]+' || '')
+          JIRA_ID=$(echo '${{ github.event.head_commit.message }}' | grep -iEo -m 1 'AJ-[0-9]+' || '')
           if [[ -z "$JIRA_ID" ]]; then
             echo ::set-output name=JIRA_ID::"missing"
           else 


### PR DESCRIPTION
If there are multiple jira ids in a commit message - e.g. if there is one in the actual message AND in the branch name - the auto-push to cromwhelm will fail because the jira id output will have extraneous text.  This change will only look for the first match to a Jira Id.