### PR TITLE
fix clone instructions

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/workspacemanager/WorkspaceManagerDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/workspacemanager/WorkspaceManagerDao.java
@@ -36,7 +36,7 @@ public class WorkspaceManagerDao {
                   .snapshot(snapshotModel.getId().toString()))
               .metadata(
                   new ReferenceResourceCommonFields()
-                      .cloningInstructions(CloningInstructionsEnum.LINK_REFERENCE)
+                      .cloningInstructions(CloningInstructionsEnum.REFERENCE)
                       .name("%s_%s".formatted(snapshotModel.getName(), timeStamp))
               ),
           UUID.fromString(workspaceId));

--- a/service/src/test/java/org/databiosphere/workspacedataservice/workspacemanager/WorkspaceManagerDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/workspacemanager/WorkspaceManagerDaoTest.java
@@ -49,7 +49,7 @@ class WorkspaceManagerDaoTest {
         workspaceManagerDao.createDataRepoSnapshotReference(testSnapshot);
         verify(mockReferencedGcpResourceApi).createDataRepoSnapshotReference(argThat(a ->
             a.getSnapshot().getSnapshot().equals(testSnapshot.getId().toString()) &&
-                a.getMetadata().getCloningInstructions().equals(CloningInstructionsEnum.LINK_REFERENCE) &&
+                a.getMetadata().getCloningInstructions().equals(CloningInstructionsEnum.REFERENCE) &&
                 a.getMetadata().getName().startsWith(testSnapshot.getName())), any());
     }
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/WOR-877

I misunderstood how cloning instructions work the first time around. Using `LINK_REFERENCE` resulted in clones linking their policies to the source instead of merging them. [Read this](https://docs.google.com/document/d/1dRtE_nZf8e231DZmk_-9CDbjYTiIN2ZZwI95uF1w2pg/edit#heading=h.nbmbwtfq4byd) for more details if you care to.