### PR TITLE
AJ-1006: set WORKSPACE_ID env var for python tests

### DIFF
--- a/.github/workflows/release-python-client.yml
+++ b/.github/workflows/release-python-client.yml
@@ -84,6 +84,7 @@ jobs:
       - name: Run WDS service and tests
         run: |
             export SAM_URL=http://localhost:9889
+            export WORKSPACE_ID=123e4567-e89b-12d3-a456-426614174000
             ./gradlew --build-cache build -x test
             ./gradlew bootRun &
             count=20
@@ -96,7 +97,6 @@ jobs:
                 exit
               fi
             done
-            curl -v -X POST http://localhost:8080/instances/v0.2/123e4567-e89b-12d3-a456-426614174000
             pip install pytest
             pytest service/src/test/python/test.py
      


### PR DESCRIPTION
The combination of:
* #206 
* #222 

makes it such that the `WORKSPACE_ID` env var is required; if that var is not set, all Sam permission checks will fail.

In the `release-python-client.yml` action, we didn't have `WORKSPACE_ID` set; so as soon as we re-enabled Sam, permission checks started to fail, and therefore at least one test failed. This PR should fix that!

