### PR TITLE
AJ-1000: tests should clean up instances when they're done

### DIFF
--- a/service/src/test/java/org/databiosphere/workspacedataservice/GeneratedClientTests.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/GeneratedClientTests.java
@@ -12,6 +12,7 @@ import org.databiosphere.workspacedata.model.RecordResponse;
 import org.databiosphere.workspacedata.model.RecordTypeSchema;
 import org.databiosphere.workspacedata.model.SearchRequest;
 import org.databiosphere.workspacedata.model.TsvUploadResponse;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -44,6 +45,12 @@ class GeneratedClientTests {
         apiClient.setBasePath("http://localhost:" + port);
         createNewInstance(instanceId);
     }
+
+    @AfterEach
+    void afterEach() throws ApiException {
+        deleteInstance(instanceId);
+    }
+
     @Test
     void uploadTsv() throws ApiException, URISyntaxException {
         RecordsApi recordsApi = new RecordsApi(apiClient);
@@ -132,5 +139,10 @@ class GeneratedClientTests {
     private void createNewInstance(UUID instanceId) throws ApiException {
         InstancesApi instancesApi = new InstancesApi(apiClient);
         instancesApi.createWDSInstance(instanceId.toString(), version);
+    }
+
+    private void deleteInstance(UUID instanceId) throws ApiException {
+        InstancesApi instancesApi = new InstancesApi(apiClient);
+        instancesApi.deleteWDSInstance(instanceId.toString(), version);
     }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -16,9 +16,11 @@ import org.databiosphere.workspacedataservice.shared.model.RecordQueryResponse;
 import org.databiosphere.workspacedataservice.shared.model.RecordRequest;
 import org.databiosphere.workspacedataservice.shared.model.RecordResponse;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -50,6 +52,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ActiveProfiles(profiles = "mock-sam")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @AutoConfigureMockMvc
 class RecordControllerMockMvcTest {
 	@Autowired
@@ -78,6 +81,18 @@ class RecordControllerMockMvcTest {
 					versionId, instanceId).content("")).andExpect(status().isOk());
 		} catch (Throwable t)  {
 			 // noop - if we fail to delete the instance, don't fail the test
+		}
+	}
+
+	@AfterAll
+	void afterAll() throws Exception {
+		MvcResult response = mockMvc
+				.perform(get("/instances/{v}", versionId))
+				.andReturn();
+		UUID[] allInstances = mapper.readValue(response.getResponse().getContentAsString(), UUID[].class);
+		for (UUID id : allInstances) {
+			mockMvc.perform(delete("/instances/{v}/{instanceid}",
+					versionId, id).content(""));
 		}
 	}
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
@@ -6,6 +6,7 @@ import org.apache.commons.csv.CSVRecord;
 import org.apache.commons.csv.QuoteMode;
 import org.databiosphere.workspacedataservice.shared.model.BatchResponse;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -54,6 +55,11 @@ class TsvDownloadTest {
 		version = "v0.2";
 		instanceId = UUID.randomUUID();
 		recordController.createInstance(instanceId, version);
+	}
+
+	@AfterEach
+	void afterEach() {
+		recordController.deleteInstance(instanceId, version);
 	}
 
 	@ParameterizedTest(name = "PK name {0} should be honored")


### PR DESCRIPTION
Unit tests should clean up after themselves.

After running the full set of unit tests, here's what the database looked like:

Before this PR:
![pr-before](https://user-images.githubusercontent.com/6041577/233735246-f262ce51-8fe3-4da1-a993-5b81bf4e0e72.png)

After this PR:
![pr-after](https://user-images.githubusercontent.com/6041577/233735274-cb40c26a-2695-4951-9918-ec406e35bd5b.png)
