### PR TITLE
AJ-836: ensure TSV download stream is closed

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -130,10 +130,10 @@ public class RecordController {
 		validateInstance(instanceId);
 		checkRecordTypeExists(instanceId, recordType);
 		List<String> headers = recordDao.getAllAttributeNames(instanceId, recordType);
-		Stream<Record> allRecords = recordDao.streamAllRecordsForType(instanceId, recordType);
 
 		StreamingResponseBody responseBody = httpResponseOutputStream -> {
-			try (CSVPrinter writer = TsvSupport.getOutputFormat(headers)
+			try (Stream<Record> allRecords = recordDao.streamAllRecordsForType(instanceId, recordType);
+				 CSVPrinter writer = TsvSupport.getOutputFormat(headers)
 					.print(new OutputStreamWriter(httpResponseOutputStream))) {
 				TsvSupport.RecordEmitter recordEmitter = new TsvSupport.RecordEmitter(writer,
 						headers.subList(1, headers.size()), objectMapper);

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
@@ -82,6 +82,7 @@ class TsvDownloadTest {
 		InputStream is = TsvDownloadTest.class.getResourceAsStream("/batch_write_tsv_data.json");
 		ResponseEntity<BatchResponse> response = recordController.streamingWrite(instanceId, version, recordType, Optional.empty(), is);
 		assertThat(response.getStatusCodeValue()).isEqualTo(200);
+		assertThat(response.getBody().recordsModified()).isEqualTo(2);
 		HttpHeaders headers = new HttpHeaders();
 		ResponseEntity<Resource> stream = restTemplate.exchange("/{instanceId}/tsv/{version}/{recordType}",
 				HttpMethod.GET, new HttpEntity<>(headers), Resource.class, instanceId, version, recordType);


### PR DESCRIPTION
Before this PR, if you 1) download a TSV for a given table and then 2) attempt to delete the table, you hang.

The TSV download was leaving a stream unclosed, which I hypothesize was not properly releasing a db lock or a thread (or something!).

This PR ensures the stream is closed, and manual testing shows it addresses the issue.

