### PR TITLE
AJ-1005: Create Dockerfile to include postgres client for prod WDS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 FROM us.gcr.io/broad-dsp-gcr-public/base/jre:17-alpine
 
 # Add postgres client for pg_dump command
-RUN apk add --no-cache postgresql-client
+RUN apk add --no-cache postgresql-client~=15.2
 
 # Temp storage location for pg_dump outputs on Azure backups
 VOLUME /backup

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,9 @@
-# https://github.com/docker-library/docs/blob/master/eclipse-temurin/README.md#creating-a-jre-using-jlink
+### This Dockerfile is used to extend the app-sec blessed Docker image for JRE-17
+### We extend the Dockerfile within WDS to include a PostgreSQL client -- the client is primarily used
+### to faciliate the cloning of a WDS instance/workspace in Terra
 
-########## start of code directly from https://github.com/broadinstitute/dsp-appsec-blessed-images/blob/main/jre/Dockerfile.17-alpine
-FROM eclipse-temurin:17-jdk-alpine as jre-build
-
-# Create a custom Java runtime
-RUN apk add --no-cache binutils && \
-    $JAVA_HOME/bin/jlink \
-         --add-modules java.base \
-         --strip-debug \
-         --no-man-pages \
-         --no-header-files \
-         --compress=2 \
-         --output /javaruntime
-
-# Define your base image
-FROM alpine
-
-RUN apk --no-cache -U upgrade
-
-ENV JAVA_HOME=/opt/java/openjdk
-ENV PATH="${JAVA_HOME}/bin:${PATH}"
-
-COPY --from=jre-build /javaruntime $JAVA_HOME
-########## end of code directly from https://github.com/broadinstitute/dsp-appsec-blessed-images/blob/main/jre/Dockerfile.17-alpine
+### Sourced from https://github.com/broadinstitute/dsp-appsec-blessed-images/blob/main/jre/Dockerfile.17-alpine
+FROM us.gcr.io/broad-dsp-gcr-public/base/jre:17-alpine
 
 # Add postgres client for pg_dump command
 RUN apk add --no-cache postgresql-client

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# https://github.com/docker-library/docs/blob/master/eclipse-temurin/README.md#creating-a-jre-using-jlink
+
+########## start of code directly from https://github.com/broadinstitute/dsp-appsec-blessed-images/blob/main/jre/Dockerfile.17-alpine
+FROM eclipse-temurin:17-jdk-alpine as jre-build
+
+# Create a custom Java runtime
+RUN apk add --no-cache binutils && \
+    $JAVA_HOME/bin/jlink \
+         --add-modules java.base \
+         --strip-debug \
+         --no-man-pages \
+         --no-header-files \
+         --compress=2 \
+         --output /javaruntime
+
+# Define your base image
+FROM alpine
+
+RUN apk --no-cache -U upgrade
+
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+COPY --from=jre-build /javaruntime $JAVA_HOME
+########## end of code directly from https://github.com/broadinstitute/dsp-appsec-blessed-images/blob/main/jre/Dockerfile.17-alpine
+
+# Add postgres client for pg_dump command
+RUN apk add --no-cache postgresql-client
+
+# Temp storage location for pg_dump outputs on Azure backups
+VOLUME /backup

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,11 @@
 ### to faciliate the cloning of a WDS instance/workspace in Terra
 
 ### Sourced from https://github.com/broadinstitute/dsp-appsec-blessed-images/blob/main/jre/Dockerfile.17-alpine
-FROM us.gcr.io/broad-dsp-gcr-public/base/jre:17-alpine
+FROM us.gcr.io/broad-dsp-gcr-public/base/jre:17-debian
 
 # Add postgres client for pg_dump command
-RUN apk add --no-cache postgresql-client~=15.2
+RUN apt-get update && \
+    apt-get install -y postgresql-client
 
 # Temp storage location for pg_dump outputs on Azure backups
 VOLUME /backup

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 ### We extend the Dockerfile within WDS to include a PostgreSQL client -- the client is primarily used
 ### to faciliate the cloning of a WDS instance/workspace in Terra
 
-### Sourced from https://github.com/broadinstitute/dsp-appsec-blessed-images/blob/main/jre/Dockerfile.17-alpine
+### Sourced from https://github.com/broadinstitute/dsp-appsec-blessed-images/blob/main/jre/Dockerfile.17-debian
 FROM us.gcr.io/broad-dsp-gcr-public/base/jre:17-debian
 
 # Add postgres client for pg_dump command


### PR DESCRIPTION
We need to invoke `pg_dump` in WDS during cloning of workspaces -- this Dockerfile allows us to include the Postgres client -- it extends from app-sec blessed code here: https://github.com/broadinstitute/dsp-appsec-blessed-images/blob/main/jre/Dockerfile.17-alpine

Reminder:
All PRs merged into main will generate a PR in https://github.com/broadinstitute/cromwhelm to update the WDS image deployed to kubernetes. 
After your merge, you must go to this repo and approve this generated PR and make sure it merges.
That merge will then generate a PR in https://github.com/DataBiosphere/leonardo.  This may or may not automerge; be sure to watch it to ensure it merges.
