### PR TITLE
AJ-1010 fix snapshot attributes

### DIFF
--- a/service/src/test/java/org/databiosphere/workspacedataservice/datarepo/DataRepoServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/datarepo/DataRepoServiceTest.java
@@ -8,6 +8,7 @@ import bio.terra.workspace.api.ReferencedGcpResourceApi;
 import org.databiosphere.workspacedataservice.dao.InstanceDao;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.databiosphere.workspacedataservice.service.DataRepoService;
+import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 import org.databiosphere.workspacedataservice.workspacemanager.WorkspaceManagerClientFactory;
 import org.databiosphere.workspacedataservice.workspacemanager.WorkspaceManagerDao;
@@ -26,8 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
@@ -92,7 +92,10 @@ class DataRepoServiceTest {
         assertTrue(recordDao.recordTypeExists(INSTANCE, RecordType.valueOf(DataRepoService.TDRIMPORT_TABLE)));
         List<org.databiosphere.workspacedataservice.shared.model.Record> result = recordDao.queryForRecords(RecordType.valueOf(DataRepoService.TDRIMPORT_TABLE),3,0,"asc",null,INSTANCE);
         for (int i = 0; i < 3; i++){
-            assertEquals(result.get(i).getId(), "table"+(i+1));
+            Record rec = result.get(i);
+            assertEquals("table"+(i+1), rec.getId());
+            assertEquals(snapshotId.toString(), rec.getAttributeValue(DataRepoService.TDRIMPORT_SNAPSHOT_ID));
+            assertNotNull(rec.getAttributeValue(DataRepoService.TDRIMPORT_IMPORT_TIME));
         }
     }
 

--- a/service/src/test/python/test.py
+++ b/service/src/test/python/test.py
@@ -242,4 +242,11 @@ class WdsTests(TestCase):
     # import snapshot from TDR with appropriate permissions
     def test_import_snapshot(self):
         self.snapshot_client.import_snapshot(self.current_workspaceId, self.version, "123e4567-e89b-12d3-a456-426614174000")
-        #At this point, just testing that an error is not thrown.  Further work will do further testing.
+        # should create a tdr-imports table
+        ent_types = self.schema_client.describe_record_type(self.current_workspaceId, self.version, "tdr-imports")
+        self.assertEqual(ent_types.count, 2)
+
+        # clean up
+        response = self.schema_client.delete_record_type(self.current_workspaceId, self.version, "tdr-imports")
+        workspace_ent_type = self.schema_client.describe_all_record_types(self.current_workspaceId, self.version)
+        self.assertTrue(len(workspace_ent_type) == 0)

--- a/service/src/test/python/test.py
+++ b/service/src/test/python/test.py
@@ -5,8 +5,6 @@ from unittest import TestCase
 import  wds_client
 from datetime import date, datetime
 import random
-import uuid
-import json
 import csv
 
 # generate records for testing
@@ -245,7 +243,12 @@ class WdsTests(TestCase):
         # should create a tdr-imports table
         ent_types = self.schema_client.describe_record_type(self.current_workspaceId, self.version, "tdr-imports")
         self.assertEqual(ent_types.count, 2)
-
+        search_request = { "offset": 0, "limit": 10}
+        records = self.records_client.query_records(self.current_workspaceId, self.version, "tdr-imports", search_request)
+        testRecord = records.records[0]
+        self.assertEqual(testRecord.id, "table1")
+        self.assertEqual(testRecord.attributes['Snapshot Id'], "123e4567-e89b-12d3-a456-426614174000")
+        self.assertIsNotNone(testRecord.attributes['Import Time'])
         # clean up
         response = self.schema_client.delete_record_type(self.current_workspaceId, self.version, "tdr-imports")
         workspace_ent_type = self.schema_client.describe_all_record_types(self.current_workspaceId, self.version)


### PR DESCRIPTION
https://github.com/DataBiosphere/terra-workspace-data-service/pull/239 added `Snapshot Id` and `Import Time` attributes to the snapshot import, but as these were last minute add-ons, they were not covered by tests - and didn't work correctly!  This PR ensures they are actually added to the import table and updates tests to verify that.