### PR TITLE
AJ-1088: upgrade spring boot 2.7.11 -> 2.7.12, addresses CVE-2023-20883

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import org.hidetake.gradle.swagger.generator.GenerateSwaggerCode
 import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
 plugins {
-    id 'org.springframework.boot' version '2.7.11' apply false
+    id 'org.springframework.boot' version '2.7.12' apply false
     id 'io.spring.dependency-management' version '1.1.0' apply false
     id 'com.google.cloud.tools.jib' version '3.2.1' apply false
     id "org.sonarqube" version "4.0.0.2929" apply false


### PR DESCRIPTION
Upgrades Spring Boot. See https://spring.io/blog/2023/05/18/spring-boot-2-7-12-available-now

I don't believe we are vulnerable to CVE-2023-20883 but let's upgrade anyway.