### PR TITLE
AJ-1028 Fix PostgreSQL error caused by blank TSV headers

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -101,7 +101,7 @@ public class RecordDao {
 	public void createRecordType(UUID instanceId, Map<String, DataTypeMapping> tableInfo, RecordType recordType,
 			RelationCollection relations, String recordTypePrimaryKey) {
 		//this handles the case where the user incorrectly includes the primary key data in the attributes
-		tableInfo = Maps.filterKeys(tableInfo, k -> !k.equals(recordTypePrimaryKey)); 
+		tableInfo = Maps.filterKeys(tableInfo, k -> !k.equals(recordTypePrimaryKey));
 		String columnDefs = genColumnDefs(tableInfo, recordTypePrimaryKey);
 		try {
 			namedTemplate.getJdbcTemplate().update("create table " + getQualifiedTableName(recordType, instanceId)

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -100,8 +100,11 @@ public class RecordDao {
 	@SuppressWarnings("squid:S2077")
 	public void createRecordType(UUID instanceId, Map<String, DataTypeMapping> tableInfo, RecordType recordType,
 			RelationCollection relations, String recordTypePrimaryKey) {
+		// ADINA NOTE: Why won't this remove null values???
+		tableInfo.values().removeAll(Collections.singleton(null));
 		//this handles the case where the user incorrectly includes the primary key data in the attributes
-		tableInfo = Maps.filterKeys(tableInfo, k -> !k.equals(recordTypePrimaryKey));
+		// ADINA NOTE: Why won't this remove empty keys???
+		tableInfo = Maps.filterKeys(tableInfo, k -> (!k.equals(recordTypePrimaryKey) || !k.isEmpty()));
 		String columnDefs = genColumnDefs(tableInfo, recordTypePrimaryKey);
 		try {
 			namedTemplate.getJdbcTemplate().update("create table " + getQualifiedTableName(recordType, instanceId)

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -100,11 +100,8 @@ public class RecordDao {
 	@SuppressWarnings("squid:S2077")
 	public void createRecordType(UUID instanceId, Map<String, DataTypeMapping> tableInfo, RecordType recordType,
 			RelationCollection relations, String recordTypePrimaryKey) {
-		// ADINA NOTE: Why won't this remove null values???
-		tableInfo.values().removeAll(Collections.singleton(null));
 		//this handles the case where the user incorrectly includes the primary key data in the attributes
-		// ADINA NOTE: Why won't this remove empty keys???
-		tableInfo = Maps.filterKeys(tableInfo, k -> (!k.equals(recordTypePrimaryKey) || !k.isEmpty()));
+		tableInfo = Maps.filterKeys(tableInfo, k -> !k.equals(recordTypePrimaryKey)); 
 		String columnDefs = genColumnDefs(tableInfo, recordTypePrimaryKey);
 		try {
 			namedTemplate.getJdbcTemplate().update("create table " + getQualifiedTableName(recordType, instanceId)

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/TsvStreamWriteHandler.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/TsvStreamWriteHandler.java
@@ -49,9 +49,6 @@ public class TsvStreamWriteHandler implements StreamingWriteHandler {
 		FormatSchema formatSchema = tsvIterator.getParser().getSchema();
 		if (formatSchema instanceof CsvSchema actualSchema) {
 			colNames = actualSchema.getColumnNames();
-			// ADINA NOTE: This removes empty columns/headers! 
-			// Except how do you actually commit this back to the stream? We cooooooooould throw an error I guess. 
-			colNames.removeIf(col -> col.isEmpty());
 		} else {
 			throw new InvalidTsvException("Could not determine primary key column; unexpected schema type:" + formatSchema.getSchemaType());
 		}
@@ -103,6 +100,7 @@ public class TsvStreamWriteHandler implements StreamingWriteHandler {
 							+ " column or has a null or empty string value in that column");
 		}
 		row.removeAttribute(primaryKey);
+		row.removeNullHeaders();
 		return new Record(recordId.toString(), recordType, row);
 	}
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/TsvStreamWriteHandler.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/TsvStreamWriteHandler.java
@@ -49,6 +49,9 @@ public class TsvStreamWriteHandler implements StreamingWriteHandler {
 		FormatSchema formatSchema = tsvIterator.getParser().getSchema();
 		if (formatSchema instanceof CsvSchema actualSchema) {
 			colNames = actualSchema.getColumnNames();
+			// ADINA NOTE: This removes empty columns/headers! 
+			// Except how do you actually commit this back to the stream? We cooooooooould throw an error I guess. 
+			colNames.removeIf(col -> col.isEmpty());
 		} else {
 			throw new InvalidTsvException("Could not determine primary key column; unexpected schema type:" + formatSchema.getSchemaType());
 		}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributes.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributes.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.Iterator;
 
 /**
  * Represents the attributes of a Record.
@@ -103,14 +104,18 @@ public class RecordAttributes {
 	}
 
 	public RecordAttributes removeNullHeaders() {
-		// Can't iterate over a TreeMap, so iterate over its set, check for empty keys, 
-		// then remove them from the TreeMap.
+		// Can't iterate over a TreeMap (or remove entries while iterating), so iterate over its 
+		// set, count empty keys, then iterate and remove them from the TreeMap.
 		Set<Map.Entry<String, Object>> attributeSet = this.attributes.entrySet();
+		int i = 0;
 		for(Map.Entry<String, Object> attribute : attributeSet) {
 			if (attribute.getKey().isEmpty()) {
-				this.attributes.remove(attribute.getKey());
+				i++;
 			}
 		}	
+		for(; i > 0; i--) {
+			this.attributes.remove("");
+		}
 		return this;
 	}
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributes.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributes.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.Iterator;
 
 /**
  * Represents the attributes of a Record.

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributes.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributes.java
@@ -104,18 +104,8 @@ public class RecordAttributes {
 	}
 
 	public RecordAttributes removeNullHeaders() {
-		// Can't iterate over a TreeMap (or remove entries while iterating), so iterate over its 
-		// set, count empty keys, then iterate and remove them from the TreeMap.
-		Set<Map.Entry<String, Object>> attributeSet = this.attributes.entrySet();
-		int i = 0;
-		for(Map.Entry<String, Object> attribute : attributeSet) {
-			if (attribute.getKey().isEmpty()) {
-				i++;
-			}
-		}	
-		for(; i > 0; i--) {
-			this.attributes.remove("");
-		}
+		// There can only be one unique key so remove it.
+		attributes.remove("");
 		return this;
 	}
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributes.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributes.java
@@ -102,6 +102,18 @@ public class RecordAttributes {
 		return this;
 	}
 
+	public RecordAttributes removeNullHeaders() {
+		// Can't iterate over a TreeMap, so iterate over its set, check for empty keys, 
+		// then remove them from the TreeMap.
+		Set<Map.Entry<String, Object>> attributeSet = this.attributes.entrySet();
+		for(Map.Entry<String, Object> attribute : attributeSet) {
+			if (attribute.getKey().isEmpty()) {
+				this.attributes.remove(attribute.getKey());
+			}
+		}	
+		return this;
+	}
+
 	// ========== utils
 
 	@Override

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -341,8 +341,13 @@ class RecordControllerMockMvcTest {
 					bar		
 					baz		""".getBytes());
 
-		mockMvc.perform(multipart("/{instanceId}/tsv/{version}/{recordType}", instanceId, versionId, "null-headers")
+		String recordType = "null-headers";
+		mockMvc.perform(multipart("/{instanceId}/tsv/{version}/{recordType}", instanceId, versionId, recordType)
 				.file(file)).andExpect(status().isOk());
+		MvcResult schemaResult = mockMvc
+				.perform(get("/{instanceid}/types/{v}/{type}", instanceId, versionId, recordType)).andReturn();
+		RecordTypeSchema schema = mapper.readValue(schemaResult.getResponse().getContentAsString(), RecordTypeSchema.class);
+		assertEquals(1, schema.attributes().size());
 	}
 
 	@Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -333,6 +333,20 @@ class RecordControllerMockMvcTest {
 
 	@Test
 	@Transactional
+	void tsvWithNullHeader() throws Exception {
+		MockMultipartFile file = new MockMultipartFile("records", "null_header.tsv", MediaType.TEXT_PLAIN_VALUE,
+				"""
+					value		
+					foo
+					bar		
+					baz		""".getBytes());
+
+		mockMvc.perform(multipart("/{instanceId}/tsv/{version}/{recordType}", instanceId, versionId, "null-headers")
+				.file(file)).andExpect(status().isOk());
+	}
+
+	@Test
+	@Transactional
 	void tsvWithDuplicateRowIdsInDifferentBatches(@Value("${twds.write.batch.size}") int batchSize) throws Exception {
 		StringBuilder tsvContent = new StringBuilder("idcol\tcol1\n");
 		// append two separate batches, each of which use the same record ids

--- a/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributesTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributesTest.java
@@ -8,6 +8,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 
 class RecordAttributesTest {
 
@@ -22,5 +24,16 @@ class RecordAttributesTest {
         recordAttributes.putAttribute("Z", "1");
         List<String> attributeNamesInOrder = recordAttributes.attributeSet().stream().map(Map.Entry::getKey).collect(Collectors.toList());
         assertThat(attributeNamesInOrder).isEqualTo(List.of("Z", "a", "A", "B", "C"));
+    }
+
+    @Test
+    void removeAttributesWithNullHeaders() {
+        RecordAttributes recordAttributes = RecordAttributes.empty("Z");
+        recordAttributes.putAttribute("a", 11);
+        recordAttributes.putAttribute("", null);
+        recordAttributes.putAttribute("", "null");
+        recordAttributes.putAttribute("b", 12);
+        recordAttributes.removeNullHeaders();
+        assertEquals(2, recordAttributes.attributeSet().size());
     }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributesTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributesTest.java
@@ -31,7 +31,7 @@ class RecordAttributesTest {
         RecordAttributes recordAttributes = RecordAttributes.empty("Z");
         recordAttributes.putAttribute("a", 11);
         recordAttributes.putAttribute("", null);
-        recordAttributes.putAttribute("", "null");
+        recordAttributes.putAttribute("", null);
         recordAttributes.putAttribute("b", 12);
         recordAttributes.removeNullHeaders();
         assertEquals(2, recordAttributes.attributeSet().size());

--- a/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributesTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributesTest.java
@@ -31,8 +31,8 @@ class RecordAttributesTest {
         RecordAttributes recordAttributes = RecordAttributes.empty("Z");
         recordAttributes.putAttribute("a", 11);
         recordAttributes.putAttribute("", null);
-        recordAttributes.putAttribute("", null);
         recordAttributes.putAttribute("b", 12);
+        assertEquals(3, recordAttributes.attributeSet().size());
         recordAttributes.removeNullHeaders();
         assertEquals(2, recordAttributes.attributeSet().size());
     }


### PR DESCRIPTION
Fixes [AJ-1028](https://broadworkbench.atlassian.net/browse/AJ-1028)

This PR fixes an issue caused by extra tabs in a TSV file, specifically in the headers. This created empty columns and serializing issues for Postgres (specifically, `ERROR: zero-length delimited identifier`).
This fix is inserted in TsvStreamWriteHandler.java when we're processing records. It iterates through the attributes (which converts the Treemap to a Set since `while` looping and removing directly would give us false negatives if the value `remove()` returns is null) removing any entries with empty keys (aka empty TSV headers). 

We're now seeing happy 200s
![image](https://github.com/DataBiosphere/terra-workspace-data-service/assets/9140651/68054658-bc0e-42bd-b7a9-8621be8540d7)


[AJ-1028]: https://broadworkbench.atlassian.net/browse/AJ-1028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ