### PR TITLE
AJ-678: Give WDS the ability to leverage Azure Application Insights

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ logs/
 !**/src/test/**/build/
 service/build/
 service/logs/
+service/applicationinsights.log
 
 ### STS ###
 .apt_generated

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -30,7 +30,7 @@ jib {
 }
 
 dependencies {
-
+	implementation 'com.microsoft.azure:applicationinsights-runtime-attach:3.4.9'
 	implementation 'org.springframework.boot:spring-boot-starter'
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/service/src/main/java/org/databiosphere/workspacedataservice/WorkspaceDataServiceApplication.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/WorkspaceDataServiceApplication.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.cfg.CoercionAction;
 import com.fasterxml.jackson.databind.cfg.CoercionInputShape;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.type.LogicalType;
+import com.microsoft.applicationinsights.attach.ApplicationInsights;
 import com.zaxxer.hikari.HikariDataSource;
 import org.databiosphere.workspacedataservice.service.DataTypeInferer;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -129,6 +130,7 @@ public class WorkspaceDataServiceApplication {
 	}
 
 	public static void main(String[] args) {
+		ApplicationInsights.attach();
 		SpringApplication.run(WorkspaceDataServiceApplication.class, args);
 	}
 }

--- a/service/src/main/resources/applicationinsights.json
+++ b/service/src/main/resources/applicationinsights.json
@@ -1,0 +1,3 @@
+{
+  "connectionString": "InstrumentationKey=<some-uuid>;IngestionEndpoint=<azure-url>;LiveEndpoint=<azure-url>"
+}

--- a/service/src/main/resources/applicationinsights.json
+++ b/service/src/main/resources/applicationinsights.json
@@ -1,3 +1,0 @@
-{
-  "connectionString": "InstrumentationKey=<some-uuid>;IngestionEndpoint=<azure-url>;LiveEndpoint=<azure-url>"
-}


### PR DESCRIPTION
Relates to https://broadworkbench.atlassian.net/browse/AJ-764

Validated via a workspace within a BEE: https://terra.wds-only.bee.envs-terra.bio/#workspaces/wdsonlybillling/appInsightsTest

Then observing data incoming to https://portal.azure.com/#@broadinstitute.org/resource/subscriptions/0fa61a72-3a6b-4d51-a7e9-75fbeb7c7ed9/resourceGroups/mrg-terra-dev-previ-20230224115705/providers/Microsoft.Insights/components/lz9c9522004165f6249b4e9e9545c3de2f2a97220ea65e14ee345942cc7192f9f1/overview

