### PR TITLE
AJ-992: update jackson in :client project

### DIFF
--- a/client/swagger.gradle
+++ b/client/swagger.gradle
@@ -1,6 +1,6 @@
 ext {
 	swagger_annotations_version = "2.0.0"
-	jackson_version = "2.13.2"
+	jackson_version = "2.14.2"
 	jersey_version = "2.36"
 }
 


### PR DESCRIPTION
Updates jackson to 2.14.2 inside the `:client` build, as recommended by the [dependency graph](https://github.com/DataBiosphere/terra-workspace-data-service/network/dependencies).