### PR TITLE
AJ-1063: upgrade Sam client and org.json:json

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -52,7 +52,7 @@ dependencies {
 	implementation 'org.ehcache:ehcache:3.10.8'
 
 	// Terra libraries
-	implementation group: 'org.broadinstitute.dsde.workbench', name: 'sam-client_2.13', version: '0.1-b7e47d2'
+	implementation group: 'org.broadinstitute.dsde.workbench', name: 'sam-client_2.13', version: '0.1-08b6588'
 	implementation 'com.squareup.okhttp3:okhttp:4.10.0' // required by Sam client
 	implementation "bio.terra:datarepo-client:1.476.0-SNAPSHOT"
 	implementation "bio.terra:workspace-manager-client:0.254.717-SNAPSHOT"
@@ -63,6 +63,12 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'
 	testImplementation project(':client')
+
+	constraints {
+		implementation('org.json:json:20230227') {
+			because("CVE-2022-45688")
+		}
+	}
 }
 
 sonarqube {


### PR DESCRIPTION
* upgrades `sam-client` to latest version
* puts a constraint on `org.json:json`, which is a transitive dependency of `sam-client`, to use the latest version `20230227`. This addresses CVE-2022-45688.

Note: the fix from #228 does NOT appear necessary in this case, since the `dependencies.constraints` stanza is in service/build.gradle, not build.gradle. This means the POM file generation in the :client project is unaffected.