### PR TITLE
AJ-958: fix liquibase changeset

### DIFF
--- a/service/src/main/resources/liquibase/changesets/20230426_domains.yaml
+++ b/service/src/main/resources/liquibase/changesets/20230426_domains.yaml
@@ -11,16 +11,16 @@ databaseChangeLog:
               '
               DECLARE
               BEGIN
-                  IF NOT EXISTS (SELECT 1 FROM information_schema.domains WHERE domain_name = ''relation'' and domain_schema = ''sys_wds'') THEN
+                  IF NOT EXISTS (SELECT 1 FROM information_schema.domains WHERE domain_name = ''relation'') THEN
                       create domain relation as text;
                   END IF;
-                  IF NOT EXISTS (SELECT 1 FROM information_schema.domains WHERE domain_name = ''array_of_relation'' and domain_schema = ''sys_wds'') THEN
+                  IF NOT EXISTS (SELECT 1 FROM information_schema.domains WHERE domain_name = ''array_of_relation'') THEN
                        create domain array_of_relation as text[];
                    END IF;
-                  IF NOT EXISTS (SELECT 1 FROM information_schema.domains WHERE domain_name = ''file'' and domain_schema = ''sys_wds'') THEN
+                  IF NOT EXISTS (SELECT 1 FROM information_schema.domains WHERE domain_name = ''file'') THEN
                       create domain file as text;
                   END IF;
-                  IF NOT EXISTS (SELECT 1 FROM information_schema.domains WHERE domain_name = ''array_of_file'' and domain_schema = ''sys_wds'') THEN
+                  IF NOT EXISTS (SELECT 1 FROM information_schema.domains WHERE domain_name = ''array_of_file'') THEN
                       create domain array_of_file as text[];
                   END IF;
               END;


### PR DESCRIPTION
A Liquibase changeset was faulty; this fixes it.

Normally we want to make a second changeset that fixes the first, and we should consider changesets immutable - especially since Liquibase creates hashes of them in the `databasechangelog` table, and will error if it sees that an already-run changeset is different.

In this case I am intentionally changing the existing changeset, knowing that very few people (and no end users) have run this already. If you, as a developer, have problems running Liquibase because you have already run this changeset, try dropping your db - if you're running a local postgres via `./local-dev/run_postgres.sh` you can just stop/start your local Postgres.