### PR TITLE
AJ-1063 - Change GAH to always run python tests

### DIFF
--- a/.github/workflows/release-python-client.yml
+++ b/.github/workflows/release-python-client.yml
@@ -2,8 +2,6 @@ name: Build, test and publish Python client to PyPI
 
 on:
   pull_request:
-    paths:
-      - '**/openapi-docs.yaml'
   workflow_call:
     inputs:
       new-tag:


### PR DESCRIPTION
This changes the logic to run python tests on any new PR and PR update. The GAH already specifies to only publish the client if the branch that the GAH action is being run on is "main". 


Reminder:

PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 
