### PR TITLE
AJ-954: submit deps for dependabot

### DIFF
--- a/.github/workflows/submit-dependencies.yml
+++ b/.github/workflows/submit-dependencies.yml
@@ -1,0 +1,22 @@
+name: Publish Docker Images to GCR and ACR
+on:
+  workflow_call:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Dependency Submission
+    runs-on: ubuntu-latest
+    permissions: # The Dependency Submission API requires write permission
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Submit Dependencies
+        uses: mikepenz/gradle-dependency-submission@v0.8.6
+        with:
+    gradle-build-module: |-
+      :client
+      :service

--- a/.github/workflows/submit-dependencies.yml
+++ b/.github/workflows/submit-dependencies.yml
@@ -1,6 +1,6 @@
 name: Publish Docker Images to GCR and ACR
 on:
-  workflow_call:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/submit-dependencies.yml
+++ b/.github/workflows/submit-dependencies.yml
@@ -1,4 +1,4 @@
-name: Publish Docker Images to GCR and ACR
+name: Gradle Dependency Submission
 on:
   workflow_dispatch:
   push:
@@ -17,6 +17,6 @@ jobs:
       - name: Submit Dependencies
         uses: mikepenz/gradle-dependency-submission@v0.8.6
         with:
-    gradle-build-module: |-
-      :client
-      :service
+          gradle-build-module: |-
+            :client
+            :service


### PR DESCRIPTION
Github's dependabot analysis has limited support for Gradle, which will not work out of the box for our project. You can see WDS's depdencies here: https://github.com/DataBiosphere/terra-workspace-data-service/network/dependencies - right now, there's no Java dependencies listed because Dependabot isn't parsing Gradle. See [this simple summary](https://dev.to/cricketsamya/gradle-with-dependabot-1o47) or details in [this issue report](https://github.com/dependabot/dependabot-core/issues/1164) for explanation of the Dependabot/Gradle issues.

So, this PR sets up the [gradle-dependency-submission](https://github.com/marketplace/actions/gradle-dependency-submission) action to submit gradle dependencies directly to the [Dependency Submission API](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/using-the-dependency-submission-api). This will allow dependency analysis, but not automatic PR creation.

According to the action author:
> ℹ️ Currently the action has to be run on the default branch. Running it as part of a PR won't update the [Dependency graph](https://github.com/mikepenz/gradle-dependency-submission/network/dependencies) of your projects [Insights](https://github.com/mikepenz/gradle-dependency-submission/pulse) - This seems to be a GitHub requirement.

So, do we just merge and see if it works?