### PR TITLE
AJ-945 - Adjust PR template wording

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -2,6 +2,6 @@ Reminder:
 
 PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 
 
-After your manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.
+After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.
 
 The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,5 +1,7 @@
 Reminder:
 
-PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag.yml. 
-After your manually trigger the github action (and it completes with no errors), you must go to [this](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged succesfully.
-The terra-helmfile PR merge will then generate a PR in https://github.com/DataBiosphere/leonardo.  This may or may not automerge; be sure to watch it to ensure it merges.
+PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 
+
+After your manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.
+
+The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 


### PR DESCRIPTION
Reminder:

PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag.yml. 
After your manually trigger the github action (and it completes with no errors), you must go to [this](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged succesfully.
The terra-helmfile PR merge will then generate a PR in https://github.com/DataBiosphere/leonardo.  This may or may not automerge; be sure to watch it to ensure it merges.
