### PR TITLE
Revert "AJ-1088: upgrade pact, which upgrades xerces transitively (#262)"

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -5,7 +5,7 @@ plugins {
 	id 'org.sonarqube'
 	id 'com.gorylenko.gradle-git-properties'
 	id 'jacoco'
-	id "au.com.dius.pact" version "4.6.0"
+	id "au.com.dius.pact" version "4.3.10"
 }
 
 springBoot {
@@ -64,7 +64,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'
 	testImplementation project(':client')
-	testImplementation 'au.com.dius.pact.consumer:junit5:4.6.0'
+	testImplementation 'au.com.dius.pact.consumer:junit5:4.1.7'
 
 	constraints {
 		implementation('org.json:json:20230227') {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/pact/SamPactTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/pact/SamPactTest.java
@@ -5,7 +5,6 @@ import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
 import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
 import au.com.dius.pact.consumer.junit5.PactConsumerTestExt;
 import au.com.dius.pact.consumer.junit5.PactTestFor;
-import au.com.dius.pact.core.model.PactSpecVersion;
 import au.com.dius.pact.core.model.RequestResponsePact;
 import au.com.dius.pact.core.model.annotations.Pact;
 import org.broadinstitute.dsde.workbench.client.sam.model.SystemStatus;
@@ -151,7 +150,7 @@ class SamPactTest {
     }
 
     @Test
-    @PactTestFor(pactMethod = "statusApiPact", pactVersion = PactSpecVersion.V3)
+    @PactTestFor(pactMethod = "statusApiPact")
     void testSamServiceStatusCheck(MockServer mockServer) {
         SamClientFactory clientFactory = new HttpSamClientFactory(mockServer.getUrl());
         SamDao samDao = new HttpSamDao(clientFactory, new HttpSamClientSupport(), UUID.randomUUID().toString());
@@ -161,7 +160,7 @@ class SamPactTest {
     }
 
     @Test
-    @PactTestFor(pactMethod = "downStatusApiPact", pactVersion = PactSpecVersion.V3)
+    @PactTestFor(pactMethod = "downStatusApiPact")
     void testSamServiceDown(MockServer mockServer) {
         SamClientFactory clientFactory = new HttpSamClientFactory(mockServer.getUrl());
         SamDao samDao = new HttpSamDao(clientFactory, new HttpSamClientSupport(), UUID.randomUUID().toString());
@@ -171,7 +170,7 @@ class SamPactTest {
     }
 
     @Test
-    @PactTestFor(pactMethod = "userStatusPact", pactVersion = PactSpecVersion.V3)
+    @PactTestFor(pactMethod = "userStatusPact")
     void testSamServiceUserStatusInfo(MockServer mockServer) {
         SamClientFactory clientFactory = new HttpSamClientFactory(mockServer.getUrl());
         SamDao samDao = new HttpSamDao(clientFactory, new HttpSamClientSupport(), UUID.randomUUID().toString());
@@ -180,7 +179,7 @@ class SamPactTest {
     }
 
     @Test
-    @PactTestFor(pactMethod = "noUserStatusPact", pactVersion = PactSpecVersion.V3)
+    @PactTestFor(pactMethod = "noUserStatusPact")
     void testSamServiceNoUser(MockServer mockServer) {
         SamClientFactory clientFactory = new HttpSamClientFactory(mockServer.getUrl());
         SamDao samDao = new HttpSamDao(clientFactory, new HttpSamClientSupport(), UUID.randomUUID().toString());
@@ -190,7 +189,7 @@ class SamPactTest {
     }
 
     @Test
-    @PactTestFor(pactMethod = "deleteNoPermissionPact", pactVersion = PactSpecVersion.V3)
+    @PactTestFor(pactMethod = "deleteNoPermissionPact")
     void testSamDeleteNoPermission(MockServer mockServer) {
         SamClientFactory clientFactory = new HttpSamClientFactory(mockServer.getUrl());
         SamDao samDao = new HttpSamDao(clientFactory, new HttpSamClientSupport(), dummyResourceId);
@@ -199,7 +198,7 @@ class SamPactTest {
     }
 
     @Test
-    @PactTestFor(pactMethod = "deletePermissionPact", pactVersion = PactSpecVersion.V3)
+    @PactTestFor(pactMethod = "deletePermissionPact")
     void testSamDeletePermission(MockServer mockServer) {
         SamClientFactory clientFactory = new HttpSamClientFactory(mockServer.getUrl());
         SamDao samDao = new HttpSamDao(clientFactory, new HttpSamClientSupport(), dummyResourceId);
@@ -208,7 +207,7 @@ class SamPactTest {
     }
 
     @Test
-    @PactTestFor(pactMethod = "writeNoPermissionPact", pactVersion = PactSpecVersion.V3)
+    @PactTestFor(pactMethod = "writeNoPermissionPact")
     void testSamWriteNoPermission(MockServer mockServer) {
         SamClientFactory clientFactory = new HttpSamClientFactory(mockServer.getUrl());
         SamDao samDao = new HttpSamDao(clientFactory, new HttpSamClientSupport(), dummyResourceId);
@@ -217,7 +216,7 @@ class SamPactTest {
     }
 
     @Test
-    @PactTestFor(pactMethod = "writePermissionPact", pactVersion = PactSpecVersion.V3)
+    @PactTestFor(pactMethod = "writePermissionPact")
     void testSamWritePermission(MockServer mockServer) {
         SamClientFactory clientFactory = new HttpSamClientFactory(mockServer.getUrl());
         SamDao samDao = new HttpSamDao(clientFactory, new HttpSamClientSupport(), dummyResourceId);


### PR DESCRIPTION
This reverts commit 2a502ee6fc791c36da7cea0ceee8b7576296c208.

sam-provider contract tests for wds-consumer are failing after this commit. Let's revert and get everything passing until we figure out what's actually happening.
