### PR TITLE
AJ-1068 Duplicate TSV Column Names Throws Error

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/TsvStreamWriteHandler.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/TsvStreamWriteHandler.java
@@ -14,6 +14,7 @@ import org.databiosphere.workspacedataservice.shared.model.RecordType;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -44,11 +45,15 @@ public class TsvStreamWriteHandler implements StreamingWriteHandler {
 			throw new InvalidTsvException("We could not parse any data rows in your tsv file.");
 		}
 
-		// extract column names from the schema
+		// extract column names from the schema, throwing an error if we detect any duplicate column names.
 		List<String> colNames;
 		FormatSchema formatSchema = tsvIterator.getParser().getSchema();
 		if (formatSchema instanceof CsvSchema actualSchema) {
 			colNames = actualSchema.getColumnNames();
+			if (colNames.stream().anyMatch(col -> Collections.frequency(colNames, col) > 1)) {
+				throw new InvalidTsvException("TSV contains duplicate column names."
+					+ "Please use distinct column names to prevent overwriting data");
+			}
 		} else {
 			throw new InvalidTsvException("Could not determine primary key column; unexpected schema type:" + formatSchema.getSchemaType());
 		}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -333,6 +333,21 @@ class RecordControllerMockMvcTest {
 
 	@Test
 	@Transactional
+	void tsvWithDuplicateColumnNames() throws Exception {
+		MockMultipartFile file = new MockMultipartFile("records", "duplicate_col_name.tsv", MediaType.TEXT_PLAIN_VALUE,
+				"col1\tcol1\nfoo\tbar\n".getBytes());
+
+		MvcResult mvcResult = mockMvc.perform(multipart("/{instanceId}/tsv/{version}/{recordType}", instanceId, versionId, "duplicate-rowids")
+				.file(file)).andExpect(status().isBadRequest()).andReturn();
+
+		Exception e = mvcResult.getResolvedException();
+		assertNotNull(e, "expected an InvalidTsvException");
+		assertEquals("TSV contains duplicate column names."
+					+ "Please use distinct column names to prevent overwriting data", e.getMessage());
+	}
+
+	@Test
+	@Transactional
 	void tsvWithNullHeader() throws Exception {
 		MockMultipartFile file = new MockMultipartFile("records", "null_header.tsv", MediaType.TEXT_PLAIN_VALUE,
 				"""


### PR DESCRIPTION
Fixes [Jira Bug](https://broadworkbench.atlassian.net/browse/AJ-1068)

Current behavior: User uploads a TSV with duplicate column names, which is currently allowed, but database cannot support that so it overwrites the first column with the duplicate column. 

Fix: Throw an error if we detect duplicate column names. 