### PR TITLE
AJ-968: prefer artifactory caching proxy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,10 @@ plugins {
     id 'jacoco'
 }
 
-repositories { mavenCentral() }
+repositories {
+    maven { url 'https://broadinstitute.jfrog.io/artifactory/maven-central' }
+    mavenCentral()
+}
 
 subprojects {
     group = 'org.databiosphere'

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -7,7 +7,10 @@ plugins {
 	id 'org.hidetake.swagger.generator'
 }
 
-repositories { mavenCentral() }
+repositories {
+	maven { url 'https://broadinstitute.jfrog.io/artifactory/maven-central' }
+	mavenCentral()
+}
 
 apply from: 'artifactory.gradle'
 apply from: 'swagger.gradle'

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -12,6 +12,7 @@ springBoot {
 }
 
 repositories {
+	maven { url 'https://broadinstitute.jfrog.io/artifactory/maven-central' }
 	mavenCentral()
 	maven { url 'https://broadinstitute.jfrog.io/artifactory/libs-snapshot' }
 	maven { url 'https://broadinstitute.jfrog.io/artifactory/libs-release' }


### PR DESCRIPTION
Adds the Broad Artifactory caching proxy as the first repository, with maven central as the second.

This will help with any maven central outages.