### PR TITLE
AJ-1063: @DirtiesContext

### DIFF
--- a/env.txt
+++ b/env.txt
@@ -1,0 +1,12 @@
+WORKSPACE_ID=1117a5d3-9f2c-42d0-9961-550cdbe3585a
+SAM_URL=https://sam.dsde-dev.broadinstitute.org/
+DATA_REPO_URL=https://jade.datarepo-dev.broadinstitute.org/
+WORKSPACE_MANAGER_URL=https://workspace.dsde-dev.broadinstitute.org/
+WDS_DB_HOST=host.docker.internal
+WDS_DB_PORT=5432
+WDS_DB_USER=wds
+WDS_DB_PASSWORD=wds
+WDS_DB_NAME=wds
+LZ_MRG=dockertesting
+RELEASE_NAME=dockertesting
+CLIENT_ID=123

--- a/service/src/test/java/org/databiosphere/workspacedataservice/DataTypeInfererTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/DataTypeInfererTest.java
@@ -18,8 +18,10 @@ import org.databiosphere.workspacedataservice.shared.model.RecordType;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 
- @SpringBootTest(classes = {JsonConfig.class, DataTypeInfererConfig.class})
+@DirtiesContext
+@SpringBootTest(classes = {JsonConfig.class, DataTypeInfererConfig.class})
 class DataTypeInfererTest {
 
 	@Autowired

--- a/service/src/test/java/org/databiosphere/workspacedataservice/GeneratedClientTests.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/GeneratedClientTests.java
@@ -28,7 +28,7 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ActiveProfiles(profiles = "mock-sam")
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class GeneratedClientTests {
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/InstanceInitializerBeanTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/InstanceInitializerBeanTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 
@@ -18,6 +19,7 @@ import static org.mockito.Mockito.*;
 
 @ActiveProfiles({"mock-instance-dao", "local"})
 @TestPropertySource(properties = {"twds.instance.workspace-id=90e1b179-9f83-4a6f-a8c2-db083df4cd03"})
+@DirtiesContext
 @SpringBootTest(classes = {InstanceInitializerConfig.class, MockInstanceDaoConfig.class})
 class InstanceInitializerBeanTest {
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/InstanceInitializerNoWorkspaceIdTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/InstanceInitializerNoWorkspaceIdTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 
@@ -16,6 +17,7 @@ import static org.mockito.Mockito.verify;
 
 @ActiveProfiles({"mock-instance-dao", "local"})
 @TestPropertySource(properties = {"twds.instance.workspace-id="})
+@DirtiesContext
 @SpringBootTest(classes = {InstanceInitializerConfig.class, MockInstanceDaoConfig.class})
 class InstanceInitializerNoWorkspaceIdTest {
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/ConcurrentDataTypeChangesTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/ConcurrentDataTypeChangesTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ActiveProfiles(profiles = "mock-sam")
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class ConcurrentDataTypeChangesTest {
     @Autowired

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/CorsLiveMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/CorsLiveMockMvcTest.java
@@ -22,7 +22,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  *
  * See also CorsLocalMockMvcTest for testing CORS behavior in the "local" Spring profile
  */
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext
 @SpringBootTest
 @AutoConfigureMockMvc
 class CorsLiveMockMvcTest {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/CorsLocalMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/CorsLocalMockMvcTest.java
@@ -25,7 +25,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * See also CorsLiveMockMvcTest for testing CORS behavior in live deployments.
  */
 @ActiveProfiles(profiles = {"local"})
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext
 @SpringBootTest
 @AutoConfigureMockMvc
 class CorsLocalMockMvcTest {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/DataRepoControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/DataRepoControllerMockMvcTest.java
@@ -17,6 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -28,6 +29,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ActiveProfiles(profiles = "mock-sam")
+@DirtiesContext
 @SpringBootTest
 @AutoConfigureMockMvc
 class DataRepoControllerMockMvcTest {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackMDCRequestResponseTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackMDCRequestResponseTest.java
@@ -19,7 +19,7 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
 		"spring.main.allow-bean-definition-overriding=true"})
 class FullStackMDCRequestResponseTest {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
@@ -56,7 +56,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * this test suite is currently focused on validating expected error handling
  */
 @ActiveProfiles(profiles = "mock-sam")
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
 		"spring.main.allow-bean-definition-overriding=true"})
 @Import(SmallBatchWriteTestConfig.class)

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -50,7 +50,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @ActiveProfiles(profiles = "mock-sam")
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @AutoConfigureMockMvc

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
@@ -37,7 +37,7 @@ import static org.databiosphere.workspacedataservice.service.model.ReservedNames
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ActiveProfiles(profiles = "mock-sam")
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class TsvDownloadTest {
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvInputFormatsTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvInputFormatsTest.java
@@ -30,7 +30,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ActiveProfiles(profiles = "mock-sam")
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext
 @SpringBootTest
 @AutoConfigureMockMvc
 class TsvInputFormatsTest {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoCacheTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoCacheTest.java
@@ -21,7 +21,7 @@ import java.util.UUID;
 import static org.mockito.Mockito.*;
 
 @ContextConfiguration
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext
 @SpringBootTest
 class RecordDaoCacheTest {
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
@@ -40,7 +40,7 @@ import java.util.stream.IntStream;
 import static org.databiosphere.workspacedataservice.service.model.ReservedNames.RECORD_ID;
 import static org.junit.jupiter.api.Assertions.*;
 
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class RecordDaoTest {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/datarepo/DataRepoDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/datarepo/DataRepoDaoTest.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
+import org.springframework.test.annotation.DirtiesContext;
 
 import java.util.UUID;
 
@@ -17,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
+@DirtiesContext
 @SpringBootTest(
         classes = {DataRepoConfig.class})
 class DataRepoDaoTest {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/retry/TransactionRetryTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/retry/TransactionRetryTest.java
@@ -17,7 +17,7 @@ import java.util.stream.Stream;
 import static org.junit.jupiter.api.Assertions.*;
 
 
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext
 // aggressive retry settings to make this test fast; these are
 // inappropriate for runtime behavior.
 @SpringBootTest(properties = {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/sam/BearerTokenFilterTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/sam/BearerTokenFilterTest.java
@@ -23,7 +23,7 @@ import static org.springframework.web.context.request.RequestAttributes.SCOPE_RE
 /**
  * Tests for @see BearerTokenFilter
  */
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext
 @SpringBootTest
 class BearerTokenFilterTest {
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/sam/HttpSamClientSupportTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/sam/HttpSamClientSupportTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.test.annotation.DirtiesContext;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -25,6 +26,7 @@ import static org.databiosphere.workspacedataservice.sam.HttpSamClientSupport.Vo
 /**
  * Tests for @see HttpSamClientSupport
  */
+@DirtiesContext
 @SpringBootTest(classes = {SamConfig.class, RetryLoggingListener.class},
         properties = {"sam.retry.maxAttempts=2",
                 "sam.retry.backoff.delay=10"}) // aggressive retry settings so unit test doesn't run too long

--- a/service/src/test/java/org/databiosphere/workspacedataservice/sam/SamDaoInvalidWorkspaceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/sam/SamDaoInvalidWorkspaceTest.java
@@ -3,6 +3,7 @@ package org.databiosphere.workspacedataservice.sam;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -11,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * that all Sam checks return false, and we get an exception
  * from Sam status checks.
  */
+@DirtiesContext
 @SpringBootTest(
         classes = {SamConfig.class},
         properties = {"twds.instance.workspace-id=not-a-real-id"})

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceNoPermissionSamTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceNoPermissionSamTest.java
@@ -15,6 +15,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
@@ -26,6 +27,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 
 @ActiveProfiles(profiles = "mock-instance-dao")
+@DirtiesContext
 @SpringBootTest(classes = { MockInstanceDaoConfig.class, SamConfig.class })
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class InstanceServiceNoPermissionSamTest {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamExceptionTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamExceptionTest.java
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 
@@ -51,6 +52,7 @@ import static org.mockito.BDDMockito.given;
  *          with a 500 error code.
  */
 @ActiveProfiles(profiles = "mock-instance-dao")
+@DirtiesContext
 @SpringBootTest(classes = { MockInstanceDaoConfig.class, SamConfig.class })
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestPropertySource(properties = {"twds.instance.workspace-id=123e4567-e89b-12d3-a456-426614174000"}) // example uuid from https://en.wikipedia.org/wiki/Universally_unique_identifier

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamTest.java
@@ -17,6 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 
@@ -28,6 +29,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
 @ActiveProfiles(profiles = "mock-instance-dao")
+@DirtiesContext
 @SpringBootTest(classes = { MockInstanceDaoConfig.class, SamConfig.class })
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestPropertySource(properties = {"twds.instance.workspace-id=123e4567-e89b-12d3-a456-426614174000"}) // example uuid from https://en.wikipedia.org/wiki/Universally_unique_identifier

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
@@ -20,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ActiveProfiles(profiles = { "mock-sam", "mock-instance-dao" })
+@DirtiesContext
 @SpringBootTest(classes = { MockInstanceDaoConfig.class, SamConfig.class, MockSamClientFactoryConfig.class })
 class InstanceServiceTest {
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/PermissionsStatusServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/PermissionsStatusServiceTest.java
@@ -23,7 +23,7 @@ import org.springframework.test.context.TestPropertySource;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext
 @SpringBootTest(properties = "spring.cache.type=NONE")
 @TestPropertySource(properties = {"twds.instance.workspace-id=123e4567-e89b-12d3-a456-426614174000"}) // example uuid from https://en.wikipedia.org/wiki/Universally_unique_identifier
 class PermissionsStatusServiceTest {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorSamTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorSamTest.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext
 @SpringBootTest(properties = {"sam.retry.maxAttempts=2",
         "sam.retry.backoff.delay=10"}) // aggressive retry settings so unit test doesn't run too long)
 @ActiveProfiles(profiles = { "mock-sam", "mock-instance-dao" })

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ActiveProfiles(profiles = { "mock-sam" })
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext
 @SpringBootTest
 class RecordOrchestratorServiceTest {
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/StreamingTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/StreamingTest.java
@@ -14,7 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.databiosphere.workspacedataservice.shared.model.OperationType.DELETE;
 import static org.databiosphere.workspacedataservice.shared.model.OperationType.UPSERT;
 
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext
 @SpringBootTest(classes = JsonConfig.class)
 class StreamingTest {
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordRequestTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordRequestTest.java
@@ -7,12 +7,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 
 import java.math.BigInteger;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@DirtiesContext
 @SpringBootTest(classes = JsonConfig.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class RecordRequestTest {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordResponseTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordResponseTest.java
@@ -11,8 +11,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.util.StringUtils;
 
+@DirtiesContext
 @SpringBootTest(classes = JsonConfig.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class RecordResponseTest {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 
 import java.math.BigInteger;
 import java.util.Arrays;
@@ -17,6 +18,7 @@ import java.util.Map;
 import static org.databiosphere.workspacedataservice.service.model.ReservedNames.RESERVED_NAME_PREFIX;
 import static org.junit.jupiter.api.Assertions.*;
 
+@DirtiesContext
 @SpringBootTest(classes = JsonConfig.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class RecordTest {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvDeserializerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvDeserializerTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 
 import java.math.BigInteger;
 import java.util.List;
@@ -24,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @see TsvJsonArgumentsProvider
  */
+@DirtiesContext
 @SpringBootTest(classes = {DataTypeInfererConfig.class, JsonConfig.class, TsvConfig.class})
 class TsvDeserializerTest {
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvJsonEquivalenceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvJsonEquivalenceTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -27,6 +28,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @see TsvJsonArgumentsProvider
  */
+@DirtiesContext
 @SpringBootTest(classes = {DataTypeInfererConfig.class, JsonConfig.class, TsvConfig.class})
 class TsvJsonEquivalenceTest {
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/workspacemanager/WorkspaceManagerDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/workspacemanager/WorkspaceManagerDaoTest.java
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.util.UUID;
@@ -27,6 +28,7 @@ import static org.mockito.Mockito.verify;
 
 
 @ActiveProfiles(profiles = "mock-sam")
+@DirtiesContext
 @SpringBootTest(classes = {WorkspaceManagerConfig.class})
 class WorkspaceManagerDaoTest {
 


### PR DESCRIPTION
In #239, @calypsomatic is running into an issue where unit tests attempt to reuse a Spring CacheManager from a previous test's context - and this fails with an ehcache error of "Cache … is closed".

This PR adds `@DirtiesContext` to all `@SpringBootTest` tests that were missing it. In my testing (see draft PR #243), this resolved the issue.

For consistency and clarity, I've also replaced all instances of `@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)` with `@DirtiesContext`, since `AFTER_CLASS` is the default and these are equivalent.