### PR TITLE
AJ-845 and AJ-846: Fix response types for /status and /version in swagger definitions, properly describe types

### DIFF
--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -38,6 +38,10 @@ paths:
       responses:
         200:
           description: Health status retrieved
+          content:
+            application/json:
+              schema:
+                type: string
   /version:
     get:
       summary: Gets related git and build version info for WDS -- generated via Spring Boot Actuator (see https://docs.spring.io/spring-boot/docs/current/actuator-api/htmlsingle/#info for details)
@@ -47,6 +51,10 @@ paths:
       responses:
         200:
           description: Info retrieved
+          content:
+            application/json:
+              schema:
+                type: string
   /{instanceid}/records/{v}/{type}/{id}:
     get:
       summary: Get record

--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -37,7 +37,6 @@ paths:
         - General WDS Information
       responses:
         200:
-          description: Health status retrieved
           $ref: '#/components/responses/StatusResponseBody'
   /version:
     get:
@@ -855,7 +854,7 @@ components:
         name:
           type: string
         time:
-          type: string
+          type: date-time
         version:
           type: string
         group:

--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -38,10 +38,7 @@ paths:
       responses:
         200:
           description: Health status retrieved
-          content:
-            application/json:
-              schema:
-                type: string
+          $ref: '#/components/responses/StatusResponseBody'
   /version:
     get:
       summary: Gets related git and build version info for WDS -- generated via Spring Boot Actuator (see https://docs.spring.io/spring-boot/docs/current/actuator-api/htmlsingle/#info for details)
@@ -50,11 +47,7 @@ paths:
         - General WDS Information
       responses:
         200:
-          description: Info retrieved
-          content:
-            application/json:
-              schema:
-                type: string
+          $ref: '#/components/responses/VersionResponseBody'
   /{instanceid}/records/{v}/{type}/{id}:
     get:
       summary: Get record
@@ -82,7 +75,7 @@ paths:
         Creates or replaces the record using the specified type and id.
         If the record already exists, its entire set of attributes will be overwritten by
         the attributes in the request body.
-        
+
         TODO: add a query parameter to allow/disallow overwriting existing records?
       operationId: createOrReplaceRecord
       tags:
@@ -559,6 +552,18 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/RecordResponse'
+    VersionResponseBody:
+      description: Version Info
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/VersionResponse'
+    StatusResponseBody:
+      description: Status Info
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/StatusResponse'
   requestBodies:
     SearchRequestBody:
       description: A paginated search request
@@ -827,3 +832,70 @@ components:
           type: integer
           description: line number
       description: ""
+    VersionResponse:
+      type: object
+      properties:
+        git:
+          $ref: '#/components/schemas/git'
+        build:
+          $ref: '#/components/schemas/build'
+    StatusResponse:
+      type: object
+      properties:
+        status:
+          type: string
+        components:
+          $ref: '#/components/schemas/components'
+        groups:
+          type: string
+    build:
+      type: object
+      properties:
+        artifact:
+          type: string
+        name:
+          type: string
+        time:
+          type: string
+        version:
+          type: string
+        group:
+          type: string
+    git:
+      type: object
+      properties:
+          branch:
+            type: string
+          commit:
+            $ref: '#/components/schemas/commit'
+    commit:
+      type: object
+      properties:
+        id:
+          type: string
+        time:
+          type: string
+          format: date-time
+    components:
+      type: object
+      properties:
+         db:
+           $ref: '#/components/schemas/dbComponent'
+         diskSpace:
+           $ref: '#/components/schemas/component'
+         ping:
+           $ref: '#/components/schemas/component'
+    component:
+      type: object
+      properties:
+        status:
+          type: string
+        details:
+          type: string
+    dbComponent:
+      type: object
+      properties:
+        status:
+          type: string
+        components:
+          type: string

--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -854,7 +854,8 @@ components:
         name:
           type: string
         time:
-          type: date-time
+          type: string
+          format: date-time
         version:
           type: string
         group:

--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -75,7 +75,6 @@ paths:
         Creates or replaces the record using the specified type and id.
         If the record already exists, its entire set of attributes will be overwritten by
         the attributes in the request body.
-
         TODO: add a query parameter to allow/disallow overwriting existing records?
       operationId: createOrReplaceRecord
       tags:

--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -598,7 +598,7 @@ components:
           description: name of this attribute.
         datatype:
           type: string
-          enum: [boolean, date, datetime, string, json, long, double, relation, array_of_boolean, array_of_string, array_of_number, array_of_date, array_of_datetime]
+          enum: [BOOLEAN, NUMBER, DATE, DATE_TIME, STRING, JSON, RELATION, ARRAY_OF_BOOLEAN, ARRAY_OF_STRING, ARRAY_OF_NUMBER, ARRAY_OF_DATE, ARRAY_OF_DATE_TIME]
           description: |
             Datatype of this attribute. The enum of datatypes is in flux and will change. Please
             comment at https://docs.google.com/document/d/1d352ZoN5kEYWPjy0NqqWGxdf7HEu5VEdrLmiAv7dMmQ/edit#heading=h.naxag0augkgf.


### PR DESCRIPTION
See [AJ-845](https://broadworkbench.atlassian.net/browse/AJ-845) and [AJ-846](https://broadworkbench.atlassian.net/browse/AJ-846). 

Before both calls were returning "None", now they return objects. Generated the client locally and tested to make sure everything worked as expected. 

version: 

![image](https://user-images.githubusercontent.com/9418602/219101543-e8e605b6-7377-4d1e-8da5-8805fefc02d6.png)

status: 

![image](https://user-images.githubusercontent.com/9418602/219101626-b750bee3-cb43-460d-a295-57e06fdc857a.png)

Tested for all datatypes and adjusted the casing and naming appropriately. It will likely make sense to generate tests for these, but that work fits better into defining what automated testing looks like for the client which is captured in [this ticket](https://broadworkbench.atlassian.net/browse/AJ-816). 

[AJ-845]: https://broadworkbench.atlassian.net/browse/AJ-845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[AJ-846]: https://broadworkbench.atlassian.net/browse/AJ-846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ