### PR TITLE
AJ-1055 Create publish-pacts.yml

### DIFF
--- a/.github/workflows/publish-pacts.yml
+++ b/.github/workflows/publish-pacts.yml
@@ -1,0 +1,88 @@
+name: Publish contract tests
+on:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - 'README.md'
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'README.md'
+
+jobs:
+  init-github-context:
+      runs-on: ubuntu-latest
+      outputs:
+        repo-branch: ${{ steps.extract-branch.outputs.repo-branch }}
+        repo-version: ${{ steps.extract-branch.outputs.repo-version }}
+        
+      steps:
+      - uses: actions/checkout@v3
+      
+      - name: Extract branch
+        id: extract-branch
+        run: |
+          GITHUB_EVENT_NAME=${{ github.event_name }}
+          if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
+            GITHUB_REF=${{ github.ref }}
+            GITHUB_SHA=${{ github.sha }}
+          elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            GITHUB_REF=refs/heads/${{ github.head_ref }}
+            GITHUB_SHA=${{ github.event.pull_request.head.sha }}
+          else
+            echo "Failed to extract branch information"
+            exit 1
+          fi
+          echo "ref=$GITHUB_REF" >> $GITHUB_OUTPUT
+          echo "sha=$GITHUB_SHA" >> $GITHUB_OUTPUT
+          echo "sha-short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "branch=${GITHUB_REF/refs\/heads\//""}" >> $GITHUB_OUTPUT
+
+      - name: Echo branch information
+        run: |
+          echo ${{ steps.extract-branch.outputs.ref }}
+          echo ${{ steps.extract-branch.outputs.sha }}
+          echo ${{ steps.extract-branch.outputs.sha-short }}
+          echo ${{ steps.extract-branch.outputs.branch }}
+        
+  run-consumer-contract-tests:
+    runs-on: ubuntu-latest
+    needs: [init-github-context]
+    outputs:
+      sha-short: ${{ steps.extract-branch.outputs.sha-short }}
+      pact-b64: ${{ steps.encode-pact.outputs.pact-b64 }}
+
+    steps:
+      - name: Checkout current code
+        uses: actions/checkout@v3
+        
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - name: Run consumer tests
+        run: ./gradlew pactTests
+      - name: Output consumer contract as non-breaking base64 string
+        id: encode-pact
+        run: |
+          NON_BREAKING_B64=$(cat service/build/pacts/wds-consumer-sam-provider.json | base64 -w 0)
+          echo "pact-b64=${NON_BREAKING_B64}" >> $GITHUB_OUTPUT
+
+  publish-pact-job:
+    runs-on: ubuntu-latest
+    needs: [init-github-context, run-consumer-contract-tests]
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - name: Dispatch to terra-github-workflows
+        uses: aurelien-baudet/workflow-dispatch@93e95b157d791ae7f42aef8f8a0d3d723eba1c31 #commit sha for v2.1.1
+        with:
+          workflow: publish-pacts.yaml
+          repo: broadinstitute/terra-github-workflows
+          ref: refs/heads/main
+          token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
+          inputs: '{ "consumer-name": "wds-consumer", "consumer-version": "${{ needs.run-consumer-contract-tests.outputs.sha-short }}", "provider-name": "sam-provider", "pact-b64": "${{ needs.run-consumer-contract-tests.outputs.pact-b64 }}" }'

--- a/.github/workflows/publish-pacts.yml
+++ b/.github/workflows/publish-pacts.yml
@@ -15,8 +15,7 @@ jobs:
   init-github-context:
       runs-on: ubuntu-latest
       outputs:
-        repo-branch: ${{ steps.extract-branch.outputs.repo-branch }}
-        repo-version: ${{ steps.extract-branch.outputs.repo-version }}
+        sha-short: ${{ steps.extract-branch.outputs.sha-short }}
         
       steps:
       - uses: actions/checkout@v3
@@ -51,7 +50,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [init-github-context]
     outputs:
-      sha-short: ${{ steps.extract-branch.outputs.sha-short }}
       pact-b64: ${{ steps.encode-pact.outputs.pact-b64 }}
 
     steps:
@@ -85,4 +83,4 @@ jobs:
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
-          inputs: '{ "consumer-name": "wds-consumer", "consumer-version": "${{ needs.run-consumer-contract-tests.outputs.sha-short }}", "provider-name": "sam-provider", "pact-b64": "${{ needs.run-consumer-contract-tests.outputs.pact-b64 }}" }'
+          inputs: '{ "consumer-name": "wds-consumer", "consumer-version": "${{ needs.init-github-context.outputs.sha-short }}", "provider-name": "sam-provider", "pact-b64": "${{ needs.run-consumer-contract-tests.outputs.pact-b64 }}" }'

--- a/.github/workflows/publish-pacts.yml
+++ b/.github/workflows/publish-pacts.yml
@@ -30,21 +30,20 @@ jobs:
           elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
             GITHUB_REF=refs/heads/${{ github.head_ref }}
             GITHUB_SHA=${{ github.event.pull_request.head.sha }}
+          elif [[ "$GITHUB_EVENT_NAME" == "merge_group" ]]; then
+            GITHUB_REF=refs/heads/${{ github.head_ref }}
           else
             echo "Failed to extract branch information"
             exit 1
           fi
-          echo "ref=$GITHUB_REF" >> $GITHUB_OUTPUT
-          echo "sha=$GITHUB_SHA" >> $GITHUB_OUTPUT
-          echo "sha-short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-          echo "branch=${GITHUB_REF/refs\/heads\//""}" >> $GITHUB_OUTPUT
-
-      - name: Echo branch information
+          echo "repo-branch=${GITHUB_REF/refs\/heads\//""}" >> $GITHUB_OUTPUT
+          echo "repo-version=${GITHUB_SHA}" >> $GITHUB_OUTPUT
+      - name: Echo repo and branch information
         run: |
-          echo ${{ steps.extract-branch.outputs.ref }}
-          echo ${{ steps.extract-branch.outputs.sha }}
-          echo ${{ steps.extract-branch.outputs.sha-short }}
-          echo ${{ steps.extract-branch.outputs.branch }}
+          echo "repo-owner=${{ github.repository_owner }}"
+          echo "repo-name=${{ github.event.repository.name }}"
+          echo "repo-branch=${{ steps.extract-branch.outputs.repo-branch }}"
+          echo "repo-version=${{ steps.extract-branch.outputs.repo-version }}"
         
   run-consumer-contract-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-pacts.yml
+++ b/.github/workflows/publish-pacts.yml
@@ -14,6 +14,8 @@ jobs:
       runs-on: ubuntu-latest
       outputs:
         sha-short: ${{ steps.extract-branch.outputs.sha-short }}
+        repo-branch: ${{ steps.extract-branch.outputs.repo-branch }}
+        repo-version: ${{ steps.extract-branch.outputs.repo-version }}
         
       steps:
       - uses: actions/checkout@v3
@@ -75,10 +77,10 @@ jobs:
       id-token: 'write'
     steps:
       - name: Dispatch to terra-github-workflows
-        uses: aurelien-baudet/workflow-dispatch@93e95b157d791ae7f42aef8f8a0d3d723eba1c31 #commit sha for v2.1.1
+        uses: broadinstitute/workflow-dispatch@v3
         with:
           workflow: publish-pacts.yaml
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
-          inputs: '{ "consumer-name": "wds-consumer", "consumer-version": "${{ needs.init-github-context.outputs.sha-short }}", "provider-name": "sam-provider", "pact-b64": "${{ needs.run-consumer-contract-tests.outputs.pact-b64 }}" }'
+          inputs: '{ "pact-b64": "${{ needs.run-consumer-contract-tests.outputs.pact-b64 }}", "repo-owner": "${{ github.repository_owner }}", "repo-name": "${{ github.event.repository.name }}", "repo-branch": "${{ needs.init-github-context.outputs.repo-branch }}" }'

--- a/.github/workflows/publish-pacts.yml
+++ b/.github/workflows/publish-pacts.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Dispatch to terra-github-workflows
         uses: broadinstitute/workflow-dispatch@v3
         with:
-          workflow: publish-pacts.yaml
+          workflow: .github/workflows/publish-contracts.yaml
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo

--- a/.github/workflows/publish-pacts.yml
+++ b/.github/workflows/publish-pacts.yml
@@ -3,13 +3,11 @@ on:
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - 'README.md'
+    paths-ignore: [ '**.md' ]
   push:
     branches:
       - main
-    paths-ignore:
-      - 'README.md'
+    paths-ignore: [ '**.md' ]
 
 jobs:
   init-github-context:


### PR DESCRIPTION
See [AJ-1055](https://broadworkbench.atlassian.net/browse/AJ-1055)
This PR adds a github action to automatically publish consumer tests to the [DSP Pact Broker](https://pact-broker.dsp-eng-tools.broadinstitute.org/).  The action, as written, specifically names tests written as Sam as provider; that will need to be adjusted in the future when contract tests against other providers are added.  
See the link to the pact broker to verify that `wds-consumer/sam-provider` contracts were updated at the time of this PR.

[AJ-1055]: https://broadworkbench.atlassian.net/browse/AJ-1055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ