### PR TITLE
AJ-678 File datatype in WDS

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -304,21 +304,11 @@ public class RecordController {
 		relationCols.addAll(recordDao.getRelationCols(instanceId, recordType));
 		Map<String, RecordType> relations = relationCols.stream()
 				.collect(Collectors.toMap(Relation::relationColName, Relation::relationRecordType));
-//		List<AttributeSchema> attrSchema = schema.entrySet().stream().sorted(Map.Entry.comparingByKey())
-//				.map(entry -> createAttributeSchema(entry.getKey(), entry.getValue(), relations.get(entry.getKey())))
-//				.toList();
 		List<AttributeSchema> attrSchema = schema.entrySet().stream().sorted(Map.Entry.comparingByKey())
 				.map(entry -> new AttributeSchema(entry.getKey(), entry.getValue().toString(), relations.get(entry.getKey())))
 				.toList();
 		int recordCount = recordDao.countRecords(instanceId, recordType);
 		return new RecordTypeSchema(recordType, attrSchema, recordCount, recordDao.getPrimaryKeyColumn(recordType, instanceId));
-	}
-
-	private AttributeSchema createAttributeSchema(String name, DataTypeMapping datatype, RecordType relation) {
-		if (relation == null) {
-			return new AttributeSchema(name, datatype.toString(), null);
-		}
-		return new AttributeSchema(name, "STRING".equals(datatype.toString()) ? "RELATION" : "ARRAY_OF_RELATION", relation);
 	}
 
 	private static void validateVersion(String version) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -304,8 +304,11 @@ public class RecordController {
 		relationCols.addAll(recordDao.getRelationCols(instanceId, recordType));
 		Map<String, RecordType> relations = relationCols.stream()
 				.collect(Collectors.toMap(Relation::relationColName, Relation::relationRecordType));
+//		List<AttributeSchema> attrSchema = schema.entrySet().stream().sorted(Map.Entry.comparingByKey())
+//				.map(entry -> createAttributeSchema(entry.getKey(), entry.getValue(), relations.get(entry.getKey())))
+//				.toList();
 		List<AttributeSchema> attrSchema = schema.entrySet().stream().sorted(Map.Entry.comparingByKey())
-				.map(entry -> createAttributeSchema(entry.getKey(), entry.getValue(), relations.get(entry.getKey())))
+				.map(entry -> new AttributeSchema(entry.getKey(), entry.getValue().toString(), relations.get(entry.getKey())))
 				.toList();
 		int recordCount = recordDao.countRecords(instanceId, recordType);
 		return new RecordTypeSchema(recordType, attrSchema, recordCount, recordDao.getPrimaryKeyColumn(recordType, instanceId));

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -549,7 +549,7 @@ public class RecordDao {
 
 	private Object[] getListAsArray(List<?> attVal, DataTypeMapping typeMapping) {
 		switch (typeMapping){
-			case ARRAY_OF_STRING, ARRAY_OF_RELATION, ARRAY_OF_DATE, ARRAY_OF_DATE_TIME, ARRAY_OF_NUMBER, EMPTY_ARRAY:
+			case ARRAY_OF_STRING, ARRAY_OF_FILE, ARRAY_OF_RELATION, ARRAY_OF_DATE, ARRAY_OF_DATE_TIME, ARRAY_OF_NUMBER, EMPTY_ARRAY:
 				return attVal.stream().map(Object::toString).toList().toArray(new String[0]);
 			case ARRAY_OF_BOOLEAN:
 				//accept all casings of True and False if they're strings

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -248,7 +248,7 @@ public class RecordDao {
 	public Map<String, DataTypeMapping> getExistingTableSchema(UUID instanceId, RecordType recordType) {
 		MapSqlParameterSource params = new MapSqlParameterSource(INSTANCE_ID, instanceId.toString());
 		params.addValue("tableName", recordType.getName());
-		String sql = "select column_name, udt_name::regtype as data_type from INFORMATION_SCHEMA.COLUMNS " +
+		String sql = "select column_name,coalesce(domain_name, udt_name::regtype::varchar) as data_type from INFORMATION_SCHEMA.COLUMNS " +
 				"where table_schema = :instanceId and table_name = :tableName";
 		return getTableSchema(sql, params);
 	}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/DataTypeInferer.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/DataTypeInferer.java
@@ -103,10 +103,6 @@ public class DataTypeInferer {
 		// when we load from TSV, numbers are converted to strings, we need to go back
 		// to numbers
 		String sVal = val.toString();
-		if (isFileType(sVal)){
-			return FILE;
-		}
-
 
 		if (isNumericValue(sVal)) {
 			return NUMBER;
@@ -348,8 +344,8 @@ public class DataTypeInferer {
 	}
 
 	private boolean isFileType(String possibleFile){
-		//https://[].blob.core.windows.net/sc-[] or drs://[]
-		Pattern AZURE_FILE_PATTERN = Pattern.compile("https://[a-z0-9]*.blob.core.windows.net/sc-[a-z0-9-]*", Pattern.CASE_INSENSITIVE);
+		//https://[].blob.core.windows.net/[] or drs://[]
+		Pattern AZURE_FILE_PATTERN = Pattern.compile("https://[a-z0-9]*.blob.core.windows.net/[a-z0-9.\\/\\-_]*", Pattern.CASE_INSENSITIVE);
 		Pattern DRS_FILE_PATTERN = Pattern.compile("drs://[a-z0-9.\\/\\-_]*", Pattern.CASE_INSENSITIVE);
 		return AZURE_FILE_PATTERN.matcher(possibleFile).matches() || DRS_FILE_PATTERN.matcher(possibleFile).matches();
 	}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/DataTypeInferer.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/DataTypeInferer.java
@@ -3,7 +3,6 @@ package org.databiosphere.workspacedataservice.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Preconditions;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
@@ -12,8 +11,6 @@ import org.databiosphere.workspacedataservice.service.model.RelationCollection;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
 import org.springframework.util.CollectionUtils;
-import org.springframework.web.util.UriComponents;
-import org.springframework.web.util.UriComponentsBuilder;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/DataTypeMapping.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/DataTypeMapping.java
@@ -21,7 +21,7 @@ public enum DataTypeMapping {
 	ARRAY_OF_DATE_TIME(String[].class, "timestamp with time zone[]", true, "?::timestamp with time zone[]"),
 	ARRAY_OF_STRING(String[].class, "text[]", true, "?"),
 	ARRAY_OF_RELATION(String[].class, "array_of_relation", true, "?"),
-	ARRAY_OF_FILE(String[].class, "text[]", true, "?"),
+	ARRAY_OF_FILE(String[].class, "array_of_file", true, "?"),
 	ARRAY_OF_BOOLEAN(Boolean[].class, "boolean[]", true, "?");
 
 	private Class javaArrayTypeForDbWrites;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/DataTypeMapping.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/DataTypeMapping.java
@@ -15,11 +15,13 @@ public enum DataTypeMapping {
 	RELATION(null, "relation", false, "?"),
 	JSON(null, "jsonb", false, "?::jsonb"),
 	NUMBER(null, "numeric", false, "?"),
+	FILE(null, "file", false, "?"),
 	ARRAY_OF_NUMBER(Double[].class, "numeric[]", true, "?::numeric[]"),
 	ARRAY_OF_DATE(String[].class, "date[]", true, "?::date[]"),
 	ARRAY_OF_DATE_TIME(String[].class, "timestamp with time zone[]", true, "?::timestamp with time zone[]"),
 	ARRAY_OF_STRING(String[].class, "text[]", true, "?"),
 	ARRAY_OF_RELATION(String[].class, "array_of_relation", true, "?"),
+	ARRAY_OF_FILE(String[].class, "text[]", true, "?"),
 	ARRAY_OF_BOOLEAN(Boolean[].class, "boolean[]", true, "?");
 
 	private Class javaArrayTypeForDbWrites;
@@ -69,6 +71,8 @@ public enum DataTypeMapping {
 		switch (baseType){
 			case STRING :
 				return ARRAY_OF_STRING;
+			case FILE :
+				return ARRAY_OF_FILE;
 			case RELATION :
 				return ARRAY_OF_RELATION;
 			case BOOLEAN:

--- a/service/src/main/resources/data.sql
+++ b/service/src/main/resources/data.sql
@@ -12,5 +12,8 @@ BEGIN
     IF NOT EXISTS (SELECT 1 FROM information_schema.domains WHERE domain_name = ''file'') THEN
         create domain file as text;
     END IF;
+    IF NOT EXISTS (SELECT 1 FROM information_schema.domains WHERE domain_name = ''array_of_file'') THEN
+        create domain array_of_file as text[];
+    END IF;
 END;
 ';

--- a/service/src/main/resources/data.sql
+++ b/service/src/main/resources/data.sql
@@ -9,5 +9,8 @@ BEGIN
     IF NOT EXISTS (SELECT 1 FROM information_schema.domains WHERE domain_name = ''array_of_relation'') THEN
          create domain array_of_relation as text[];
      END IF;
+    IF NOT EXISTS (SELECT 1 FROM information_schema.domains WHERE domain_name = ''file'') THEN
+        create domain file as text;
+    END IF;
 END;
 ';

--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -587,7 +587,7 @@ components:
           description: name of this attribute.
         datatype:
           type: string
-          enum: [boolean, date, datetime, string, json, long, double, relation, array_of_boolean, array_of_string, array_of_number, array_of_date, array_of_datetime]
+          enum: [boolean, date, datetime, string, json, long, double, relation, file, array_of_boolean, array_of_string, array_of_number, array_of_date, array_of_datetime, array_of_relation, array_of_file]
           description: |
             Datatype of this attribute. The enum of datatypes is in flux and will change. Please
             comment at https://docs.google.com/document/d/1d352ZoN5kEYWPjy0NqqWGxdf7HEu5VEdrLmiAv7dMmQ/edit#heading=h.naxag0augkgf.
@@ -680,11 +680,14 @@ components:
           "numericAttr": 123,
           "booleanAttr": true,
           "relationAttr": "terra-wds:/target-type/target-id",
+          "fileAttr": "https://account_name.blob.core.windows.net/container-1/blob1",
           "arrayString": ["green", "red"],
           "arrayBoolean": [true, false],
           "arrayNumber": [12821.112, 0.12121211, 11],
           "arrayDate": ["2022-11-03"],
-          "arrayDateTime": ["2022-11-03T04:36:20"]
+          "arrayDateTime": ["2022-11-03T04:36:20"],
+          "arrayRelation": ["terra-wds:/target-type/target-id-1", "terra-wds:/target-type/target-id-2"],
+          "arrayFile": ["drs://drs.example.org/file_id_1", "https://account_name.blob.core.windows.net/container-2/blob2"]
         }
     RecordAttributeDefinition:
       required:

--- a/service/src/test/java/org/databiosphere/workspacedataservice/DataTypeInfererTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/DataTypeInfererTest.java
@@ -5,8 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.*;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.databiosphere.workspacedataservice.service.DataTypeInferer;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/DataTypeInfererTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/DataTypeInfererTest.java
@@ -133,7 +133,7 @@ class DataTypeInfererTest {
 		assertThat(inferer.inferType(List.of(RelationUtils.createRelationString(RecordType.valueOf("testType"),"recordId"), RelationUtils.createRelationString(RecordType.valueOf("testType"),"recordId2"), RelationUtils.createRelationString(RecordType.valueOf("testType"),"recordId3")), InBoundDataSource.JSON)).isEqualTo(DataTypeMapping.ARRAY_OF_RELATION);
 		assertThat(inferer.inferType(List.of(RelationUtils.createRelationString(RecordType.valueOf("testType"),"recordId"), "not a relation string", RelationUtils.createRelationString(RecordType.valueOf("testType"),"recordId3")), InBoundDataSource.JSON)).isEqualTo(DataTypeMapping.ARRAY_OF_STRING);
 		assertThat(inferer.inferType(RelationUtils.createRelationString(RecordType.valueOf("testType"),"recordId3"), InBoundDataSource.JSON)).isEqualTo(DataTypeMapping.RELATION);
-		assertThat(inferer.inferType("https://lz1a2b345c67def8a91234bc.blob.core.windows.net/sc-7ad51c5d-eb4c-4685-bffe-62b861f7753f/file.pdf", InBoundDataSource.JSON)).isEqualTo(DataTypeMapping.FILE);
+		assertThat(inferer.inferType("https://lz1a2b345c67def8a91234bc.blob.core.windows.net/sc-7ad51c5d-eb4c-4685-bffe-62b861f7753f/my%20file.pdf", InBoundDataSource.JSON)).isEqualTo(DataTypeMapping.FILE);
 	}
 
 	@Test
@@ -165,7 +165,7 @@ class DataTypeInfererTest {
 						Map.entry("rel_arr", List.of(RelationUtils.createRelationString(RecordType.valueOf("testRecordType"), "testRecordId"),
 								RelationUtils.createRelationString(RecordType.valueOf("testRecordType"), "testRecordId2"),
 								RelationUtils.createRelationString(RecordType.valueOf("testRecordType"), "testRecordId3"))),
-						Map.entry("file_val", "https://lz1a2b345c67def8a91234bc.blob.core.windows.net/sc-7ad51c5d-eb4c-4685-bffe-62b861f7753f/file."),
+						Map.entry("file_val", "https://lz1a2b345c67def8a91234bc.blob.core.windows.net/sc-7ad51c5d-eb4c-4685-bffe-62b861f7753f/file.cram?param=foo"),
 						Map.entry("array_of_file", List.of("https://lz1a2b345c67def8a91234bc.blob.core.windows.net/sc-7ad51c5d-eb4c-4685-bffe-62b861f7753f/notebook.ipynb","drs://jade.datarepo-dev.broadinstitute.org/v1_9545e956-aa6a-4b84-a037-d0ed164c1890"))
 				));
 	}
@@ -176,7 +176,7 @@ class DataTypeInfererTest {
 						"date_val", "2001-11-03", "date_time_val", "2001-11-03T10:00:00",
 						"file_val", "https://lz1a2b345c67def8a91234bc.blob.core.windows.net/sc-7ad51c5d-eb4c-4685-bffe-62b861f7753f/file.bam",
 						"array_of_file",
-						"[\"https://lz1a2b345c67def8a91234bc.blob.core.windows.net/sc-7ad51c5d-eb4c-4685-bffe-62b861f7753f/file.fasta\",\"drs://jade.datarepo-dev.broadinstitute.org/v1_9545e956-aa6a-4b84-a037-d0ed164c1890\"]",
+						"[\"https://lz1a2b345c67def8a91234bc.blob.core.windows.net/sc-7ad51c5d-eb4c-4685-bffe-62b861f7753f/file.fasta\",\"drs://jade.datarepo-dev.broadinstitute.org/v1%209545e956%20d0ed164c1890\"]",
 						"number_or_string", "47",
 						"relation", RelationUtils.createRelationString(RecordType.valueOf("testRecordType"), "testRecordId"),
 						"rel_arr", "[\""+RelationUtils.createRelationString(RecordType.valueOf("testRecordType"), "testRecordId")+"\", \""

--- a/service/src/test/java/org/databiosphere/workspacedataservice/DataTypeInfererTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/DataTypeInfererTest.java
@@ -133,7 +133,7 @@ class DataTypeInfererTest {
 		assertThat(inferer.inferType(List.of(RelationUtils.createRelationString(RecordType.valueOf("testType"),"recordId"), RelationUtils.createRelationString(RecordType.valueOf("testType"),"recordId2"), RelationUtils.createRelationString(RecordType.valueOf("testType"),"recordId3")), InBoundDataSource.JSON)).isEqualTo(DataTypeMapping.ARRAY_OF_RELATION);
 		assertThat(inferer.inferType(List.of(RelationUtils.createRelationString(RecordType.valueOf("testType"),"recordId"), "not a relation string", RelationUtils.createRelationString(RecordType.valueOf("testType"),"recordId3")), InBoundDataSource.JSON)).isEqualTo(DataTypeMapping.ARRAY_OF_STRING);
 		assertThat(inferer.inferType(RelationUtils.createRelationString(RecordType.valueOf("testType"),"recordId3"), InBoundDataSource.JSON)).isEqualTo(DataTypeMapping.RELATION);
-		assertThat(inferer.inferType("https://lz1a2b345c67def8a91234bc.blob.core.windows.net/sc-7ad51c5d-eb4c-4685-bffe-62b861f7753f", InBoundDataSource.JSON)).isEqualTo(DataTypeMapping.FILE);
+		assertThat(inferer.inferType("https://lz1a2b345c67def8a91234bc.blob.core.windows.net/sc-7ad51c5d-eb4c-4685-bffe-62b861f7753f/file.pdf", InBoundDataSource.JSON)).isEqualTo(DataTypeMapping.FILE);
 	}
 
 	@Test
@@ -165,8 +165,8 @@ class DataTypeInfererTest {
 						Map.entry("rel_arr", List.of(RelationUtils.createRelationString(RecordType.valueOf("testRecordType"), "testRecordId"),
 								RelationUtils.createRelationString(RecordType.valueOf("testRecordType"), "testRecordId2"),
 								RelationUtils.createRelationString(RecordType.valueOf("testRecordType"), "testRecordId3"))),
-						Map.entry("file_val", "https://lz1a2b345c67def8a91234bc.blob.core.windows.net/sc-7ad51c5d-eb4c-4685-bffe-62b861f7753f"),
-						Map.entry("array_of_file", List.of("https://lz1a2b345c67def8a91234bc.blob.core.windows.net/sc-7ad51c5d-eb4c-4685-bffe-62b861f7753f","drs://jade.datarepo-dev.broadinstitute.org/v1_9545e956-aa6a-4b84-a037-d0ed164c1890"))
+						Map.entry("file_val", "https://lz1a2b345c67def8a91234bc.blob.core.windows.net/sc-7ad51c5d-eb4c-4685-bffe-62b861f7753f/file."),
+						Map.entry("array_of_file", List.of("https://lz1a2b345c67def8a91234bc.blob.core.windows.net/sc-7ad51c5d-eb4c-4685-bffe-62b861f7753f/notebook.ipynb","drs://jade.datarepo-dev.broadinstitute.org/v1_9545e956-aa6a-4b84-a037-d0ed164c1890"))
 				));
 	}
 
@@ -174,9 +174,9 @@ class DataTypeInfererTest {
 		return new RecordAttributes(
 				Map.of("int_val", "4747", "string_val", "Abracadabra Open Sesame", "json_val", "{\"list\": [\"a\", \"b\"]}",
 						"date_val", "2001-11-03", "date_time_val", "2001-11-03T10:00:00",
-						"file_val", "https://lz1a2b345c67def8a91234bc.blob.core.windows.net/sc-7ad51c5d-eb4c-4685-bffe-62b861f7753f",
+						"file_val", "https://lz1a2b345c67def8a91234bc.blob.core.windows.net/sc-7ad51c5d-eb4c-4685-bffe-62b861f7753f/file.bam",
 						"array_of_file",
-						"[\"https://lz1a2b345c67def8a91234bc.blob.core.windows.net/sc-7ad51c5d-eb4c-4685-bffe-62b861f7753f\",\"drs://jade.datarepo-dev.broadinstitute.org/v1_9545e956-aa6a-4b84-a037-d0ed164c1890\"]",
+						"[\"https://lz1a2b345c67def8a91234bc.blob.core.windows.net/sc-7ad51c5d-eb4c-4685-bffe-62b861f7753f/file.fasta\",\"drs://jade.datarepo-dev.broadinstitute.org/v1_9545e956-aa6a-4b84-a037-d0ed164c1890\"]",
 						"number_or_string", "47",
 						"relation", RelationUtils.createRelationString(RecordType.valueOf("testRecordType"), "testRecordId"),
 						"rel_arr", "[\""+RelationUtils.createRelationString(RecordType.valueOf("testRecordType"), "testRecordId")+"\", \""

--- a/service/src/test/java/org/databiosphere/workspacedataservice/TestUtils.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/TestUtils.java
@@ -23,11 +23,11 @@ public class TestUtils {
 		return "{\"id\":\"newRecordId\",\"type\":\"all-types\",\"attributes\":{\"sys_name\":\"newRecordId\"," +
 				"\"array_of_boolean\":[true,false,true,true],\"array_of_date\":[\"2021-11-03\",\"2021-11-04\"]," +
 				"\"array_of_date_time\":[\"2021-11-03T07:30:00\",\"2021-11-03T07:30:00\"]," +
-				"\"array_of_file\":[\"https://lz1a2b345c67def8a91234bc.blob.core.windows.net/sc-7ad51c5d-eb4c-4685-bffe-62b861f7753f\",\"drs://jade.datarepo-dev.broadinstitute.org/v1_9545e956-aa6a-4b84-a037-d0ed164c1890\"]," +
+				"\"array_of_file\":[\"https://lz1a2b345c67def8a91234bc.blob.core.windows.net/sc-7ad51c5d-eb4c-4685-bffe-62b861f7753f/file.bam\",\"drs://jade.datarepo-dev.broadinstitute.org/v1_9545e956-aa6a-4b84-a037-d0ed164c1890\"]," +
 				"\"array_of_relation\":[\"terra-wds:/target-record/record_0\",\"terra-wds:/target-record/record_1\"]," +
 				"\"array_of_string\":[\"a\",\"b\",\"c\",\"12\"],\"array-of-number\":[1,2,3],\"boolean\":false,\"date\":\"2021-11-03\"," +
 				"\"date-time\":\"2021-11-03T07:30:00\",\"empty-array\":[]," +
-				"\"file\":\"https://lz1a2b345c67def8a91234bc.blob.core.windows.net/sc-7ad51c5d-eb4c-4685-bffe-62b861f7753f\"," +
+				"\"file\":\"https://lz1a2b345c67def8a91234bc.blob.core.windows.net/sc-7ad51c5d-eb4c-4685-bffe-62b861f7753f/file.fasta\"," +
 				"\"json\":{\"age\":22}," +
 				"\"null\":null,\"number\":47,\"relation\":\"terra-wds:/target-record/record_0\",\"string\":\"Broad Institute\"}}";
 	}
@@ -45,13 +45,13 @@ public class TestUtils {
 				.putAttribute("string", "Broad Institute")
 				.putAttribute("json", Map.of("age", 22))
 				.putAttribute("number", 47)
-				.putAttribute("file", "https://lz1a2b345c67def8a91234bc.blob.core.windows.net/sc-7ad51c5d-eb4c-4685-bffe-62b861f7753f")
+				.putAttribute("file", "https://lz1a2b345c67def8a91234bc.blob.core.windows.net/sc-7ad51c5d-eb4c-4685-bffe-62b861f7753f/file.fasta")
 				.putAttribute("relation", RelationUtils.createRelationString(typeForRelation, "record_0"))
 				.putAttribute("array-of-number", List.of(1, 2, 3))
 				.putAttribute("array_of_date", List.of(LocalDate.of(2021, 11, 3), LocalDate.of(2021, 11, 4)))
 				.putAttribute("array_of_date_time", List.of(dateTime, dateTime))
 				.putAttribute("array_of_string", List.of("a", "b", "c", 12))
-				.putAttribute("array_of_file", List.of("https://lz1a2b345c67def8a91234bc.blob.core.windows.net/sc-7ad51c5d-eb4c-4685-bffe-62b861f7753f", "drs://jade.datarepo-dev.broadinstitute.org/v1_9545e956-aa6a-4b84-a037-d0ed164c1890"))
+				.putAttribute("array_of_file", List.of("https://lz1a2b345c67def8a91234bc.blob.core.windows.net/sc-7ad51c5d-eb4c-4685-bffe-62b861f7753f/file.bam", "drs://jade.datarepo-dev.broadinstitute.org/v1_9545e956-aa6a-4b84-a037-d0ed164c1890"))
 				.putAttribute("array_of_boolean", List.of(true, false, true, "TRUE"))
 				.putAttribute("array_of_relation", List.of(RelationUtils.createRelationString(typeForRelation, "record_0"), RelationUtils.createRelationString(typeForRelation, "record_1")));
 	}
@@ -68,12 +68,12 @@ public class TestUtils {
 				.putAttribute("json", "{\"age\": 22}")
 				.putAttribute("number", "47")
 				.putAttribute("relation", RelationUtils.createRelationString(typeForRelation, "record_0"))
-				.putAttribute("file", "https://lz1a2b345c67def8a91234bc.blob.core.windows.net/sc-7ad51c5d-eb4c-4685-bffe-62b861f7753f")
+				.putAttribute("file", "https://lz1a2b345c67def8a91234bc.blob.core.windows.net/sc-7ad51c5d-eb4c-4685-bffe-62b861f7753f/file.fasta")
 				.putAttribute("array-of-number", "[1, 2, 3]")
 				.putAttribute("array_of_date", "[\"2021-11-03\", \"2021-11-04\"]")
 				.putAttribute("array_of_date_time", "[\"2021-11-03T07:30:00\", \"2021-11-03T07:30:00\"]")
 				.putAttribute("array_of_string", "[\"a\", \"b\", \"c\", 12]")
-				.putAttribute("array_of_file", "[\"https://lz1a2b345c67def8a91234bc.blob.core.windows.net/sc-7ad51c5d-eb4c-4685-bffe-62b861f7753f\", \"drs://jade.datarepo-dev.broadinstitute.org/v1_9545e956-aa6a-4b84-a037-d0ed164c1890\"]")
+				.putAttribute("array_of_file", "[\"https://lz1a2b345c67def8a91234bc.blob.core.windows.net/sc-7ad51c5d-eb4c-4685-bffe-62b861f7753f/file.bam\", \"drs://jade.datarepo-dev.broadinstitute.org/v1_9545e956-aa6a-4b84-a037-d0ed164c1890\"]")
 				.putAttribute("array_of_boolean", "[true, false, true, \"TRUE\"]")
 				.putAttribute("array_of_relation", "[\""+RelationUtils.createRelationString(typeForRelation, "record_0")+"\",\""+RelationUtils.createRelationString(typeForRelation, "record_1")+"\"]");
 	}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/TestUtils.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/TestUtils.java
@@ -23,6 +23,7 @@ public class TestUtils {
 		return "{\"id\":\"newRecordId\",\"type\":\"all-types\",\"attributes\":{\"sys_name\":\"newRecordId\"," +
 				"\"array_of_boolean\":[true,false,true,true],\"array_of_date\":[\"2021-11-03\",\"2021-11-04\"]," +
 				"\"array_of_date_time\":[\"2021-11-03T07:30:00\",\"2021-11-03T07:30:00\"]," +
+				"\"array_of_file\":[\"https://lz1a2b345c67def8a91234bc.blob.core.windows.net/sc-7ad51c5d-eb4c-4685-bffe-62b861f7753f\",\"drs://jade.datarepo-dev.broadinstitute.org/v1_9545e956-aa6a-4b84-a037-d0ed164c1890\"]," +
 				"\"array_of_relation\":[\"terra-wds:/target-record/record_0\",\"terra-wds:/target-record/record_1\"]," +
 				"\"array_of_string\":[\"a\",\"b\",\"c\",\"12\"],\"array-of-number\":[1,2,3],\"boolean\":false,\"date\":\"2021-11-03\"," +
 				"\"date-time\":\"2021-11-03T07:30:00\",\"empty-array\":[]," +
@@ -50,6 +51,7 @@ public class TestUtils {
 				.putAttribute("array_of_date", List.of(LocalDate.of(2021, 11, 3), LocalDate.of(2021, 11, 4)))
 				.putAttribute("array_of_date_time", List.of(dateTime, dateTime))
 				.putAttribute("array_of_string", List.of("a", "b", "c", 12))
+				.putAttribute("array_of_file", List.of("https://lz1a2b345c67def8a91234bc.blob.core.windows.net/sc-7ad51c5d-eb4c-4685-bffe-62b861f7753f", "drs://jade.datarepo-dev.broadinstitute.org/v1_9545e956-aa6a-4b84-a037-d0ed164c1890"))
 				.putAttribute("array_of_boolean", List.of(true, false, true, "TRUE"))
 				.putAttribute("array_of_relation", List.of(RelationUtils.createRelationString(typeForRelation, "record_0"), RelationUtils.createRelationString(typeForRelation, "record_1")));
 	}
@@ -71,6 +73,7 @@ public class TestUtils {
 				.putAttribute("array_of_date", "[\"2021-11-03\", \"2021-11-04\"]")
 				.putAttribute("array_of_date_time", "[\"2021-11-03T07:30:00\", \"2021-11-03T07:30:00\"]")
 				.putAttribute("array_of_string", "[\"a\", \"b\", \"c\", 12]")
+				.putAttribute("array_of_file", "[\"https://lz1a2b345c67def8a91234bc.blob.core.windows.net/sc-7ad51c5d-eb4c-4685-bffe-62b861f7753f\", \"drs://jade.datarepo-dev.broadinstitute.org/v1_9545e956-aa6a-4b84-a037-d0ed164c1890\"]")
 				.putAttribute("array_of_boolean", "[true, false, true, \"TRUE\"]")
 				.putAttribute("array_of_relation", "[\""+RelationUtils.createRelationString(typeForRelation, "record_0")+"\",\""+RelationUtils.createRelationString(typeForRelation, "record_1")+"\"]");
 	}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/TestUtils.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/TestUtils.java
@@ -25,7 +25,9 @@ public class TestUtils {
 				"\"array_of_date_time\":[\"2021-11-03T07:30:00\",\"2021-11-03T07:30:00\"]," +
 				"\"array_of_relation\":[\"terra-wds:/target-record/record_0\",\"terra-wds:/target-record/record_1\"]," +
 				"\"array_of_string\":[\"a\",\"b\",\"c\",\"12\"],\"array-of-number\":[1,2,3],\"boolean\":false,\"date\":\"2021-11-03\"," +
-				"\"date-time\":\"2021-11-03T07:30:00\",\"empty-array\":[],\"json\":{\"age\":22}," +
+				"\"date-time\":\"2021-11-03T07:30:00\",\"empty-array\":[]," +
+				"\"file\":\"https://lz1a2b345c67def8a91234bc.blob.core.windows.net/sc-7ad51c5d-eb4c-4685-bffe-62b861f7753f\"," +
+				"\"json\":{\"age\":22}," +
 				"\"null\":null,\"number\":47,\"relation\":\"terra-wds:/target-record/record_0\",\"string\":\"Broad Institute\"}}";
 	}
 
@@ -42,6 +44,7 @@ public class TestUtils {
 				.putAttribute("string", "Broad Institute")
 				.putAttribute("json", Map.of("age", 22))
 				.putAttribute("number", 47)
+				.putAttribute("file", "https://lz1a2b345c67def8a91234bc.blob.core.windows.net/sc-7ad51c5d-eb4c-4685-bffe-62b861f7753f")
 				.putAttribute("relation", RelationUtils.createRelationString(typeForRelation, "record_0"))
 				.putAttribute("array-of-number", List.of(1, 2, 3))
 				.putAttribute("array_of_date", List.of(LocalDate.of(2021, 11, 3), LocalDate.of(2021, 11, 4)))
@@ -63,6 +66,7 @@ public class TestUtils {
 				.putAttribute("json", "{\"age\": 22}")
 				.putAttribute("number", "47")
 				.putAttribute("relation", RelationUtils.createRelationString(typeForRelation, "record_0"))
+				.putAttribute("file", "https://lz1a2b345c67def8a91234bc.blob.core.windows.net/sc-7ad51c5d-eb4c-4685-bffe-62b861f7753f")
 				.putAttribute("array-of-number", "[1, 2, 3]")
 				.putAttribute("array_of_date", "[\"2021-11-03\", \"2021-11-04\"]")
 				.putAttribute("array_of_date_time", "[\"2021-11-03T07:30:00\", \"2021-11-03T07:30:00\"]")


### PR DESCRIPTION
See [AJ-678](https://broadworkbench.atlassian.net/browse/AJ-678)
Adds a FILE type to record attribute data types.  Only recognizes azure storage container (https://[].blob.core.windows.net/[]) or drs (drs://[]) files.

[AJ-678]: https://broadworkbench.atlassian.net/browse/AJ-678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ