### PR TITLE
AJ-1026: update README for env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,16 +27,26 @@ jenv add /Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home
 We are using Postgres 13.1.  You do not need to have postgres installed on your system.
 Instead use the `run_postgres.sh` script to set up a docker container running postgres (see below).
 
-## Running
-### Pulling local secrets
-Before running WDS, you must populate secrets from Vault.
-After [setting up your vault-token](https://docs.google.com/document/d/11pZE-GqeZFeSOG0UpGg_xyTDQpgBRfr0MLxpxvvQgEw) run:
-```bash
-./scripts/render-config.sh [wds env] [vault env]
-```
-Here `wds env` may be `local`,`dev`,`alpha`,`perf`, or `prod`
-`vault env` can be `docker` or `local`.
+#### SAM_URL
 
+WDS contacts Sam for permission checks. You will need to configure Sam's URL by setting an
+environment variable, such as:
+```
+export SAM_URL=https://sam.dsde-dev.broadinstitute.org/
+```
+You may want to add this to your `~/.zshrc` or similar shell profile.
+
+#### WORKSPACE_ID
+
+When WDS queries Sam for permission, it queries IAM for the workspace in which WDS is running.
+This is controlled by a `WORKSPACE_ID` environment variable. You should set this to the UUID
+of a workspace you own, e.g.
+```
+export WORKSPACE_ID=123e4567-e89b-12d3-a456-426614174000
+```
+You may want to add this to your `~/.zshrc` or similar shell profile.
+
+## Running
 To just build the code, from the root directory run
 ```bash
 ./gradlew build


### PR DESCRIPTION
* add `SAM_URL` and `WORKSPACE_ID` env vars to readme
* remove `render-config.sh` from readme, since it is unnecessary. Should I remove the script entirely from the repo?