### PR TITLE
AJ-943 must approve automerge PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,3 +20,5 @@ Your PR is ready to merge when all of the following things are true:
 
 1. Two reviewers have thumbed (or otherwise approved) your PR
 2. All tests pass
+
+Until further notice, all PRs merged into main will generate a PR in https://github.com/broadinstitute/cromwhelm to update the WDS image deployed to kubernetes.  After your merge, you must go to this repo and approve this generated PR and make sure it merges.


### PR DESCRIPTION
Following the investigation of https://broadworkbench.atlassian.net/browse/AJ-943, it seems we must manually approve the automerge PRs.  Adding a line in contributing to this effect.