### PR TITLE
AJ-1026: actually upgrade snakeyaml

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,17 +40,7 @@ subprojects {
         dependencies {
             dependency 'io.swagger.core.v3:swagger-annotations:2.1.13'
             dependency 'io.swagger.codegen.v3:swagger-codegen-cli:3.0.34'
-        }
-    }
-
-    // declare versions of transitive dependencies we want to upgrade here
-    // this will apply to both the :client and the :service project
-    // see https://docs.gradle.org/current/userguide/dependency_constraints.html#sec:adding-constraints-transitive-deps
-    dependencies {
-        constraints {
-            implementation('org.yaml:snakeyaml:2.0') {
-                because 'CVE-2022-1471, CVE-2022-38750, CVE-2022-1471, CVE-2022-25857, CVE-2022-41854'
-            }
+            dependency 'org.yaml:snakeyaml:2.0'
         }
     }
 

--- a/client/swagger.gradle
+++ b/client/swagger.gradle
@@ -51,20 +51,3 @@ sourcesJar.dependsOn generateSwaggerCode
 
 // next line required by swagger client generation
 generateSwaggerCode.dependsOn generatePomFileForWdsClientPublication
-
-// Ugly hack from https://github.com/jfrog/build-info/issues/198#issuecomment-1073659209
-task fixPom {
-	doLast {
-		File file = new File("$buildDir/publications/wdsClient/pom-default.xml")
-		def text = file.text
-		def pattern = "(?s)(<dependencyManagement>.+?<dependencies>)(.+?)(</dependencies>.+?</dependencyManagement>)"
-		Matcher matcher = text =~ pattern
-		if (matcher.find()) {
-			text = text.replaceFirst(pattern, "")
-			def firstDeps = matcher.group(2)
-			text = text.replaceFirst(pattern, '$1$2' + firstDeps + '$3')
-		}
-		file.write(text)
-	}
-}
-generatePomFileForWdsClientPublication.finalizedBy fixPom


### PR DESCRIPTION
In #226 I tried to upgrade snakeyaml, but was ineffective. I specified a dependency constraint … but since the versions controlled by `io.spring.dependency-management` take precedence, the constraint did nothing.

[This comment](https://github.com/spring-projects/spring-boot/issues/34405#issuecomment-1479808747) helps with confidence that Spring Boot 2.7.11 and snakeyaml 2.0 work ok together.

In this PR:
* upgrade snakeyaml via the `dependencyManagement` block, which is the `io.spring.dependency-management`-specific way to do it
* remove the ugly rewrite-pom hack which is no longer necessary.