### PR TITLE
AJ-1063: speed up unit tests

### DIFF
--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/ConcurrentDataTypeChangesTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/ConcurrentDataTypeChangesTest.java
@@ -64,7 +64,7 @@ class ConcurrentDataTypeChangesTest {
     @Test
     void concurrentColumnCreation() {
         // concurrency factor for reads + writes
-        int numIterations = 40;
+        int numIterations = 20;
 
         // create the initial record, with no attributes
         RecordRequest recordRequest = new RecordRequest(RecordAttributes.empty());

--- a/service/src/test/java/org/databiosphere/workspacedataservice/retry/TransactionRetryTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/retry/TransactionRetryTest.java
@@ -18,7 +18,14 @@ import static org.junit.jupiter.api.Assertions.*;
 
 
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
-@SpringBootTest
+// aggressive retry settings to make this test fast; these are
+// inappropriate for runtime behavior.
+@SpringBootTest(properties = {
+        "terra.common.retry.transaction.slowRetryMaxAttempts=2",
+        "terra.common.retry.transaction.slowRetryInitialInterval=250ms",
+        "terra.common.retry.transaction.slowRetryMultiplier=1.1",
+        "terra.common.retry.transaction.fastRetryMaxAttempts=2"
+})
 class TransactionRetryTest {
 
     @Autowired TransactionRetryTestBean transactionRetryTestBean;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorSamTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorSamTest.java
@@ -25,7 +25,8 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
-@SpringBootTest
+@SpringBootTest(properties = {"sam.retry.maxAttempts=2",
+        "sam.retry.backoff.delay=10"}) // aggressive retry settings so unit test doesn't run too long)
 @ActiveProfiles(profiles = { "mock-sam", "mock-instance-dao" })
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class RecordOrchestratorSamTest {


### PR DESCRIPTION
In my environment, unit tests take ~60 seconds. This isn't bad, but we can do better.

In very unscientific testing on my local system with other apps open, I saw the following results. These times are the average of running each test 5 times.

| | Before | After |
|--------|--------|--------|
| `TransactionRetryTest` | 37.62s | 2.38s |
| `ConcurrentDataTypeChangesTest` | 8.9s | 5.7s |
| `RecordOrchestratorSamTest` | 4.2s | 0.2s |

This PR speeds up tests by:
* reducing concurrency for `ConcurrentDataTypeChangesTest`
* reducing retry counts and wait durations for `TransactionRetryTest` and `RecordOrchestratorSamTest`


