### PR TITLE
AJ-1026: dont send to Sentry for default 'unknown' environment

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/SentryInitializer.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/SentryInitializer.java
@@ -36,7 +36,7 @@ public class SentryInitializer  {
 
 	private static final Pattern SAM_ENV_PATTERN = Pattern.compile("\\.dsde-(\\p{Alnum}+)\\.");
 	private static final String DEFAULT_ENV = "unknown";
-	//Environments we want to monitor on sentry - don't send errors from local or bees
+	//Environments we want to monitor on sentry - don't send errors from local, bees, or Github actions
 	private static final List<String> environments = List.of("prod", "alpha", "staging", "dev");
 
 	@Bean

--- a/service/src/main/java/org/databiosphere/workspacedataservice/SentryInitializer.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/SentryInitializer.java
@@ -37,7 +37,7 @@ public class SentryInitializer  {
 	private static final Pattern SAM_ENV_PATTERN = Pattern.compile("\\.dsde-(\\p{Alnum}+)\\.");
 	private static final String DEFAULT_ENV = "unknown";
 	//Environments we want to monitor on sentry - don't send errors from local or bees
-	private static final List<String> environments = List.of("prod","alpha","staging", "dev", DEFAULT_ENV);
+	private static final List<String> environments = List.of("prod", "alpha", "staging", "dev");
 
 	@Bean
 	public SmartInitializingSingleton initialize() {


### PR DESCRIPTION
If we can't figure out which environment WDS is running in, don't send anything to Sentry.

This will be the case when running unit tests in GHA, for instance. It should help us cut down on noise in Sentry.