### PR TITLE
Revert "AJ-808: enable npm cache"

### DIFF
--- a/.github/workflows/release-python-client.yml
+++ b/.github/workflows/release-python-client.yml
@@ -23,10 +23,9 @@ jobs:
         with:
           python-version: 3.7
       - name: Use Node.js ${{matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v2
         with:
           node-version: 18
-          cache: 'npm'
       - name: Install openapi-generator-cli
         run: npm install @openapitools/openapi-generator-cli -g
       - name: set version to 4.3.1


### PR DESCRIPTION
Reverts DataBiosphere/terra-workspace-data-service#167

That PR apparently isn't right; it causes job failures: https://github.com/DataBiosphere/terra-workspace-data-service/actions/runs/4000813358