### PR TITLE
AJ-769: move to ehcache

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter'
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
 	implementation 'org.springframework.retry:spring-retry:1.3.4'
 	implementation 'org.aspectj:aspectjweaver:1.8.9' // required by spring-retry, not used directly by WDS
 	implementation 'org.apache.commons:commons-lang3'
@@ -47,6 +48,8 @@ dependencies {
 	implementation 'io.sentry:sentry-logback:6.12.1'
 	implementation 'com.azure:azure-identity:1.8.2'
 	implementation 'org.liquibase:liquibase-core:4.21.1'
+	implementation 'javax.cache:cache-api'
+	implementation 'org.ehcache:ehcache:3.10.8'
 
 	// Terra libraries
 	implementation group: 'org.broadinstitute.dsde.workbench', name: 'sam-client_2.13', version: '0.1-b7e47d2'

--- a/service/src/main/java/org/databiosphere/workspacedataservice/WorkspaceDataServiceApplication.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/WorkspaceDataServiceApplication.java
@@ -5,7 +5,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.retry.annotation.EnableRetry;
-import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 @SpringBootApplication(scanBasePackages = {
 		// this codebase
@@ -16,7 +15,6 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 @EnableRetry
 @EnableTransactionManagement
 @EnableCaching
-@EnableScheduling
 public class WorkspaceDataServiceApplication {
 
 	public static void main(String[] args) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/cache/CacheLogger.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/cache/CacheLogger.java
@@ -1,0 +1,16 @@
+package org.databiosphere.workspacedataservice.cache;
+
+import org.ehcache.event.CacheEvent;
+import org.ehcache.event.CacheEventListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CacheLogger implements CacheEventListener<Object, Object> {
+    private final Logger LOGGER = LoggerFactory.getLogger(CacheLogger.class);
+    @Override
+    public void onEvent(CacheEvent<?, ?> cacheEvent) {
+        LOGGER.debug("Key: {} | EventType: {} | Old value: {} | New value: {}",
+                cacheEvent.getKey(), cacheEvent.getType(), cacheEvent.getOldValue(),
+                cacheEvent.getNewValue());
+    }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamDao.java
@@ -3,9 +3,7 @@ package org.databiosphere.workspacedataservice.sam;
 import org.broadinstitute.dsde.workbench.client.sam.model.SystemStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
-import org.springframework.scheduling.annotation.Scheduled;
 
 import static org.databiosphere.workspacedataservice.sam.HttpSamClientSupport.SamFunction;
 
@@ -86,25 +84,19 @@ public class HttpSamDao implements SamDao {
     }
 
     /**
-     * Gets the System Status of Sam. Using @Cacheable, will reach out to Sam no more than once every 5 minutes.
-     * See also emptySamStatusCache()
+     * Gets the up/down status of Sam. Using @Cacheable, will reach out to Sam no more than
+     * once every 5 minutes (configured in ehcache.xml).
      */
-    @Cacheable(value = "samStatus", key="'getSystemStatus'")
+    @Cacheable(value = "samStatus", key="'getSystemStatus'", cacheNames = "samStatus")
+    public Boolean getSystemStatusOk() {
+        return getSystemStatus().getOk();
+    }
+
     public SystemStatus getSystemStatus() {
         SamFunction<SystemStatus> samFunction = () -> samClientFactory.getStatusApi().getSystemStatus();
         return httpSamClientSupport.withRetryAndErrorHandling(samFunction, "getSystemStatus");
     }
 
-    /**
-     * Clears the samStatus cache every 5 minutes, to ensure we get fresh results from Sam
-     * every so often. See also getSystemStatus()
-     */
-
-    @CacheEvict(value = "samStatus", key="'getSystemStatus'")
-    @Scheduled(fixedRateString = "${sam.healthcheck.pingTTL}")
-    public void emptySamStatusCache() {
-        LOGGER.debug("emptying samStatus cache");
-    }
 }
 
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/MisconfiguredSamDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/MisconfiguredSamDao.java
@@ -59,6 +59,11 @@ public class MisconfiguredSamDao implements SamDao {
     }
 
     @Override
+    public Boolean getSystemStatusOk() {
+        throw new RuntimeException("Sam integration failure: " + errorMessage);
+    }
+
+    @Override
     public SystemStatus getSystemStatus() {
         throw new RuntimeException("Sam integration failure: " + errorMessage);
     }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/PermissionsStatusService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/PermissionsStatusService.java
@@ -27,8 +27,8 @@ public class PermissionsStatusService extends AbstractHealthIndicator {
     public void doHealthCheck(Health.Builder builder) throws Exception {
         builder.up();
         try {
-            SystemStatus samStatus = samDao.getSystemStatus();
-            builder.withDetail("samOK", samStatus.getOk());
+            Boolean samStatus = samDao.getSystemStatusOk();
+            builder.withDetail("samOK", samStatus);
         } catch (Exception e) {
             LOGGER.warn("SAM is currently signaled as DOWN.");
             builder.withDetail("samConnectionError", e.getMessage());

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/SamDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/SamDao.java
@@ -50,7 +50,12 @@ public interface SamDao {
     boolean hasWriteInstancePermission(String token);
 
     /**
-     * Gets the System Status of SAM.
+     * Gets the up/down system status of Sam.
+     */
+    Boolean getSystemStatusOk();
+
+    /**
+     * Gets the System Status of Sam.
      */
     SystemStatus getSystemStatus();
 

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -23,6 +23,8 @@ server.error.include-message=always
 spring.servlet.multipart.max-request-size=5GB
 spring.servlet.multipart.max-file-size=5GB
 
+spring.cache.jcache.config=classpath:ehcache.xml
+
 twds.write.batch.size=5000
 twds.streaming.fetch.size=5000
 

--- a/service/src/main/resources/ehcache.xml
+++ b/service/src/main/resources/ehcache.xml
@@ -41,7 +41,7 @@
     </cache>
 
     <cache alias="primaryKeys" uses-template="default">
-        <key-type>java.util.List</key-type>
+        <key-type>java.util.ArrayList</key-type>
         <value-type>java.lang.String</value-type>
         <expiry>
             <ttl unit="hours">24</ttl>

--- a/service/src/main/resources/ehcache.xml
+++ b/service/src/main/resources/ehcache.xml
@@ -1,0 +1,56 @@
+<config
+        xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+        xmlns='http://www.ehcache.org/v3'
+        xsi:schemaLocation="
+            http://www.ehcache.org/v3
+            http://www.ehcache.org/schema/ehcache-core-3.7.xsd">
+
+    <cache-template name="default">
+        <expiry>
+            <ttl unit="seconds">30</ttl>
+        </expiry>
+        <listeners>
+            <listener>
+                <class>org.databiosphere.workspacedataservice.cache.CacheLogger</class>
+                <event-firing-mode>ASYNCHRONOUS</event-firing-mode>
+                <event-ordering-mode>UNORDERED</event-ordering-mode>
+                <events-to-fire-on>CREATED</events-to-fire-on>
+                <events-to-fire-on>EXPIRED</events-to-fire-on>
+                <events-to-fire-on>EVICTED</events-to-fire-on>
+                <events-to-fire-on>REMOVED</events-to-fire-on>
+                <events-to-fire-on>UPDATED</events-to-fire-on>
+            </listener>
+        </listeners>
+        <resources>
+            <heap>1000</heap>
+            <offheap unit="MB">10</offheap>
+            <disk persistent="true" unit="MB">20</disk>
+        </resources>
+    </cache-template>
+
+    <cache alias="samStatus" uses-template="default">
+        <key-type>java.lang.String</key-type>
+        <value-type>java.lang.Boolean</value-type>
+        <expiry>
+            <ttl unit="minutes">5</ttl>
+        </expiry>
+        <resources>
+            <heap unit="entries">1</heap>
+            <offheap unit="MB">1</offheap>
+        </resources>
+    </cache>
+
+    <cache alias="primaryKeys" uses-template="default">
+        <key-type>java.util.List</key-type>
+        <value-type>java.lang.String</value-type>
+        <expiry>
+            <ttl unit="hours">24</ttl>
+        </expiry>
+        <resources>
+            <heap unit="entries">500</heap>
+            <offheap unit="MB">8</offheap>
+        </resources>
+    </cache>
+
+
+</config>


### PR DESCRIPTION
In this PR:
1. Replace the simple in-memory ConcurrentHashMap cache provider - the "Simple" provider - with ehcache. This gives us way more features and configurability.
2. Modify the SamDao interface and implementation classes to play nice with ehcache. Previously we were caching the `org.broadinstitute.dsde.workbench.client.sam.model.SystemStatus` object, which is not serializable (ehcache requires serializable values); now we just cache a Boolean
3. Remove the eviction of Sam cache via a `@Scheduled` invocation and replace with a TTL on the cache itself
4. Add debug-level logging for cache operations

This PR is pre-work for [AJ-769](https://broadworkbench.atlassian.net/browse/AJ-769). In that ticket, I expect to make pretty heavy use of a new cache and would like control over that cache's size limits and TTL.

more info:
https://springframework.guru/using-ehcache-3-in-spring-boot/
https://www.baeldung.com/spring-boot-ehcache

[AJ-769]: https://broadworkbench.atlassian.net/browse/AJ-769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ