### PR TITLE
AJ-952: transactions must be called from another class

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/InstanceService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/InstanceService.java
@@ -1,6 +1,5 @@
 package org.databiosphere.workspacedataservice.service;
 
-import bio.terra.common.db.WriteTransaction;
 import org.databiosphere.workspacedataservice.dao.InstanceDao;
 import org.databiosphere.workspacedataservice.sam.SamDao;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthorizationException;
@@ -60,11 +59,6 @@ public class InstanceService {
         }
 
         // create instance schema in Postgres
-        createInstanceInDatabase(instanceId);
-    }
-
-    @WriteTransaction
-    void createInstanceInDatabase(UUID instanceId) {
         instanceDao.createSchema(instanceId);
     }
 
@@ -81,11 +75,6 @@ public class InstanceService {
         }
 
         // delete instance schema in Postgres
-        deleteInstanceFromDatabase(instanceId);
-    }
-
-    @WriteTransaction
-    void deleteInstanceFromDatabase(UUID instanceId) {
         instanceDao.dropSchema(instanceId);
     }
 


### PR DESCRIPTION
See the first item at https://medium.com/javarevisited/spring-transactional-mistakes-everyone-did-31418e5a6d6b:

> @Transactional is powered by [Aspect-Oriented Programming](https://docs.spring.io/spring-framework/docs/current/reference/html/core.html#aop). Therefore, processing occurs when a bean is called from another bean.

We had two cases where annotated transactions were called from within the same class; this PR removes those.