### PR TITLE
AJ-870 - update python version from 3.7 to 3.8 for swagger client generation

### DIFF
--- a/.github/workflows/release-python-client.yml
+++ b/.github/workflows/release-python-client.yml
@@ -18,10 +18,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Use Node.js ${{matrix.node-version }}
         uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
Ran through tests with generating the wds client using python 3.8 and didnt see any issues with any of the python versions. 

I could not replicate the behavior that I saw with the client not loading in python 3.10, not sure if when I originally saw it earlier it was some sort of fluke or the changes that we made in the swagger definition fixed something. 