### PR TITLE
AJ-992: upgrade to Spring Boot 2.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import org.hidetake.gradle.swagger.generator.GenerateSwaggerCode
 import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
 plugins {
-    id 'org.springframework.boot' version '2.6.14' apply false
+    id 'org.springframework.boot' version '2.7.10' apply false
     id 'io.spring.dependency-management' version '1.1.0' apply false
     id 'com.google.cloud.tools.jib' version '3.2.1' apply false
     id "org.sonarqube" version "4.0.0.2929" apply false


### PR DESCRIPTION
Upgrades from Spring Boot 2.6 to 2.7.

I didn't see anything in the [Spring Boot 2.7 release notes](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.7-Release-Notes) that needed attention.

The latest stable version of this plugin is 3.0.4. However, the [Spring Boot 3.0 release notes](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Release-Notes) "strongly recommend that you upgrade to Spring Boot 2.7 before migrating to Spring Boot 3.0" … so I'm doing that here, and we can evaluate an upgrade to 3.0 separately.