### PR TITLE
AJ-945 - Fix azure image docker image tagging

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -93,8 +93,8 @@ jobs:
         run: docker push --all-tags ${{ steps.gcr-image-name.outputs.name }}
 
       - name: Re-tag image for ACR
-        run: docker tag ${{ steps.gcr-image-name.outputs.name }}:${{ steps.setHash.outputs.git_short_sha }} ${{ steps.acr-image-name.outputs.name }}:${{ inputs.new-tag  }}
-
+        run: docker tag ${{ steps.gcr-image-name.outputs.name }}:${{ steps.setHash.outputs.git_short_sha }} ${{ steps.acr-image-name.outputs.name }}:${{ steps.setHash.outputs.git_short_sha }}
+      
       - name: Add version tag to ACR
         run: docker image tag ${{ steps.acr-image-name.outputs.name }}:${{ steps.setHash.outputs.git_short_sha }} ${{ steps.acr-image-name.outputs.name }}:${{ inputs.new-tag }}
 


### PR DESCRIPTION
I missed the part where ACR was being tagged and then re-tagged. Fixing to make sure that works correctly. 

It appears we do not use ACR images today - should we still be pushing them or just take this out until we do start to use them?