### PR TITLE
AJ-679: move @bean producers into separate classes

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/WorkspaceDataServiceApplication.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/WorkspaceDataServiceApplication.java
@@ -1,41 +1,11 @@
 package org.databiosphere.workspacedataservice;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.MapperFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectReader;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.cfg.CoercionAction;
-import com.fasterxml.jackson.databind.cfg.CoercionInputShape;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.fasterxml.jackson.databind.type.LogicalType;
 import com.microsoft.applicationinsights.attach.ApplicationInsights;
-import com.fasterxml.jackson.dataformat.csv.CsvMapper;
-import com.fasterxml.jackson.dataformat.csv.CsvParser;
-import com.fasterxml.jackson.dataformat.csv.CsvSchema;
-import com.zaxxer.hikari.HikariDataSource;
-import org.databiosphere.workspacedataservice.service.DataTypeInferer;
-import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
-import org.databiosphere.workspacedataservice.tsv.TsvDeserializer;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.cache.annotation.EnableCaching;
-import org.springframework.context.annotation.*;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
-import org.springframework.lang.NonNull;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
-import org.springframework.web.servlet.config.annotation.AsyncSupportConfigurer;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-
-import javax.sql.DataSource;
 @SpringBootApplication(scanBasePackages = {
 		// this codebase
 		"org.databiosphere.workspacedataservice",
@@ -46,122 +16,6 @@ import javax.sql.DataSource;
 @EnableTransactionManagement
 @EnableCaching
 public class WorkspaceDataServiceApplication {
-
-	@Bean
-	public ObjectMapper objectMapper() {
-		JsonMapper mapper = JsonMapper.builder().enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
-				.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
-				.configure(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN, true)
-				.configure(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS, true)
-				.configure(DeserializationFeature.USE_BIG_INTEGER_FOR_INTS, true)
-				.findAndAddModules().build();
-		mapper.coercionConfigFor(LogicalType.Boolean).setCoercion(CoercionInputShape.Integer, CoercionAction.Fail);
-		mapper.coercionConfigFor(LogicalType.Float).setCoercion(CoercionInputShape.String, CoercionAction.Fail);
-		mapper.coercionConfigFor(LogicalType.Integer).setCoercion(CoercionInputShape.String, CoercionAction.Fail);
-		return mapper;
-	}
-
-	@Bean
-	public TsvDeserializer tsvDeserializer(DataTypeInferer inferer, ObjectMapper objectMapper) {
-		return new TsvDeserializer(inferer, objectMapper);
-	}
-
-	@Bean
-	public ObjectReader tsvReader(TsvDeserializer tsvDeserializer) {
-		// read schema (column names) from the input file's header
-		CsvSchema tsvHeaderSchema = CsvSchema.emptySchema()
-				.withHeader()
-				.withEscapeChar('\\')
-				.withColumnSeparator('\t');
-
-		final CsvMapper tsvMapper = CsvMapper.builder()
-				.enable(CsvParser.Feature.SKIP_EMPTY_LINES)
-				.enable(CsvParser.Feature.EMPTY_STRING_AS_NULL)
-				.build();
-
-		SimpleModule module = new SimpleModule();
-		module.addDeserializer(RecordAttributes.class, tsvDeserializer);
-		tsvMapper.registerModule(module);
-
-		return tsvMapper
-				.readerFor(RecordAttributes.class)
-				.with(tsvHeaderSchema);
-	}
-
-	@Bean
-	public DataTypeInferer inferer(ObjectMapper mapper){
-		return new DataTypeInferer(mapper);
-	}
-
-	@Bean
-	@Qualifier("streamingDs")
-	@ConfigurationProperties("streaming.query")
-	public DataSource streamingDs() {
-		DataSource ds = DataSourceBuilder.create().build();
-		HikariDataSource hikariDataSource = (HikariDataSource) ds;
-		// https://jdbc.postgresql.org/documentation/query/#getting-results-based-on-a-cursor
-		hikariDataSource.setAutoCommit(false);
-		return hikariDataSource;
-	}
-
-	@Bean
-	@Primary
-	@ConfigurationProperties("spring.datasource")
-	public DataSource mainDb() {
-		return DataSourceBuilder.create().build();
-	}
-
-	@Bean
-	@Primary
-	public NamedParameterJdbcTemplate namedParameterJdbcTemplate() {
-		return new NamedParameterJdbcTemplate(mainDb());
-	}
-
-	@Bean
-	@Qualifier("streamingDs")
-	public NamedParameterJdbcTemplate templateForStreaming(@Qualifier("streamingDs") DataSource ds,
-			@Value("${twds.streaming.fetch.size:5000}") int fetchSize) {
-		NamedParameterJdbcTemplate jdbcTemplate = new NamedParameterJdbcTemplate(ds);
-		// https://jdbc.postgresql.org/documentation/query/#getting-results-based-on-a-cursor
-		jdbcTemplate.getJdbcTemplate().setFetchSize(fetchSize);
-		return jdbcTemplate;
-	}
-
-	/**
-	 * Configure CORS response headers.
-	 *
-	 * When running behind Terra's Azure Relay, the Relay handles CORS response headers, so WDS should not;
-	 * the two CORS configurations will conflict.
-	 *
-	 * When running WDS locally for development - i.e. not behind a Relay - you may need to enable headers.
-	 * To do so, activate the "local" Spring profile by setting spring.profiles.active=local in
-	 * application.properties (or other Spring techniques for activating a profile)
-	 */
-	@Bean
-	@Profile("local")
-	public WebMvcConfigurer corsConfigurer() {
-		return new WebMvcConfigurer() {
-			@Override
-			public void addCorsMappings(@NonNull CorsRegistry registry) {
-				registry.addMapping("/**").allowedMethods("DELETE", "GET", "HEAD", "PATCH", "POST", "PUT")
-						.allowedOrigins("*");
-
-			}
-		};
-	}
-
-	/**
-	 * Configure the app for asynchronous request processing.
-	 */
-	@Bean
-	public WebMvcConfigurer asyncConfigurer() {
-		return new WebMvcConfigurer() {
-			@Override
-			public void configureAsyncSupport(@NonNull AsyncSupportConfigurer configurer) {
-				configurer.setDefaultTimeout(-1);
-			}
-		};
-	}
 
 	public static void main(String[] args) {
 		ApplicationInsights.attach();

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/ControllerConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/ControllerConfig.java
@@ -1,0 +1,48 @@
+package org.databiosphere.workspacedataservice.controller;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.lang.NonNull;
+import org.springframework.web.servlet.config.annotation.AsyncSupportConfigurer;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class ControllerConfig {
+    /**
+     * Configure CORS response headers.
+     * <p>
+     * When running behind Terra's Azure Relay, the Relay handles CORS response headers, so WDS should not;
+     * the two CORS configurations will conflict.
+     * <p>
+     * When running WDS locally for development - i.e. not behind a Relay - you may need to enable headers.
+     * To do so, activate the "local" Spring profile by setting spring.profiles.active=local in
+     * application.properties (or other Spring techniques for activating a profile)
+     */
+    @Bean
+    @Profile("local")
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(@NonNull CorsRegistry registry) {
+                registry.addMapping("/**").allowedMethods("DELETE", "GET", "HEAD", "PATCH", "POST", "PUT")
+                        .allowedOrigins("*");
+
+            }
+        };
+    }
+
+    /**
+     * Configure the app for asynchronous request processing.
+     */
+    @Bean
+    public WebMvcConfigurer asyncConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void configureAsyncSupport(@NonNull AsyncSupportConfigurer configurer) {
+                configurer.setDefaultTimeout(-1);
+            }
+        };
+    }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/ControllerConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/ControllerConfig.java
@@ -20,6 +20,7 @@ public class ControllerConfig {
      * To do so, activate the "local" Spring profile by setting spring.profiles.active=local in
      * application.properties (or other Spring techniques for activating a profile)
      */
+    @SuppressWarnings("squid:S2077") // we explicitly want to allow * for origins
     @Bean
     @Profile("local")
     public WebMvcConfigurer corsConfigurer() {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/ControllerConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/ControllerConfig.java
@@ -20,7 +20,7 @@ public class ControllerConfig {
      * To do so, activate the "local" Spring profile by setting spring.profiles.active=local in
      * application.properties (or other Spring techniques for activating a profile)
      */
-    @SuppressWarnings("squid:S2077") // we explicitly want to allow * for origins
+    @SuppressWarnings("java:S5122") // we explicitly want to allow * for origins
     @Bean
     @Profile("local")
     public WebMvcConfigurer corsConfigurer() {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/DataSourceConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/DataSourceConfig.java
@@ -1,0 +1,52 @@
+package org.databiosphere.workspacedataservice.dao;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+import javax.sql.DataSource;
+
+@Configuration
+public class DataSourceConfig {
+
+    @Bean
+    @Primary
+    @ConfigurationProperties("spring.datasource")
+    public DataSource mainDb() {
+        return DataSourceBuilder.create().build();
+    }
+
+    @Bean
+    @Primary
+    public NamedParameterJdbcTemplate namedParameterJdbcTemplate() {
+        return new NamedParameterJdbcTemplate(mainDb());
+    }
+
+    @Bean
+    @Qualifier("streamingDs")
+    @ConfigurationProperties("streaming.query")
+    public DataSource streamingDs() {
+        DataSource ds = DataSourceBuilder.create().build();
+        HikariDataSource hikariDataSource = (HikariDataSource) ds;
+        // https://jdbc.postgresql.org/documentation/query/#getting-results-based-on-a-cursor
+        hikariDataSource.setAutoCommit(false);
+        return hikariDataSource;
+    }
+
+    @Bean
+    @Qualifier("streamingDs")
+    public NamedParameterJdbcTemplate templateForStreaming(@Qualifier("streamingDs") DataSource ds,
+                                                           @Value("${twds.streaming.fetch.size:5000}") int fetchSize) {
+        NamedParameterJdbcTemplate jdbcTemplate = new NamedParameterJdbcTemplate(ds);
+        // https://jdbc.postgresql.org/documentation/query/#getting-results-based-on-a-cursor
+        jdbcTemplate.getJdbcTemplate().setFetchSize(fetchSize);
+        return jdbcTemplate;
+    }
+
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/DataTypeInfererConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/DataTypeInfererConfig.java
@@ -1,0 +1,13 @@
+package org.databiosphere.workspacedataservice.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class DataTypeInfererConfig {
+    @Bean
+    public DataTypeInferer inferer(ObjectMapper mapper){
+        return new DataTypeInferer(mapper);
+    }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/JsonConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/JsonConfig.java
@@ -1,0 +1,30 @@
+package org.databiosphere.workspacedataservice.service;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.cfg.CoercionAction;
+import com.fasterxml.jackson.databind.cfg.CoercionInputShape;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.type.LogicalType;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JsonConfig {
+    @Bean
+    public ObjectMapper objectMapper() {
+        JsonMapper mapper = JsonMapper.builder().enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
+                .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+                .configure(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN, true)
+                .configure(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS, true)
+                .configure(DeserializationFeature.USE_BIG_INTEGER_FOR_INTS, true)
+                .findAndAddModules().build();
+        mapper.coercionConfigFor(LogicalType.Boolean).setCoercion(CoercionInputShape.Integer, CoercionAction.Fail);
+        mapper.coercionConfigFor(LogicalType.Float).setCoercion(CoercionInputShape.String, CoercionAction.Fail);
+        mapper.coercionConfigFor(LogicalType.Integer).setCoercion(CoercionInputShape.String, CoercionAction.Fail);
+        return mapper;
+    }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/tsv/TsvConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/tsv/TsvConfig.java
@@ -1,0 +1,43 @@
+package org.databiosphere.workspacedataservice.tsv;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.dataformat.csv.CsvMapper;
+import com.fasterxml.jackson.dataformat.csv.CsvParser;
+import com.fasterxml.jackson.dataformat.csv.CsvSchema;
+import org.databiosphere.workspacedataservice.service.DataTypeInferer;
+import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TsvConfig {
+    @Bean
+    public TsvDeserializer tsvDeserializer(DataTypeInferer inferer, ObjectMapper objectMapper) {
+        return new TsvDeserializer(inferer, objectMapper);
+    }
+
+    @Bean
+    public ObjectReader tsvReader(TsvDeserializer tsvDeserializer) {
+        // read schema (column names) from the input file's header
+        CsvSchema tsvHeaderSchema = CsvSchema.emptySchema()
+                .withHeader()
+                .withEscapeChar('\\')
+                .withColumnSeparator('\t');
+
+        final CsvMapper tsvMapper = CsvMapper.builder()
+                .enable(CsvParser.Feature.SKIP_EMPTY_LINES)
+                .enable(CsvParser.Feature.EMPTY_STRING_AS_NULL)
+                .build();
+
+        SimpleModule module = new SimpleModule();
+        module.addDeserializer(RecordAttributes.class, tsvDeserializer);
+        tsvMapper.registerModule(module);
+
+        return tsvMapper
+                .readerFor(RecordAttributes.class)
+                .with(tsvHeaderSchema);
+    }
+
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/DataTypeInfererTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/DataTypeInfererTest.java
@@ -8,6 +8,8 @@ import java.math.BigInteger;
 import java.util.*;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.databiosphere.workspacedataservice.service.DataTypeInferer;
+import org.databiosphere.workspacedataservice.service.DataTypeInfererConfig;
+import org.databiosphere.workspacedataservice.service.JsonConfig;
 import org.databiosphere.workspacedataservice.service.RelationUtils;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
 import org.databiosphere.workspacedataservice.shared.model.Record;
@@ -17,7 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+ @SpringBootTest(classes = {JsonConfig.class, DataTypeInfererConfig.class})
 class DataTypeInfererTest {
 
 	@Autowired

--- a/service/src/test/java/org/databiosphere/workspacedataservice/SentryInitializerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/SentryInitializerTest.java
@@ -1,15 +1,13 @@
 package org.databiosphere.workspacedataservice;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-@SpringBootTest
+
 class SentryInitializerTest {
 
     private static Stream<Arguments> provideSamUrls() {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/SqlUtilsTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/SqlUtilsTest.java
@@ -3,15 +3,12 @@ package org.databiosphere.workspacedataservice.dao;
 import org.databiosphere.workspacedataservice.service.model.exception.InvalidNameException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class SqlUtilsTest {
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/sam/HttpSamClientSupportTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/sam/HttpSamClientSupportTest.java
@@ -16,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 /**
  * Tests for @see HttpSamClientSupport
  */
-@SpringBootTest
+@SpringBootTest(classes = SamConfig.class)
 class HttpSamClientSupportTest extends HttpSamClientSupport {
 
     @DisplayName("When Sam throws an ApiException with standard http status code 401, HttpSamClientSupport should throw AuthenticationException")

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
@@ -1,5 +1,6 @@
 package org.databiosphere.workspacedataservice.service;
 
+import org.databiosphere.workspacedataservice.dao.DataSourceConfig;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.databiosphere.workspacedataservice.service.model.RecordTypeSchema;
 import org.databiosphere.workspacedataservice.service.model.exception.MissingObjectException;
@@ -26,7 +27,7 @@ import static org.databiosphere.workspacedataservice.service.RecordUtils.VERSION
 import static org.databiosphere.workspacedataservice.service.RecordUtils.validateVersion;
 import static org.junit.jupiter.api.Assertions.*;
 
-@SpringBootTest
+@SpringBootTest(classes = DataSourceConfig.class)
 class RecordOrchestratorServiceTest {
 
     @Autowired private RecordDao recordDao;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
@@ -27,7 +27,7 @@ import static org.databiosphere.workspacedataservice.service.RecordUtils.VERSION
 import static org.databiosphere.workspacedataservice.service.RecordUtils.validateVersion;
 import static org.junit.jupiter.api.Assertions.*;
 
-@SpringBootTest(classes = DataSourceConfig.class)
+@SpringBootTest
 class RecordOrchestratorServiceTest {
 
     @Autowired private RecordDao recordDao;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
@@ -1,6 +1,5 @@
 package org.databiosphere.workspacedataservice.service;
 
-import org.databiosphere.workspacedataservice.dao.DataSourceConfig;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.databiosphere.workspacedataservice.service.model.RecordTypeSchema;
 import org.databiosphere.workspacedataservice.service.model.exception.MissingObjectException;
@@ -25,7 +24,8 @@ import java.util.UUID;
 
 import static org.databiosphere.workspacedataservice.service.RecordUtils.VERSION;
 import static org.databiosphere.workspacedataservice.service.RecordUtils.validateVersion;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
 class RecordOrchestratorServiceTest {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/StreamingTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/StreamingTest.java
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.databiosphere.workspacedataservice.shared.model.OperationType.DELETE;
 import static org.databiosphere.workspacedataservice.shared.model.OperationType.UPSERT;
 
-@SpringBootTest
+@SpringBootTest(classes = JsonConfig.class)
 class StreamingTest {
 
 	@Autowired

--- a/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordRequestTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordRequestTest.java
@@ -2,6 +2,7 @@ package org.databiosphere.workspacedataservice.shared.model;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.databiosphere.workspacedataservice.service.JsonConfig;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,7 +13,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@SpringBootTest
+@SpringBootTest(classes = JsonConfig.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class RecordRequestTest {
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordResponseTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordResponseTest.java
@@ -5,13 +5,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Map;
+
+import org.databiosphere.workspacedataservice.service.JsonConfig;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.util.StringUtils;
 
-@SpringBootTest
+@SpringBootTest(classes = JsonConfig.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class RecordResponseTest {
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordTest.java
@@ -2,6 +2,7 @@ package org.databiosphere.workspacedataservice.shared.model;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.databiosphere.workspacedataservice.service.JsonConfig;
 import org.databiosphere.workspacedataservice.service.model.exception.InvalidNameException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -16,7 +17,7 @@ import java.util.Map;
 import static org.databiosphere.workspacedataservice.service.model.ReservedNames.RESERVED_NAME_PREFIX;
 import static org.junit.jupiter.api.Assertions.*;
 
-@SpringBootTest
+@SpringBootTest(classes = JsonConfig.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class RecordTest {
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvDeserializerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvDeserializerTest.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.BigIntegerNode;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.TextNode;
+import org.databiosphere.workspacedataservice.service.DataTypeInfererConfig;
+import org.databiosphere.workspacedataservice.service.JsonConfig;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
@@ -22,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @see TsvJsonArgumentsProvider
  */
-@SpringBootTest
+@SpringBootTest(classes = {DataTypeInfererConfig.class, JsonConfig.class, TsvConfig.class})
 class TsvDeserializerTest {
 
     @Autowired

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvJsonEquivalenceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvJsonEquivalenceTest.java
@@ -3,6 +3,8 @@ package org.databiosphere.workspacedataservice.tsv;
 import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
+import org.databiosphere.workspacedataservice.service.DataTypeInfererConfig;
+import org.databiosphere.workspacedataservice.service.JsonConfig;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
 import org.databiosphere.workspacedataservice.shared.model.RecordRequest;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -25,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @see TsvJsonArgumentsProvider
  */
-@SpringBootTest
+@SpringBootTest(classes = {DataTypeInfererConfig.class, JsonConfig.class, TsvConfig.class})
 class TsvJsonEquivalenceTest {
 
     @Autowired


### PR DESCRIPTION
Using `@SpringBootTest` without any qualifiers in our unit tests meant that each unit test instantiated the full set of available `@Bean`s, including the two Hikari datasource connection pools.

Given the number of unit tests we have, this eventually consumed the max connections (default 100) allowed by Postgres, and tests would intermittently fail with `Failed to obtain JDBC Connection`. In #184 this error was very easy to make happen, though it happened inconsistently on different unit tests. Additionally, raising the `max_connections` flag on Postgres makes the error stop, but that's a band-aid solution.

In this PR:
* separate the `@Bean`-producing methods into a few different `*Config` classes : `DataSourceConfig`, `DataTypeInfererConfig`, etc. Previously these all lived in `WorkspaceDataServiceApplication`. No changes to this code; just moving it.
* Update the `@SpringBootTest` annotation on some unit tests to specify only the config classes they need. Most importantly, remove `DataSourceConfig` from some of these unit tests so they don't instantiate a Hikari thread pool.
* Remove `@SpringBootTest` entirely from a few tests.

Discovered as part of AJ-679 and blocks that ticket; does not resolve that ticket.

