### PR TITLE
AJ-1000: Bump Spring Boot version to 2.7.11 to resolve security risk with Cloud Foundry

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import org.hidetake.gradle.swagger.generator.GenerateSwaggerCode
 import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
 plugins {
-    id 'org.springframework.boot' version '2.7.10' apply false
+    id 'org.springframework.boot' version '2.7.11' apply false
     id 'io.spring.dependency-management' version '1.1.0' apply false
     id 'com.google.cloud.tools.jib' version '3.2.1' apply false
     id "org.sonarqube" version "4.0.0.2929" apply false

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -41,7 +41,7 @@ dependencies {
 	implementation 'org.apache.commons:commons-csv:1.9.0'
 	implementation 'com.google.guava:guava:31.1-jre'
 	implementation 'org.postgresql:postgresql'
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator:2.7.11'
 	implementation 'org.webjars:webjars-locator-core:0.52'
 	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.14.2'
 	implementation 'io.sentry:sentry-logback:6.12.1'

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -41,7 +41,7 @@ dependencies {
 	implementation 'org.apache.commons:commons-csv:1.9.0'
 	implementation 'com.google.guava:guava:31.1-jre'
 	implementation 'org.postgresql:postgresql'
-	implementation 'org.springframework.boot:spring-boot-starter-actuator:2.7.11'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator:[2.7.11,3)'
 	implementation 'org.webjars:webjars-locator-core:0.52'
 	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.14.2'
 	implementation 'io.sentry:sentry-logback:6.12.1'

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -41,7 +41,7 @@ dependencies {
 	implementation 'org.apache.commons:commons-csv:1.9.0'
 	implementation 'com.google.guava:guava:31.1-jre'
 	implementation 'org.postgresql:postgresql'
-	implementation 'org.springframework.boot:spring-boot-starter-actuator:[2.7.11,3)'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.webjars:webjars-locator-core:0.52'
 	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.14.2'
 	implementation 'io.sentry:sentry-logback:6.12.1'


### PR DESCRIPTION
Relates to https://broadworkbench.atlassian.net/browse/AJ-1000

Resolves concern defined here: https://github.com/DataBiosphere/terra-workspace-data-service/security/dependabot/22

Release notes related to Spring Boot Actuator: https://github.com/spring-projects/spring-boot/releases/tag/v2.7.11

Reminder:
All PRs merged into main will generate a PR in https://github.com/broadinstitute/cromwhelm to update the WDS image deployed to kubernetes. 
After your merge, you must go to this repo and approve this generated PR and make sure it merges.
That merge will then generate a PR in https://github.com/DataBiosphere/leonardo.  This may or may not automerge; be sure to watch it to ensure it merges.
