### PR TITLE
AJ-1070 - Fix nginx to be an absolute path

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ To run the application, first a postgres database must be running:
 ./local-dev/run_postgres.sh start
 ```
 
-To run the application against a local SAM_URL instead of dev, you can run the following commands (from repo root) to set up nginx in a docker container locally: 
+To run the application against a local SAM_URL instead of dev, you can run the following commands (path has to be absolute, replace with path of where your wds repo exists) to set up nginx in a docker container locally: 
 ```bash
-docker run -v /service/src/test/resources/nginx.conf:/etc/nginx/nginx.conf -p 9889:80 -d nginx:1.23.3
+docker run -v /{absolute path}/service/src/test/resources/nginx.conf:/etc/nginx/nginx.conf -p 9889:80 -d nginx:1.23.3
 export SAM_URL=http://localhost:9889
 ```
 


### PR DESCRIPTION
If the path for the nginx command is not absolute, it fails. Adjust that in the ReadMe. 

Reminder:

PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 
