### PR TITLE
AJ-769: activity logging

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityEvent.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityEvent.java
@@ -2,6 +2,15 @@ package org.databiosphere.workspacedataservice.activitylog;
 
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 
+/**
+ * Represents an entry in an activity log.
+ * @param subject the identity performing the activity
+ * @param action the "verb" of the activity
+ * @param thing the object target of the activity
+ * @param recordType further qualifies the object, if this is a table or record
+ * @param quantity number of things being operated on, if "ids" is not specified
+ * @param ids ids for the things being operated on
+ */
 public record ActivityEvent(String subject,
                             ActivityModels.Action action,
                             ActivityModels.Thing thing,

--- a/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityEvent.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityEvent.java
@@ -1,40 +1,6 @@
 package org.databiosphere.workspacedataservice.activitylog;
 
-public class ActivityEvent {
-
-
-
-    private final String subject;
-    private final ActivityModels.Action action;
-    private final Long quantity;
-    private final ActivityModels.Thing thing;
-    private final String[] ids;
-
-    public ActivityEvent(String subject, ActivityModels.Action action, Long quantity, ActivityModels.Thing thing, String[] ids) {
-        this.subject = subject;
-        this.action = action;
-        this.quantity = quantity;
-        this.thing = thing;
-        this.ids = ids;
-    }
-
-    public String getSubject() {
-        return subject;
-    }
-
-    public ActivityModels.Action getAction() {
-        return action;
-    }
-
-    public Long getQuantity() {
-        return quantity;
-    }
-
-    public ActivityModels.Thing getThing() {
-        return thing;
-    }
-
-    public String[] getIds() {
-        return ids;
-    }
-}
+public record ActivityEvent(String subject,
+                            ActivityModels.Action action,
+                            ActivityModels.Thing thing,
+                            String[] ids) {}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityEvent.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityEvent.java
@@ -1,0 +1,40 @@
+package org.databiosphere.workspacedataservice.activitylog;
+
+public class ActivityEvent {
+
+
+
+    private final String subject;
+    private final ActivityModels.Action action;
+    private final Long quantity;
+    private final ActivityModels.Thing thing;
+    private final String[] ids;
+
+    public ActivityEvent(String subject, ActivityModels.Action action, Long quantity, ActivityModels.Thing thing, String[] ids) {
+        this.subject = subject;
+        this.action = action;
+        this.quantity = quantity;
+        this.thing = thing;
+        this.ids = ids;
+    }
+
+    public String getSubject() {
+        return subject;
+    }
+
+    public ActivityModels.Action getAction() {
+        return action;
+    }
+
+    public Long getQuantity() {
+        return quantity;
+    }
+
+    public ActivityModels.Thing getThing() {
+        return thing;
+    }
+
+    public String[] getIds() {
+        return ids;
+    }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityEvent.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityEvent.java
@@ -1,6 +1,10 @@
 package org.databiosphere.workspacedataservice.activitylog;
 
+import org.databiosphere.workspacedataservice.shared.model.RecordType;
+
 public record ActivityEvent(String subject,
                             ActivityModels.Action action,
                             ActivityModels.Thing thing,
+                            RecordType recordType,
+                            Integer quantity,
                             String[] ids) {}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityEventBuilder.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityEventBuilder.java
@@ -2,6 +2,8 @@ package org.databiosphere.workspacedataservice.activitylog;
 
 import org.databiosphere.workspacedataservice.sam.SamDao;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.context.request.RequestContextHolder;
 
 import java.util.UUID;
@@ -22,6 +24,8 @@ public class ActivityEventBuilder {
     private RecordType recordType;
     private int quantity;
     private String[] ids;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ActivityEventBuilder.class);
 
     /**
      * Constructor.
@@ -50,7 +54,8 @@ public class ActivityEventBuilder {
             }
 
         } catch (Exception e) {
-            this.subject = "???";
+            LOGGER.warn("Error resolving user token to id via Sam: " + e.getMessage(), e);
+            this.subject = "(unknown due to exception)";
         }
         return this;
     }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityEventBuilder.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityEventBuilder.java
@@ -76,6 +76,11 @@ public class ActivityEventBuilder {
         this.action = ActivityModels.Action.MODIFY;
         return this;
     }
+    public ActivityEventBuilder linked() {
+        this.action = ActivityModels.Action.LINK;
+        return this;
+
+    }
     // OBJECT BUILDERS
 
     public ActivityEventBuilder instance() {
@@ -93,6 +98,10 @@ public class ActivityEventBuilder {
         return this;
     }
 
+    public ActivityEventBuilder snapshotReference() {
+        this.thing = ActivityModels.Thing.SNAPSHOT_REFERENCE;
+        return this;
+    }
     // RECORD TYPE BUILDERS
     public ActivityEventBuilder withRecordType(RecordType recordType) {
         this.recordType = recordType;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityEventBuilder.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityEventBuilder.java
@@ -3,7 +3,6 @@ package org.databiosphere.workspacedataservice.activitylog;
 import org.databiosphere.workspacedataservice.sam.SamDao;
 import org.springframework.web.context.request.RequestContextHolder;
 
-import java.util.Objects;
 import java.util.UUID;
 
 import static org.databiosphere.workspacedataservice.sam.BearerTokenFilter.ATTRIBUTE_NAME_TOKEN;
@@ -18,6 +17,17 @@ public class ActivityEventBuilder {
     private ActivityModels.Action action;
     private ActivityModels.Thing thing;
     private String[] ids;
+
+    /**
+     * Takes a reference to the ActivityLogger that created this event, and which
+     * will eventually persist the event (to a log or to a db table)
+     * @param activityLogger
+     * @param samDao
+     */
+    public ActivityEventBuilder(ActivityLogger activityLogger, SamDao samDao) {
+        this.activityLogger = activityLogger;
+        this.samDao = samDao;
+    }
 
 
     // ===== SUBJECT BUILDERS
@@ -55,11 +65,6 @@ public class ActivityEventBuilder {
         return this;
     }
 
-//    public ActivityEventBuilder setAction(ActivityModels.Action action) {
-//        this.action = action;
-//        return this;
-//    }
-
     // OBJECT BUILDERS
 
     public ActivityEventBuilder instance() {
@@ -75,16 +80,6 @@ public class ActivityEventBuilder {
     public ActivityEventBuilder record() {
         this.thing = ActivityModels.Thing.RECORD;
         return this;
-    }
-//
-//    public ActivityEventBuilder setThing(ActivityModels.Thing thing) {
-//        this.thing = thing;
-//        return this;
-//    }
-
-    public ActivityEventBuilder(ActivityLogger activityLogger, SamDao samDao) {
-        this.activityLogger = activityLogger;
-        this.samDao = samDao;
     }
 
     // ID BUILDERS
@@ -106,10 +101,10 @@ public class ActivityEventBuilder {
 
 
     public void persist() {
-        this.activityLogger.saveActivity(build());
+        this.activityLogger.saveEvent(build());
     }
 
-    public ActivityEvent build() {
-        return new ActivityEvent(subject, action, (long) ids.length, thing, ids);
+    private ActivityEvent build() {
+        return new ActivityEvent(subject, action, thing, ids);
     }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityEventBuilder.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityEventBuilder.java
@@ -9,9 +9,11 @@ import java.util.UUID;
 import static org.databiosphere.workspacedataservice.sam.BearerTokenFilter.ATTRIBUTE_NAME_TOKEN;
 import static org.springframework.web.context.request.RequestAttributes.SCOPE_REQUEST;
 
+/**
+ * Builder for ActivityEvent, with many convenience functions
+ */
 public class ActivityEventBuilder {
 
-    private final ActivityLogger activityLogger;
     private final SamDao samDao;
 
     private String subject;
@@ -22,19 +24,19 @@ public class ActivityEventBuilder {
     private String[] ids;
 
     /**
-     * Takes a reference to the ActivityLogger that created this event, and which
-     * will eventually persist the event (to a log or to a db table)
-     * @param activityLogger the parent ActivityLogger
+     * Constructor.
      * @param samDao Sam dao to use for resolving the current user to a Sam id
      */
-    public ActivityEventBuilder(ActivityLogger activityLogger, SamDao samDao) {
-        this.activityLogger = activityLogger;
+    public ActivityEventBuilder(SamDao samDao) {
         this.samDao = samDao;
     }
 
 
     // ===== SUBJECT BUILDERS
 
+    /**
+     * initializes this builder with the current user's Sam id.
+     */
     public ActivityEventBuilder currentUser() {
         try {
             // grab the current user's bearer token (see BearerTokenFilter)
@@ -109,6 +111,10 @@ public class ActivityEventBuilder {
     }
 
     // QUANTITY BUILDERS
+    /**
+     * specifies the quantity of items being operated on. If ids are specified
+     * instead, the id[].length will take precedence over this quantity.
+     */
     public ActivityEventBuilder ofQuantity(int quantity) {
         this.quantity = quantity;
         return this;
@@ -126,11 +132,7 @@ public class ActivityEventBuilder {
         return this;
     }
 
-    public void persist() {
-        this.activityLogger.saveEvent(build());
-    }
-
-    private ActivityEvent build() {
+    protected ActivityEvent build() {
         return new ActivityEvent(subject, action, thing, recordType, quantity, ids);
     }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityEventBuilder.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityEventBuilder.java
@@ -1,0 +1,115 @@
+package org.databiosphere.workspacedataservice.activitylog;
+
+import org.databiosphere.workspacedataservice.sam.SamDao;
+import org.springframework.web.context.request.RequestContextHolder;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import static org.databiosphere.workspacedataservice.sam.BearerTokenFilter.ATTRIBUTE_NAME_TOKEN;
+import static org.springframework.web.context.request.RequestAttributes.SCOPE_REQUEST;
+
+public class ActivityEventBuilder {
+
+    private final ActivityLogger activityLogger;
+    private final SamDao samDao;
+
+    private String subject;
+    private ActivityModels.Action action;
+    private ActivityModels.Thing thing;
+    private String[] ids;
+
+
+    // ===== SUBJECT BUILDERS
+
+    public ActivityEventBuilder currentUser() {
+        try {
+            // grab the current user's bearer token (see BearerTokenFilter)
+            Object token = RequestContextHolder.currentRequestAttributes()
+                    .getAttribute(ATTRIBUTE_NAME_TOKEN, SCOPE_REQUEST);
+            // resolve the token to a user id via Sam
+            this.subject = samDao.getUserId(token.toString());
+        } catch (Exception e) {
+            this.subject = "???";
+        }
+        return this;
+    }
+
+
+    // ===== VERB BUILDERS
+
+    public ActivityEventBuilder created() {
+        this.action = ActivityModels.Action.CREATE;
+        return this;
+    }
+    public ActivityEventBuilder deleted() {
+        this.action = ActivityModels.Action.DELETE;
+        return this;
+    }
+    public ActivityEventBuilder updated() {
+        this.action = ActivityModels.Action.UPDATE;
+        return this;
+    }
+    public ActivityEventBuilder upserted() {
+        this.action = ActivityModels.Action.UPSERT;
+        return this;
+    }
+
+//    public ActivityEventBuilder setAction(ActivityModels.Action action) {
+//        this.action = action;
+//        return this;
+//    }
+
+    // OBJECT BUILDERS
+
+    public ActivityEventBuilder instance() {
+        this.thing = ActivityModels.Thing.INSTANCE;
+        return this;
+    }
+
+    public ActivityEventBuilder table() {
+        this.thing = ActivityModels.Thing.TABLE;
+        return this;
+    }
+
+    public ActivityEventBuilder record() {
+        this.thing = ActivityModels.Thing.RECORD;
+        return this;
+    }
+//
+//    public ActivityEventBuilder setThing(ActivityModels.Thing thing) {
+//        this.thing = thing;
+//        return this;
+//    }
+
+    public ActivityEventBuilder(ActivityLogger activityLogger, SamDao samDao) {
+        this.activityLogger = activityLogger;
+        this.samDao = samDao;
+    }
+
+    // ID BUILDERS
+
+    public ActivityEventBuilder withId(String id) {
+        this.ids = new String[]{id};
+        return this;
+    }
+
+    public ActivityEventBuilder withUuid(UUID id) {
+        this.ids = new String[]{id.toString()};
+        return this;
+    }
+
+    public ActivityEventBuilder withIds(String[] ids) {
+        this.ids = ids;
+        return this;
+    }
+
+
+    public void persist() {
+        this.activityLogger.saveActivity(build());
+    }
+
+    public ActivityEvent build() {
+        return new ActivityEvent(subject, action, (long) ids.length, thing, ids);
+    }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityLogger.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityLogger.java
@@ -70,6 +70,4 @@ public class ActivityLogger {
             LOGGER.info(sb.toString());
         }
     }
-
-
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityLogger.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityLogger.java
@@ -1,0 +1,59 @@
+package org.databiosphere.workspacedataservice.activitylog;
+
+import org.databiosphere.workspacedataservice.sam.SamDao;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.context.request.RequestContextHolder;
+
+import java.util.Objects;
+
+import static org.databiosphere.workspacedataservice.sam.BearerTokenFilter.ATTRIBUTE_NAME_TOKEN;
+import static org.springframework.web.context.request.RequestAttributes.SCOPE_REQUEST;
+
+public class ActivityLogger {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ActivityLogger.class);
+
+    private SamDao samDao;
+
+    public ActivityLogger(SamDao samDao) {
+        this.samDao = samDao;
+    }
+
+
+    public ActivityEventBuilder newEvent() {
+        return new ActivityEventBuilder(this, this.samDao);
+    }
+
+//    public void saveInstanceActivity(ActivityModels.Action action, String id) {
+//        saveActivity(action, 1L, ActivityModels.Thing.INSTANCE, new String[]{id});
+//    }
+
+//    private void saveActivity(ActivityModels.Action action, Long quantity, ActivityModels.Thing thing, String[] ids) {
+//
+//        // grab the current user's bearer token (see BearerTokenFilter)
+//        Object token = RequestContextHolder.currentRequestAttributes()
+//                .getAttribute(ATTRIBUTE_NAME_TOKEN, SCOPE_REQUEST);
+//
+//        // resolve the token to a user id via Sam
+//        String userId;
+//        if (!Objects.isNull(token)) {
+//            LOGGER.debug("setting access token for data repo request");
+//            userId = samDao.getUserId(token.toString());
+//        } else {
+//            LOGGER.warn("No access token found for data repo request.");
+//            userId = "???";
+//        }
+//        // TODO: error handling for the Sam call; we should always log
+//        ActivityEvent event = new ActivityEventBuilder().setSubject(userId).setAction(action).setQuantity(quantity).setThing(thing).setIds(ids).createActivityEvent();
+//        saveActivity(event);
+//    }
+
+    protected void saveActivity(ActivityEvent event) {
+        LOGGER.info("user {} {} {} {}(s) with ids {}", event.getSubject(), event.getAction().getName(),
+                event.getQuantity(), event.getThing().getName(),
+                event.getIds());
+    }
+
+
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityLogger.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityLogger.java
@@ -4,11 +4,13 @@ import org.databiosphere.workspacedataservice.sam.SamDao;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Arrays;
+
 public class ActivityLogger {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ActivityLogger.class);
 
-    private SamDao samDao;
+    private final SamDao samDao;
 
     public ActivityLogger(SamDao samDao) {
         this.samDao = samDao;
@@ -19,11 +21,24 @@ public class ActivityLogger {
         return new ActivityEventBuilder(this, this.samDao);
     }
 
-
     protected void saveEvent(ActivityEvent event) {
-        LOGGER.info("user {} {} {} {}(s) with ids {}", event.subject(), event.action().getName(),
-                event.ids().length, event.thing().getName(),
-                event.ids());
+        if (LOGGER.isInfoEnabled()) {
+            StringBuilder sb = new StringBuilder();
+            sb.append("user %s %s".formatted(event.subject(), event.action().getName()));
+            if (event.quantity() != null) {
+                sb.append(" %s".formatted(event.quantity()));
+            } else if (event.ids() != null) {
+                sb.append(" %s".formatted(event.ids().length));
+            }
+            sb.append(" %s(s)".formatted(event.thing().getName()));
+            if (event.recordType() != null) {
+                sb.append(" of type %s".formatted(event.recordType().getName()));
+            }
+            if (event.ids() != null) {
+                sb.append(" with id(s) %s".formatted(Arrays.toString(event.ids())));
+            }
+            LOGGER.info(sb.toString());
+        }
     }
 
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityLogger.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityLogger.java
@@ -3,12 +3,6 @@ package org.databiosphere.workspacedataservice.activitylog;
 import org.databiosphere.workspacedataservice.sam.SamDao;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.web.context.request.RequestContextHolder;
-
-import java.util.Objects;
-
-import static org.databiosphere.workspacedataservice.sam.BearerTokenFilter.ATTRIBUTE_NAME_TOKEN;
-import static org.springframework.web.context.request.RequestAttributes.SCOPE_REQUEST;
 
 public class ActivityLogger {
 
@@ -25,34 +19,11 @@ public class ActivityLogger {
         return new ActivityEventBuilder(this, this.samDao);
     }
 
-//    public void saveInstanceActivity(ActivityModels.Action action, String id) {
-//        saveActivity(action, 1L, ActivityModels.Thing.INSTANCE, new String[]{id});
-//    }
 
-//    private void saveActivity(ActivityModels.Action action, Long quantity, ActivityModels.Thing thing, String[] ids) {
-//
-//        // grab the current user's bearer token (see BearerTokenFilter)
-//        Object token = RequestContextHolder.currentRequestAttributes()
-//                .getAttribute(ATTRIBUTE_NAME_TOKEN, SCOPE_REQUEST);
-//
-//        // resolve the token to a user id via Sam
-//        String userId;
-//        if (!Objects.isNull(token)) {
-//            LOGGER.debug("setting access token for data repo request");
-//            userId = samDao.getUserId(token.toString());
-//        } else {
-//            LOGGER.warn("No access token found for data repo request.");
-//            userId = "???";
-//        }
-//        // TODO: error handling for the Sam call; we should always log
-//        ActivityEvent event = new ActivityEventBuilder().setSubject(userId).setAction(action).setQuantity(quantity).setThing(thing).setIds(ids).createActivityEvent();
-//        saveActivity(event);
-//    }
-
-    protected void saveActivity(ActivityEvent event) {
-        LOGGER.info("user {} {} {} {}(s) with ids {}", event.getSubject(), event.getAction().getName(),
-                event.getQuantity(), event.getThing().getName(),
-                event.getIds());
+    protected void saveEvent(ActivityEvent event) {
+        LOGGER.info("user {} {} {} {}(s) with ids {}", event.subject(), event.action().getName(),
+                event.ids().length, event.thing().getName(),
+                event.ids());
     }
 
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityLogger.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityLogger.java
@@ -25,10 +25,10 @@ public class ActivityLogger {
         if (LOGGER.isInfoEnabled()) {
             StringBuilder sb = new StringBuilder();
             sb.append("user %s %s".formatted(event.subject(), event.action().getName()));
-            if (event.quantity() != null) {
-                sb.append(" %s".formatted(event.quantity()));
-            } else if (event.ids() != null) {
+            if (event.ids() != null) {
                 sb.append(" %s".formatted(event.ids().length));
+            } else if (event.quantity() != null) {
+                sb.append(" %s".formatted(event.quantity()));
             }
             sb.append(" %s(s)".formatted(event.thing().getName()));
             if (event.recordType() != null) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityLoggerConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityLoggerConfig.java
@@ -1,0 +1,15 @@
+package org.databiosphere.workspacedataservice.activitylog;
+
+import org.databiosphere.workspacedataservice.sam.SamDao;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ActivityLoggerConfig {
+
+    @Bean
+    public ActivityLogger getActivityLogger(SamDao samDao) {
+        return new ActivityLogger(samDao);
+    }
+
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityModels.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityModels.java
@@ -1,0 +1,39 @@
+package org.databiosphere.workspacedataservice.activitylog;
+
+public class ActivityModels {
+
+    public enum Action {
+        CREATE("created"), DELETE("deleted"), UPDATE("updated"), UPSERT("upserted");
+
+        private final String name;
+
+        public String getName() {
+            return name;
+        }
+
+        Action(String name) {
+            this.name = name;
+        }
+    }
+
+    public enum Thing {
+        INSTANCE("instance"), TABLE("table"), RECORD("record");
+
+        private final String name;
+
+        public String getName() {
+            return name;
+        }
+
+        Thing(String name) {
+            this.name = name;
+        }
+    }
+
+
+
+
+
+
+
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityModels.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityModels.java
@@ -32,11 +32,4 @@ public class ActivityModels {
             this.name = name;
         }
     }
-
-
-
-
-
-
-
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityModels.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityModels.java
@@ -3,7 +3,9 @@ package org.databiosphere.workspacedataservice.activitylog;
 public class ActivityModels {
 
     public enum Action {
-        CREATE("created"), DELETE("deleted"), UPDATE("updated"), UPSERT("upserted");
+        CREATE("created"), DELETE("deleted"),
+        UPDATE("updated"), UPSERT("upserted"),
+        MODIFY("modified");
 
         private final String name;
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityModels.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityModels.java
@@ -5,7 +5,7 @@ public class ActivityModels {
     public enum Action {
         CREATE("created"), DELETE("deleted"),
         UPDATE("updated"), UPSERT("upserted"),
-        MODIFY("modified");
+        MODIFY("modified"), LINK("linked");
 
         private final String name;
 
@@ -19,7 +19,8 @@ public class ActivityModels {
     }
 
     public enum Thing {
-        INSTANCE("instance"), TABLE("table"), RECORD("record");
+        INSTANCE("instance"), TABLE("table"),
+        RECORD("record"), SNAPSHOT_REFERENCE("snapshot reference");
 
         private final String name;
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/DataRepoController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/DataRepoController.java
@@ -1,24 +1,24 @@
 package org.databiosphere.workspacedataservice.controller;
 
-import bio.terra.datarepo.model.SnapshotModel;
-import org.databiosphere.workspacedataservice.datarepo.DataRepoDao;
 import org.databiosphere.workspacedataservice.retry.RetryableApi;
-import org.databiosphere.workspacedataservice.workspacemanager.WorkspaceManagerDao;
+import org.databiosphere.workspacedataservice.service.DataRepoService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.UUID;
+
+import static org.databiosphere.workspacedataservice.service.RecordUtils.validateVersion;
 
 @RestController
 public class DataRepoController {
 
-    private final DataRepoDao dataRepoDao;
-    private final WorkspaceManagerDao workspaceManagerDao;
+    private final DataRepoService dataRepoService;
 
-    public DataRepoController(DataRepoDao dataRepoDao, WorkspaceManagerDao workspaceManagerDao) {
-        this.dataRepoDao = dataRepoDao;
-        this.workspaceManagerDao = workspaceManagerDao;
+    public DataRepoController(DataRepoService dataRepoService) {
+        this.dataRepoService = dataRepoService;
     }
 
     @PostMapping("/{instanceId}/snapshots/{version}/{snapshotId}")
@@ -26,14 +26,9 @@ public class DataRepoController {
     public ResponseEntity<Void> importSnapshot(@PathVariable("instanceId") UUID instanceId,
                                                              @PathVariable("version") String version,
                                                              @PathVariable("snapshotId") UUID snapshotId) {
-        // getSnapshot will throw exception is caller does not have access
-        SnapshotModel snapshot = dataRepoDao.getSnapshot(snapshotId);
-
-        // createDataRepoSnapshotReference is required to setup policy and will throw exception if policy conflicts
-        workspaceManagerDao.createDataRepoSnapshotReference(snapshot);
-
-        // TODO do the import
-
+        validateVersion(version);
+        // TODO: validate the instance, when it's time to actually write anything to that instance
+        dataRepoService.importSnapshot(instanceId, snapshotId);
         return new ResponseEntity<>(HttpStatus.ACCEPTED);
     }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -1,5 +1,6 @@
 package org.databiosphere.workspacedataservice.controller;
 
+import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
 import org.databiosphere.workspacedataservice.retry.RetryableApi;
 import org.databiosphere.workspacedataservice.service.InstanceService;
 import org.databiosphere.workspacedataservice.service.RecordOrchestratorService;
@@ -39,9 +40,12 @@ public class RecordController {
 	private final InstanceService instanceService;
 	private final RecordOrchestratorService recordOrchestratorService;
 
-	public RecordController(InstanceService instanceService, RecordOrchestratorService recordOrchestratorService) {
+	private final ActivityLogger activityLogger;
+
+	public RecordController(InstanceService instanceService, RecordOrchestratorService recordOrchestratorService, ActivityLogger activityLogger) {
 		this.instanceService = instanceService;
 		this.recordOrchestratorService = recordOrchestratorService;
+		this.activityLogger = activityLogger;
 	}
 
 	@PatchMapping("/{instanceId}/records/{version}/{recordType}/{recordId}")
@@ -51,6 +55,7 @@ public class RecordController {
 			@PathVariable("recordId") String recordId, @RequestBody RecordRequest recordRequest) {
 		RecordResponse response = recordOrchestratorService
 			.updateSingleRecord(instanceId, version, recordType, recordId, recordRequest);
+		activityLogger.newEvent().currentUser().updated().record().withId(recordId).persist();
 		return new ResponseEntity<>(response, HttpStatus.OK);
 	}
 
@@ -98,8 +103,11 @@ public class RecordController {
 			@PathVariable("version") String version, @PathVariable("recordType") RecordType recordType,
 			@PathVariable("recordId") String recordId, @RequestParam(name= "primaryKey", required = false) Optional<String> primaryKey,
 			 @RequestBody RecordRequest recordRequest) {
-			return recordOrchestratorService.upsertSingleRecord(instanceId, version, recordType, recordId, primaryKey,
+		ResponseEntity<RecordResponse> response = recordOrchestratorService.upsertSingleRecord(instanceId, version, recordType, recordId, primaryKey,
 				recordRequest);
+		// TODO: read response OK vs. CREATED and call updated() or created()
+		activityLogger.newEvent().currentUser().upserted().record().withId(recordId).persist();
+		return response;
 	}
 
 	@GetMapping("/instances/{version}")

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -98,7 +98,7 @@ public class RecordController {
 			@PathVariable("version") String version, @PathVariable("recordType") RecordType recordType,
 			@PathVariable("recordId") String recordId, @RequestParam(name= "primaryKey", required = false) Optional<String> primaryKey,
 			 @RequestBody RecordRequest recordRequest) {
-		return recordOrchestratorService.upsertSingleRecord(instanceId, version, recordType, recordId, primaryKey,
+			return recordOrchestratorService.upsertSingleRecord(instanceId, version, recordType, recordId, primaryKey,
 				recordRequest);
 	}
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -1,6 +1,5 @@
 package org.databiosphere.workspacedataservice.controller;
 
-import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
 import org.databiosphere.workspacedataservice.retry.RetryableApi;
 import org.databiosphere.workspacedataservice.service.InstanceService;
 import org.databiosphere.workspacedataservice.service.RecordOrchestratorService;
@@ -40,12 +39,9 @@ public class RecordController {
 	private final InstanceService instanceService;
 	private final RecordOrchestratorService recordOrchestratorService;
 
-	private final ActivityLogger activityLogger;
-
-	public RecordController(InstanceService instanceService, RecordOrchestratorService recordOrchestratorService, ActivityLogger activityLogger) {
+	public RecordController(InstanceService instanceService, RecordOrchestratorService recordOrchestratorService) {
 		this.instanceService = instanceService;
 		this.recordOrchestratorService = recordOrchestratorService;
-		this.activityLogger = activityLogger;
 	}
 
 	@PatchMapping("/{instanceId}/records/{version}/{recordType}/{recordId}")
@@ -55,7 +51,6 @@ public class RecordController {
 			@PathVariable("recordId") String recordId, @RequestBody RecordRequest recordRequest) {
 		RecordResponse response = recordOrchestratorService
 			.updateSingleRecord(instanceId, version, recordType, recordId, recordRequest);
-		activityLogger.newEvent().currentUser().updated().record().withId(recordId).persist();
 		return new ResponseEntity<>(response, HttpStatus.OK);
 	}
 
@@ -103,11 +98,8 @@ public class RecordController {
 			@PathVariable("version") String version, @PathVariable("recordType") RecordType recordType,
 			@PathVariable("recordId") String recordId, @RequestParam(name= "primaryKey", required = false) Optional<String> primaryKey,
 			 @RequestBody RecordRequest recordRequest) {
-		ResponseEntity<RecordResponse> response = recordOrchestratorService.upsertSingleRecord(instanceId, version, recordType, recordId, primaryKey,
+		return recordOrchestratorService.upsertSingleRecord(instanceId, version, recordType, recordId, primaryKey,
 				recordRequest);
-		// TODO: read response OK vs. CREATED and call updated() or created()
-		activityLogger.newEvent().currentUser().upserted().record().withId(recordId).persist();
-		return response;
 	}
 
 	@GetMapping("/instances/{version}")

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamClientFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamClientFactory.java
@@ -85,5 +85,4 @@ public class HttpSamClientFactory implements SamClientFactory {
         usersApi.setApiClient(apiClient);
         return usersApi;
     }
-
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamClientFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamClientFactory.java
@@ -4,6 +4,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.dsde.workbench.client.sam.ApiClient;
 import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.StatusApi;
+import org.broadinstitute.dsde.workbench.client.sam.api.UsersApi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.context.request.RequestContextHolder;
@@ -76,6 +77,13 @@ public class HttpSamClientFactory implements SamClientFactory {
         StatusApi statusApi = new StatusApi();
         statusApi.setApiClient(apiClient);
         return statusApi;
+    }
+
+    public UsersApi getUsersApi(String token) {
+        ApiClient apiClient = getApiClient(token);
+        UsersApi usersApi = new UsersApi();
+        usersApi.setApiClient(apiClient);
+        return usersApi;
     }
 
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamClientSupport.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamClientSupport.java
@@ -55,7 +55,11 @@ public class HttpSamClientSupport {
         try {
             LOGGER.debug("Sending {} request to Sam ...", loggerHint);
             T functionResult = samFunction.run();
-            LOGGER.debug("{} Sam request successful, result: {}", loggerHint, functionResult);
+            if (LOGGER.isTraceEnabled()) {
+                LOGGER.trace("{} Sam request successful, result: {}", loggerHint, functionResult);
+            } else {
+                LOGGER.debug("{} Sam request successful", loggerHint);
+            }
             return functionResult;
         } catch (ApiException apiException) {
             LOGGER.error(loggerHint + " Sam request resulted in ApiException(" + apiException.getCode() + ")",

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/MisconfiguredSamDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/MisconfiguredSamDao.java
@@ -59,6 +59,12 @@ public class MisconfiguredSamDao implements SamDao {
     }
 
     @Override
+    public String getUserId(String token) {
+        logWarning();
+        return "n/a";
+    }
+
+    @Override
     public Boolean getSystemStatusOk() {
         throw new RuntimeException("Sam integration failure: " + errorMessage);
     }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/SamClientFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/SamClientFactory.java
@@ -2,6 +2,7 @@ package org.databiosphere.workspacedataservice.sam;
 
 import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.StatusApi;
+import org.broadinstitute.dsde.workbench.client.sam.api.UsersApi;
 
 /**
  * interface for SamClientFactory, allowing various implementations:
@@ -12,5 +13,7 @@ public interface SamClientFactory {
 
     ResourcesApi getResourcesApi(String token);
     StatusApi getStatusApi();
+    UsersApi getUsersApi(String token);
+
 
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/SamDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/SamDao.java
@@ -49,6 +49,8 @@ public interface SamDao {
 
     boolean hasWriteInstancePermission(String token);
 
+    public String getUserId(String token);
+
     /**
      * Gets the up/down system status of Sam.
      */

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/DataRepoService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/DataRepoService.java
@@ -28,7 +28,8 @@ public class DataRepoService {
         // createDataRepoSnapshotReference is required to setup policy and will throw exception if policy conflicts
         workspaceManagerDao.createDataRepoSnapshotReference(snapshot);
 
-        activityLogger.newEvent().currentUser().linked().snapshotReference().withUuid(snapshotId).persist();
+        activityLogger.saveEventForCurrentUser(event ->
+                event.linked().snapshotReference().withUuid(snapshotId));
         // TODO do the import
     }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/DataRepoService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/DataRepoService.java
@@ -1,0 +1,35 @@
+package org.databiosphere.workspacedataservice.service;
+
+import bio.terra.datarepo.model.SnapshotModel;
+import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
+import org.databiosphere.workspacedataservice.datarepo.DataRepoDao;
+import org.databiosphere.workspacedataservice.workspacemanager.WorkspaceManagerDao;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+public class DataRepoService {
+
+    private final DataRepoDao dataRepoDao;
+    private final WorkspaceManagerDao workspaceManagerDao;
+    private final ActivityLogger activityLogger;
+
+    public DataRepoService(DataRepoDao dataRepoDao, WorkspaceManagerDao workspaceManagerDao, ActivityLogger activityLogger) {
+        this.dataRepoDao = dataRepoDao;
+        this.workspaceManagerDao = workspaceManagerDao;
+        this.activityLogger = activityLogger;
+    }
+
+    public void importSnapshot(UUID instanceID, UUID snapshotId) {
+        // getSnapshot will throw exception is caller does not have access
+        SnapshotModel snapshot = dataRepoDao.getSnapshot(snapshotId);
+
+        // createDataRepoSnapshotReference is required to setup policy and will throw exception if policy conflicts
+        workspaceManagerDao.createDataRepoSnapshotReference(snapshot);
+
+        activityLogger.newEvent().currentUser().linked().snapshotReference().withUuid(snapshotId);
+        // TODO do the import
+    }
+
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/DataRepoService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/DataRepoService.java
@@ -22,7 +22,7 @@ public class DataRepoService {
     }
 
     public void importSnapshot(UUID instanceId, UUID snapshotId) {
-        // getSnapshot will throw exception is caller does not have access
+        // getSnapshot will throw exception if caller does not have access
         SnapshotModel snapshot = dataRepoDao.getSnapshot(snapshotId);
 
         // createDataRepoSnapshotReference is required to setup policy and will throw exception if policy conflicts
@@ -32,5 +32,4 @@ public class DataRepoService {
                 user.linked().snapshotReference().withUuid(snapshotId));
         // TODO do the import
     }
-
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/DataRepoService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/DataRepoService.java
@@ -28,8 +28,8 @@ public class DataRepoService {
         // createDataRepoSnapshotReference is required to setup policy and will throw exception if policy conflicts
         workspaceManagerDao.createDataRepoSnapshotReference(snapshot);
 
-        activityLogger.saveEventForCurrentUser(event ->
-                event.linked().snapshotReference().withUuid(snapshotId));
+        activityLogger.saveEventForCurrentUser(user ->
+                user.linked().snapshotReference().withUuid(snapshotId));
         // TODO do the import
     }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/DataRepoService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/DataRepoService.java
@@ -21,14 +21,14 @@ public class DataRepoService {
         this.activityLogger = activityLogger;
     }
 
-    public void importSnapshot(UUID instanceID, UUID snapshotId) {
+    public void importSnapshot(UUID instanceId, UUID snapshotId) {
         // getSnapshot will throw exception is caller does not have access
         SnapshotModel snapshot = dataRepoDao.getSnapshot(snapshotId);
 
         // createDataRepoSnapshotReference is required to setup policy and will throw exception if policy conflicts
         workspaceManagerDao.createDataRepoSnapshotReference(snapshot);
 
-        activityLogger.newEvent().currentUser().linked().snapshotReference().withUuid(snapshotId);
+        activityLogger.newEvent().currentUser().linked().snapshotReference().withUuid(snapshotId).persist();
         // TODO do the import
     }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/InstanceService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/InstanceService.java
@@ -64,8 +64,8 @@ public class InstanceService {
         // create instance schema in Postgres
         instanceDao.createSchema(instanceId);
 
-        activityLogger.saveEventForCurrentUser(event ->
-                event.created().instance().withUuid(instanceId));
+        activityLogger.saveEventForCurrentUser(user ->
+                user.created().instance().withUuid(instanceId));
     }
 
     public void deleteInstance(UUID instanceId, String version) {
@@ -83,8 +83,8 @@ public class InstanceService {
         // delete instance schema in Postgres
         instanceDao.dropSchema(instanceId);
 
-        activityLogger.saveEventForCurrentUser(event ->
-                event.currentUser().deleted().instance().withUuid(instanceId));
+        activityLogger.saveEventForCurrentUser(user ->
+                user.deleted().instance().withUuid(instanceId));
     }
 
     public void validateInstance(UUID instanceId) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/InstanceService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/InstanceService.java
@@ -1,5 +1,7 @@
 package org.databiosphere.workspacedataservice.service;
 
+import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
+import org.databiosphere.workspacedataservice.activitylog.ActivityModels;
 import org.databiosphere.workspacedataservice.dao.InstanceDao;
 import org.databiosphere.workspacedataservice.sam.SamDao;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthorizationException;
@@ -20,12 +22,14 @@ public class InstanceService {
 
     private final InstanceDao instanceDao;
     private final SamDao samDao;
+    private final ActivityLogger activityLogger;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(InstanceService.class);
 
-    public InstanceService(InstanceDao instanceDao, SamDao samDao) {
+    public InstanceService(InstanceDao instanceDao, SamDao samDao, ActivityLogger activityLogger) {
         this.instanceDao = instanceDao;
         this.samDao = samDao;
+        this.activityLogger = activityLogger;
     }
 
     public List<UUID> listInstances(String version) {
@@ -60,6 +64,8 @@ public class InstanceService {
 
         // create instance schema in Postgres
         instanceDao.createSchema(instanceId);
+
+        activityLogger.newEvent().currentUser().created().instance().withUuid(instanceId).persist();
     }
 
     public void deleteInstance(UUID instanceId, String version) {
@@ -76,6 +82,8 @@ public class InstanceService {
 
         // delete instance schema in Postgres
         instanceDao.dropSchema(instanceId);
+
+        activityLogger.newEvent().currentUser().deleted().instance().withUuid(instanceId).persist();
     }
 
     public void validateInstance(UUID instanceId) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/InstanceService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/InstanceService.java
@@ -1,7 +1,6 @@
 package org.databiosphere.workspacedataservice.service;
 
 import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
-import org.databiosphere.workspacedataservice.activitylog.ActivityModels;
 import org.databiosphere.workspacedataservice.dao.InstanceDao;
 import org.databiosphere.workspacedataservice.sam.SamDao;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthorizationException;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/InstanceService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/InstanceService.java
@@ -64,7 +64,8 @@ public class InstanceService {
         // create instance schema in Postgres
         instanceDao.createSchema(instanceId);
 
-        activityLogger.newEvent().currentUser().created().instance().withUuid(instanceId).persist();
+        activityLogger.saveEventForCurrentUser(event ->
+                event.created().instance().withUuid(instanceId));
     }
 
     public void deleteInstance(UUID instanceId, String version) {
@@ -82,7 +83,8 @@ public class InstanceService {
         // delete instance schema in Postgres
         instanceDao.dropSchema(instanceId);
 
-        activityLogger.newEvent().currentUser().deleted().instance().withUuid(instanceId).persist();
+        activityLogger.saveEventForCurrentUser(event ->
+                event.currentUser().deleted().instance().withUuid(instanceId));
     }
 
     public void validateInstance(UUID instanceId) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
@@ -3,7 +3,6 @@ package org.databiosphere.workspacedataservice.service;
 import bio.terra.common.db.ReadTransaction;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.csv.CSVPrinter;
-import org.databiosphere.workspacedataservice.activitylog.ActivityEventBuilder;
 import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.databiosphere.workspacedataservice.sam.SamDao;
@@ -76,7 +75,8 @@ public class RecordOrchestratorService { // TODO give me a better name
         validateAndPermissions(instanceId, version);
         checkRecordTypeExists(instanceId, recordType);
         RecordResponse response = recordService.updateSingleRecord(instanceId, recordType, recordId, recordRequest);
-        activityLogger.newEvent().currentUser().updated().record().withRecordType(recordType).withId(recordId).persist();
+        activityLogger.saveEventForCurrentUser(event ->
+                event.updated().record().withRecordType(recordType).withId(recordId));
         return response;
     }
 
@@ -109,7 +109,8 @@ public class RecordOrchestratorService { // TODO give me a better name
             recordService.validatePrimaryKey(instanceId, recordType, primaryKey);
         }
         int qty = batchWriteService.batchWriteTsvStream(records.getInputStream(), instanceId, recordType, primaryKey);
-        activityLogger.newEvent().currentUser().upserted().record().withRecordType(recordType).ofQuantity(qty).persist();
+        activityLogger.saveEventForCurrentUser(event ->
+                event.upserted().record().withRecordType(recordType).ofQuantity(qty));
         return qty;
     }
 
@@ -169,11 +170,12 @@ public class RecordOrchestratorService { // TODO give me a better name
         validateAndPermissions(instanceId, version);
         ResponseEntity<RecordResponse> response = recordService.upsertSingleRecord(instanceId, recordType, recordId, primaryKey, recordRequest);
 
-        ActivityEventBuilder activityEventBuilder = activityLogger.newEvent().currentUser().record().withRecordType(recordType).withId(recordId);
         if (response.getStatusCode() == HttpStatus.CREATED) {
-            activityEventBuilder.created().persist();
+            activityLogger.saveEventForCurrentUser(event ->
+                    event.created().record().withRecordType(recordType).withId(recordId));
         } else {
-            activityEventBuilder.updated().persist();
+            activityLogger.saveEventForCurrentUser(event ->
+                    event.updated().record().withRecordType(recordType).withId(recordId));
         }
         return response;
 
@@ -183,7 +185,8 @@ public class RecordOrchestratorService { // TODO give me a better name
         validateAndPermissions(instanceId, version);
         checkRecordTypeExists(instanceId, recordType);
         boolean response = recordService.deleteSingleRecord(instanceId, recordType, recordId);
-        activityLogger.newEvent().currentUser().deleted().record().withRecordType(recordType).withId(recordId).persist();
+        activityLogger.saveEventForCurrentUser(event ->
+                event.deleted().record().withRecordType(recordType).withId(recordId));
         return response;
 
     }
@@ -192,7 +195,8 @@ public class RecordOrchestratorService { // TODO give me a better name
         validateAndPermissions(instanceId, version);
         checkRecordTypeExists(instanceId, recordType);
         recordService.deleteRecordType(instanceId, recordType);
-        activityLogger.newEvent().currentUser().deleted().table().ofQuantity(1).withRecordType(recordType).persist();
+        activityLogger.saveEventForCurrentUser(event ->
+                event.deleted().table().ofQuantity(1).withRecordType(recordType));
     }
 
     @ReadTransaction
@@ -220,7 +224,8 @@ public class RecordOrchestratorService { // TODO give me a better name
         }
 
         int qty = batchWriteService.batchWriteJsonStream(is, instanceId, recordType, primaryKey);
-        activityLogger.newEvent().currentUser().modified().record().withRecordType(recordType).ofQuantity(qty).persist();
+        activityLogger.saveEventForCurrentUser(event ->
+                event.modified().record().withRecordType(recordType).ofQuantity(qty));
         return qty;
     }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
@@ -75,8 +75,8 @@ public class RecordOrchestratorService { // TODO give me a better name
         validateAndPermissions(instanceId, version);
         checkRecordTypeExists(instanceId, recordType);
         RecordResponse response = recordService.updateSingleRecord(instanceId, recordType, recordId, recordRequest);
-        activityLogger.saveEventForCurrentUser(event ->
-                event.updated().record().withRecordType(recordType).withId(recordId));
+        activityLogger.saveEventForCurrentUser(user ->
+                user.updated().record().withRecordType(recordType).withId(recordId));
         return response;
     }
 
@@ -109,8 +109,8 @@ public class RecordOrchestratorService { // TODO give me a better name
             recordService.validatePrimaryKey(instanceId, recordType, primaryKey);
         }
         int qty = batchWriteService.batchWriteTsvStream(records.getInputStream(), instanceId, recordType, primaryKey);
-        activityLogger.saveEventForCurrentUser(event ->
-                event.upserted().record().withRecordType(recordType).ofQuantity(qty));
+        activityLogger.saveEventForCurrentUser(user ->
+                user.upserted().record().withRecordType(recordType).ofQuantity(qty));
         return qty;
     }
 
@@ -171,11 +171,11 @@ public class RecordOrchestratorService { // TODO give me a better name
         ResponseEntity<RecordResponse> response = recordService.upsertSingleRecord(instanceId, recordType, recordId, primaryKey, recordRequest);
 
         if (response.getStatusCode() == HttpStatus.CREATED) {
-            activityLogger.saveEventForCurrentUser(event ->
-                    event.created().record().withRecordType(recordType).withId(recordId));
+            activityLogger.saveEventForCurrentUser(user ->
+                    user.created().record().withRecordType(recordType).withId(recordId));
         } else {
-            activityLogger.saveEventForCurrentUser(event ->
-                    event.updated().record().withRecordType(recordType).withId(recordId));
+            activityLogger.saveEventForCurrentUser(user ->
+                    user.updated().record().withRecordType(recordType).withId(recordId));
         }
         return response;
 
@@ -185,8 +185,8 @@ public class RecordOrchestratorService { // TODO give me a better name
         validateAndPermissions(instanceId, version);
         checkRecordTypeExists(instanceId, recordType);
         boolean response = recordService.deleteSingleRecord(instanceId, recordType, recordId);
-        activityLogger.saveEventForCurrentUser(event ->
-                event.deleted().record().withRecordType(recordType).withId(recordId));
+        activityLogger.saveEventForCurrentUser(user ->
+                user.deleted().record().withRecordType(recordType).withId(recordId));
         return response;
 
     }
@@ -195,8 +195,8 @@ public class RecordOrchestratorService { // TODO give me a better name
         validateAndPermissions(instanceId, version);
         checkRecordTypeExists(instanceId, recordType);
         recordService.deleteRecordType(instanceId, recordType);
-        activityLogger.saveEventForCurrentUser(event ->
-                event.deleted().table().ofQuantity(1).withRecordType(recordType));
+        activityLogger.saveEventForCurrentUser(user ->
+                user.deleted().table().ofQuantity(1).withRecordType(recordType));
     }
 
     @ReadTransaction
@@ -224,8 +224,8 @@ public class RecordOrchestratorService { // TODO give me a better name
         }
 
         int qty = batchWriteService.batchWriteJsonStream(is, instanceId, recordType, primaryKey);
-        activityLogger.saveEventForCurrentUser(event ->
-                event.modified().record().withRecordType(recordType).ofQuantity(qty));
+        activityLogger.saveEventForCurrentUser(user ->
+                user.modified().record().withRecordType(recordType).ofQuantity(qty));
         return qty;
     }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
@@ -192,7 +192,7 @@ public class RecordOrchestratorService { // TODO give me a better name
         validateAndPermissions(instanceId, version);
         checkRecordTypeExists(instanceId, recordType);
         recordService.deleteRecordType(instanceId, recordType);
-        activityLogger.newEvent().currentUser().deleted().table().withRecordType(recordType).persist();
+        activityLogger.newEvent().currentUser().deleted().table().ofQuantity(1).withRecordType(recordType).persist();
     }
 
     @ReadTransaction

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
@@ -3,6 +3,8 @@ package org.databiosphere.workspacedataservice.service;
 import bio.terra.common.db.ReadTransaction;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.csv.CSVPrinter;
+import org.databiosphere.workspacedataservice.activitylog.ActivityEventBuilder;
+import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.databiosphere.workspacedataservice.sam.SamDao;
 import org.databiosphere.workspacedataservice.service.model.AttributeSchema;
@@ -51,26 +53,31 @@ public class RecordOrchestratorService { // TODO give me a better name
     private final InstanceService instanceService;
     private final ObjectMapper objectMapper;
     private final SamDao samDao;
+    private final ActivityLogger activityLogger;
 
     public RecordOrchestratorService(RecordDao recordDao,
                                      BatchWriteService batchWriteService,
                                      RecordService recordService,
                                      InstanceService instanceService,
                                      ObjectMapper objectMapper,
-                                     SamDao samDao) {
+                                     SamDao samDao,
+                                     ActivityLogger activityLogger) {
         this.recordDao = recordDao;
         this.batchWriteService = batchWriteService;
         this.recordService = recordService;
         this.instanceService = instanceService;
         this.objectMapper = objectMapper;
         this.samDao = samDao;
+        this.activityLogger = activityLogger;
     }
 
     public RecordResponse updateSingleRecord(UUID instanceId, String version, RecordType recordType, String recordId,
                               RecordRequest recordRequest) {
         validateAndPermissions(instanceId, version);
         checkRecordTypeExists(instanceId, recordType);
-        return recordService.updateSingleRecord(instanceId, recordType, recordId, recordRequest);
+        RecordResponse response = recordService.updateSingleRecord(instanceId, recordType, recordId, recordRequest);
+        activityLogger.newEvent().currentUser().updated().record().withRecordType(recordType).withId(recordId).persist();
+        return response;
     }
 
     public void validateAndPermissions(UUID instanceId, String version) {
@@ -101,7 +108,9 @@ public class RecordOrchestratorService { // TODO give me a better name
         if(recordDao.recordTypeExists(instanceId, recordType)){
             recordService.validatePrimaryKey(instanceId, recordType, primaryKey);
         }
-        return batchWriteService.batchWriteTsvStream(records.getInputStream(), instanceId, recordType, primaryKey);
+        int qty = batchWriteService.batchWriteTsvStream(records.getInputStream(), instanceId, recordType, primaryKey);
+        activityLogger.newEvent().currentUser().upserted().record().withRecordType(recordType).ofQuantity(qty).persist();
+        return qty;
     }
 
     // TODO: enable read transaction
@@ -158,14 +167,24 @@ public class RecordOrchestratorService { // TODO give me a better name
                                                              String recordId, Optional<String> primaryKey,
                                                              RecordRequest recordRequest) {
         validateAndPermissions(instanceId, version);
-        return recordService.upsertSingleRecord(instanceId, recordType, recordId, primaryKey, recordRequest);
+        ResponseEntity<RecordResponse> response = recordService.upsertSingleRecord(instanceId, recordType, recordId, primaryKey, recordRequest);
+
+        ActivityEventBuilder activityEventBuilder = activityLogger.newEvent().currentUser().record().withRecordType(recordType).withId(recordId);
+        if (response.getStatusCode() == HttpStatus.CREATED) {
+            activityEventBuilder.created().persist();
+        } else {
+            activityEventBuilder.updated().persist();
+        }
+        return response;
 
     }
 
     public boolean deleteSingleRecord(UUID instanceId, String version, RecordType recordType, String recordId) {
         validateAndPermissions(instanceId, version);
         checkRecordTypeExists(instanceId, recordType);
-        return recordService.deleteSingleRecord(instanceId, recordType, recordId);
+        boolean response = recordService.deleteSingleRecord(instanceId, recordType, recordId);
+        activityLogger.newEvent().currentUser().deleted().record().withRecordType(recordType).withId(recordId).persist();
+        return response;
 
     }
 
@@ -173,7 +192,7 @@ public class RecordOrchestratorService { // TODO give me a better name
         validateAndPermissions(instanceId, version);
         checkRecordTypeExists(instanceId, recordType);
         recordService.deleteRecordType(instanceId, recordType);
-
+        activityLogger.newEvent().currentUser().deleted().table().withRecordType(recordType).persist();
     }
 
     @ReadTransaction
@@ -199,7 +218,10 @@ public class RecordOrchestratorService { // TODO give me a better name
         if(recordDao.recordTypeExists(instanceId, recordType)){
             recordService.validatePrimaryKey(instanceId, recordType, primaryKey);
         }
-        return batchWriteService.batchWriteJsonStream(is, instanceId, recordType, primaryKey);
+
+        int qty = batchWriteService.batchWriteJsonStream(is, instanceId, recordType, primaryKey);
+        activityLogger.newEvent().currentUser().modified().record().withRecordType(recordType).ofQuantity(qty).persist();
+        return qty;
     }
 
     private void checkRecordTypeExists(UUID instanceId, RecordType recordType) {

--- a/service/src/main/resources/ehcache.xml
+++ b/service/src/main/resources/ehcache.xml
@@ -52,5 +52,17 @@
         </resources>
     </cache>
 
+    <cache alias="tokenResolution" uses-template="default">
+        <key-type>java.lang.Integer</key-type>
+        <value-type>java.lang.String</value-type>
+        <expiry>
+            <ttl unit="minutes">10</ttl>
+        </expiry>
+        <resources>
+            <heap unit="entries">500</heap>
+            <offheap unit="MB">8</offheap>
+        </resources>
+    </cache>
+
 
 </config>

--- a/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/ActivityEventBuilderTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/ActivityEventBuilderTest.java
@@ -1,0 +1,81 @@
+package org.databiosphere.workspacedataservice.activitylog;
+
+import org.broadinstitute.dsde.workbench.client.sam.ApiException;
+import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
+import org.broadinstitute.dsde.workbench.client.sam.api.UsersApi;
+import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo;
+import org.databiosphere.workspacedataservice.sam.BearerTokenFilter;
+import org.databiosphere.workspacedataservice.sam.SamClientFactory;
+import org.databiosphere.workspacedataservice.service.InstanceService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
+import static org.springframework.web.context.request.RequestAttributes.SCOPE_REQUEST;
+
+@ActiveProfiles(profiles = "mock-sam")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SpringBootTest
+@AutoConfigureMockMvc
+@ExtendWith(OutputCaptureExtension.class)
+public class ActivityEventBuilderTest {
+
+    @Autowired
+    InstanceService instanceService;
+
+    @MockBean
+    SamClientFactory mockSamClientFactory;
+
+    UsersApi mockUsersApi = Mockito.mock(UsersApi.class);
+    ResourcesApi mockResourcesApi = Mockito.mock(ResourcesApi.class);
+
+    @BeforeEach
+    void beforeEach() {
+        given(mockSamClientFactory.getUsersApi(any())).willReturn(mockUsersApi);
+        given(mockSamClientFactory.getResourcesApi(any())).willReturn(mockResourcesApi);
+    }
+
+    @Test
+    void testTokenResolutionViaSam(CapturedOutput output) throws ApiException {
+        // set up the Sam mocks
+        UserStatusInfo userStatusInfo = new UserStatusInfo();
+        userStatusInfo.userSubjectId("userid-for-unit-tests-hello!");
+        when(mockUsersApi.getUserStatusInfo()).thenReturn(userStatusInfo);
+        when(mockResourcesApi.resourcePermissionV2(any(), any(), any())).thenReturn(true);
+
+        // instanceId
+        UUID instanceId = UUID.randomUUID();
+
+        // ensure we have a token in the current request; else we'll get "anonymous" for our user
+        RequestAttributes currentAttributes = RequestContextHolder.currentRequestAttributes();
+        currentAttributes.setAttribute(BearerTokenFilter.ATTRIBUTE_NAME_TOKEN, "fakey-token", SCOPE_REQUEST);
+        RequestContextHolder.setRequestAttributes(currentAttributes);
+
+        // create an instance; this will trigger logging
+        instanceService.createInstance(instanceId, "v0.2");
+
+        // did we log the
+        assertThat(output.getOut())
+                .contains("user userid-for-unit-tests-hello! created 1 instance(s) with id(s) [%s]".formatted(instanceId));
+
+
+    }
+
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/LogStatementTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/LogStatementTest.java
@@ -1,0 +1,55 @@
+package org.databiosphere.workspacedataservice.activitylog;
+
+import org.databiosphere.workspacedataservice.dao.MockInstanceDaoConfig;
+import org.databiosphere.workspacedataservice.datarepo.DataRepoConfig;
+import org.databiosphere.workspacedataservice.sam.MockSamClientFactoryConfig;
+import org.databiosphere.workspacedataservice.sam.SamConfig;
+import org.databiosphere.workspacedataservice.service.DataRepoService;
+import org.databiosphere.workspacedataservice.service.InstanceService;
+import org.databiosphere.workspacedataservice.workspacemanager.WorkspaceManagerConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@ActiveProfiles(profiles = { "mock-sam", "mock-instance-dao" })
+@SpringBootTest(classes = {ActivityLoggerConfig.class,
+        DataRepoService.class, DataRepoConfig.class,
+        WorkspaceManagerConfig.class,
+        MockSamClientFactoryConfig.class, SamConfig.class,
+        InstanceService.class, MockInstanceDaoConfig.class
+})
+@ExtendWith(OutputCaptureExtension.class)
+public class LogStatementTest {
+
+    private final String VERSION = "v0.2";
+
+    @Autowired
+    InstanceService instanceService;
+
+    @Test
+    void createInstanceLogging(CapturedOutput output) {
+        UUID instanceId = UUID.randomUUID();
+        instanceService.createInstance(instanceId, VERSION);
+        assertThat(output.getOut())
+                .contains("user anonymous created 1 instance(s) with id(s) [%s]".formatted(instanceId));
+    }
+
+    @Test
+    void deleteInstanceLogging(CapturedOutput output) {
+        UUID instanceId = UUID.randomUUID();
+        instanceService.createInstance(instanceId, VERSION);
+        instanceService.deleteInstance(instanceId, VERSION);
+        assertThat(output.getOut())
+                .contains("user anonymous deleted 1 instance(s) with id(s) [%s]".formatted(instanceId));
+    }
+
+
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/LogStatementTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/LogStatementTest.java
@@ -26,6 +26,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -41,6 +42,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 @ActiveProfiles(profiles = { "mock-sam" })
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @SpringBootTest
 @ExtendWith(OutputCaptureExtension.class)
 public class LogStatementTest {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/LogStatementTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/LogStatementTest.java
@@ -1,12 +1,25 @@
 package org.databiosphere.workspacedataservice.activitylog;
 
+import org.databiosphere.workspacedataservice.dao.CachedQueryDao;
+import org.databiosphere.workspacedataservice.dao.DataSourceConfig;
 import org.databiosphere.workspacedataservice.dao.MockInstanceDaoConfig;
+import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.databiosphere.workspacedataservice.datarepo.DataRepoConfig;
 import org.databiosphere.workspacedataservice.sam.MockSamClientFactoryConfig;
 import org.databiosphere.workspacedataservice.sam.SamConfig;
+import org.databiosphere.workspacedataservice.service.BatchWriteService;
 import org.databiosphere.workspacedataservice.service.DataRepoService;
+import org.databiosphere.workspacedataservice.service.DataTypeInfererConfig;
 import org.databiosphere.workspacedataservice.service.InstanceService;
+import org.databiosphere.workspacedataservice.service.JsonConfig;
+import org.databiosphere.workspacedataservice.service.RecordOrchestratorService;
+import org.databiosphere.workspacedataservice.service.RecordService;
+import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
+import org.databiosphere.workspacedataservice.shared.model.RecordRequest;
+import org.databiosphere.workspacedataservice.shared.model.RecordType;
+import org.databiosphere.workspacedataservice.tsv.TsvConfig;
 import org.databiosphere.workspacedataservice.workspacemanager.WorkspaceManagerConfig;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,17 +28,14 @@ import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-@ActiveProfiles(profiles = { "mock-sam", "mock-instance-dao" })
-@SpringBootTest(classes = {ActivityLoggerConfig.class,
-        DataRepoService.class, DataRepoConfig.class,
-        WorkspaceManagerConfig.class,
-        MockSamClientFactoryConfig.class, SamConfig.class,
-        InstanceService.class, MockInstanceDaoConfig.class
-})
+@ActiveProfiles(profiles = { "mock-sam" })
+@SpringBootTest
 @ExtendWith(OutputCaptureExtension.class)
 public class LogStatementTest {
 
@@ -33,23 +43,113 @@ public class LogStatementTest {
 
     @Autowired
     InstanceService instanceService;
+    @Autowired
+    RecordOrchestratorService recordOrchestratorService;
 
-    @Test
-    void createInstanceLogging(CapturedOutput output) {
-        UUID instanceId = UUID.randomUUID();
-        instanceService.createInstance(instanceId, VERSION);
-        assertThat(output.getOut())
-                .contains("user anonymous created 1 instance(s) with id(s) [%s]".formatted(instanceId));
+    @AfterEach
+    void afterEach() {
+        List<UUID> allInstances = instanceService.listInstances(VERSION);
+        for (UUID id : allInstances) {
+            instanceService.deleteInstance(id, VERSION);
+        }
     }
 
     @Test
-    void deleteInstanceLogging(CapturedOutput output) {
+    void createAndDeleteInstanceLogging(CapturedOutput output) {
         UUID instanceId = UUID.randomUUID();
         instanceService.createInstance(instanceId, VERSION);
         instanceService.deleteInstance(instanceId, VERSION);
         assertThat(output.getOut())
+                .contains("user anonymous created 1 instance(s) with id(s) [%s]".formatted(instanceId));
+        assertThat(output.getOut())
                 .contains("user anonymous deleted 1 instance(s) with id(s) [%s]".formatted(instanceId));
     }
+
+    @Test
+    void upsertRecordLogging(CapturedOutput output) {
+        UUID instanceId = UUID.randomUUID();
+        RecordType recordType = RecordType.valueOf("mytype");
+        String recordId = "my-record-id";
+        instanceService.createInstance(instanceId, VERSION);
+        // loop twice - this creates the record and then updates it,
+        // using the same upsert method.
+        for(int i = 0; i<=1; i++) {
+            recordOrchestratorService.upsertSingleRecord(instanceId, VERSION,
+                    recordType, recordId,
+                    Optional.empty(),
+                    new RecordRequest(RecordAttributes.empty()));
+        }
+        assertThat(output.getOut())
+                .contains("user anonymous created 1 record(s) of type %s with id(s) [%s]"
+                        .formatted(recordType.getName(), recordId));
+        assertThat(output.getOut())
+                .contains("user anonymous updated 1 record(s) of type %s with id(s) [%s]"
+                        .formatted(recordType.getName(), recordId));
+    }
+
+    @Test
+    void updateRecordLogging(CapturedOutput output) {
+        UUID instanceId = UUID.randomUUID();
+        RecordType recordType = RecordType.valueOf("mytype");
+        String recordId = "my-record-id";
+        instanceService.createInstance(instanceId, VERSION);
+        // create the record
+        recordOrchestratorService.upsertSingleRecord(instanceId, VERSION,
+                recordType, recordId,
+                Optional.empty(),
+                new RecordRequest(RecordAttributes.empty()));
+        // now update the record - this is the method under test
+        recordOrchestratorService.updateSingleRecord(instanceId, VERSION,
+                recordType, recordId,
+                new RecordRequest(RecordAttributes.empty()));
+        assertThat(output.getOut())
+                .contains("user anonymous updated 1 record(s) of type %s with id(s) [%s]"
+                        .formatted(recordType.getName(), recordId));
+    }
+
+    @Test
+    void deleteRecordLogging(CapturedOutput output) {
+        UUID instanceId = UUID.randomUUID();
+        RecordType recordType = RecordType.valueOf("mytype");
+        String recordId = "my-record-id";
+        instanceService.createInstance(instanceId, VERSION);
+        // create the record
+        recordOrchestratorService.upsertSingleRecord(instanceId, VERSION,
+                recordType, recordId,
+                Optional.empty(),
+                new RecordRequest(RecordAttributes.empty()));
+        // now delete the record - this is the method under test
+        recordOrchestratorService.deleteSingleRecord(instanceId, VERSION,
+                recordType, recordId);
+        assertThat(output.getOut())
+                .contains("user anonymous deleted 1 record(s) of type %s with id(s) [%s]"
+                        .formatted(recordType.getName(), recordId));
+    }
+
+    @Test
+    void deleteRecordTypeLogging(CapturedOutput output) {
+        UUID instanceId = UUID.randomUUID();
+        RecordType recordType = RecordType.valueOf("mytype");
+        String recordId = "my-record-id";
+        instanceService.createInstance(instanceId, VERSION);
+        // create the record
+        recordOrchestratorService.upsertSingleRecord(instanceId, VERSION,
+                recordType, recordId,
+                Optional.empty(),
+                new RecordRequest(RecordAttributes.empty()));
+        // now delete the entire record type - this is the method under test
+        recordOrchestratorService.deleteRecordType(instanceId, VERSION,
+                recordType);
+        assertThat(output.getOut())
+                .contains("user anonymous deleted 1 table(s) of type %s"
+                        .formatted(recordType.getName()));
+    }
+
+    // TODO: tsv upload
+    // TODO: batch upload
+    // TODO: link snapshot
+
+
 
 
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/sam/MockSamClientFactory.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/sam/MockSamClientFactory.java
@@ -2,6 +2,7 @@ package org.databiosphere.workspacedataservice.sam;
 
 import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.StatusApi;
+import org.broadinstitute.dsde.workbench.client.sam.api.UsersApi;
 
 /**
  * Mock for SamClientFactory, which returns a MockSamResourcesApi.
@@ -17,4 +18,8 @@ public class MockSamClientFactory implements SamClientFactory {
         return new StatusApi();
     }
 
+    @Override
+    public UsersApi getUsersApi(String token) {
+        return null;
+    }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceNoPermissionSamTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceNoPermissionSamTest.java
@@ -2,6 +2,8 @@ package org.databiosphere.workspacedataservice.service;
 
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
 import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
+import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
+import org.databiosphere.workspacedataservice.activitylog.ActivityLoggerConfig;
 import org.databiosphere.workspacedataservice.dao.InstanceDao;
 import org.databiosphere.workspacedataservice.dao.MockInstanceDaoConfig;
 import org.databiosphere.workspacedataservice.sam.SamClientFactory;
@@ -26,7 +28,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 
 @ActiveProfiles(profiles = "mock-instance-dao")
-@SpringBootTest(classes = { MockInstanceDaoConfig.class, SamConfig.class })
+@SpringBootTest(classes = { MockInstanceDaoConfig.class, SamConfig.class, ActivityLoggerConfig.class })
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class InstanceServiceNoPermissionSamTest {
 
@@ -34,6 +36,7 @@ class InstanceServiceNoPermissionSamTest {
 
     @Autowired private InstanceDao instanceDao;
     @Autowired private SamDao samDao;
+    @Autowired private ActivityLogger activityLogger;
 
     // mock for the SamClientFactory; since this is a Spring bean we can use @MockBean
     @MockBean
@@ -44,7 +47,7 @@ class InstanceServiceNoPermissionSamTest {
 
     @BeforeEach
     void beforeEach() {
-        instanceService = new InstanceService(instanceDao, samDao);
+        instanceService = new InstanceService(instanceDao, samDao, activityLogger);
     }
 
     @Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamExceptionTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamExceptionTest.java
@@ -2,6 +2,8 @@ package org.databiosphere.workspacedataservice.service;
 
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
 import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
+import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
+import org.databiosphere.workspacedataservice.activitylog.ActivityLoggerConfig;
 import org.databiosphere.workspacedataservice.dao.InstanceDao;
 import org.databiosphere.workspacedataservice.dao.MockInstanceDaoConfig;
 import org.databiosphere.workspacedataservice.sam.SamClientFactory;
@@ -51,7 +53,7 @@ import static org.mockito.BDDMockito.given;
  *          with a 500 error code.
  */
 @ActiveProfiles(profiles = "mock-instance-dao")
-@SpringBootTest(classes = { MockInstanceDaoConfig.class, SamConfig.class })
+@SpringBootTest(classes = { MockInstanceDaoConfig.class, SamConfig.class, ActivityLoggerConfig.class })
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestPropertySource(properties = {"twds.instance.workspace-id=123e4567-e89b-12d3-a456-426614174000"}) // example uuid from https://en.wikipedia.org/wiki/Universally_unique_identifier
 class InstanceServiceSamExceptionTest {
@@ -60,6 +62,7 @@ class InstanceServiceSamExceptionTest {
 
     @Autowired private InstanceDao instanceDao;
     @Autowired private SamDao samDao;
+    @Autowired private ActivityLogger activityLogger;
 
     // mock for the SamClientFactory; since this is a Spring bean we can use @MockBean
     @MockBean
@@ -73,7 +76,7 @@ class InstanceServiceSamExceptionTest {
 
     @BeforeEach
     void beforeEach() {
-        instanceService = new InstanceService(instanceDao, samDao);
+        instanceService = new InstanceService(instanceDao, samDao, activityLogger);
 
         // return the mock ResourcesApi from the mock SamClientFactory
         given(mockSamClientFactory.getResourcesApi(null))

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamTest.java
@@ -3,6 +3,8 @@ package org.databiosphere.workspacedataservice.service;
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
 import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
 import org.broadinstitute.dsde.workbench.client.sam.model.CreateResourceRequestV2;
+import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
+import org.databiosphere.workspacedataservice.activitylog.ActivityLoggerConfig;
 import org.databiosphere.workspacedataservice.dao.InstanceDao;
 import org.databiosphere.workspacedataservice.dao.MockInstanceDaoConfig;
 import org.databiosphere.workspacedataservice.sam.SamClientFactory;
@@ -28,7 +30,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
 @ActiveProfiles(profiles = "mock-instance-dao")
-@SpringBootTest(classes = { MockInstanceDaoConfig.class, SamConfig.class })
+@SpringBootTest(classes = { MockInstanceDaoConfig.class, SamConfig.class, ActivityLoggerConfig.class })
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestPropertySource(properties = {"twds.instance.workspace-id=123e4567-e89b-12d3-a456-426614174000"}) // example uuid from https://en.wikipedia.org/wiki/Universally_unique_identifier
 class InstanceServiceSamTest {
@@ -37,6 +39,7 @@ class InstanceServiceSamTest {
 
     @Autowired private InstanceDao instanceDao;
     @Autowired private SamDao samDao;
+    @Autowired private ActivityLogger activityLogger;
 
     // mock for the SamClientFactory; since this is a Spring bean we can use @MockBean
     @MockBean
@@ -50,7 +53,7 @@ class InstanceServiceSamTest {
 
     @BeforeEach
     void beforeEach() throws ApiException {
-        instanceService = new InstanceService(instanceDao, samDao);
+        instanceService = new InstanceService(instanceDao, samDao, activityLogger);
 
         // return the mock ResourcesApi from the mock SamClientFactory
         given(mockSamClientFactory.getResourcesApi(null))

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceTest.java
@@ -1,5 +1,7 @@
 package org.databiosphere.workspacedataservice.service;
 
+import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
+import org.databiosphere.workspacedataservice.activitylog.ActivityLoggerConfig;
 import org.databiosphere.workspacedataservice.dao.InstanceDao;
 import org.databiosphere.workspacedataservice.dao.MockInstanceDaoConfig;
 import org.databiosphere.workspacedataservice.sam.MockSamClientFactoryConfig;
@@ -20,19 +22,20 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ActiveProfiles(profiles = { "mock-sam", "mock-instance-dao" })
-@SpringBootTest(classes = { MockInstanceDaoConfig.class, SamConfig.class, MockSamClientFactoryConfig.class })
+@SpringBootTest(classes = { MockInstanceDaoConfig.class, SamConfig.class, MockSamClientFactoryConfig.class, ActivityLoggerConfig.class })
 class InstanceServiceTest {
 
     private InstanceService instanceService;
     @Autowired private InstanceDao instanceDao;
     @Autowired private SamDao samDao;
+    @Autowired private ActivityLogger activityLogger;
 
 
     private static final UUID INSTANCE = UUID.fromString("111e9999-e89b-12d3-a456-426614174000");
 
     @BeforeEach
     void setUp() {
-        instanceService = new InstanceService(instanceDao, samDao);
+        instanceService = new InstanceService(instanceDao, samDao, activityLogger);
         // Delete all instances
         instanceDao.listInstanceSchemas().forEach(instance -> {
             instanceDao.dropSchema(instance);


### PR DESCRIPTION
Enables activity logging for all write operations, as part of control M1 for production readiness. I end up with log entries like this:
```
2023-05-17 15:25:31,925 INFO  [a50716bb-eb7b-4003-b571-26ee004d52cf] org.databiosphere.workspacedataservice.activitylog.ActivityLogger: user 213400982345703434599 created 1 instance(s) with id(s) [b0a945bd-a737-4017-a519-786392023a0d]
2023-05-17 15:25:58,307 INFO  [eee6fd6f-b108-4db9-8844-b8ae0b92ba83] org.databiosphere.workspacedataservice.activitylog.ActivityLogger: user 213400982345703434599 created 1 record(s) of type mytype with id(s) [123]
2023-05-17 15:26:05,042 INFO  [db12c397-3b56-412c-8846-6670f3358970] org.databiosphere.workspacedataservice.activitylog.ActivityLogger: user 213400982345703434599 deleted 1 record(s) of type mytype with id(s) [123]
```

The implementation in this PR is a bit extra and over-designed. I am looking ahead to a time when we are also saving activity log entries to a db and eventually expose them to end users, so end users can see the history/provenance of their data. It's overkill for now, when all we need is log entries.

Additional changes in this PR:
* Changed logging such that responses from Sam aren't logged unless we turn on trace-level logging. Sam responses can and do contain user email addresses, and we don't want to log those.
* Updated SamDaos to include the call to resolve a token to a userid
* Added a cache for resolving tokens to Sam userids, so we're not continually pinging Sam for this info.
* Moved the snapshot-import implementation out of DataRepoController and into a new DataRepoService, because this matches the design for our other controllers.

ATTENTION REVIEWER: I suggest reviewing this "top down" - that is, read the unit tests in `LogStatementTest` as a specification of what this code is supposed to do; then read the changes in `InstanceService`, `DataRepoService`, and `RecordOrchestratorService` to see how methods add entries to the activity log; then, read the files in the `org.databiosphere.workspacedataservice.activitylog` package and the Sam changes to see how it's all implemented under the covers.




