### PR TITLE
AJ-1026: fix artifactory publish

### DIFF
--- a/client/artifactory.gradle
+++ b/client/artifactory.gradle
@@ -18,7 +18,7 @@ java {
 
 publishing {
 	publications {
-		workspacedataserviceResttemplateClientLibrary(MavenPublication) {
+		wdsClient(MavenPublication) {
 			artifactId = 'workspacedataservice-client'
 			from components.java
 			versionMapping {
@@ -41,7 +41,7 @@ artifactory {
 		defaults {
 			// This is how we tell the Artifactory Plugin which artifacts should be published to Artifactory.
 			// Reference to Gradle publications defined in the build script.
-			publications('workspacedataserviceResttemplateClientLibrary')
+			publications('wdsClient')
 			publishArtifacts = true
 			publishPom = true
 		}

--- a/client/swagger.gradle
+++ b/client/swagger.gradle
@@ -50,12 +50,12 @@ compileJava.dependsOn generateSwaggerCode
 sourcesJar.dependsOn generateSwaggerCode
 
 // next line required by swagger client generation
-generateSwaggerCode.dependsOn generatePomFileForWorkspacedataserviceResttemplateClientLibraryPublication
+generateSwaggerCode.dependsOn generatePomFileForWdsClientPublication
 
 // Ugly hack from https://github.com/jfrog/build-info/issues/198#issuecomment-1073659209
 task fixPom {
 	doLast {
-		File file = new File("$buildDir/publications/workspacedataserviceResttemplateClientLibrary/pom-default.xml")
+		File file = new File("$buildDir/publications/wdsClient/pom-default.xml")
 		def text = file.text
 		def pattern = "(?s)(<dependencyManagement>.+?<dependencies>)(.+?)(</dependencies>.+?</dependencyManagement>)"
 		Matcher matcher = text =~ pattern
@@ -67,4 +67,4 @@ task fixPom {
 		file.write(text)
 	}
 }
-generatePomFileForWorkspacedataserviceResttemplateClientLibraryPublication.finalizedBy fixPom
+generatePomFileForWdsClientPublication.finalizedBy fixPom

--- a/client/swagger.gradle
+++ b/client/swagger.gradle
@@ -1,3 +1,5 @@
+import java.util.regex.Matcher
+
 ext {
 	swagger_annotations_version = "2.0.0"
 	jackson_version = "2.14.2"
@@ -46,5 +48,23 @@ idea.module.generatedSourceDirs = [file("${generateSwaggerCode.outputDir}/src/ma
 sourceSets.main.java.srcDir "${generateSwaggerCode.outputDir}/src/main/java"
 compileJava.dependsOn generateSwaggerCode
 sourcesJar.dependsOn generateSwaggerCode
+
 // next line required by swagger client generation
 generateSwaggerCode.dependsOn generatePomFileForWorkspacedataserviceResttemplateClientLibraryPublication
+
+// Ugly hack from https://github.com/jfrog/build-info/issues/198#issuecomment-1073659209
+task fixPom {
+	doLast {
+		File file = new File("$buildDir/publications/workspacedataserviceResttemplateClientLibrary/pom-default.xml")
+		def text = file.text
+		def pattern = "(?s)(<dependencyManagement>.+?<dependencies>)(.+?)(</dependencies>.+?</dependencyManagement>)"
+		Matcher matcher = text =~ pattern
+		if (matcher.find()) {
+			text = text.replaceFirst(pattern, "")
+			def firstDeps = matcher.group(2)
+			text = text.replaceFirst(pattern, '$1$2' + firstDeps + '$3')
+		}
+		file.write(text)
+	}
+}
+generatePomFileForWorkspacedataserviceResttemplateClientLibraryPublication.finalizedBy fixPom


### PR DESCRIPTION
The addition of a `dependencies.constraints {` stanza in #226 caused artifactory publishing to fail.

This is explained in [this jfrog issue](https://github.com/jfrog/build-info/issues/198).

After poking around a bit, I have implemented the hack fix from the comments in that issue.

As a bonus, I renamed the gradle task `workspacedataserviceResttemplateClientLibrary` to `wdsClient` - shorter, easier to use, and doesn't tie us to using rest template.