### PR TITLE
AJ-992: spring boot, spring dep mgmt updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,8 @@ import org.hidetake.gradle.swagger.generator.GenerateSwaggerCode
 import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
 plugins {
-    id 'org.springframework.boot' version '2.6.8' apply false
-    id 'io.spring.dependency-management' version '1.0.11.RELEASE' apply false
+    id 'org.springframework.boot' version '2.6.14' apply false
+    id 'io.spring.dependency-management' version '1.1.0' apply false
     id 'com.google.cloud.tools.jib' version '3.2.1' apply false
     id "org.sonarqube" version "4.0.0.2929" apply false
     id 'idea'


### PR DESCRIPTION
Update versions of spring boot and spring dependency management plugins.

Spring boot latest is 3.0.5. I've updated to 2.6.14, the latest available version of the 2.6 series. I'd like to go higher but prefer to do that in a separate PR with more testing and reviewing of release notes.