### PR TITLE
AJ-808: enable npm cache

### DIFF
--- a/.github/workflows/release-python-client.yml
+++ b/.github/workflows/release-python-client.yml
@@ -23,9 +23,10 @@ jobs:
         with:
           python-version: 3.7
       - name: Use Node.js ${{matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 18
+          cache: 'npm'
       - name: Install openapi-generator-cli
         run: npm install @openapitools/openapi-generator-cli -g
       - name: set version to 4.3.1


### PR DESCRIPTION
We've seen sporadic failures in GHA when running `openapi-generator-cli version-manager set 4.3.1`. Let's try enabling the npm cache and see if that alleviates it. 

setup-node/npm cache documentation: https://github.com/actions/setup-node