### PR TITLE
AJ-954: upgrade gradle to allow dependecy submission to work

### DIFF
--- a/.github/workflows/submit-dependencies.yml
+++ b/.github/workflows/submit-dependencies.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Submit Dependencies
         uses: mikepenz/gradle-dependency-submission@v0.8.6
         with:
+          gradle-project-path: "terra-workspace-data-service"
           gradle-build-module: |-
             :service
             :client

--- a/.github/workflows/submit-dependencies.yml
+++ b/.github/workflows/submit-dependencies.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches: [ '**' ]
 
 jobs:
   build:
@@ -18,5 +20,6 @@ jobs:
         uses: mikepenz/gradle-dependency-submission@v0.8.6
         with:
           gradle-build-module: |-
-            :client
             :service
+            :client
+            

--- a/.github/workflows/submit-dependencies.yml
+++ b/.github/workflows/submit-dependencies.yml
@@ -20,5 +20,6 @@ jobs:
         uses: mikepenz/gradle-dependency-submission@v0.8.6
         with:
           gradle-build-module: |-
-            :
+            :service
+            :client
             

--- a/.github/workflows/submit-dependencies.yml
+++ b/.github/workflows/submit-dependencies.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches: [ '**' ]
 
 jobs:
   build:

--- a/.github/workflows/submit-dependencies.yml
+++ b/.github/workflows/submit-dependencies.yml
@@ -19,8 +19,6 @@ jobs:
       - name: Submit Dependencies
         uses: mikepenz/gradle-dependency-submission@v0.8.6
         with:
-          gradle-project-path: "terra-workspace-data-service"
           gradle-build-module: |-
-            :service
-            :client
+            :
             

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'org.springframework.boot' version '2.6.8' apply false
     id 'io.spring.dependency-management' version '1.0.11.RELEASE' apply false
     id 'com.google.cloud.tools.jib' version '3.2.1' apply false
-    id "org.sonarqube" version "3.4.0.2513" apply false
+    id "org.sonarqube" version "4.0.0.2929" apply false
     id 'idea'
     id 'org.hidetake.swagger.generator' version '2.19.2' apply false
     id 'java'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Followup to #198.

In this PR:
* Upgrade gradle to 8.0.2. I didn't realize the `gradle-dependency-submission` action required gradle 7.5, even though that's [clearly documented](https://github.com/marketplace/actions/gradle-dependency-submission). I figured we'd upgrade to latest.
* Upgrade sonarqube to 4.0.0.2929, to be compatible with the newer maven. The older version of sonarqube broke on gradle 8.
* swap the order of the :service and :client modules when processing dependencies … I figured :service is more important and if we run into any errors, at least we'll have a better chance of seeing the output of :service in the action's logs.

In earlier commits of this PR, I set the action to run on PRs, you can see the successful run of the action here:
https://github.com/DataBiosphere/terra-workspace-data-service/actions/runs/4638828397/jobs/8209021872?pr=201#step:3:61 … hopefully this means when this merges to main it'll work and we won't have to iterate more.
