### PR TITLE
AJ-679: extract InstanceDao from RecordDao

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/InstanceDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/InstanceDao.java
@@ -1,0 +1,14 @@
+package org.databiosphere.workspacedataservice.dao;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface InstanceDao {
+    boolean instanceSchemaExists(UUID instanceId);
+
+    List<UUID> listInstanceSchemas();
+
+    void createSchema(UUID instanceId);
+
+    void dropSchema(UUID instanceId);
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresInstanceDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresInstanceDao.java
@@ -1,0 +1,92 @@
+package org.databiosphere.workspacedataservice.dao;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+import static org.databiosphere.workspacedataservice.dao.SqlUtils.quote;
+
+@Repository
+public class PostgresInstanceDao implements InstanceDao {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PostgresInstanceDao.class);
+
+    @Value("${spring.datasource.username}")
+    private String wdsDbUser;
+
+    private final NamedParameterJdbcTemplate namedTemplate;
+
+    public PostgresInstanceDao(NamedParameterJdbcTemplate namedTemplate, @Value("${twds.instance.workspace-id}") String workspaceId) {
+        this.namedTemplate = namedTemplate;
+        createDefaultInstanceSchema(workspaceId);
+    }
+
+    @Override
+    public boolean instanceSchemaExists(UUID instanceId) {
+        return Boolean.TRUE.equals(namedTemplate.queryForObject(
+                "select exists(select from information_schema.schemata WHERE schema_name = :workspaceSchema)",
+                new MapSqlParameterSource("workspaceSchema", instanceId.toString()), Boolean.class));
+    }
+
+    @Override
+    public List<UUID> listInstanceSchemas() {
+        List<String> schemas = namedTemplate.getJdbcTemplate()
+                .queryForList("select schema_name from information_schema.schemata " +
+                                "where schema_owner = ? order by schema_name",
+                        String.class, wdsDbUser);
+        // WDS only allows creation of schemas that are UUIDs
+        return schemas.stream().map(s -> safeParseUUID(s))
+                .filter(Objects::nonNull).toList();
+    }
+
+    @Override
+    public void createSchema(UUID instanceId) {
+        namedTemplate.getJdbcTemplate().update("create schema " + quote(instanceId.toString()));
+    }
+
+
+    @Override
+    @SuppressWarnings("squid:S2077") // since instanceId must be a UUID, it is safe to use inline
+    public void dropSchema(UUID instanceId) {
+        namedTemplate.getJdbcTemplate().update("drop schema " + quote(instanceId.toString()) + " cascade");
+    }
+
+
+    private void createDefaultInstanceSchema(String workspaceId) {
+        LOGGER.info("Default workspace id loaded as {}", workspaceId);
+
+        // TODO: AJ-897 execute this as the WDS managed identity so it can call Sam
+        // TODO: AJ-897 move to a dedicated StartupBean
+
+        try {
+            UUID instanceId = UUID.fromString(workspaceId);
+            if (!instanceSchemaExists(instanceId)) {
+                createSchema(instanceId);
+                LOGGER.info("Creating default schema id succeeded for workspaceId {}", workspaceId);
+            }
+        } catch (IllegalArgumentException e) {
+            LOGGER.warn("Workspace id could not be parsed, a default schema won't be created. Provided id: {}", workspaceId);
+        } catch (DataAccessException e) {
+            LOGGER.error("Failed to create default schema id for workspaceId {}", workspaceId);
+        }
+    }
+
+    private UUID safeParseUUID(String input) {
+        try {
+            return UUID.fromString(input);
+        } catch (IllegalArgumentException iae) {
+            LOGGER.warn("Found unexpected schema name while listing schemas: [{}]", input);
+            return null;
+        }
+    }
+
+
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresInstanceDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresInstanceDao.java
@@ -48,6 +48,7 @@ public class PostgresInstanceDao implements InstanceDao {
     }
 
     @Override
+    @SuppressWarnings("squid:S2077") // since instanceId must be a UUID, it is safe to use inline
     public void createSchema(UUID instanceId) {
         namedTemplate.getJdbcTemplate().update("create schema " + quote(instanceId.toString()));
     }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/SqlUtils.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/SqlUtils.java
@@ -26,4 +26,8 @@ public class SqlUtils {
 		return name;
 	}
 
+	public static String quote(String toQuote) {
+		return "\"" + toQuote + "\"";
+	}
+
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/InstanceService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/InstanceService.java
@@ -1,6 +1,7 @@
 package org.databiosphere.workspacedataservice.service;
 
 import bio.terra.common.db.WriteTransaction;
+import org.databiosphere.workspacedataservice.dao.InstanceDao;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.databiosphere.workspacedataservice.sam.SamDao;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthorizationException;
@@ -20,19 +21,19 @@ import static org.databiosphere.workspacedataservice.service.RecordUtils.validat
 @Service
 public class InstanceService {
 
-    private final RecordDao recordDao;
+    private final InstanceDao instanceDao;
     private final SamDao samDao;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(InstanceService.class);
 
-    public InstanceService(RecordDao recordDao, SamDao samDao) {
-        this.recordDao = recordDao;
+    public InstanceService(InstanceDao instanceDao, SamDao samDao) {
+        this.instanceDao = instanceDao;
         this.samDao = samDao;
     }
 
     public List<UUID> listInstances(String version) {
         validateVersion(version);
-        return recordDao.listInstanceSchemas();
+        return instanceDao.listInstanceSchemas();
     }
 
     /**
@@ -60,7 +61,7 @@ public class InstanceService {
             throw new AuthorizationException("Caller does not have permission to create instance.");
         }
 
-        if (recordDao.instanceSchemaExists(instanceId)) {
+        if (instanceDao.instanceSchemaExists(instanceId)) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "This instance already exists");
         }
 
@@ -72,7 +73,7 @@ public class InstanceService {
 
     @WriteTransaction
     void createInstanceInDatabase(UUID instanceId) {
-        recordDao.createSchema(instanceId);
+        instanceDao.createSchema(instanceId);
     }
 
     public void deleteInstance(UUID instanceId, String version) {
@@ -95,11 +96,11 @@ public class InstanceService {
 
     @WriteTransaction
     void deleteInstanceFromDatabase(UUID instanceId) {
-        recordDao.dropSchema(instanceId);
+        instanceDao.dropSchema(instanceId);
     }
 
     public void validateInstance(UUID instanceId) {
-        if (!recordDao.instanceSchemaExists(instanceId)) {
+        if (!instanceDao.instanceSchemaExists(instanceId)) {
             throw new MissingObjectException("Instance");
         }
     }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/MockInstanceDao.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/MockInstanceDao.java
@@ -1,0 +1,55 @@
+package org.databiosphere.workspacedataservice.dao;
+
+import org.postgresql.util.ServerErrorMessage;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Mock implementation of InstanceDao that is in-memory instead of requiring Postgres
+ */
+public class MockInstanceDao implements InstanceDao {
+
+    // backing "database" for this mock
+    private Set<UUID> instances = ConcurrentHashMap.newKeySet();
+
+    public MockInstanceDao() {
+        super();
+    }
+
+
+    @Override
+    public boolean instanceSchemaExists(UUID instanceId) {
+        return instances.contains(instanceId);
+    }
+
+    @Override
+    public List<UUID> listInstanceSchemas() {
+        return instances.stream().toList();
+    }
+
+    @Override
+    public void createSchema(UUID instanceId) {
+        if (instances.contains(instanceId)) {
+            ServerErrorMessage sqlMsg = new ServerErrorMessage("ERROR: schema \"" + instanceId.toString() + "\" already exists");
+            SQLException ex = new org.postgresql.util.PSQLException(sqlMsg);
+            String sql = "create schema \"" + instanceId + "\"";
+            throw new org.springframework.jdbc.BadSqlGrammarException("StatementCallback", sql, ex);
+        }
+        instances.add(instanceId);
+    }
+
+    @Override
+    public void dropSchema(UUID instanceId) {
+        if (!instances.contains(instanceId)) {
+            ServerErrorMessage sqlMsg = new ServerErrorMessage("ERROR: schema \"" + instanceId.toString() + "\" does not exist");
+            SQLException ex = new org.postgresql.util.PSQLException(sqlMsg);
+            String sql = "drop schema \"" + instanceId + "\" cascade";
+            throw new org.springframework.jdbc.BadSqlGrammarException("StatementCallback", sql, ex);
+        }
+        instances.remove(instanceId);
+    }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/MockInstanceDaoConfig.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/MockInstanceDaoConfig.java
@@ -1,0 +1,17 @@
+package org.databiosphere.workspacedataservice.dao;
+
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+public class MockInstanceDaoConfig {
+    @Bean
+    @Profile("mock-instance-dao")
+    @Primary
+    InstanceDao mockInstanceDao() {
+        return new MockInstanceDao();
+    }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/PostgresInstanceDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/PostgresInstanceDaoTest.java
@@ -1,0 +1,21 @@
+package org.databiosphere.workspacedataservice.dao;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+@SpringBootTest(classes = DataSourceConfig.class)
+public class PostgresInstanceDaoTest {
+
+    @Autowired
+    NamedParameterJdbcTemplate namedTemplate;
+
+    @Test
+    void workspaceIDNotProvidedNoExceptionThrown() {
+        assertDoesNotThrow(() -> new PostgresInstanceDao(namedTemplate, "UNDEFINED"));
+    }
+
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceNoPermissionSamTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceNoPermissionSamTest.java
@@ -2,7 +2,7 @@ package org.databiosphere.workspacedataservice.service;
 
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
 import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
-import org.databiosphere.workspacedataservice.dao.RecordDao;
+import org.databiosphere.workspacedataservice.dao.InstanceDao;
 import org.databiosphere.workspacedataservice.sam.SamClientFactory;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthorizationException;
 import org.junit.jupiter.api.Test;
@@ -29,7 +29,7 @@ class InstanceServiceNoPermissionSamTest {
     private InstanceService instanceService;
 
     @Autowired
-    private RecordDao recordDao;
+    private InstanceDao instanceDao;
 
     // mock for the SamClientFactory; since this is a Spring bean we can use @MockBean
     @MockBean
@@ -74,7 +74,7 @@ class InstanceServiceNoPermissionSamTest {
 
         UUID instanceId = UUID.randomUUID();
         // create the instance (directly in the db, bypassing Sam)
-        recordDao.createSchema(instanceId);
+        instanceDao.createSchema(instanceId);
 
         assertThrows(AuthorizationException.class,
                 () -> instanceService.deleteInstance(instanceId, VERSION),

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceNoPermissionSamTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceNoPermissionSamTest.java
@@ -3,14 +3,19 @@ package org.databiosphere.workspacedataservice.service;
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
 import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
 import org.databiosphere.workspacedataservice.dao.InstanceDao;
+import org.databiosphere.workspacedataservice.dao.MockInstanceDaoConfig;
 import org.databiosphere.workspacedataservice.sam.SamClientFactory;
+import org.databiosphere.workspacedataservice.sam.SamConfig;
+import org.databiosphere.workspacedataservice.sam.SamDao;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthorizationException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 import java.util.Optional;
@@ -21,15 +26,15 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 
-@SpringBootTest
+@ActiveProfiles(profiles = "mock-instance-dao")
+@SpringBootTest(classes = { MockInstanceDaoConfig.class, SamConfig.class })
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class InstanceServiceNoPermissionSamTest {
 
-    @Autowired
     private InstanceService instanceService;
 
-    @Autowired
-    private InstanceDao instanceDao;
+    @Autowired private InstanceDao instanceDao;
+    @Autowired private SamDao samDao;
 
     // mock for the SamClientFactory; since this is a Spring bean we can use @MockBean
     @MockBean
@@ -37,6 +42,11 @@ class InstanceServiceNoPermissionSamTest {
 
     // mock for the ResourcesApi class inside the Sam client; since this is not a Spring bean we have to mock it manually
     ResourcesApi mockResourcesApi = Mockito.mock(ResourcesApi.class);
+
+    @BeforeEach
+    void beforeEach() {
+        instanceService = new InstanceService(instanceDao, samDao);
+    }
 
     @Test
     void testCreateInstanceNoPermission() throws ApiException {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamExceptionTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamExceptionTest.java
@@ -3,7 +3,7 @@ package org.databiosphere.workspacedataservice.service;
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
 import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
 import org.broadinstitute.dsde.workbench.client.sam.model.CreateResourceRequestV2;
-import org.databiosphere.workspacedataservice.dao.RecordDao;
+import org.databiosphere.workspacedataservice.dao.InstanceDao;
 import org.databiosphere.workspacedataservice.sam.SamClientFactory;
 import org.databiosphere.workspacedataservice.sam.SamDao;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthenticationException;
@@ -55,7 +55,7 @@ class InstanceServiceSamExceptionTest {
     private InstanceService instanceService;
 
     @Autowired
-    private RecordDao recordDao;
+    private InstanceDao instanceDao;
 
     // mock for the SamClientFactory; since this is a Spring bean we can use @MockBean
     @MockBean
@@ -74,9 +74,9 @@ class InstanceServiceSamExceptionTest {
     @AfterEach
     void afterEach() {
         // clean up any instances left in the db
-        List<UUID> allInstances = recordDao.listInstanceSchemas();
+        List<UUID> allInstances = instanceDao.listInstanceSchemas();
         allInstances.forEach(instanceId ->
-                recordDao.dropSchema(instanceId));
+                instanceDao.dropSchema(instanceId));
     }
 
     @DisplayName("if Sam throws ApiException(401) on resourcePermissionV2, createInstance and deleteInstance should throw AuthenticationException")
@@ -335,7 +335,7 @@ class InstanceServiceSamExceptionTest {
 
     private void doAuthnDeleteTest(UUID instanceId, Class<? extends Exception> expectedExceptionClass) {
         // create the instance (directly in the db, bypassing Sam)
-        recordDao.createSchema(instanceId);
+        instanceDao.createSchema(instanceId);
         List<UUID> allInstances = instanceService.listInstances(VERSION);
         assertTrue(allInstances.contains(instanceId), "unit test should have created the instances.");
 
@@ -368,7 +368,7 @@ class InstanceServiceSamExceptionTest {
 
     private void doSamDeleteTest(UUID instanceId, int expectedSamExceptionCode) {
         // bypass Sam and create the instance directly in the db
-        recordDao.createSchema(instanceId);
+        instanceDao.createSchema(instanceId);
         List<UUID> allInstances = instanceService.listInstances(VERSION);
         assertTrue(allInstances.contains(instanceId), "unit test should have created the instances.");
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamExceptionTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamExceptionTest.java
@@ -4,7 +4,10 @@ import org.broadinstitute.dsde.workbench.client.sam.ApiException;
 import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
 import org.broadinstitute.dsde.workbench.client.sam.model.CreateResourceRequestV2;
 import org.databiosphere.workspacedataservice.dao.InstanceDao;
+import org.databiosphere.workspacedataservice.dao.MockInstanceDaoConfig;
+import org.databiosphere.workspacedataservice.sam.HttpSamDao;
 import org.databiosphere.workspacedataservice.sam.SamClientFactory;
+import org.databiosphere.workspacedataservice.sam.SamConfig;
 import org.databiosphere.workspacedataservice.sam.SamDao;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthenticationException;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthorizationException;
@@ -20,6 +23,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -47,15 +51,15 @@ import static org.mockito.BDDMockito.willThrow;
  *      - if Sam returns some other exception such as NullPointerException, they should throw a SamException
  *          with a 500 error code.
  */
-@SpringBootTest
+@ActiveProfiles(profiles = "mock-instance-dao")
+@SpringBootTest(classes = { MockInstanceDaoConfig.class, SamConfig.class })
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class InstanceServiceSamExceptionTest {
 
-    @Autowired
     private InstanceService instanceService;
 
-    @Autowired
-    private InstanceDao instanceDao;
+    @Autowired private InstanceDao instanceDao;
+    @Autowired private SamDao samDao;
 
     // mock for the SamClientFactory; since this is a Spring bean we can use @MockBean
     @MockBean
@@ -66,6 +70,8 @@ class InstanceServiceSamExceptionTest {
 
     @BeforeEach
     void beforeEach() {
+        instanceService = new InstanceService(instanceDao, samDao);
+
         // return the mock ResourcesApi from the mock SamClientFactory
         given(mockSamClientFactory.getResourcesApi())
                 .willReturn(mockResourcesApi);

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamTest.java
@@ -3,7 +3,7 @@ package org.databiosphere.workspacedataservice.service;
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
 import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
 import org.broadinstitute.dsde.workbench.client.sam.model.CreateResourceRequestV2;
-import org.databiosphere.workspacedataservice.dao.RecordDao;
+import org.databiosphere.workspacedataservice.dao.InstanceDao;
 import org.databiosphere.workspacedataservice.sam.SamClientFactory;
 import org.databiosphere.workspacedataservice.sam.SamDao;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,12 +16,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
-
 import java.util.Optional;
 import java.util.UUID;
 
 import static org.databiosphere.workspacedataservice.service.RecordUtils.VERSION;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
@@ -34,7 +33,7 @@ class InstanceServiceSamTest {
     private InstanceService instanceService;
 
     @Autowired
-    private RecordDao recordDao;
+    private InstanceDao instanceDao;
 
     // mock for the SamClientFactory; since this is a Spring bean we can use @MockBean
     @MockBean
@@ -113,7 +112,7 @@ class InstanceServiceSamTest {
         InOrder callOrder = inOrder(mockResourcesApi);
 
         // bypass Sam and create the instance directly in the db
-        recordDao.createSchema(instanceId);
+        instanceDao.createSchema(instanceId);
 
         // call deleteInstance
         instanceService.deleteInstance(instanceId, VERSION);

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamTest.java
@@ -4,7 +4,11 @@ import org.broadinstitute.dsde.workbench.client.sam.ApiException;
 import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
 import org.broadinstitute.dsde.workbench.client.sam.model.CreateResourceRequestV2;
 import org.databiosphere.workspacedataservice.dao.InstanceDao;
+import org.databiosphere.workspacedataservice.dao.MockInstanceDaoConfig;
+import org.databiosphere.workspacedataservice.sam.HttpSamDao;
+import org.databiosphere.workspacedataservice.sam.MockSamClientFactoryConfig;
 import org.databiosphere.workspacedataservice.sam.SamClientFactory;
+import org.databiosphere.workspacedataservice.sam.SamConfig;
 import org.databiosphere.workspacedataservice.sam.SamDao;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -15,6 +19,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -25,15 +30,15 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
-@SpringBootTest
+@ActiveProfiles(profiles = "mock-instance-dao")
+@SpringBootTest(classes = { MockInstanceDaoConfig.class, SamConfig.class })
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class InstanceServiceSamTest {
 
-    @Autowired
     private InstanceService instanceService;
 
-    @Autowired
-    private InstanceDao instanceDao;
+    @Autowired private InstanceDao instanceDao;
+    @Autowired private SamDao samDao;
 
     // mock for the SamClientFactory; since this is a Spring bean we can use @MockBean
     @MockBean
@@ -44,6 +49,8 @@ class InstanceServiceSamTest {
 
     @BeforeEach
     void beforeEach() throws ApiException {
+        instanceService = new InstanceService(instanceDao, samDao);
+
         // return the mock ResourcesApi from the mock SamClientFactory
         given(mockSamClientFactory.getResourcesApi())
                 .willReturn(mockResourcesApi);

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceTest.java
@@ -1,6 +1,10 @@
 package org.databiosphere.workspacedataservice.service;
 
 import org.databiosphere.workspacedataservice.dao.InstanceDao;
+import org.databiosphere.workspacedataservice.dao.MockInstanceDaoConfig;
+import org.databiosphere.workspacedataservice.sam.MockSamClientFactoryConfig;
+import org.databiosphere.workspacedataservice.sam.SamConfig;
+import org.databiosphere.workspacedataservice.sam.SamDao;
 import org.databiosphere.workspacedataservice.service.model.exception.MissingObjectException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,18 +20,20 @@ import static org.databiosphere.workspacedataservice.service.RecordUtils.VERSION
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@ActiveProfiles(profiles = "mock-sam")
-@SpringBootTest
+@ActiveProfiles(profiles = { "mock-sam", "mock-instance-dao" })
+@SpringBootTest(classes = { MockInstanceDaoConfig.class, SamConfig.class, MockSamClientFactoryConfig.class })
 class InstanceServiceTest {
 
-    @Autowired private InstanceService instanceService;
+    private InstanceService instanceService;
     @Autowired private InstanceDao instanceDao;
+    @Autowired private SamDao samDao;
 
 
     private static final UUID INSTANCE = UUID.fromString("111e9999-e89b-12d3-a456-426614174000");
 
     @BeforeEach
     void setUp() {
+        instanceService = new InstanceService(instanceDao, samDao);
         // Delete all instances
         instanceDao.listInstanceSchemas().forEach(instance -> {
             instanceDao.dropSchema(instance);

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceTest.java
@@ -1,6 +1,6 @@
 package org.databiosphere.workspacedataservice.service;
 
-import org.databiosphere.workspacedataservice.dao.RecordDao;
+import org.databiosphere.workspacedataservice.dao.InstanceDao;
 import org.databiosphere.workspacedataservice.service.model.exception.MissingObjectException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -13,14 +13,15 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.databiosphere.workspacedataservice.service.RecordUtils.VERSION;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ActiveProfiles(profiles = "mock-sam")
 @SpringBootTest
 class InstanceServiceTest {
 
     @Autowired private InstanceService instanceService;
-    @Autowired private RecordDao recordDao;
+    @Autowired private InstanceDao instanceDao;
 
 
     private static final UUID INSTANCE = UUID.fromString("111e9999-e89b-12d3-a456-426614174000");
@@ -28,8 +29,8 @@ class InstanceServiceTest {
     @BeforeEach
     void setUp() {
         // Delete all instances
-        recordDao.listInstanceSchemas().forEach(instance -> {
-            recordDao.dropSchema(instance);
+        instanceDao.listInstanceSchemas().forEach(instance -> {
+            instanceDao.dropSchema(instance);
         });
     }
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
@@ -1,5 +1,6 @@
 package org.databiosphere.workspacedataservice.service;
 
+import org.databiosphere.workspacedataservice.dao.InstanceDao;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.databiosphere.workspacedataservice.service.model.RecordTypeSchema;
 import org.databiosphere.workspacedataservice.service.model.exception.MissingObjectException;
@@ -31,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class RecordOrchestratorServiceTest {
 
     @Autowired private RecordDao recordDao;
+    @Autowired private InstanceDao instanceDao;
     @Autowired private RecordOrchestratorService recordOrchestratorService;
 
     private static final UUID INSTANCE = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
@@ -42,14 +44,14 @@ class RecordOrchestratorServiceTest {
 
     @BeforeEach
     void setUp() {
-        if (!recordDao.instanceSchemaExists(INSTANCE)) {
-            recordDao.createSchema(INSTANCE);
+        if (!instanceDao.instanceSchemaExists(INSTANCE)) {
+            instanceDao.createSchema(INSTANCE);
         }
     }
 
     @AfterEach
     void cleanUp() {
-        recordDao.dropSchema(INSTANCE);
+        instanceDao.dropSchema(INSTANCE);
     }
 
     @Test


### PR DESCRIPTION
In this PR:
* Extract the instance-related methods out of `RecordDao` and into `PostgresInstanceDao`, which implements the interface `InstanceDao`
* create a `MockInstanceDao` for testing
* use the `MockInstanceDao` in all four of the `InstanceService*` tests, which prevents them from creating a Hikari connection pool at all

Discovered as part of AJ-679 and blocks that ticket; does not resolve that ticket.