### PR TITLE
[AJ-719] Update publish-docker.yml

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -36,7 +36,7 @@ jobs:
         id: find-jira-id
         run: |
           set +e
-          JIRA_ID=$(echo '${{ github.event.head_commit.message }}' | grep -iEo -m 1 'AJ-[0-9]+' || '')
+          JIRA_ID=$(echo '${{ github.event.head_commit.message }}' | grep -iEo -m 1 'AJ-[0-9]+' | head -1 || '')
           if [[ -z "$JIRA_ID" ]]; then
             echo ::set-output name=JIRA_ID::"missing"
           else 


### PR DESCRIPTION
https://github.com/DataBiosphere/terra-workspace-data-service/pull/164 attempted to only grab the first jira id in a commit message if there was only one.  For some reason I thought it was working when apparently it was not.  Hopefully this time is correct.
