### PR TITLE
AJ-1059 compare primary key on tsvs

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
@@ -106,7 +106,7 @@ public class RecordOrchestratorService { // TODO give me a better name
                           MultipartFile records) throws IOException {
         validateAndPermissions(instanceId, version);
         if(recordDao.recordTypeExists(instanceId, recordType)){
-            recordService.validatePrimaryKey(instanceId, recordType, primaryKey);
+            primaryKey = Optional.of(recordService.validatePrimaryKey(instanceId, recordType, primaryKey));
         }
         int qty = batchWriteService.batchWriteTsvStream(records.getInputStream(), instanceId, recordType, primaryKey);
         activityLogger.saveEventForCurrentUser(user ->

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordService.java
@@ -277,10 +277,12 @@ public class RecordService {
         prepareAndUpsert(instanceId, recordType, records, requestSchema, primaryKey.orElse(ReservedNames.RECORD_ID));
     }
 
-    public void validatePrimaryKey(UUID instanceId, RecordType recordType, Optional<String> primaryKey) {
-        if (primaryKey.isPresent() && !primaryKey.get().equals(recordDao.getPrimaryKeyColumn(recordType, instanceId))) {
+    public String validatePrimaryKey(UUID instanceId, RecordType recordType, Optional<String> primaryKey) {
+        String existingKey = recordDao.getPrimaryKeyColumn(recordType, instanceId);
+        if (primaryKey.isPresent() && !primaryKey.get().equals(existingKey)) {
             throw new NewPrimaryKeyException(primaryKey.get(), recordType);
         }
+        return existingKey;
     }
 
     @WriteTransaction

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/TsvStreamWriteHandler.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/TsvStreamWriteHandler.java
@@ -61,7 +61,7 @@ public class TsvStreamWriteHandler implements StreamingWriteHandler {
 		// if a primary key is specified, check if it is present in the TSV
 		if (primaryKey.isPresent() && !colNames.contains(primaryKey.get())) {
 			throw new InvalidTsvException(
-					"Uploaded TSV is either missing the " + primaryKey
+					"Uploaded TSV is either missing the " + primaryKey.get()
 							+ " column or has a null or empty string value in that column");
 		}
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -306,6 +306,26 @@ class RecordControllerMockMvcTest {
 	}
 
 	@Test
+	void tsvConflictPrimaryKeyShouldFail() throws Exception {
+		MockMultipartFile file = new MockMultipartFile("records", "tsv_orig.tsv", MediaType.TEXT_PLAIN_VALUE,
+				"col1\tcol2\nfoo\tbar\n".getBytes());
+
+		String recordType = "tsv-pk-change";
+		mockMvc.perform(multipart("/{instanceId}/tsv/{version}/{recordType}", instanceId, versionId, recordType)
+				.file(file)).andExpect(status().isOk());
+
+
+		MockMultipartFile file2 = new MockMultipartFile("records", "tsv_pk_change.tsv", MediaType.TEXT_PLAIN_VALUE,
+				"id\tcol2\nfoo\tbar\n".getBytes());
+		MvcResult mvcResult = mockMvc.perform(multipart("/{instanceId}/tsv/{version}/{recordType}", instanceId, versionId, recordType)
+				.file(file2)).andExpect(status().isBadRequest()).andReturn();
+		//Return message should be helpful
+		Exception e = mvcResult.getResolvedException();
+		assertNotNull(e, "expected an InvalidTsvException");
+		assertTrue(e.getMessage().contains("Uploaded TSV is either missing"));
+	}
+
+	@Test
 	@Transactional
 	void tsvWithEmptyStringIdentifier() throws Exception {
 		MockMultipartFile file = new MockMultipartFile("records", "empty_row_id.tsv", MediaType.TEXT_PLAIN_VALUE,


### PR DESCRIPTION
[AJ-1059](https://broadworkbench.atlassian.net/browse/AJ-1059)
If a user tried to upload a tsv to a pre-existing table, but the primary key (leftmost column) in the tsv differed from that in the existing table, they received a hideous error.  If the primary key was passed as a parameter in the API call, then it was checked for conflict before reading the TSV.  But if it was not passed as a parameter, we could only find it out by reading the tsv, at which point we're past the point of checking against the existing table.
I solved this the easy way, by fetching the pre-existing primary key at the conflict check and passing it in to the `TSVStreamWriteHandler`, where previously would only be the parameter-passed key.  This results in a message "Uploaded TSV is either missing the `primaryKey` column or has a null or empty string value in that column" - which may be somewhat less clear than the "The primary key for `recordType` is already set to `oldPk` if you wish to change it you'll need to create a new record type." message we would get at the initial conflict check, but requires a lot less code change - am putting out this PR for discussion.

[AJ-1059]: https://broadworkbench.atlassian.net/browse/AJ-1059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ