### PR TITLE
AJ-856: downgrade jackson-dataformat-csv

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 	implementation 'org.postgresql:postgresql'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.webjars:webjars-locator-core:0.52'
-	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.14.2'
+	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.13.5'
 	implementation 'io.sentry:sentry-logback:6.12.1'
 	implementation 'com.azure:azure-identity:1.8.2'
 	implementation 'org.liquibase:liquibase-core:4.21.1'

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/TsvStreamWriteHandler.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/TsvStreamWriteHandler.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Spliterator;
 import java.util.Spliterators;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/TsvStreamWriteHandler.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/TsvStreamWriteHandler.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Spliterator;
 import java.util.Spliterators;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -49,7 +50,10 @@ public class TsvStreamWriteHandler implements StreamingWriteHandler {
 		List<String> colNames;
 		FormatSchema formatSchema = tsvIterator.getParser().getSchema();
 		if (formatSchema instanceof CsvSchema actualSchema) {
-			colNames = actualSchema.getColumnNames();
+			colNames = StreamSupport.stream(actualSchema.spliterator(), false)
+					.map(CsvSchema.Column::getName)
+					.toList();
+
 			if (colNames.stream().anyMatch(col -> Collections.frequency(colNames, col) > 1)) {
 				throw new InvalidTsvException("TSV contains duplicate column names."
 					+ "Please use distinct column names to prevent overwriting data");


### PR DESCRIPTION
The version of `jackson-dataformat-csv` we had was not in sync with Spring Boot's version of other Jackson libraries, and this caused some annoying errors, like `java.lang.NoSuchFieldError: USE_FAST_DOUBLE_WRITER`.

This PR aligns the jackson versions and fixes the one syntax compatibility issue that came from the downgrade.