### PR TITLE
AJ-899: retries for Sam

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamClientSupport.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamClientSupport.java
@@ -49,7 +49,8 @@ public class HttpSamClientSupport {
     @Retryable(include = {SamRetryableException.class},
             maxAttemptsExpression = "${sam.retry.maxAttempts}",
             backoff = @Backoff(delayExpression = "${sam.retry.backoff.delay}",
-                    multiplierExpression = "${sam.retry.backoff.multiplier}"))
+                    multiplierExpression = "${sam.retry.backoff.multiplier}"),
+            listeners = {"retryLoggingListener"})
     public <T> T withRetryAndErrorHandling(SamFunction<T> samFunction, String loggerHint) throws SamException, AuthenticationException, AuthorizationException {
         try {
             LOGGER.debug("Sending {} request to Sam ...", loggerHint);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamClientSupport.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamClientSupport.java
@@ -47,8 +47,9 @@ public class HttpSamClientSupport {
      * @throws AuthorizationException on a 403 from the Sam client request
      */
     @Retryable(include = {SamRetryableException.class},
-            maxAttempts = 5,
-            backoff = @Backoff(delay = 500, multiplier = 1.5))
+            maxAttemptsExpression = "${sam.retry.maxAttempts}",
+            backoff = @Backoff(delayExpression = "${sam.retry.backoff.delay}",
+                    multiplierExpression = "${sam.retry.backoff.multiplier}"))
     public <T> T withRetryAndErrorHandling(SamFunction<T> samFunction, String loggerHint) throws SamException, AuthenticationException, AuthorizationException {
         try {
             LOGGER.debug("Sending {} request to Sam ...", loggerHint);
@@ -91,8 +92,9 @@ public class HttpSamClientSupport {
      * @throws AuthorizationException on a 403 from the Sam client request
      */
     @Retryable(include = {SamRetryableException.class},
-            maxAttempts = 5,
-            backoff = @Backoff(delay = 500, multiplier = 1.5))
+            maxAttemptsExpression = "${sam.retry.maxAttempts}",
+            backoff = @Backoff(delayExpression = "${sam.retry.backoff.delay}",
+                    multiplierExpression = "${sam.retry.backoff.multiplier}"))
     public void withRetryAndErrorHandling(VoidSamFunction voidSamFunction, String loggerHint) throws SamException, AuthenticationException, AuthorizationException {
 
         // wrap void function in something that returns an object

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamClientSupport.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamClientSupport.java
@@ -3,10 +3,15 @@ package org.databiosphere.workspacedataservice.sam;
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthenticationException;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthorizationException;
+import org.databiosphere.workspacedataservice.service.model.exception.SamConnectionException;
 import org.databiosphere.workspacedataservice.service.model.exception.SamException;
+import org.databiosphere.workspacedataservice.service.model.exception.SamRetryableException;
+import org.databiosphere.workspacedataservice.service.model.exception.SamServerException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 
 import java.util.Objects;
 
@@ -24,9 +29,9 @@ import java.util.Objects;
  *          throw SamException with status 500
  *      - if we catch a non-ApiException from the Sam client,
  *          throw SamException with status 500
- * - TODO: AJ-899 retry calls to Sam on retryable exceptions
+ * - retry calls to Sam on retryable exceptions
  */
-public abstract class HttpSamClientSupport {
+public class HttpSamClientSupport {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(HttpSamClientSupport.class);
 
@@ -41,7 +46,10 @@ public abstract class HttpSamClientSupport {
      * @throws AuthenticationException on a 401 from the Sam client request
      * @throws AuthorizationException on a 403 from the Sam client request
      */
-    <T> T withSamErrorHandling(SamFunction<T> samFunction, String loggerHint) throws SamException, AuthenticationException, AuthorizationException {
+    @Retryable(include = {SamRetryableException.class},
+            maxAttempts = 5,
+            backoff = @Backoff(delay = 500, multiplier = 1.5))
+    public <T> T withRetryAndErrorHandling(SamFunction<T> samFunction, String loggerHint) throws SamException, AuthenticationException, AuthorizationException {
         try {
             LOGGER.debug("Sending {} request to Sam ...", loggerHint);
             T functionResult = samFunction.run();
@@ -51,10 +59,15 @@ public abstract class HttpSamClientSupport {
             LOGGER.error(loggerHint + " Sam request resulted in ApiException(" + apiException.getCode() + ")",
                     apiException);
             int code = apiException.getCode();
-            if (code == 401) {
+
+            if (code == 0) {
+                throw new SamConnectionException();
+            } else if (code == 401) {
                 throw new AuthenticationException(apiException.getMessage());
             } else if (code == 403) {
                 throw new AuthorizationException(apiException.getMessage());
+            } else if (code == 500 || code == 502 || code == 503 || code == 504) {
+                throw new SamServerException(HttpStatus.resolve(code), apiException.getMessage());
             } else {
                 HttpStatus resolvedStatus = HttpStatus.resolve(code);
                 if (Objects.isNull(resolvedStatus)) {
@@ -77,14 +90,17 @@ public abstract class HttpSamClientSupport {
      * @throws AuthenticationException on a 401 from the Sam client request
      * @throws AuthorizationException on a 403 from the Sam client request
      */
-    void withSamErrorHandling(VoidSamFunction voidSamFunction, String loggerHint) throws SamException, AuthenticationException, AuthorizationException {
+    @Retryable(include = {SamRetryableException.class},
+            maxAttempts = 5,
+            backoff = @Backoff(delay = 500, multiplier = 1.5))
+    public void withRetryAndErrorHandling(VoidSamFunction voidSamFunction, String loggerHint) throws SamException, AuthenticationException, AuthorizationException {
 
         // wrap void function in something that returns an object
         SamFunction<String> wrappedFunction = () -> {
             voidSamFunction.run();
             return "void";
         };
-        withSamErrorHandling(wrappedFunction, loggerHint);
+        withRetryAndErrorHandling(wrappedFunction, loggerHint);
     }
 
     /**

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/SamConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/SamConfig.java
@@ -19,6 +19,10 @@ public class SamConfig {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SamConfig.class);
 
+    @Bean HttpSamClientSupport getHttpSamClientSupport() {
+        return new HttpSamClientSupport();
+    }
+
     @Bean
     public SamClientFactory getSamClientFactory() {
         // TODO: AJ-898 what validation of the sam url should we do here?
@@ -35,8 +39,8 @@ public class SamConfig {
     }
 
     @Bean
-    public SamDao samDao(SamClientFactory samClientFactory) {
-        return new HttpSamDao(samClientFactory);
+    public SamDao samDao(SamClientFactory samClientFactory, HttpSamClientSupport httpSamClientSupport) {
+        return new HttpSamDao(samClientFactory, httpSamClientSupport);
     }
 
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/SamConnectionException.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/SamConnectionException.java
@@ -1,0 +1,17 @@
+package org.databiosphere.workspacedataservice.service.model.exception;
+
+import org.springframework.http.HttpStatus;
+
+/**
+ * Indicates a failure to connect to Sam, typically a timeout, and generally due to
+ * transient network or connection issues.
+ */
+public class SamConnectionException extends SamRetryableException {
+
+    public SamConnectionException() {
+        super(HttpStatus.INTERNAL_SERVER_ERROR, "Could not connect to Sam");
+    }
+    public SamConnectionException(HttpStatus status, String message) {
+        super(status, message);
+    }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/SamRetryableException.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/SamRetryableException.java
@@ -6,7 +6,7 @@ import org.springframework.http.HttpStatus;
  * Base class for Sam exceptions that are valid to be retried.
  */
 public abstract class SamRetryableException extends SamException {
-    public SamRetryableException(HttpStatus status, String message) {
+    protected SamRetryableException(HttpStatus status, String message) {
         super(status, message);
     }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/SamRetryableException.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/SamRetryableException.java
@@ -1,0 +1,12 @@
+package org.databiosphere.workspacedataservice.service.model.exception;
+
+import org.springframework.http.HttpStatus;
+
+/**
+ * Base class for Sam exceptions that are valid to be retried.
+ */
+public abstract class SamRetryableException extends SamException {
+    public SamRetryableException(HttpStatus status, String message) {
+        super(status, message);
+    }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/SamServerException.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/SamServerException.java
@@ -1,0 +1,12 @@
+package org.databiosphere.workspacedataservice.service.model.exception;
+
+import org.springframework.http.HttpStatus;
+
+/**
+ * Indicates an error response from Sam of a 500, 502, 503, or 504
+ */
+public class SamServerException extends SamRetryableException {
+    public SamServerException(HttpStatus status, String message) {
+        super(status, message);
+    }
+}

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -34,6 +34,9 @@ sentry.releasename=${RELEASE_NAME:}
 
 # How often WDS should ping SAM URL for a health check - 300000 milliseconds = 5 minutes
 sam.healthcheck.pingTTL=300000
+sam.retry.maxAttempts=10
+sam.retry.backoff.delay=150
+sam.retry.backoff.multiplier=1.5
 
 # activate the "local" profile to turn on CORS response headers,
 # which may be necessary for local development.

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -34,8 +34,8 @@ sentry.releasename=${RELEASE_NAME:}
 
 # How often WDS should ping SAM URL for a health check - 300000 milliseconds = 5 minutes
 sam.healthcheck.pingTTL=300000
-sam.retry.maxAttempts=10
-sam.retry.backoff.delay=150
+sam.retry.maxAttempts=5
+sam.retry.backoff.delay=500
 sam.retry.backoff.multiplier=1.5
 
 # activate the "local" profile to turn on CORS response headers,

--- a/service/src/test/java/org/databiosphere/workspacedataservice/sam/HttpSamClientSupportTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/sam/HttpSamClientSupportTest.java
@@ -1,6 +1,7 @@
 package org.databiosphere.workspacedataservice.sam;
 
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
+import org.databiosphere.workspacedataservice.retry.RetryLoggingListener;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthenticationException;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthorizationException;
 import org.databiosphere.workspacedataservice.service.model.exception.SamException;
@@ -24,7 +25,7 @@ import static org.databiosphere.workspacedataservice.sam.HttpSamClientSupport.Vo
 /**
  * Tests for @see HttpSamClientSupport
  */
-@SpringBootTest(classes = SamConfig.class,
+@SpringBootTest(classes = {SamConfig.class, RetryLoggingListener.class},
         properties = {"sam.retry.maxAttempts=2",
                 "sam.retry.backoff.delay=10"}) // aggressive retry settings so unit test doesn't run too long
 @EnableRetry

--- a/service/src/test/java/org/databiosphere/workspacedataservice/sam/HttpSamClientSupportTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/sam/HttpSamClientSupportTest.java
@@ -24,7 +24,9 @@ import static org.databiosphere.workspacedataservice.sam.HttpSamClientSupport.Vo
 /**
  * Tests for @see HttpSamClientSupport
  */
-@SpringBootTest(classes = SamConfig.class)
+@SpringBootTest(classes = SamConfig.class,
+        properties = {"sam.retry.maxAttempts=2",
+                "sam.retry.backoff.delay=10"}) // aggressive retry setings so unit test doesn't run too long
 @EnableRetry
 class HttpSamClientSupportTest {
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/sam/HttpSamClientSupportTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/sam/HttpSamClientSupportTest.java
@@ -8,16 +8,25 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.retry.annotation.EnableRetry;
+
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import static org.databiosphere.workspacedataservice.sam.HttpSamClientSupport.*;
 
 /**
  * Tests for @see HttpSamClientSupport
  */
 @SpringBootTest(classes = SamConfig.class)
-class HttpSamClientSupportTest extends HttpSamClientSupport {
+@EnableRetry
+class HttpSamClientSupportTest {
+
+    @Autowired HttpSamClientSupport httpSamClientSupport;
 
     @DisplayName("When Sam throws an ApiException with standard http status code 401, HttpSamClientSupport should throw AuthenticationException")
     @Test
@@ -30,10 +39,10 @@ class HttpSamClientSupportTest extends HttpSamClientSupport {
             throw new ApiException(samCode, "");
         };
         assertThrows(AuthenticationException.class,
-                () -> withSamErrorHandling(samFunction, "AuthenticationException"),
+                () -> httpSamClientSupport.withRetryAndErrorHandling(samFunction, "AuthenticationException"),
                 "samFunction should throw AuthenticationException");
         assertThrows(AuthenticationException.class,
-                () -> withSamErrorHandling(voidSamFunction, "AuthenticationException"),
+                () -> httpSamClientSupport.withRetryAndErrorHandling(voidSamFunction, "AuthenticationException"),
                 "voidSamFunction should throw AuthenticationException");
     }
 
@@ -48,10 +57,10 @@ class HttpSamClientSupportTest extends HttpSamClientSupport {
             throw new ApiException(samCode, "");
         };
         assertThrows(AuthorizationException.class,
-                () -> withSamErrorHandling(samFunction, "AuthorizationException"),
+                () -> httpSamClientSupport.withRetryAndErrorHandling(samFunction, "AuthorizationException"),
                 "samFunction should throw AuthorizationException");
         assertThrows(AuthorizationException.class,
-                () -> withSamErrorHandling(voidSamFunction, "AuthorizationException"),
+                () -> httpSamClientSupport.withRetryAndErrorHandling(voidSamFunction, "AuthorizationException"),
                 "voidSamFunction should throw AuthorizationException");
     }
 
@@ -108,9 +117,67 @@ class HttpSamClientSupportTest extends HttpSamClientSupport {
         expectSamExceptionWithStatusCode(samCode, voidSamFunction);
     }
 
+
+    @ParameterizedTest(name = "withSamErrorHandling will retry on status code {0}")
+    @ValueSource(ints = {0, 500, 502, 503, 504})
+    void retryableExceptions(int samCode) {
+        AtomicInteger counter = new AtomicInteger(0);
+
+        HttpSamClientSupport.SamFunction<Boolean> samFunction = () -> {
+            counter.incrementAndGet();
+            throw new ApiException(samCode, "");
+        };
+
+        // this test doesn't care what exception is thrown; other tests verify that
+        assertThrows(Exception.class, () -> httpSamClientSupport.withRetryAndErrorHandling(samFunction, "retryableExceptions"));
+
+        // this test does care how many times the samFunction was invoked
+        assertEquals(5, counter.get(), "SamFunction should have retried");
+
+        // reset counter
+        counter.set(0);
+
+        HttpSamClientSupport.VoidSamFunction voidSamFunction = () -> {
+            counter.incrementAndGet();
+            throw new ApiException(samCode, "");
+        };
+        // this test doesn't care what exception is thrown; other tests verify that
+        assertThrows(Exception.class, () -> httpSamClientSupport.withRetryAndErrorHandling(voidSamFunction, "retryableExceptions"));
+        // this test does care how many times the samFunction was invoked
+        assertEquals(5, counter.get(), "VoidSamFunction should have retried");
+    }
+
+    @ParameterizedTest(name = "withSamErrorHandling will not retry on status code {0}")
+    @ValueSource(ints = {400, 401, 403, 404, 409, 501})
+    void nonRetryableExceptions(int samCode) {
+        AtomicInteger counter = new AtomicInteger(0);
+
+        HttpSamClientSupport.SamFunction<Boolean> samFunction = () -> {
+            counter.incrementAndGet();
+            throw new ApiException(samCode, "");
+        };
+
+        // this test doesn't care what exception is thrown; other tests verify that
+        assertThrows(Exception.class, () -> httpSamClientSupport.withRetryAndErrorHandling(samFunction, "retryableExceptions"));
+        // this test does care how many times the samFunction was invoked
+        assertEquals(1, counter.get(), "SamFunction should not have retried");
+
+        // reset counter
+        counter.set(0);
+
+        HttpSamClientSupport.VoidSamFunction voidSamFunction = () -> {
+            counter.incrementAndGet();
+            throw new ApiException(samCode, "");
+        };
+        // this test doesn't care what exception is thrown; other tests verify that
+        assertThrows(Exception.class, () -> httpSamClientSupport.withRetryAndErrorHandling(voidSamFunction, "retryableExceptions"));
+        // this test does care how many times the samFunction was invoked
+        assertEquals(1, counter.get(), "VoidSamFunction should not have retried");
+    }
+
     private void expectSamExceptionWithStatusCode(int expectedStatusCode, SamFunction<?> samFunction) {
         SamException actual = assertThrows(SamException.class,
-                () -> withSamErrorHandling(samFunction, "samFunction-unittest"),
+                () -> httpSamClientSupport.withRetryAndErrorHandling(samFunction, "samFunction-unittest"),
                 "samFunction should throw SamException");
 
         assertEquals(expectedStatusCode, actual.getRawStatusCode(), "samFunction: Incorrect status code in SamException");
@@ -118,7 +185,7 @@ class HttpSamClientSupportTest extends HttpSamClientSupport {
 
     private void expectSamExceptionWithStatusCode(int expectedStatusCode, VoidSamFunction voidSamFunction) {
         SamException actual = assertThrows(SamException.class,
-                () -> withSamErrorHandling(voidSamFunction, "samFunction-unittest"),
+                () -> httpSamClientSupport.withRetryAndErrorHandling(voidSamFunction, "samFunction-unittest"),
                 "voidSamFunction should throw SamException");
 
         assertEquals(expectedStatusCode, actual.getRawStatusCode(), "voidSamFunction: Incorrect status code in SamException");

--- a/service/src/test/java/org/databiosphere/workspacedataservice/sam/HttpSamClientSupportTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/sam/HttpSamClientSupportTest.java
@@ -16,8 +16,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import static org.databiosphere.workspacedataservice.sam.HttpSamClientSupport.*;
+import static org.databiosphere.workspacedataservice.sam.HttpSamClientSupport.SamFunction;
+import static org.databiosphere.workspacedataservice.sam.HttpSamClientSupport.VoidSamFunction;
 
 /**
  * Tests for @see HttpSamClientSupport
@@ -130,9 +132,9 @@ class HttpSamClientSupportTest {
 
         // this test doesn't care what exception is thrown; other tests verify that
         assertThrows(Exception.class, () -> httpSamClientSupport.withRetryAndErrorHandling(samFunction, "retryableExceptions"));
-
-        // this test does care how many times the samFunction was invoked
-        assertEquals(5, counter.get(), "SamFunction should have retried");
+        // with current settings, will retry 5 times. Any retry means we'll have more than
+        // one invocation.
+        assertTrue(counter.get() > 1, "SamFunction should have retried");
 
         // reset counter
         counter.set(0);
@@ -143,8 +145,9 @@ class HttpSamClientSupportTest {
         };
         // this test doesn't care what exception is thrown; other tests verify that
         assertThrows(Exception.class, () -> httpSamClientSupport.withRetryAndErrorHandling(voidSamFunction, "retryableExceptions"));
-        // this test does care how many times the samFunction was invoked
-        assertEquals(5, counter.get(), "VoidSamFunction should have retried");
+        // with current settings, will retry 5 times. Any retry means we'll have more than
+        // one invocation.
+        assertTrue(counter.get() > 1, "VoidSamFunction should have retried");
     }
 
     @ParameterizedTest(name = "withSamErrorHandling will not retry on status code {0}")

--- a/service/src/test/java/org/databiosphere/workspacedataservice/sam/HttpSamClientSupportTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/sam/HttpSamClientSupportTest.java
@@ -26,7 +26,7 @@ import static org.databiosphere.workspacedataservice.sam.HttpSamClientSupport.Vo
  */
 @SpringBootTest(classes = SamConfig.class,
         properties = {"sam.retry.maxAttempts=2",
-                "sam.retry.backoff.delay=10"}) // aggressive retry setings so unit test doesn't run too long
+                "sam.retry.backoff.delay=10"}) // aggressive retry settings so unit test doesn't run too long
 @EnableRetry
 class HttpSamClientSupportTest {
 


### PR DESCRIPTION
In this PR:
* `HttpSamClientSupport` graduates from an abstract class to a Spring bean, so it can implement `@Retryable`
* all calls to Sam gain retries, if the Sam client encounters a 500, 502, 503, 504, or 0; 0 indicates a failure to connect such as a `SocketTimeoutException`
* some new Sam Exception classes, to disambiguate the retryable exceptions from the not-retryable.

#194 adds retries for APIs and introduces the `RetryLoggingListener`. If #194 merges before this PR, this PR should update to use the logging listener in the Sam retries. If this PR merges before #194, we'll want a follow-on PR to add the logging listener.

