### PR TITLE
AJ-963: temporarily disable Sam operations

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/DisabledSamResourcesApi.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/DisabledSamResourcesApi.java
@@ -1,0 +1,29 @@
+package org.databiosphere.workspacedataservice.sam;
+
+import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
+import org.broadinstitute.dsde.workbench.client.sam.model.CreateResourceRequestV2;
+
+/**
+ *  TODO: davidan - temporarily disable all Sam resource operations until AJ-964 and WM-1862 land.
+ *  Use this instead of using the real ResourcesApi from the Sam client.
+ *  This class returns true for all permission checks
+ *  and does not create or delete any Sam resources.
+ */
+public class DisabledSamResourcesApi extends ResourcesApi {
+
+    @Override
+    public Boolean resourcePermissionV2(String resourceTypeName, String resourceId, String action) {
+        return true;
+    }
+
+    @Override
+    public void createResourceV2(String resourceTypeName, CreateResourceRequestV2 resourceCreate) {
+        // noop; returns void
+    }
+
+    @Override
+    public void deleteResourceV2(String resourceTypeName, String resourceId) {
+        // noop; returns void
+    }
+
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamClientFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamClientFactory.java
@@ -24,9 +24,11 @@ public class HttpSamClientFactory implements SamClientFactory {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(HttpSamClientFactory.class);
 
+    private boolean isSamEnabled;
 
-    public HttpSamClientFactory(String samUrl) {
+    public HttpSamClientFactory(String samUrl, boolean isSamEnabled) {
         this.samUrl = samUrl;
+        this.isSamEnabled = isSamEnabled;
     }
 
     private ApiClient getApiClient(String accessToken) {
@@ -61,19 +63,19 @@ public class HttpSamClientFactory implements SamClientFactory {
      * @return the usable Sam client
      */
     public ResourcesApi getResourcesApi(String token) {
-        // TODO: davidan - temporarily disable all Sam resource operations until AJ-964 and WM-1862 land.
-        // instead of using the real ResourcesApi from the Sam client,
+        // TODO: davidan - allow disabling all Sam resource operations until AJ-964 and WM-1862 land.
+        // when disabled, instead of using the real ResourcesApi from the Sam client,
         // return a DisabledSamResourcesApi, which returns true for all permission checks
         // and does not create or delete any Sam resources.
         // note that the Sam StatusApi below is still functional.
-        /*
-        ApiClient apiClient = getApiClient(token);
-        ResourcesApi resourcesApi = new ResourcesApi();
-        resourcesApi.setApiClient(apiClient);
-        return resourcesApi;
-        */
-        return new DisabledSamResourcesApi();
-
+        if (isSamEnabled) {
+            ApiClient apiClient = getApiClient(token);
+            ResourcesApi resourcesApi = new ResourcesApi();
+            resourcesApi.setApiClient(apiClient);
+            return resourcesApi;
+        } else {
+            return new DisabledSamResourcesApi();
+        }
     }
 
     /**

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamClientFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamClientFactory.java
@@ -61,10 +61,19 @@ public class HttpSamClientFactory implements SamClientFactory {
      * @return the usable Sam client
      */
     public ResourcesApi getResourcesApi(String token) {
+        // TODO: davidan - temporarily disable all Sam resource operations until AJ-964 and WM-1862 land.
+        // instead of using the real ResourcesApi from the Sam client,
+        // return a DisabledSamResourcesApi, which returns true for all permission checks
+        // and does not create or delete any Sam resources.
+        // note that the Sam StatusApi below is still functional.
+        /*
         ApiClient apiClient = getApiClient(token);
         ResourcesApi resourcesApi = new ResourcesApi();
         resourcesApi.setApiClient(apiClient);
         return resourcesApi;
+        */
+        return new DisabledSamResourcesApi();
+
     }
 
     /**

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/SamConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/SamConfig.java
@@ -17,6 +17,9 @@ public class SamConfig {
     @Value("${SAM_URL:}")
     private String samUrl;
 
+    @Value("${sam.enabled:true}")
+    private boolean isSamEnabled;
+
     private static final Logger LOGGER = LoggerFactory.getLogger(SamConfig.class);
 
     @Bean HttpSamClientSupport getHttpSamClientSupport() {
@@ -35,7 +38,13 @@ public class SamConfig {
         // - disable Sam integration, which could result in unauthorized access
         // - stop WDS, which would obviously prevent WDS from working at all
         LOGGER.info("Using Sam base url: '{}'", samUrl);
-        return new HttpSamClientFactory(samUrl);
+        if (isSamEnabled) {
+            LOGGER.info("Sam integration enabled.");
+        } else {
+            LOGGER.warn("Sam integration disabled via sam.enabled property. " +
+                    "All Sam calls will return true/successful but will not connect to Sam.");
+        }
+        return new HttpSamClientFactory(samUrl, isSamEnabled);
     }
 
     @Bean

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -38,6 +38,7 @@ sam.healthcheck.pingTTL=300000
 sam.retry.maxAttempts=5
 sam.retry.backoff.delay=500
 sam.retry.backoff.multiplier=1.5
+sam.enabled=false
 
 api.retry.maxAttempts=10
 api.retry.backoff.delay=150


### PR DESCRIPTION
Temporarily disable all Sam resource operations until AJ-964 and WM-1862 land.

This PR replaces the `ResourcesApi` from the Sam client with a noop class that returns true for all permission checks and does not create or delete any Sam resources.