### PR TITLE
AJ-945 Adjust release github action to require Jira Id as part of manual trigger

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -5,6 +5,9 @@ on:
       new-tag:
         required: true
         type: string
+      jiraId:
+        required: true
+        type: string
     secrets:
       ACR_SP_PASSWORD:
         required: true
@@ -32,11 +35,11 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-      - name: Look for AJ (Analysis Journeys) Jira ID in the commit message
+      - name: Look for AJ (Analysis Journeys) Jira ID in the manual workflow trigger message
         id: find-jira-id
         run: |
           set +e
-          JIRA_ID=$(echo "${{ github.event.head_commit.message }}" | grep -iEo -m 1 'AJ-[0-9]+' | head -1 || '')
+          JIRA_ID=$(echo "${{ inputs.jiraId }}" | grep -iEo -m 1 'AJ-[0-9]+' | head -1 || '')
           if [[ -z "$JIRA_ID" ]]; then
             echo "JIRA_ID=missing" >> $GITHUB_OUTPUT
           else 
@@ -90,7 +93,7 @@ jobs:
         run: docker push --all-tags ${{ steps.gcr-image-name.outputs.name }}
 
       - name: Re-tag image for ACR
-        run: docker tag ${{ steps.gcr-image-name.outputs.name }}:${{ steps.setHash.outputs.git_short_sha }} ${{ steps.acr-image-name.outputs.name }}:${{ steps.setHash.outputs.git_short_sha }}
+        run: docker tag ${{ steps.gcr-image-name.outputs.name }}:${{ steps.setHash.outputs.git_short_sha }} ${{ steps.acr-image-name.outputs.name }}:${{ inputs.new-tag  }}
 
       - name: Add version tag to ACR
         run: docker image tag ${{ steps.acr-image-name.outputs.name }}:${{ steps.setHash.outputs.git_short_sha }} ${{ steps.acr-image-name.outputs.name }}:${{ inputs.new-tag }}
@@ -100,6 +103,7 @@ jobs:
           echo ${{ secrets.ACR_SP_PASSWORD }} | docker login ${ACR_REGISTRY} \
           --username ${{ secrets.ACR_SP_USER }} \
           --password-stdin
+          docker push --all-tags ${{ steps.acr-image-name.outputs.name }}
           
       - name: Clone terra-helmfile
         uses: actions/checkout@v3

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -3,11 +3,11 @@ on:
   workflow_dispatch:
     # Inputs the workflow accepts.
     inputs:
-      name:
+      jiraId:
         # Friendly description to be shown in the UI instead of 'name'
-        description: 'Reason for manual execution'
+        description: 'Jira ID'
         # Default value if no value is explicitly provided
-        default: 'WDS Release'
+        default: 'Required: Include later Jira ID'
         # Input has to be provided for the workflow to run
         required: true
         # The data type of the input
@@ -52,6 +52,7 @@ jobs:
       uses: ./.github/workflows/publish-docker.yml
       with:
         new-tag: ${{ needs.tag-job.outputs.new_tag }}
+        jiraId: ${{ inputs.jiraId }}
       secrets:
         ACR_SP_PASSWORD: ${{ secrets.ACR_SP_PASSWORD }}
         ACR_SP_USER: ${{ secrets.ACR_SP_USER }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -7,7 +7,7 @@ on:
         # Friendly description to be shown in the UI instead of 'name'
         description: 'Jira ID'
         # Default value if no value is explicitly provided
-        default: 'Required: Include later Jira ID'
+        default: 'Required: Include latest Jira ID'
         # Input has to be provided for the workflow to run
         required: true
         # The data type of the input


### PR DESCRIPTION
Also it appears that some changes didnt make it (as well as a line of code was deleted that should not have been in the previous PR). Honestly not sure how that happened now, maybe somehow my laptop and PC had conflicting versions (not sure) and some of my earlier changes on the previous PR got overwritten. Anyways, fixing so it should work now. 

Basically there was no error but PR didnt get created since there is no Jira ID present: https://github.com/DataBiosphere/terra-workspace-data-service/actions/runs/4985324312/jobs/8924787454