### PR TITLE
stop using relative path in swagger gen

### DIFF
--- a/client/swagger.gradle
+++ b/client/swagger.gradle
@@ -23,7 +23,7 @@ dependencies {
 
 
 generateSwaggerCode {
-	inputFile = file('../service/src/main/resources/static/swagger/openapi-docs.yaml')
+	inputFile = file('${projectDir}/service/src/main/resources/static/swagger/openapi-docs.yaml')
 	language = 'java'
 	library = 'jersey2'
 


### PR DESCRIPTION
We were consistently getting the following error whenever WDS would build:
```
 WARN  i.s.codegen.v3.utils.URLPathUtil - Not valid URL: ../
java.net.MalformedURLException: no protocol: ../
        at java.base/java.net.URL.<init>(URL.java:674)
        at java.base/java.net.URL.<init>(URL.java:569)
        at java.base/java.net.URL.<init>(URL.java:516)
        at io.swagger.codegen.v3.utils.URLPathUtil.getServerURL(URLPathUtil.java:33)
        at io.swagger.codegen.v3.utils.URLPathUtil.getScheme(URLPathUtil.java:79)
        at io.swagger.codegen.v3.DefaultGenerator.buildSupportFileBundle(DefaultGenerator.java:735)
        at io.swagger.codegen.v3.DefaultGenerator.generate(DefaultGenerator.java:788)
        at io.swagger.codegen.v3.cli.cmd.Generate.run(Generate.java:388)
        at java.base/java.lang.Thread.run(Thread.java:833)
```
which didn't hurt anything but always alarmed everyone when they tried to run WDS.  30 seconds of investigation revealed that the problem was the `generateSwaggerCode` job defined with a relative path.  Switching to an absolute path there stopped the warning from appearing, but resulted in nonfunctional client code:
```
FullStackRecordControllerTest.java:387: error: cannot find symbol new HttpEntity<>(mapper.writeValueAsString(batchOperations), headers), ErrorResponse.class, instanceId,
  symbol:   class ErrorResponse
  location: class FullStackRecordControllerTest
```