### PR TITLE
AJ-1010 fix import python test

### DIFF
--- a/service/src/test/python/test.py
+++ b/service/src/test/python/test.py
@@ -242,4 +242,11 @@ class WdsTests(TestCase):
     # import snapshot from TDR with appropriate permissions
     def test_import_snapshot(self):
         self.snapshot_client.import_snapshot(self.current_workspaceId, self.version, "123e4567-e89b-12d3-a456-426614174000")
-        #At this point, just testing that an error is not thrown.  Further work will do further testing.
+        # should create a tdr-imports table
+        ent_types = self.schema_client.describe_record_type(self.current_workspaceId, self.version, "tdr-imports")
+        self.assertEqual(ent_types.count, 2)
+
+        # clean up
+        response = self.schema_client.delete_record_type(self.current_workspaceId, self.version, "tdr-imports")
+        workspace_ent_type = self.schema_client.describe_all_record_types(self.current_workspaceId, self.version)
+        self.assertTrue(len(workspace_ent_type) == 0)


### PR DESCRIPTION
https://github.com/DataBiosphere/terra-workspace-data-service/pull/239 changed the behavior of tdr import to create a table, but did not update the python test to reflect these changes.  The import snapshot python test was then leaving extra tables in the db, causing other tests to fail.  This PR tests the behavior and then cleans up after itself.