### PR TITLE
AJ-734 Update arrays of relations

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -350,6 +350,11 @@ public class RecordDao {
 		}
 	}
 
+	public void removeFromJoin(UUID instanceId, Relation column, RecordType fromType, List<String> recordIds){
+			namedTemplate.update("delete from " + getQualifiedJoinTableName(instanceId, column.relationColName(), fromType) + " where "
+					+ quote(getFromColumnName(fromType)) + "in (:recordIds)", new MapSqlParameterSource("recordIds", recordIds));
+	}
+
 	public void batchUpsert(UUID instanceId, RecordType recordType, List<Record> records,
 							Map<String, DataTypeMapping> schema){
 		batchUpsert(instanceId, recordType, records, schema, cachedQueryDao.getPrimaryKeyColumn(recordType, instanceId));

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/BatchWriteService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/BatchWriteService.java
@@ -78,6 +78,11 @@ public class BatchWriteService {
 		for (Map.Entry<String, MapDifference.ValueDifference<DataTypeMapping>> entry : differenceMap.entrySet()) {
 			String column = entry.getKey();
 			MapDifference.ValueDifference<DataTypeMapping> valueDifference = entry.getValue();
+			//Don't allow updating relation columns
+			if (valueDifference.leftValue() == DataTypeMapping.ARRAY_OF_RELATION ||
+					valueDifference.leftValue() == DataTypeMapping.RELATION ){
+				throw new InvalidRelationException("Unable to update a relation or array of relation attribute type");
+			}
 			DataTypeMapping updatedColType = inferer.selectBestType(valueDifference.leftValue(),
 					valueDifference.rightValue());
 			recordDao.changeColumn(instanceId, recordType, column, updatedColType);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordService.java
@@ -38,6 +38,8 @@ public class RecordService {
         Map<Relation, List<RelationValue>> relationArrayValues = getAllRelationArrayValues(records, relationArrays);
         recordDao.batchUpsert(instanceId, recordType, records, requestSchema, primaryKey);
         for (Map.Entry<Relation, List<RelationValue>> rel : relationArrayValues.entrySet()) {
+            //remove existing values from join table and replace with new ones
+            recordDao.removeFromJoin(instanceId, rel.getKey(), recordType, rel.getValue().stream().map(relVal -> relVal.fromRecord().getId()).toList());
             recordDao.insertIntoJoin(instanceId, rel.getKey(), recordType, rel.getValue());
         }
     }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -1400,8 +1400,6 @@ class RecordControllerMockMvcTest {
 						.andExpect(status().isForbidden());
 
 		//Record should not have been updated
-		mockMvc.perform(get("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
-				relationArrayType, relArrId)).andExpect(status().isOk());
 		MockHttpServletResponse res = mockMvc.perform(get("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
 				relationArrayType, relArrId)).andExpect(status().isOk()).andReturn().getResponse();
 		RecordResponse recordResponse = mapper.readValue(res.getContentAsString(), RecordResponse.class);
@@ -1451,6 +1449,42 @@ class RecordControllerMockMvcTest {
 
 		List<String> joinVals = getRelationArrayValues(instanceId, "relArrAttr", recordWithRelationArray, recordType);
 		assertIterableEquals(List.of("record_1", "record_2"), joinVals);
+	}
+
+	@Test
+	void testUpdateRelationArrayDataType() throws Exception {
+		// add some records to be relations
+		RecordType recordType = RecordType.valueOf("referencedRecords");
+		createSomeRecords(recordType, 2);
+
+		//Create record with relation array
+		RecordType relationArrayType = RecordType.valueOf("relationArrayType");
+		String relArrId = "recordWithRelationArr";
+		List<String> relArr = List.of(RelationUtils.createRelationString(recordType, "record_0"), RelationUtils.createRelationString(recordType, "record_1"));
+		Record recordWithRelationArray = new Record(relArrId, relationArrayType, new RecordAttributes(Map.of("relArrAttr", relArr)));
+		RecordAttributes relAttr = new RecordAttributes(Map.of("relArrAttr", relArr));
+		mockMvc.perform(put("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
+						relationArrayType, relArrId).contentType(MediaType.APPLICATION_JSON)
+						.content(mapper.writeValueAsString(new RecordRequest(relAttr))))
+				.andExpect(status().isCreated()).andExpect(jsonPath("$.attributes.relArrAttr", is(relArr)));
+
+		//Update relation array attribute to non-relation array datatype
+		RecordAttributes incorrectRelAttr = new RecordAttributes(Map.of("relArrAttr", "not an array of relations"));
+		mockMvc.perform(patch("/{instanceId}/records/{versionId}/{recordType}/{recordId}", instanceId, versionId,
+						relationArrayType, relArrId).contentType(MediaType.APPLICATION_JSON)
+						.content(mapper.writeValueAsString(new RecordRequest(incorrectRelAttr))))
+				.andExpect(status().isForbidden());
+
+		//Record should not have been updated
+		MockHttpServletResponse res = mockMvc.perform(get("/{instanceId}/records/{version}/{recordType}/{recordId}", instanceId, versionId,
+				relationArrayType, relArrId)).andExpect(status().isOk()).andReturn().getResponse();
+		RecordResponse recordResponse = mapper.readValue(res.getContentAsString(), RecordResponse.class);
+		List<String> actualAttrValue = assertInstanceOf(List.class, recordResponse.recordAttributes().getAttributeValue("relArrAttr"));
+		assertIterableEquals(relArr, actualAttrValue);
+
+		//Join table should not have been updated
+		List<String> joinVals = getRelationArrayValues(instanceId, "relArrAttr", recordWithRelationArray, recordType);
+		assertIterableEquals(List.of("record_0", "record_1"), joinVals);
 	}
 
 	//TODO: A better way to do this?

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -2,7 +2,6 @@ package org.databiosphere.workspacedataservice.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.databiosphere.workspacedataservice.TestUtils;
-import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.databiosphere.workspacedataservice.dao.TestDao;
 import org.databiosphere.workspacedataservice.service.RelationUtils;
 import org.databiosphere.workspacedataservice.service.model.*;
@@ -60,10 +59,6 @@ class RecordControllerMockMvcTest {
 
 	@Autowired
 	TestDao testDao;
-
-	@Autowired
-	RecordDao recordDao;
-
 
 	@BeforeEach
 	void beforeEach() throws Exception {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
@@ -21,7 +21,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
@@ -49,8 +48,12 @@ class RecordDaoTest {
 	private static final String PRIMARY_KEY = "row_id";
 	@Autowired
 	RecordDao recordDao;
+
 	UUID instanceId;
 	RecordType recordType;
+
+	@Autowired
+	TestDao testDao;
 
 	@Autowired
 	NamedParameterJdbcTemplate namedTemplate;
@@ -242,7 +245,7 @@ class RecordDaoTest {
 		recordDao.batchDelete(instanceId, referencer, referencingRecords);
 		for (Record rec : referencingRecords){
 			assertTrue(recordDao.getSingleRecord(instanceId, referencer, rec.getId()).isEmpty());
-			assertTrue(getRelationArrayValues(instanceId, "attr1", rec, referencedRt).isEmpty());
+			assertTrue(testDao.getRelationArrayValues(instanceId, "attr1", rec, referencedRt).isEmpty());
 		}
 	}
 
@@ -445,7 +448,7 @@ class RecordDaoTest {
 		//Record should have been deleted
 		assert(recordDao.getSingleRecord(instanceId, recordType, "recordWithRelationArr").isEmpty());
 		//Check that values are removed from join table
-		assertTrue(getRelationArrayValues(instanceId, "relArrAttr", recordWithRelationArray, recordType).isEmpty());
+		assertTrue(testDao.getRelationArrayValues(instanceId, "relArrAttr", recordWithRelationArray, recordType).isEmpty());
 	}
 	@Test
 	@Transactional
@@ -571,7 +574,7 @@ class RecordDaoTest {
 		assertFalse(recordDao.recordTypeExists(instanceId, relationArrayType));
 
 		//check that join table is gone as well
-		assertFalse(joinTableExists(instanceId, "relArrAttr", relationArrayType ));
+		assertFalse(testDao.joinTableExists(instanceId, "relArrAttr", relationArrayType ));
 	}
 
 	@Test
@@ -586,7 +589,7 @@ class RecordDaoTest {
 		List<Relation> relationArrays = recordDao.getRelationArrayCols(instanceId, secondRecordType);
 		assertEquals(1, relationArrays.size());
 		assertTrue(relationArrays.contains(new Relation("refArray", recordType)));
-		assertTrue(joinTableExists(instanceId, "refArray", secondRecordType));
+		assertTrue(testDao.joinTableExists(instanceId, "refArray", secondRecordType));
 	}
 
 	@Test
@@ -607,7 +610,7 @@ class RecordDaoTest {
 		assertEquals(List.of(singleRelation), relationCols);
 		List<Relation> relationArrayCols = recordDao.getRelationArrayCols(instanceId, relationarrayType);
 		assertEquals(List.of(arrayRelation), relationArrayCols);
-		assertTrue(joinTableExists(instanceId, "relArrAttr", relationarrayType));
+		assertTrue(testDao.joinTableExists(instanceId, "relArrAttr", relationarrayType));
 	}
 
 	@Test
@@ -645,7 +648,7 @@ class RecordDaoTest {
 		//The purpose of inserting in to the join is to make sure foreign keys are consistent
 		//So we need to make sure no error is thrown
 		assertDoesNotThrow(() -> recordDao.insertIntoJoin(instanceId, arrayRelation, relationArrayType, List.of(new RelationValue(record, referencedRecord), new RelationValue(record, referencedRecord2))));
-		assertEquals(List.of(refRecordId, refRecordId2), getRelationArrayValues(instanceId, "relArrAttr", record, recordType));
+		assertEquals(List.of(refRecordId, refRecordId2), testDao.getRelationArrayValues(instanceId, "relArrAttr", record, recordType));
 	}
 	@Test
 	@Transactional
@@ -695,42 +698,24 @@ class RecordDaoTest {
 				new RelationValue(fromRecord3, toRecord),new RelationValue(fromRecord3, toRecord2)));
 
 		//Check that values are in join table
-		List<String> joinVals1 = getRelationArrayValues(instanceId, "referenceArray", fromRecord, toType);
+		List<String> joinVals1 = testDao.getRelationArrayValues(instanceId, "referenceArray", fromRecord, toType);
 		assertIterableEquals(List.of(toRecordId, toRecordId2), joinVals1);
-		List<String> joinVals2 = getRelationArrayValues(instanceId, "referenceArray", fromRecord2, toType);
+		List<String> joinVals2 = testDao.getRelationArrayValues(instanceId, "referenceArray", fromRecord2, toType);
 		assertIterableEquals(List.of(toRecordId, toRecordId2), joinVals2);
-		List<String> joinVals3 = getRelationArrayValues(instanceId, "referenceArray", fromRecord3, toType);
+		List<String> joinVals3 = testDao.getRelationArrayValues(instanceId, "referenceArray", fromRecord3, toType);
 		assertIterableEquals(List.of(toRecordId, toRecordId2), joinVals3);
 
 		//remove from join table
 		recordDao.removeFromJoin(instanceId, rel, recordType, List.of(fromRecordId, fromRecordId3));
 
 		//Make sure values have been removed
-		joinVals1 = getRelationArrayValues(instanceId, "referenceArray", fromRecord, toType);
+		joinVals1 = testDao.getRelationArrayValues(instanceId, "referenceArray", fromRecord, toType);
 		assert(joinVals1.isEmpty());
-		joinVals3 = getRelationArrayValues(instanceId, "referenceArray", fromRecord3, toType);
+		joinVals3 = testDao.getRelationArrayValues(instanceId, "referenceArray", fromRecord3, toType);
 		assert(joinVals3.isEmpty());
 		//But not other values
-		joinVals2 = getRelationArrayValues(instanceId, "referenceArray", fromRecord2, toType);
+		joinVals2 = testDao.getRelationArrayValues(instanceId, "referenceArray", fromRecord2, toType);
 		assertIterableEquals(List.of(toRecordId, toRecordId2), joinVals2);
-	}
-
-	//Helper Methods
-	private boolean joinTableExists(UUID instanceId, String tableName, RecordType referringRecordType) {
-		//This method gives us the name in quotes, need to be able to strip them off
-		String joinTableName = recordDao.getJoinTableName(tableName, referringRecordType);
-		return Boolean.TRUE.equals(namedTemplate.queryForObject(
-				"select exists(select from pg_tables where schemaname = :instanceId AND tablename  = :joinName)",
-				new MapSqlParameterSource(
-						Map.of("instanceId", instanceId.toString(), "joinName", joinTableName.substring(1, joinTableName.length()-1))),
-				Boolean.class));
-	}
-
-	private List<String> getRelationArrayValues(UUID instanceId, String columnName, Record record, RecordType toRecordType) {
-		return namedTemplate.queryForList(
-				"select \"" + recordDao.getToColumnName(toRecordType) + "\" from " + recordDao.getQualifiedJoinTableName(instanceId, columnName, record.getRecordType()) + " where "
-						+ "\"" + recordDao.getFromColumnName(record.getRecordType()) + "\" = :recordId",
-				new MapSqlParameterSource("recordId", record.getId()), String.class);
 	}
 
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/TestDao.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/TestDao.java
@@ -1,0 +1,39 @@
+package org.databiosphere.workspacedataservice.dao;
+
+import org.databiosphere.workspacedataservice.shared.model.Record;
+import org.databiosphere.workspacedataservice.shared.model.RecordType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Repository
+public class TestDao {
+
+    @Autowired
+    NamedParameterJdbcTemplate namedTemplate;
+
+    @Autowired
+    RecordDao recordDao;
+
+    public boolean joinTableExists(UUID instanceId, String tableName, RecordType referringRecordType) {
+        //This method gives us the name in quotes, need to be able to strip them off
+        String joinTableName = recordDao.getJoinTableName(tableName, referringRecordType);
+        return Boolean.TRUE.equals(namedTemplate.queryForObject(
+                "select exists(select from pg_tables where schemaname = :instanceId AND tablename  = :joinName)",
+                new MapSqlParameterSource(
+                        Map.of("instanceId", instanceId.toString(), "joinName", joinTableName.substring(1, joinTableName.length()-1))),
+                Boolean.class));
+    }
+
+    public List<String> getRelationArrayValues(UUID instanceId, String columnName, Record record, RecordType toRecordType) {
+        return namedTemplate.queryForList(
+                "select \"" + recordDao.getToColumnName(toRecordType) + "\" from " + recordDao.getQualifiedJoinTableName(instanceId, columnName, record.getRecordType()) + " where "
+                        + "\"" + recordDao.getFromColumnName(record.getRecordType()) + "\" = :recordId",
+                new MapSqlParameterSource("recordId", record.getId()), String.class);
+    }
+}


### PR DESCRIPTION
See [AJ-734](https://broadworkbench.atlassian.net/browse/AJ-734)
Adds support to update array-of-relations attributes.  Current behavior fails on updating attribute datatype of relations, so this is reinforced with arrays of relations and given clearer messaging.

[AJ-734]: https://broadworkbench.atlassian.net/browse/AJ-734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ