### PR TITLE
AJ-964: use workspace Sam resource, not wds-instance

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/InstanceInitializerBean.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/InstanceInitializerBean.java
@@ -1,9 +1,6 @@
 package org.databiosphere.workspacedataservice;
 
 import org.databiosphere.workspacedataservice.dao.InstanceDao;
-import org.databiosphere.workspacedataservice.dao.ManagedIdentityDao;
-import org.databiosphere.workspacedataservice.sam.SamDao;
-import org.databiosphere.workspacedataservice.service.model.exception.SamException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -13,19 +10,15 @@ import java.util.UUID;
 
 public class InstanceInitializerBean {
 
-    private final SamDao samDao;
     private final InstanceDao instanceDao;
-    private final ManagedIdentityDao managedIdentityDao;
 
     @Value("${twds.instance.workspace-id}")
     private String workspaceId;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(InstanceInitializerBean.class);
 
-    public InstanceInitializerBean(SamDao samDao, InstanceDao instanceDao, ManagedIdentityDao managedIdentityDao){
-        this.samDao = samDao;
+    public InstanceInitializerBean(InstanceDao instanceDao){
         this.instanceDao = instanceDao;
-        this.managedIdentityDao = managedIdentityDao;
     }
 
     public void initializeInstance() {
@@ -33,32 +26,18 @@ public class InstanceInitializerBean {
 
         try {
             UUID instanceId = UUID.fromString(workspaceId);
-            String token = managedIdentityDao.getAzureCredential();
-            if (token != null){
-                // create `wds-instance` resource in Sam if it doesn't exist
-                if (!samDao.instanceResourceExists(instanceId, token)){
-                    LOGGER.info("Creating wds-resource for workspaceId {}", workspaceId);
-                    samDao.createInstanceResource(instanceId, instanceId, token);
-                } else {
-                    LOGGER.debug("wds-resource for workspaceId {} already exists; skipping creation.", workspaceId);
-                }
-                if (!instanceDao.instanceSchemaExists(instanceId)) {
-                    instanceDao.createSchema(instanceId);
-                    LOGGER.info("Creating default schema id succeeded for workspaceId {}", workspaceId);
-                } else {
-                    LOGGER.debug("Default schema for workspaceId {} already exists; skipping creation.", workspaceId);
-                }
+
+            if (!instanceDao.instanceSchemaExists(instanceId)) {
+                instanceDao.createSchema(instanceId);
+                LOGGER.info("Creating default schema id succeeded for workspaceId {}", workspaceId);
             } else {
-                LOGGER.warn("No token acquired from azure managed identity; wds-instance resource and default schema not created");
+                LOGGER.debug("Default schema for workspaceId {} already exists; skipping creation.", workspaceId);
             }
 
         } catch (IllegalArgumentException e) {
             LOGGER.warn("Workspace id could not be parsed, a default schema won't be created. Provided id: {}", workspaceId);
-        } catch (
-        DataAccessException e) {
+        } catch (DataAccessException e) {
             LOGGER.error("Failed to create default schema id for workspaceId {}", workspaceId);
-        } catch (SamException e) {
-            LOGGER.error("Exception thrown from sam, wds-instance resource and default schema not created : {}", e.getMessage());
         }
     }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/InstanceInitializerConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/InstanceInitializerConfig.java
@@ -2,7 +2,6 @@ package org.databiosphere.workspacedataservice;
 
 import org.databiosphere.workspacedataservice.dao.InstanceDao;
 import org.databiosphere.workspacedataservice.dao.ManagedIdentityDao;
-import org.databiosphere.workspacedataservice.sam.SamDao;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -10,8 +9,8 @@ import org.springframework.context.annotation.Configuration;
 public class InstanceInitializerConfig {
 
     @Bean
-    public InstanceInitializerBean instanceInitializerBean(SamDao samDao, InstanceDao instanceDao, ManagedIdentityDao managedIdentityDao) {
-        return new InstanceInitializerBean(samDao, instanceDao, managedIdentityDao);
+    public InstanceInitializerBean instanceInitializerBean(InstanceDao instanceDao) {
+        return new InstanceInitializerBean(instanceDao);
     }
 
     @Bean

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -111,9 +111,8 @@ public class RecordController {
 
 	@PostMapping("/instances/{version}/{instanceId}")
 	public ResponseEntity<String> createInstance(@PathVariable("instanceId") UUID instanceId,
-			@PathVariable("version") String version,
-			@RequestParam(name= "workspaceid", required = false) Optional<UUID> workspaceId) {
-		instanceService.createInstance(instanceId, version, workspaceId);
+			@PathVariable("version") String version) {
+		instanceService.createInstance(instanceId, version);
 		return new ResponseEntity<>(HttpStatus.CREATED);
 	}
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/FailingSamDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/FailingSamDao.java
@@ -1,0 +1,73 @@
+package org.databiosphere.workspacedataservice.sam;
+
+import org.broadinstitute.dsde.workbench.client.sam.model.SystemStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.UUID;
+
+/**
+ * This class will be used instead of HttpSamDao if the WORKSPACE_ID env var
+ * contains a non-UUID value, including being blank.
+ * <p>
+ * This class will fail all permission checks and log a warning each time. Its
+ * objective is to disallow any write operations that require permissions, while still
+ * allowing WDS to start up and for users to read any data already in WDS.
+ */
+public class FailingSamDao implements SamDao {
+
+    private final String errorMessage;
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    public FailingSamDao(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    @Override
+    public boolean hasCreateInstancePermission(UUID parentWorkspaceId) {
+        logWarning();
+        return false;
+    }
+
+    @Override
+    public boolean hasCreateInstancePermission(UUID parentWorkspaceId, String token) {
+        logWarning();
+        return false;
+    }
+
+    @Override
+    public boolean hasDeleteInstancePermission(UUID instanceId) {
+        logWarning();
+        return false;
+    }
+
+    @Override
+    public boolean hasDeleteInstancePermission(UUID instanceId, String token) {
+        logWarning();
+        return false;
+    }
+
+    @Override
+    public boolean hasWriteInstancePermission(UUID instanceId) {
+        logWarning();
+        return false;
+    }
+
+    @Override
+    public boolean hasWriteInstancePermission(UUID instanceId, String token) {
+        logWarning();
+        return false;
+    }
+
+    @Override
+    public SystemStatus getSystemStatus() {
+        throw new RuntimeException("Sam integration failure: " + errorMessage);
+    }
+
+    private void logWarning() {
+        logger.warn("Sam permission check failed. {}", errorMessage);
+    }
+
+
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/FailingSamDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/FailingSamDao.java
@@ -4,8 +4,6 @@ import org.broadinstitute.dsde.workbench.client.sam.model.SystemStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.UUID;
-
 /**
  * This class will be used instead of HttpSamDao if the WORKSPACE_ID env var
  * contains a non-UUID value, including being blank.
@@ -25,37 +23,37 @@ public class FailingSamDao implements SamDao {
     }
 
     @Override
-    public boolean hasCreateInstancePermission(UUID parentWorkspaceId) {
+    public boolean hasCreateInstancePermission() {
         logWarning();
         return false;
     }
 
     @Override
-    public boolean hasCreateInstancePermission(UUID parentWorkspaceId, String token) {
+    public boolean hasCreateInstancePermission(String token) {
         logWarning();
         return false;
     }
 
     @Override
-    public boolean hasDeleteInstancePermission(UUID instanceId) {
+    public boolean hasDeleteInstancePermission() {
         logWarning();
         return false;
     }
 
     @Override
-    public boolean hasDeleteInstancePermission(UUID instanceId, String token) {
+    public boolean hasDeleteInstancePermission(String token) {
         logWarning();
         return false;
     }
 
     @Override
-    public boolean hasWriteInstancePermission(UUID instanceId) {
+    public boolean hasWriteInstancePermission() {
         logWarning();
         return false;
     }
 
     @Override
-    public boolean hasWriteInstancePermission(UUID instanceId, String token) {
+    public boolean hasWriteInstancePermission(String token) {
         logWarning();
         return false;
     }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamDao.java
@@ -21,10 +21,12 @@ public class HttpSamDao implements SamDao {
     protected final SamClientFactory samClientFactory;
     private static final Logger LOGGER = LoggerFactory.getLogger(HttpSamDao.class);
     private final HttpSamClientSupport httpSamClientSupport;
+    private final String workspaceId;
 
-    public HttpSamDao(SamClientFactory samClientFactory, HttpSamClientSupport httpSamClientSupport) {
+    public HttpSamDao(SamClientFactory samClientFactory, HttpSamClientSupport httpSamClientSupport, String workspaceId) {
         this.samClientFactory = samClientFactory;
         this.httpSamClientSupport = httpSamClientSupport;
+        this.workspaceId = workspaceId;
     }
 
     /**
@@ -64,8 +66,9 @@ public class HttpSamDao implements SamDao {
 
     // helper implementation for permission checks
     private boolean hasPermission(String resourceType, String resourceId, String action, String loggerHint, String token) {
+        LOGGER.debug("Checking Sam permission for {}/{}/{} on behalf of instance {} ...", resourceType, workspaceId, action, resourceId);
         SamFunction<Boolean> samFunction = () -> samClientFactory.getResourcesApi(token)
-                .resourcePermissionV2(resourceType, resourceId, action);
+                .resourcePermissionV2(resourceType, workspaceId, action);
         return httpSamClientSupport.withRetryAndErrorHandling(samFunction, loggerHint);
     }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamDao.java
@@ -7,8 +7,6 @@ import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.scheduling.annotation.Scheduled;
 
-import java.util.UUID;
-
 import static org.databiosphere.workspacedataservice.sam.HttpSamClientSupport.SamFunction;
 
 /**
@@ -33,17 +31,16 @@ public class HttpSamDao implements SamDao {
      * Check if the current user has permission to create a "wds-instance" resource in Sam.
      * Implemented as a check for write permission on the workspace which will contain this instance.
      *
-     * @param parentWorkspaceId the workspaceId which will be the parent of the "wds-instance" resource
      * @return true if the user has permission
      */
     @Override
-    public boolean hasCreateInstancePermission(UUID parentWorkspaceId) {
-        return hasCreateInstancePermission(parentWorkspaceId, null);
+    public boolean hasCreateInstancePermission() {
+        return hasCreateInstancePermission(null);
     }
 
     @Override
-    public boolean hasCreateInstancePermission(UUID parentWorkspaceId, String token) {
-        return hasPermission(RESOURCE_NAME_WORKSPACE, parentWorkspaceId.toString(), ACTION_WRITE,
+    public boolean hasCreateInstancePermission(String token) {
+        return hasPermission(ACTION_WRITE,
                 "hasCreateInstancePermission", token);
     }
 
@@ -51,24 +48,23 @@ public class HttpSamDao implements SamDao {
      * Check if the current user has permission to delete a "wds-instance" resource from Sam.
      * Implemented as a check for delete permission on the resource.
      *
-     * @param instanceId the id of the "wds-instance" resource to be deleted
      * @return true if the user has permission
      */
     @Override
-    public boolean hasDeleteInstancePermission(UUID instanceId) {
-        return hasDeleteInstancePermission(instanceId, null);
+    public boolean hasDeleteInstancePermission() {
+        return hasDeleteInstancePermission(null);
     }
     @Override
-    public boolean hasDeleteInstancePermission(UUID instanceId, String token) {
-        return hasPermission(RESOURCE_NAME_WORKSPACE, instanceId.toString(), ACTION_DELETE,
+    public boolean hasDeleteInstancePermission(String token) {
+        return hasPermission(ACTION_DELETE,
                 "hasDeleteInstancePermission", token);
     }
 
     // helper implementation for permission checks
-    private boolean hasPermission(String resourceType, String resourceId, String action, String loggerHint, String token) {
-        LOGGER.debug("Checking Sam permission for {}/{}/{} on behalf of instance {} ...", resourceType, workspaceId, action, resourceId);
+    private boolean hasPermission(String action, String loggerHint, String token) {
+        LOGGER.debug("Checking Sam permission for {}/{}/{} ...", SamDao.RESOURCE_NAME_WORKSPACE, workspaceId, action);
         SamFunction<Boolean> samFunction = () -> samClientFactory.getResourcesApi(token)
-                .resourcePermissionV2(resourceType, workspaceId, action);
+                .resourcePermissionV2(SamDao.RESOURCE_NAME_WORKSPACE, workspaceId, action);
         return httpSamClientSupport.withRetryAndErrorHandling(samFunction, loggerHint);
     }
 
@@ -76,17 +72,16 @@ public class HttpSamDao implements SamDao {
      * Check if the current user has permission to write to a "wds-instance" resource from Sam.
      * Implemented as a check for write permission on the resource.
      *
-     * @param instanceId the id of the "wds-instance" resource to be written to
      * @return true if the user has permission
      */
     @Override
-    public boolean hasWriteInstancePermission(UUID instanceId) {
-        return hasWriteInstancePermission(instanceId, null);
+    public boolean hasWriteInstancePermission() {
+        return hasWriteInstancePermission(null);
     }
 
     @Override
-    public boolean hasWriteInstancePermission(UUID instanceId, String token) {
-        return hasPermission(RESOURCE_NAME_WORKSPACE, instanceId.toString(), ACTION_WRITE,
+    public boolean hasWriteInstancePermission(String token) {
+        return hasPermission(ACTION_WRITE,
                 "hasWriteInstancePermission", token);
     }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamDao.java
@@ -125,7 +125,7 @@ public class HttpSamDao implements SamDao {
 
     @Override
     public boolean hasWriteInstancePermission(UUID instanceId, String token) {
-        return hasPermission(RESOURCE_NAME_INSTANCE, instanceId.toString(), ACTION_WRITE,
+        return hasPermission(RESOURCE_NAME_WORKSPACE, instanceId.toString(), ACTION_WRITE,
                 "hasWriteInstancePermission", token);
     }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamDao.java
@@ -60,7 +60,7 @@ public class HttpSamDao implements SamDao {
     }
     @Override
     public boolean hasDeleteInstancePermission(UUID instanceId, String token) {
-        return hasPermission(RESOURCE_NAME_WORKSPACE, instanceId.toString(), ACTION_WRITE,
+        return hasPermission(RESOURCE_NAME_WORKSPACE, instanceId.toString(), ACTION_DELETE,
                 "hasDeleteInstancePermission", token);
     }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/MisconfiguredSamDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/MisconfiguredSamDao.java
@@ -12,13 +12,13 @@ import org.slf4j.LoggerFactory;
  * objective is to disallow any write operations that require permissions, while still
  * allowing WDS to start up and for users to read any data already in WDS.
  */
-public class FailingSamDao implements SamDao {
+public class MisconfiguredSamDao implements SamDao {
 
     private final String errorMessage;
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
-    public FailingSamDao(String errorMessage) {
+    public MisconfiguredSamDao(String errorMessage) {
         this.errorMessage = errorMessage;
     }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/SamConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/SamConfig.java
@@ -54,6 +54,14 @@ public class SamConfig {
 
     @Bean
     public SamDao samDao(SamClientFactory samClientFactory, HttpSamClientSupport httpSamClientSupport) {
+        // if Sam integration is disabled, always return HttpSamDao and rely on the
+        // HttpSamClientFactory enabled/disabled setting from getSamClientFactory() above
+        if (!isSamEnabled) {
+            return new HttpSamDao(samClientFactory, httpSamClientSupport, workspaceIdArgument);
+        }
+
+        // if Sam integration is enabled, try to parse the WORKSPACE_ID env var;
+        // return a FailingSamDao if it can't be parsed.
         try {
             String workspaceId = UUID.fromString(workspaceIdArgument).toString(); // verify UUID-ness
             LOGGER.info("Sam integration will query type={}, resourceId={}, action={}",

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/SamConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/SamConfig.java
@@ -57,6 +57,8 @@ public class SamConfig {
         String workspaceId;
         try {
             workspaceId = UUID.fromString(workspaceIdArgument).toString(); // verify UUID-ness
+            LOGGER.info("Sam integration will query type={}, resourceId={}, action={}",
+                    SamDao.RESOURCE_NAME_WORKSPACE, workspaceId, SamDao.ACTION_WRITE);
         } catch (IllegalArgumentException e) {
             // TODO: in this corner case, instead of returning HttpSamDao that will always fail,
             // should we prevent startup? Should we return a different subclass of SamDao that

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/SamConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/SamConfig.java
@@ -61,7 +61,7 @@ public class SamConfig {
         }
 
         // if Sam integration is enabled, try to parse the WORKSPACE_ID env var;
-        // return a FailingSamDao if it can't be parsed.
+        // return a MisconfiguredSamDao if it can't be parsed.
         try {
             String workspaceId = UUID.fromString(workspaceIdArgument).toString(); // verify UUID-ness
             LOGGER.info("Sam integration will query type={}, resourceId={}, action={}",
@@ -69,10 +69,10 @@ public class SamConfig {
             return new HttpSamDao(samClientFactory, httpSamClientSupport, workspaceId);
         } catch (IllegalArgumentException e) {
             LOGGER.warn("Workspace id could not be parsed, all Sam permission checks will fail. Provided id: {}", workspaceIdArgument);
-            return new FailingSamDao("WDS was started with invalid WORKSPACE_ID of: " + workspaceIdArgument);
+            return new MisconfiguredSamDao("WDS was started with invalid WORKSPACE_ID of: " + workspaceIdArgument);
         } catch (Exception e) {
             LOGGER.warn("Error during initial Sam configuration: " + e.getMessage());
-            return new FailingSamDao(e.getMessage());
+            return new MisconfiguredSamDao(e.getMessage());
         }
     }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/SamDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/SamDao.java
@@ -2,8 +2,6 @@ package org.databiosphere.workspacedataservice.sam;
 
 import org.broadinstitute.dsde.workbench.client.sam.model.SystemStatus;
 
-import java.util.UUID;
-
 /**
  * Interface for SamDao, allowing various dao implementations.
  * Currently, the only implementation is HttpSamDao.
@@ -26,30 +24,30 @@ public interface SamDao {
 
     /**
      * Check if the current user has permission to create a "wds-instance" resource in Sam
-     * @param parentWorkspaceId the workspaceId which will be the parent of the "wds-instance" resource
+     *
      * @return true if the user has permission
      */
-    boolean hasCreateInstancePermission(UUID parentWorkspaceId);
+    boolean hasCreateInstancePermission();
 
-    boolean hasCreateInstancePermission(UUID parentWorkspaceId, String token);
+    boolean hasCreateInstancePermission(String token);
 
     /**
      * Check if the current user has permission to delete a "wds-instance" resource from Sam
-     * @param instanceId the id of the "wds-instance" resource to be deleted
+     *
      * @return true if the user has permission
      */
-    boolean hasDeleteInstancePermission(UUID instanceId);
+    boolean hasDeleteInstancePermission();
 
-    boolean hasDeleteInstancePermission(UUID instanceId, String token);
+    boolean hasDeleteInstancePermission(String token);
 
     /**
      * Check if the current user has permission to write to a "wds-instance" resource from Sam
-     * @param instanceId the id of the "wds-instance" resource to be written to
+     *
      * @return true if the user has permission
      */
-    boolean hasWriteInstancePermission(UUID instanceId);
+    boolean hasWriteInstancePermission();
 
-    boolean hasWriteInstancePermission(UUID instanceId, String token);
+    boolean hasWriteInstancePermission(String token);
 
     /**
      * Gets the System Status of SAM.

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/SamDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/SamDao.java
@@ -21,11 +21,6 @@ public interface SamDao {
     String ACTION_WRITE = "write";
 
     /**
-     * Sam action name for read permission
-     */
-    String ACTION_READ = "read";
-
-    /**
      * Check if the current user has permission to create a "wds-instance" resource in Sam
      * @param parentWorkspaceId the workspaceId which will be the parent of the "wds-instance" resource
      * @return true if the user has permission

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/SamDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/SamDao.java
@@ -19,6 +19,10 @@ public interface SamDao {
      * Sam action name for write permission
      */
     String ACTION_WRITE = "write";
+    /**
+     * Sam action name for delete permission
+     */
+    String ACTION_DELETE = "delete";
 
     /**
      * Check if the current user has permission to create a "wds-instance" resource in Sam

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/SamDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/SamDao.java
@@ -11,10 +11,6 @@ import java.util.UUID;
 public interface SamDao {
 
     /**
-     * Sam resource type name for WDS instances
-     */
-    String RESOURCE_NAME_INSTANCE = "wds-instance";
-    /**
      * Sam resource type name for Workspaces
      */
     String RESOURCE_NAME_WORKSPACE = "workspace";
@@ -23,10 +19,7 @@ public interface SamDao {
      * Sam action name for write permission
      */
     String ACTION_WRITE = "write";
-    /**
-     * Sam action name for delete permission
-     */
-    String ACTION_DELETE = "delete";
+
     /**
      * Sam action name for read permission
      */
@@ -51,21 +44,6 @@ public interface SamDao {
     boolean hasDeleteInstancePermission(UUID instanceId, String token);
 
     /**
-     * Creates a "wds-instance" Sam resource
-     * @param instanceId the id to use for the "wds-instance" resource
-     * @param parentWorkspaceId the id to use for the "wds-instance" resource's parent
-     */
-    void createInstanceResource(UUID instanceId, UUID parentWorkspaceId);
-
-    void createInstanceResource(UUID instanceId, UUID parentWorkspaceId, String token);
-
-    /**
-     * Deletes a "wds-instance" Sam resource
-     * @param instanceId the id of the "wds-instance" resource to be deleted
-     */
-    void deleteInstanceResource(UUID instanceId);
-
-    /**
      * Check if the current user has permission to write to a "wds-instance" resource from Sam
      * @param instanceId the id of the "wds-instance" resource to be written to
      * @return true if the user has permission
@@ -73,16 +51,6 @@ public interface SamDao {
     boolean hasWriteInstancePermission(UUID instanceId);
 
     boolean hasWriteInstancePermission(UUID instanceId, String token);
-    void deleteInstanceResource(UUID instanceId, String token);
-
-    /**
-     * Checks whether a "wds-instance" Sam resource already exists
-     * @param instanceId wds-instance resource id
-     * @return true if wds-resource with this id already exists in Sam
-     */
-    boolean instanceResourceExists(UUID instanceId);
-
-    boolean instanceResourceExists(UUID instanceId, String token);
 
     /**
      * Gets the System Status of SAM.

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/InstanceService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/InstanceService.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 import static org.databiosphere.workspacedataservice.service.RecordUtils.validateVersion;
@@ -43,18 +42,13 @@ public class InstanceService {
      * two Sam resources having the same id - one of type `workspace` and another of type `wds-instance.
      *
      * @param instanceId id of the instance to create
-     * @param version WDS API version
-     * @param workspaceId optional - id of the parent workspace, if different than the instance id
+     * @param version    WDS API version
      */
-    public void createInstance(UUID instanceId, String version, Optional<UUID> workspaceId) {
+    public void createInstance(UUID instanceId, String version) {
         validateVersion(version);
 
-        // id of workspace in which this instance exists
-        // if not specified, assume the workspace id is equal to the instance id
-        UUID containingWorkspaceId = workspaceId.orElse(instanceId);
-
         // check that the current user has permission on the parent workspace
-        boolean hasCreateInstancePermission = samDao.hasCreateInstancePermission(containingWorkspaceId);
+        boolean hasCreateInstancePermission = samDao.hasCreateInstancePermission();
         LOGGER.debug("hasCreateInstancePermission? {}", hasCreateInstancePermission);
 
         if (!hasCreateInstancePermission) {
@@ -79,7 +73,7 @@ public class InstanceService {
         validateInstance(instanceId);
 
         // check that the current user has permission to delete the Sam resource
-        boolean hasDeleteInstancePermission = samDao.hasDeleteInstancePermission(instanceId);
+        boolean hasDeleteInstancePermission = samDao.hasDeleteInstancePermission();
         LOGGER.debug("hasDeleteInstancePermission? {}", hasDeleteInstancePermission);
 
         if (!hasDeleteInstancePermission) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/InstanceService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/InstanceService.java
@@ -2,7 +2,6 @@ package org.databiosphere.workspacedataservice.service;
 
 import bio.terra.common.db.WriteTransaction;
 import org.databiosphere.workspacedataservice.dao.InstanceDao;
-import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.databiosphere.workspacedataservice.sam.SamDao;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthorizationException;
 import org.databiosphere.workspacedataservice.service.model.exception.MissingObjectException;
@@ -65,8 +64,6 @@ public class InstanceService {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "This instance already exists");
         }
 
-        // create `wds-instance` resource in Sam, specifying workspace as parent
-        samDao.createInstanceResource(samResourceId, samParentResourceId);
         // create instance schema in Postgres
         createInstanceInDatabase(instanceId);
     }
@@ -88,8 +85,6 @@ public class InstanceService {
             throw new AuthorizationException("Caller does not have permission to delete instance.");
         }
 
-        // delete `wds-instance` resource in Sam
-        samDao.deleteInstanceResource(instanceId);
         // delete instance schema in Postgres
         deleteInstanceFromDatabase(instanceId);
     }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/InstanceService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/InstanceService.java
@@ -49,11 +49,12 @@ public class InstanceService {
     public void createInstance(UUID instanceId, String version, Optional<UUID> workspaceId) {
         validateVersion(version);
 
-        UUID samResourceId = instanceId; // id of "wds-instance" Sam resource we will create
-        UUID samParentResourceId = workspaceId.orElse(instanceId); // id of "workspace" Sam resource to use as the parent of "wds-instance"
+        // id of workspace in which this instance exists
+        // if not specified, assume the workspace id is equal to the instance id
+        UUID containingWorkspaceId = workspaceId.orElse(instanceId);
 
         // check that the current user has permission on the parent workspace
-        boolean hasCreateInstancePermission = samDao.hasCreateInstancePermission(samParentResourceId);
+        boolean hasCreateInstancePermission = samDao.hasCreateInstancePermission(containingWorkspaceId);
         LOGGER.debug("hasCreateInstancePermission? {}", hasCreateInstancePermission);
 
         if (!hasCreateInstancePermission) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
@@ -77,7 +77,7 @@ public class RecordOrchestratorService { // TODO give me a better name
         validateVersion(version);
         instanceService.validateInstance(instanceId);
 
-        boolean hasWriteInstancePermission = samDao.hasWriteInstancePermission(instanceId);
+        boolean hasWriteInstancePermission = samDao.hasWriteInstancePermission();
         LOGGER.debug("hasWriteInstancePermission? {}", hasWriteInstancePermission);
 
         if (!hasWriteInstancePermission) {

--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -307,7 +307,6 @@ paths:
       parameters:
         - $ref: '#/components/parameters/instanceIdPathParam'
         - $ref: '#/components/parameters/versionPathParam'
-        - $ref: '#/components/parameters/workspaceIdQueryParam'
       responses:
         201:
           description: Success
@@ -459,14 +458,6 @@ components:
       schema:
         type: string
         default: v0.2
-    workspaceIdQueryParam:
-      name: workspaceid
-      in: query
-      description: Id of workspace containing a WDS instance. If omitted, assumed to be equal to the instance id.
-      required: false
-      schema:
-        type: string
-        format: uuid
 
   responses:
     RecordResponseBody:

--- a/service/src/test/java/org/databiosphere/workspacedataservice/GeneratedClientTests.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/GeneratedClientTests.java
@@ -131,6 +131,6 @@ class GeneratedClientTests {
 
     private void createNewInstance(UUID instanceId) throws ApiException {
         InstancesApi instancesApi = new InstancesApi(apiClient);
-        instancesApi.createWDSInstance(instanceId.toString(), version, instanceId);
+        instancesApi.createWDSInstance(instanceId.toString(), version);
     }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/InstanceInitializerBeanTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/InstanceInitializerBeanTest.java
@@ -1,21 +1,11 @@
 package org.databiosphere.workspacedataservice;
 
-import org.broadinstitute.dsde.workbench.client.sam.ApiException;
-import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
 import org.databiosphere.workspacedataservice.dao.InstanceDao;
-import org.databiosphere.workspacedataservice.dao.ManagedIdentityDao;
 import org.databiosphere.workspacedataservice.dao.MockInstanceDaoConfig;
-import org.databiosphere.workspacedataservice.sam.MockSamClientFactoryConfig;
-import org.databiosphere.workspacedataservice.sam.SamClientFactory;
-import org.databiosphere.workspacedataservice.sam.SamConfig;
-import org.databiosphere.workspacedataservice.sam.SamDao;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
@@ -24,90 +14,51 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
-@ActiveProfiles({"mock-sam","mock-instance-dao", "local"})
+@ActiveProfiles({"mock-instance-dao", "local"})
 @TestPropertySource(properties = {"twds.instance.workspace-id=90e1b179-9f83-4a6f-a8c2-db083df4cd03"})
-@SpringBootTest(classes = {SamConfig.class, MockSamClientFactoryConfig.class, InstanceInitializerConfig.class, MockInstanceDaoConfig.class})
+@SpringBootTest(classes = {InstanceInitializerConfig.class, MockInstanceDaoConfig.class})
 class InstanceInitializerBeanTest {
 
     @Autowired
     InstanceInitializerBean instanceInitializerBean;
     @SpyBean
     InstanceDao instanceDao;
-    @SpyBean
-    SamDao samDao;
 
     //randomly generated UUID
     UUID instanceID = UUID.fromString("90e1b179-9f83-4a6f-a8c2-db083df4cd03");
 
-    @MockBean
-    ManagedIdentityDao mockManagedIdentityDao;
-    @MockBean
-    SamClientFactory mockSamClientFactory;
-
-    ResourcesApi mockResourcesApi = Mockito.mock(ResourcesApi.class);
-
     @BeforeEach
     void beforeEach() {
-        given(mockManagedIdentityDao.getAzureCredential())
-                .willReturn("aRandomTokenString");
-        given(mockSamClientFactory.getResourcesApi(any()))
-                .willReturn(mockResourcesApi);
-
-    }
-
-    @AfterEach
-    void afterEach() {
         // clean up any instances left in the db
         List<UUID> allInstances = instanceDao.listInstanceSchemas();
         allInstances.forEach(instanceId -> {
-                    samDao.deleteInstanceResource(instanceId);
-                    instanceDao.dropSchema(instanceId);
-                });
+            instanceDao.dropSchema(instanceId);
+        });
     }
 
+
     @Test
-    void testHappyPath() throws ApiException{
-        given(mockResourcesApi.resourcePermissionV2("wds-instance", instanceID.toString(), SamDao.ACTION_READ))
-                .willReturn(false);
+    void testHappyPath() {
+        // instance does not exist
+        assertFalse(instanceDao.instanceSchemaExists(instanceID));
         assertDoesNotThrow(() -> instanceInitializerBean.initializeInstance());
-        verify(samDao, times(1)).createInstanceResource(any(), any(), any());
         assert(instanceDao.instanceSchemaExists(instanceID));
     }
 
     @Test
-    void testResourceExistsButNotSchema() throws ApiException {
-        given(mockResourcesApi.resourcePermissionV2("wds-instance", instanceID.toString(), SamDao.ACTION_READ))
-                .willReturn(true);
+    void testSchemaAlreadyExists() {
+        // instance does not exist
+        assertFalse(instanceDao.instanceSchemaExists(instanceID));
+        // create the instance outside of the initializer
+        instanceDao.createSchema(instanceID);
+        assertTrue(instanceDao.instanceSchemaExists(instanceID));
+        // now run the initializer
         instanceInitializerBean.initializeInstance();
-        //verify that method to create sam resource was NOT called
-        verify(samDao, times(0)).createInstanceResource(any(), any(), any());
-        assert(instanceDao.instanceSchemaExists(instanceID));
-    }
-
-    @Test
-    void testNullToken() {
-        given(mockManagedIdentityDao.getAzureCredential()
-        ).willReturn(null);
-        assertDoesNotThrow(() -> instanceInitializerBean.initializeInstance());
-        //verify that method to create resources was NOT called
-        verify(samDao, times(0)).createInstanceResource(any(), any(), any());
-        assertFalse(instanceDao.instanceSchemaExists(instanceID));
-
-    }
-
-    @Test
-    void testSamException() throws ApiException {
-        given(mockResourcesApi.resourcePermissionV2(anyString(), eq(instanceID.toString()), anyString()))
-                .willThrow(new ApiException(401, "intentional exception for unit test"));
-        assertDoesNotThrow(() -> instanceInitializerBean.initializeInstance());
-        //verify that method to create resources was NOT called
-        verify(samDao, times(0)).createInstanceResource(any(), any(), any());
-        assertFalse(instanceDao.instanceSchemaExists(instanceID));
-
+        //verify that method to create instance was NOT called again. We expect one call from the setup above.
+        verify(instanceDao, times(1)).createSchema(any());
+        assertTrue(instanceDao.instanceSchemaExists(instanceID));
     }
 
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/InstanceInitializerBeanTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/InstanceInitializerBeanTest.java
@@ -33,9 +33,7 @@ class InstanceInitializerBeanTest {
     void beforeEach() {
         // clean up any instances left in the db
         List<UUID> allInstances = instanceDao.listInstanceSchemas();
-        allInstances.forEach(instanceId -> {
-            instanceDao.dropSchema(instanceId);
-        });
+        allInstances.forEach(instanceId -> instanceDao.dropSchema(instanceId));
     }
 
 
@@ -51,7 +49,7 @@ class InstanceInitializerBeanTest {
     void testSchemaAlreadyExists() {
         // instance does not exist
         assertFalse(instanceDao.instanceSchemaExists(instanceID));
-        // create the instance outside of the initializer
+        // create the instance outside the initializer
         instanceDao.createSchema(instanceID);
         assertTrue(instanceDao.instanceSchemaExists(instanceID));
         // now run the initializer

--- a/service/src/test/java/org/databiosphere/workspacedataservice/InstanceInitializerNoWorkspaceIdTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/InstanceInitializerNoWorkspaceIdTest.java
@@ -2,8 +2,6 @@ package org.databiosphere.workspacedataservice;
 
 import org.databiosphere.workspacedataservice.dao.InstanceDao;
 import org.databiosphere.workspacedataservice.dao.MockInstanceDaoConfig;
-import org.databiosphere.workspacedataservice.sam.SamConfig;
-import org.databiosphere.workspacedataservice.sam.SamDao;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -16,23 +14,20 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@ActiveProfiles({"mock-sam","mock-instance-dao", "local"})
+@ActiveProfiles({"mock-instance-dao", "local"})
 @TestPropertySource(properties = {"twds.instance.workspace-id="})
-@SpringBootTest(classes = {SamConfig.class, InstanceInitializerConfig.class, MockInstanceDaoConfig.class})
+@SpringBootTest(classes = {InstanceInitializerConfig.class, MockInstanceDaoConfig.class})
 class InstanceInitializerNoWorkspaceIdTest {
 
     @Autowired
     InstanceInitializerBean instanceInitializerBean;
     @SpyBean
     InstanceDao instanceDao;
-    @SpyBean
-    SamDao samDao;
 
     @Test
     void workspaceIDNotProvidedNoExceptionThrown() {
         assertDoesNotThrow(() -> instanceInitializerBean.initializeInstance());
-        //verify that method to create resources was NOT called
-        verify(samDao, times(0)).createInstanceResource(any(), any(), any());
+        //verify that method to create instance was NOT called
         verify(instanceDao, times(0)).createSchema(any());
     }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
@@ -53,7 +53,7 @@ class TsvDownloadTest {
 	void init(){
 		version = "v0.2";
 		instanceId = UUID.randomUUID();
-		recordController.createInstance(instanceId, version, Optional.empty());
+		recordController.createInstance(instanceId, version);
 	}
 
 	@ParameterizedTest(name = "PK name {0} should be honored")

--- a/service/src/test/java/org/databiosphere/workspacedataservice/sam/SamDaoInvalidWorkspaceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/sam/SamDaoInvalidWorkspaceTest.java
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 @SpringBootTest(
         classes = {SamConfig.class},
-        properties = {"twds.instance.workspace-id=not-a-real-id"})
+        properties = {"twds.instance.workspace-id=not-a-real-id", "sam.enabled=true"})
 public class SamDaoInvalidWorkspaceTest {
 
     @Autowired

--- a/service/src/test/java/org/databiosphere/workspacedataservice/sam/SamDaoInvalidWorkspaceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/sam/SamDaoInvalidWorkspaceTest.java
@@ -4,8 +4,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import java.util.UUID;
-
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -21,8 +19,6 @@ public class SamDaoInvalidWorkspaceTest {
     @Autowired
     SamDao samDao;
 
-    private final UUID someUuid = UUID.randomUUID();
-
     @Test
     public void createsFailingDao() {
         assertInstanceOf(FailingSamDao.class, samDao);
@@ -30,12 +26,12 @@ public class SamDaoInvalidWorkspaceTest {
 
     @Test
     public void permissionsReturnFalse() {
-        assertFalse(samDao.hasCreateInstancePermission(someUuid));
-        assertFalse(samDao.hasCreateInstancePermission(someUuid, "token"));
-        assertFalse(samDao.hasDeleteInstancePermission(someUuid));
-        assertFalse(samDao.hasDeleteInstancePermission(someUuid, "token"));
-        assertFalse(samDao.hasWriteInstancePermission(someUuid));
-        assertFalse(samDao.hasWriteInstancePermission(someUuid, "token"));
+        assertFalse(samDao.hasCreateInstancePermission());
+        assertFalse(samDao.hasCreateInstancePermission("token"));
+        assertFalse(samDao.hasDeleteInstancePermission());
+        assertFalse(samDao.hasDeleteInstancePermission("token"));
+        assertFalse(samDao.hasWriteInstancePermission());
+        assertFalse(samDao.hasWriteInstancePermission("token"));
     }
 
     @Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/sam/SamDaoInvalidWorkspaceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/sam/SamDaoInvalidWorkspaceTest.java
@@ -21,7 +21,7 @@ public class SamDaoInvalidWorkspaceTest {
 
     @Test
     public void createsFailingDao() {
-        assertInstanceOf(FailingSamDao.class, samDao);
+        assertInstanceOf(MisconfiguredSamDao.class, samDao);
     }
 
     @Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/sam/SamDaoInvalidWorkspaceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/sam/SamDaoInvalidWorkspaceTest.java
@@ -1,0 +1,47 @@
+package org.databiosphere.workspacedataservice.sam;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * When the WORKSPACE_ID env var is not a valid UUID, ensure
+ * that all Sam checks return false, and we get an exception
+ * from Sam status checks.
+ */
+@SpringBootTest(
+        classes = {SamConfig.class},
+        properties = {"twds.instance.workspace-id=not-a-real-id"})
+public class SamDaoInvalidWorkspaceTest {
+
+    @Autowired
+    SamDao samDao;
+
+    private final UUID someUuid = UUID.randomUUID();
+
+    @Test
+    public void createsFailingDao() {
+        assertInstanceOf(FailingSamDao.class, samDao);
+    }
+
+    @Test
+    public void permissionsReturnFalse() {
+        assertFalse(samDao.hasCreateInstancePermission(someUuid));
+        assertFalse(samDao.hasCreateInstancePermission(someUuid, "token"));
+        assertFalse(samDao.hasDeleteInstancePermission(someUuid));
+        assertFalse(samDao.hasDeleteInstancePermission(someUuid, "token"));
+        assertFalse(samDao.hasWriteInstancePermission(someUuid));
+        assertFalse(samDao.hasWriteInstancePermission(someUuid, "token"));
+    }
+
+    @Test
+    public void statusThrows() {
+        assertThrows(RuntimeException.class,
+                () ->samDao.getSystemStatus());
+    }
+
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceNoPermissionSamTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceNoPermissionSamTest.java
@@ -18,7 +18,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 import static org.databiosphere.workspacedataservice.service.RecordUtils.VERSION;
@@ -62,7 +61,7 @@ class InstanceServiceNoPermissionSamTest {
 
         UUID instanceId = UUID.randomUUID();
         assertThrows(AuthorizationException.class,
-                () -> instanceService.createInstance(instanceId, VERSION, Optional.empty()),
+                () -> instanceService.createInstance(instanceId, VERSION),
                 "createInstance should throw if caller does not have permission to create wds-instance resource in Sam"
         );
         List<UUID> allInstances = instanceService.listInstances(VERSION);

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamExceptionTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamExceptionTest.java
@@ -28,7 +28,6 @@ import org.springframework.test.context.TestPropertySource;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 import static org.databiosphere.workspacedataservice.service.RecordUtils.VERSION;
@@ -164,7 +163,7 @@ class InstanceServiceSamExceptionTest {
 
         // attempt to create the instance, which should fail
         assertThrows(expectedExceptionClass,
-                () -> instanceService.createInstance(instanceId, VERSION, Optional.empty()),
+                () -> instanceService.createInstance(instanceId, VERSION),
                 "createInstance should throw if caller does not have permission to create wds-instance resource in Sam"
         );
         List<UUID> allInstances = instanceService.listInstances(VERSION);
@@ -195,7 +194,7 @@ class InstanceServiceSamExceptionTest {
     private void doSamCreateTest(UUID instanceId, int expectedSamExceptionCode) {
         // attempt to create the instance, which should fail
         SamException samException = assertThrows(SamException.class,
-                () -> instanceService.createInstance(instanceId, VERSION, Optional.empty()),
+                () -> instanceService.createInstance(instanceId, VERSION),
                 "createInstance should throw if caller does not have permission to create wds-instance resource in Sam"
         );
         assertEquals(expectedSamExceptionCode, samException.getRawStatusCode(),

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamTest.java
@@ -65,14 +65,14 @@ class InstanceServiceSamTest {
     @Test
     void createInstanceSamCalls() throws ApiException {
         UUID instanceId = UUID.randomUUID();
-        doCreateInstanceTest(instanceId, Optional.empty(), instanceId);
+        doCreateInstanceTest(instanceId, Optional.empty());
     }
 
     @Test
     void createInstanceWithWorkspaceIdSamCalls() throws ApiException {
         UUID instanceId = UUID.randomUUID();
         UUID workspaceId = UUID.randomUUID();
-        doCreateInstanceTest(instanceId, Optional.of(workspaceId), workspaceId);
+        doCreateInstanceTest(instanceId, Optional.of(workspaceId));
     }
 
     @Test
@@ -82,7 +82,7 @@ class InstanceServiceSamTest {
     }
 
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-    void doCreateInstanceTest(UUID instanceId, Optional<UUID> workspaceIdInput, UUID expectedWorkspaceId) throws ApiException {
+    void doCreateInstanceTest(UUID instanceId, Optional<UUID> workspaceIdInput) throws ApiException {
         // setup: capture order of calls to Sam
         InOrder callOrder = inOrder(mockResourcesApi);
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamTest.java
@@ -22,7 +22,6 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.databiosphere.workspacedataservice.service.RecordUtils.VERSION;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamTest.java
@@ -87,7 +87,7 @@ class InstanceServiceSamTest {
         InOrder callOrder = inOrder(mockResourcesApi);
 
         // call createInstance
-        instanceService.createInstance(instanceId, VERSION, workspaceIdInput);
+        instanceService.createInstance(instanceId, VERSION);
 
         // createInstance should check permission with Sam exactly once:
         verify(mockResourcesApi, times(1))

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamTest.java
@@ -46,7 +46,7 @@ class InstanceServiceSamTest {
     ResourcesApi mockResourcesApi = Mockito.mock(ResourcesApi.class);
 
     @Value("${twds.instance.workspace-id}")
-    String containingWorkspaceId;
+    String parentWorkspaceId;
 
     @BeforeEach
     void beforeEach() throws ApiException {
@@ -100,7 +100,7 @@ class InstanceServiceSamTest {
         // the permission call should be first,
         // and that check should be for "write" permission on a workspace with workspaceId=containingWorkspaceId
         callOrder.verify(mockResourcesApi)
-                .resourcePermissionV2(SamDao.RESOURCE_NAME_WORKSPACE, containingWorkspaceId, SamDao.ACTION_WRITE);
+                .resourcePermissionV2(SamDao.RESOURCE_NAME_WORKSPACE, parentWorkspaceId, SamDao.ACTION_WRITE);
 
         // and that should be the only call we made to Sam
         verifyNoMoreInteractions(mockResourcesApi);
@@ -128,7 +128,7 @@ class InstanceServiceSamTest {
         // the permission call should be first,
         // and that check should be for "write" permission on a workspace with workspaceId=containingWorkspaceId
         callOrder.verify(mockResourcesApi)
-                .resourcePermissionV2(SamDao.RESOURCE_NAME_WORKSPACE, containingWorkspaceId, SamDao.ACTION_DELETE);
+                .resourcePermissionV2(SamDao.RESOURCE_NAME_WORKSPACE, parentWorkspaceId, SamDao.ACTION_DELETE);
 
         // and that should be the only call we made to Sam
         verifyNoMoreInteractions(mockResourcesApi);

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamTest.java
@@ -128,7 +128,7 @@ class InstanceServiceSamTest {
         // the permission call should be first,
         // and that check should be for "write" permission on a workspace with workspaceId=containingWorkspaceId
         callOrder.verify(mockResourcesApi)
-                .resourcePermissionV2(SamDao.RESOURCE_NAME_WORKSPACE, containingWorkspaceId, SamDao.ACTION_WRITE);
+                .resourcePermissionV2(SamDao.RESOURCE_NAME_WORKSPACE, containingWorkspaceId, SamDao.ACTION_DELETE);
 
         // and that should be the only call we made to Sam
         verifyNoMoreInteractions(mockResourcesApi);

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceTest.java
@@ -13,7 +13,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 import static org.databiosphere.workspacedataservice.service.RecordUtils.VERSION;
@@ -42,7 +41,7 @@ class InstanceServiceTest {
 
     @Test
     void testCreateAndValidateInstance() {
-        instanceService.createInstance(INSTANCE, VERSION, Optional.empty());
+        instanceService.createInstance(INSTANCE, VERSION);
         instanceService.validateInstance(INSTANCE);
 
         UUID invalidInstance = UUID.fromString("000e4444-e22b-22d1-a333-426614174000");
@@ -55,10 +54,10 @@ class InstanceServiceTest {
 
     @Test
     void listInstances() {
-        instanceService.createInstance(INSTANCE, VERSION, Optional.empty());
+        instanceService.createInstance(INSTANCE, VERSION);
 
         UUID secondInstanceId = UUID.fromString("999e1111-e89b-12d3-a456-426614174000");
-        instanceService.createInstance(secondInstanceId, VERSION, Optional.empty());
+        instanceService.createInstance(secondInstanceId, VERSION);
 
         List<UUID> instances = instanceService.listInstances(VERSION);
 
@@ -72,7 +71,7 @@ class InstanceServiceTest {
 
     @Test
     void deleteInstance() {
-        instanceService.createInstance(INSTANCE, VERSION, Optional.empty());
+        instanceService.createInstance(INSTANCE, VERSION);
         instanceService.validateInstance(INSTANCE);
 
         instanceService.deleteInstance(INSTANCE, VERSION);


### PR DESCRIPTION
In this PR:
* don't create or delete `wds-instance` Sam resources when creating/deleting WDS instances, including at startup time
* write APIs check permissions against the `workspace` Sam resource, not against `wds-instance` child resources
* we always check permission against the workspace specified in the `WORKSPACE_ID` env var, regardless of the WDS instance id
* _**remove the workspaceId query parameter from the create-instance API, since it is now obsolete and we rely on the `WORKSPACE_ID` env var instead**_
* if the `WORKSPACE_ID` env var can't be parsed to a UUID at startup, inject a `FailingSamDao` class instead of `HttpSamDao` - this will return false for all permission checks, log the failure reasons, and show the failure reason in WDS' `/status` API
* simplify a bunch of method signatures since we don't need the instanceId anymore when calling Sam

Impacts:
* You must be a workspace writer to upload a TSV, write or delete records, or create a WDS instance 
* You must be a workspace owner to delete a WDS instance
* _**As a developer running WDS locally, you'll want to set the `WORKSPACE_ID` env var or the `twds.instance.workspace-id` Spring property to the UUID of one of your workspaces**_
* If the `WORKSPACE_ID` env var is not set correctly, all write APIs will fail with auth errors

Open questions:
* ~I've left `hasCreateInstancePermission`, `hasDeleteInstancePermission`, and `hasWriteInstancePermission` as separate methods, though we could collapse them all into one method. Should we collapse these?~ Decision: leave these as-is
* ~since we're always checking the same workspaceid, does it even make sense to pass the instanceid into the Sam methods? Should we clean that up and simplify signatures?~ Decision: these are now cleaned up.
* ~should we remove `ManagedIdentityDao` and the `azure-identity` library entirely? Will we need those before too long when we get to multi-user WDS and have an app identity?~ Decision: leave this in place; we'll need it soon
* ~I'm not satisfied with the explosion in complexity of Sam integration - all the different Sam beans and configuration settings. I'd like to simplify that and make it easier to understand … is that worth doing in this PR, or as a follow-on?~ Decision: do this in a future PR - maybe after we re-enable Sam