### PR TITLE
AJ-1088: upgrade pact, which upgrades xerces transitively

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -5,7 +5,7 @@ plugins {
 	id 'org.sonarqube'
 	id 'com.gorylenko.gradle-git-properties'
 	id 'jacoco'
-	id "au.com.dius.pact" version "4.3.10"
+	id "au.com.dius.pact" version "4.6.0"
 }
 
 springBoot {
@@ -64,7 +64,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'
 	testImplementation project(':client')
-	testImplementation 'au.com.dius.pact.consumer:junit5:4.1.7'
+	testImplementation 'au.com.dius.pact.consumer:junit5:4.6.0'
 
 	constraints {
 		implementation('org.json:json:20230227') {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/pact/SamPactTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/pact/SamPactTest.java
@@ -5,6 +5,7 @@ import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
 import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
 import au.com.dius.pact.consumer.junit5.PactConsumerTestExt;
 import au.com.dius.pact.consumer.junit5.PactTestFor;
+import au.com.dius.pact.core.model.PactSpecVersion;
 import au.com.dius.pact.core.model.RequestResponsePact;
 import au.com.dius.pact.core.model.annotations.Pact;
 import org.broadinstitute.dsde.workbench.client.sam.model.SystemStatus;
@@ -150,7 +151,7 @@ class SamPactTest {
     }
 
     @Test
-    @PactTestFor(pactMethod = "statusApiPact")
+    @PactTestFor(pactMethod = "statusApiPact", pactVersion = PactSpecVersion.V3)
     void testSamServiceStatusCheck(MockServer mockServer) {
         SamClientFactory clientFactory = new HttpSamClientFactory(mockServer.getUrl());
         SamDao samDao = new HttpSamDao(clientFactory, new HttpSamClientSupport(), UUID.randomUUID().toString());
@@ -160,7 +161,7 @@ class SamPactTest {
     }
 
     @Test
-    @PactTestFor(pactMethod = "downStatusApiPact")
+    @PactTestFor(pactMethod = "downStatusApiPact", pactVersion = PactSpecVersion.V3)
     void testSamServiceDown(MockServer mockServer) {
         SamClientFactory clientFactory = new HttpSamClientFactory(mockServer.getUrl());
         SamDao samDao = new HttpSamDao(clientFactory, new HttpSamClientSupport(), UUID.randomUUID().toString());
@@ -170,7 +171,7 @@ class SamPactTest {
     }
 
     @Test
-    @PactTestFor(pactMethod = "userStatusPact")
+    @PactTestFor(pactMethod = "userStatusPact", pactVersion = PactSpecVersion.V3)
     void testSamServiceUserStatusInfo(MockServer mockServer) {
         SamClientFactory clientFactory = new HttpSamClientFactory(mockServer.getUrl());
         SamDao samDao = new HttpSamDao(clientFactory, new HttpSamClientSupport(), UUID.randomUUID().toString());
@@ -179,7 +180,7 @@ class SamPactTest {
     }
 
     @Test
-    @PactTestFor(pactMethod = "noUserStatusPact")
+    @PactTestFor(pactMethod = "noUserStatusPact", pactVersion = PactSpecVersion.V3)
     void testSamServiceNoUser(MockServer mockServer) {
         SamClientFactory clientFactory = new HttpSamClientFactory(mockServer.getUrl());
         SamDao samDao = new HttpSamDao(clientFactory, new HttpSamClientSupport(), UUID.randomUUID().toString());
@@ -189,7 +190,7 @@ class SamPactTest {
     }
 
     @Test
-    @PactTestFor(pactMethod = "deleteNoPermissionPact")
+    @PactTestFor(pactMethod = "deleteNoPermissionPact", pactVersion = PactSpecVersion.V3)
     void testSamDeleteNoPermission(MockServer mockServer) {
         SamClientFactory clientFactory = new HttpSamClientFactory(mockServer.getUrl());
         SamDao samDao = new HttpSamDao(clientFactory, new HttpSamClientSupport(), dummyResourceId);
@@ -198,7 +199,7 @@ class SamPactTest {
     }
 
     @Test
-    @PactTestFor(pactMethod = "deletePermissionPact")
+    @PactTestFor(pactMethod = "deletePermissionPact", pactVersion = PactSpecVersion.V3)
     void testSamDeletePermission(MockServer mockServer) {
         SamClientFactory clientFactory = new HttpSamClientFactory(mockServer.getUrl());
         SamDao samDao = new HttpSamDao(clientFactory, new HttpSamClientSupport(), dummyResourceId);
@@ -207,7 +208,7 @@ class SamPactTest {
     }
 
     @Test
-    @PactTestFor(pactMethod = "writeNoPermissionPact")
+    @PactTestFor(pactMethod = "writeNoPermissionPact", pactVersion = PactSpecVersion.V3)
     void testSamWriteNoPermission(MockServer mockServer) {
         SamClientFactory clientFactory = new HttpSamClientFactory(mockServer.getUrl());
         SamDao samDao = new HttpSamDao(clientFactory, new HttpSamClientSupport(), dummyResourceId);
@@ -216,7 +217,7 @@ class SamPactTest {
     }
 
     @Test
-    @PactTestFor(pactMethod = "writePermissionPact")
+    @PactTestFor(pactMethod = "writePermissionPact", pactVersion = PactSpecVersion.V3)
     void testSamWritePermission(MockServer mockServer) {
         SamClientFactory clientFactory = new HttpSamClientFactory(mockServer.getUrl());
         SamDao samDao = new HttpSamDao(clientFactory, new HttpSamClientSupport(), dummyResourceId);


### PR DESCRIPTION
Addresses CVE-2022-23437.

Xerces is a (deeply) transitive dependency of pact. This PR upgrades the pact gradle plugin and pact consumer/junit library to latest, which carries an upgrade to a non-vulnerable version of xerces.

between versions 4.2.21 and 4.3.0, pact changed behavior of `pactVersion` in `@PactTestFor`. Our tests were failing unless we explicitly specified `pactVersion = PactSpecVersion.V3`
