### PR TITLE
AJ-856: Migrate TSV Write to use Jackson over Apache

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -40,7 +40,6 @@ dependencies {
 	implementation 'org.springframework.retry:spring-retry:1.3.4'
 	implementation 'org.aspectj:aspectjweaver:1.8.9' // required by spring-retry, not used directly by WDS
 	implementation 'org.apache.commons:commons-lang3'
-	implementation 'org.apache.commons:commons-csv:1.9.0'
 	implementation 'com.google.guava:guava:31.1-jre'
 	implementation 'org.postgresql:postgresql'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
@@ -2,7 +2,6 @@ package org.databiosphere.workspacedataservice.service;
 
 import bio.terra.common.db.ReadTransaction;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.csv.CSVPrinter;
 import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.databiosphere.workspacedataservice.sam.SamDao;
@@ -29,7 +28,6 @@ import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBo
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStreamWriter;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -121,17 +119,10 @@ public class RecordOrchestratorService { // TODO give me a better name
         checkRecordTypeExists(instanceId, recordType);
         List<String> headers = recordDao.getAllAttributeNames(instanceId, recordType);
 
-        // TODO: consider rewriting this using jackson-dataformat-csv and removing org.apache.commons:commons-csv altogether
         return httpResponseOutputStream -> {
             try (Stream<Record> allRecords = recordDao.streamAllRecordsForType(instanceId, recordType)) {
                 TsvSupport.WriteCsvToStream(allRecords, httpResponseOutputStream, headers);
             }
-            //      CSVPrinter writer = TsvSupport.getOutputFormat(headers)
-            //          .print(new OutputStreamWriter(httpResponseOutputStream))) {
-            //     TsvSupport.RecordEmitter recordEmitter = new TsvSupport.RecordEmitter(writer,
-            //         headers.subList(1, headers.size()), objectMapper);
-            //     allRecords.forEach(recordEmitter);
-            // }
         };
     }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
@@ -123,13 +123,15 @@ public class RecordOrchestratorService { // TODO give me a better name
 
         // TODO: consider rewriting this using jackson-dataformat-csv and removing org.apache.commons:commons-csv altogether
         return httpResponseOutputStream -> {
-            try (Stream<Record> allRecords = recordDao.streamAllRecordsForType(instanceId, recordType);
-                 CSVPrinter writer = TsvSupport.getOutputFormat(headers)
-                     .print(new OutputStreamWriter(httpResponseOutputStream))) {
-                TsvSupport.RecordEmitter recordEmitter = new TsvSupport.RecordEmitter(writer,
-                    headers.subList(1, headers.size()), objectMapper);
-                allRecords.forEach(recordEmitter);
+            try (Stream<Record> allRecords = recordDao.streamAllRecordsForType(instanceId, recordType)) {
+                TsvSupport.WriteCsvToStream(allRecords, httpResponseOutputStream, headers);
             }
+            //      CSVPrinter writer = TsvSupport.getOutputFormat(headers)
+            //          .print(new OutputStreamWriter(httpResponseOutputStream))) {
+            //     TsvSupport.RecordEmitter recordEmitter = new TsvSupport.RecordEmitter(writer,
+            //         headers.subList(1, headers.size()), objectMapper);
+            //     allRecords.forEach(recordEmitter);
+            // }
         };
     }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/TsvSupport.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/TsvSupport.java
@@ -1,19 +1,14 @@
 package org.databiosphere.workspacedataservice.service;
 
+import com.fasterxml.jackson.databind.SequenceWriter;
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SequenceWriter;
-import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVPrinter;
-import org.apache.commons.csv.QuoteMode;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.ArrayList;
-import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 
@@ -22,43 +17,9 @@ public class TsvSupport {
 	private TsvSupport() {
 	}
 
-	public static CSVFormat getOutputFormat(List<String> headers) {
-		return CSVFormat.DEFAULT.builder().setDelimiter('\t').setQuoteMode(QuoteMode.MINIMAL)
-				.setHeader(headers.toArray(new String[0])).build();
-	}
-
-	public static class RecordEmitter implements Consumer<Record> {
-
-		private final CSVPrinter csvPrinter;
-		private final List<String> attributeNames;
-
-		private final ObjectMapper objectMapper;
-
-		public RecordEmitter(CSVPrinter csvPrinter, List<String> attributeNames, ObjectMapper objectMapper) {
-			this.csvPrinter = csvPrinter;
-			this.attributeNames = attributeNames;
-			this.objectMapper = objectMapper;
-		}
-
-		@Override
-		public void accept(Record rcd) {
-			try {
-				csvPrinter.print(rcd.getId());
-				for (String attributeName : attributeNames) {
-					Object attributeValue = rcd.getAttributeValue(attributeName);
-					csvPrinter.print(attributeValue != null && attributeValue.getClass().isArray() ? objectMapper.writeValueAsString(attributeValue) : attributeValue);
-				}
-				csvPrinter.println();
-			} catch (IOException e) {
-				throw new RuntimeException(e);
-			}
-		}
-	}
-
 	public static void WriteCsvToStream (Stream<Record> records, OutputStream stream, List<String> headers) throws IOException {
 
 		CsvSchema tsvHeaderSchema = CsvSchema.emptySchema()
-		.withHeader()
 		.withEscapeChar('\\')
 		.withColumnSeparator('\t');
 
@@ -74,7 +35,8 @@ public class TsvSupport {
 		}
 		seqW.close();		
 	}
-	public static List<Object> RecordToRow(Record record, List<String> headers) {
+
+	private static List<Object> RecordToRow(Record record, List<String> headers) {
 		List<Object> row = new ArrayList<Object>();
 		row.add(record.getId());
 		headers.forEach(h -> {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/TsvSupport.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/TsvSupport.java
@@ -1,14 +1,21 @@
 package org.databiosphere.workspacedataservice.service;
 
+import com.fasterxml.jackson.dataformat.csv.CsvMapper;
+import com.fasterxml.jackson.dataformat.csv.CsvSchema;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SequenceWriter;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 import org.apache.commons.csv.QuoteMode;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.List;
+import java.util.ArrayList;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
+
 
 public class TsvSupport {
 
@@ -46,5 +53,33 @@ public class TsvSupport {
 				throw new RuntimeException(e);
 			}
 		}
+	}
+
+	public static void WriteCsvToStream (Stream<Record> records, OutputStream stream, List<String> headers) throws IOException {
+
+		CsvSchema tsvHeaderSchema = CsvSchema.emptySchema()
+		.withHeader()
+		.withEscapeChar('\\')
+		.withColumnSeparator('\t');
+
+		final CsvMapper tsvMapper = CsvMapper.builder()
+		.build();
+
+		SequenceWriter seqW = tsvMapper.writer(tsvHeaderSchema)
+			.writeValues(stream);
+		seqW.write(headers);
+		for (Record record : records.toList()) {
+			List<Object> row = RecordToRow(record, headers);
+			seqW.write(row);
+		}
+		seqW.close();		
+	}
+	public static List<Object> RecordToRow(Record record, List<String> headers) {
+		List<Object> row = new ArrayList<Object>();
+		row.add(record.getId());
+		headers.forEach(h -> {
+			row.add(record.getAttributeValue(h));
+		});
+		return row;
 	}
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
@@ -1,11 +1,10 @@
 package org.databiosphere.workspacedataservice.controller;
 
-import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVParser;
-import org.apache.commons.csv.CSVRecord;
-import org.apache.commons.csv.QuoteMode;
 import org.databiosphere.workspacedataservice.shared.model.BatchResponse;
+import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
+import com.fasterxml.jackson.databind.MappingIterator;
+import com.fasterxml.jackson.databind.ObjectReader;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,7 +27,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.util.Iterator;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -47,6 +45,8 @@ class TsvDownloadTest {
 	private String version;
 	private UUID instanceId;
 
+	@Autowired
+    private ObjectReader tsvReader;
 
 	@BeforeEach
 	void init(){
@@ -71,16 +71,13 @@ class TsvDownloadTest {
 		ResponseEntity<Resource> stream = restTemplate.exchange("/{instanceId}/tsv/{version}/{recordType}",
 				HttpMethod.GET, new HttpEntity<>(headers), Resource.class, instanceId, version, recordType);
 		InputStream inputStream = stream.getBody().getInputStream();
-		CSVFormat csvFormat = CSVFormat.DEFAULT.builder().setHeader().setSkipHeaderRecord(true).setDelimiter("\t")
-				.setQuoteMode(QuoteMode.MINIMAL).build();
 		InputStreamReader reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
-		Iterable<CSVRecord> records = new CSVParser(reader, csvFormat);
-		Iterator<CSVRecord> iterator = records.iterator();
-		CSVRecord rcd = iterator.next();
-		assertThat(rcd.get(primaryKeyName)).isEqualTo(primaryKeyName+"_val");
-		assertThat(rcd.get("col_1")).isEqualTo("Fido");
-		assertThat(rcd.get("col_2")).isEqualTo("Jerry");
-		assertThat(iterator.hasNext()).isFalse();
+        MappingIterator<RecordAttributes> tsvIterator = tsvReader.readValues(reader);
+        RecordAttributes recordAttributes = tsvIterator.next();
+		assertThat(recordAttributes.getAttributeValue(primaryKeyName)).isEqualTo(primaryKeyName+"_val");
+		assertThat(recordAttributes.getAttributeValue("col_1")).isEqualTo("Fido");
+		assertThat(recordAttributes.getAttributeValue("col_2")).isEqualTo("Jerry");
+		assertThat(tsvIterator.hasNext()).isFalse();
 		reader.close();
 	}
 	@Test
@@ -95,18 +92,15 @@ class TsvDownloadTest {
 		ResponseEntity<Resource> stream = restTemplate.exchange("/{instanceId}/tsv/{version}/{recordType}",
 				HttpMethod.GET, new HttpEntity<>(headers), Resource.class, instanceId, version, recordType);
 		InputStream inputStream = stream.getBody().getInputStream();
-		CSVFormat csvFormat = CSVFormat.DEFAULT.builder().setHeader().setSkipHeaderRecord(true).setDelimiter("\t")
-				.setQuoteMode(QuoteMode.MINIMAL).build();
 		InputStreamReader reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
-		Iterable<CSVRecord> records = new CSVParser(reader, csvFormat);
-		Iterator<CSVRecord> iterator = records.iterator();
-		CSVRecord rcd = iterator.next();
-		assertThat(rcd.get("description")).isEqualTo("Embedded\tTab");
-		rcd = iterator.next();
-		assertThat(rcd.get("description")).isEqualTo("\n,Weird\n String");
-		assertThat(rcd.get("location")).isEqualTo("Cambridge, \"MA\"");
-		assertThat(rcd.get("unicodeData")).isEqualTo("\uD83D\uDCA9ȇ");
-		assertThat(iterator.hasNext()).isFalse();
+        MappingIterator<RecordAttributes> tsvIterator = tsvReader.readValues(reader);
+		RecordAttributes recordAttributes = tsvIterator.next();
+		assertThat(recordAttributes.getAttributeValue("description")).isEqualTo("Embedded\tTab");
+		recordAttributes = tsvIterator.next();
+		assertThat(recordAttributes.getAttributeValue("description")).isEqualTo("\n,Weird\n String");
+		assertThat(recordAttributes.getAttributeValue("location")).isEqualTo("Cambridge, \"MA\"");
+		assertThat(recordAttributes.getAttributeValue("unicodeData")).isEqualTo("\uD83D\uDCA9ȇ");
+		assertThat(tsvIterator.hasNext()).isFalse();
 		reader.close();
 	}
 }


### PR DESCRIPTION
Fixes https://broadworkbench.atlassian.net/browse/AJ-856

Current behavior: Still using org.apache.commons:commons-csv for TSV writing despite previously switching to Jackson for TSV reading. 

Fix: This PR switches to using Jackson for consistency sake and removes org.apache.commons:commons-csv from build. No noticeable change for users. 
Note: previous TSV Reading PR created custom deserializer class as well as a reader Bean. I found this to be unnecessary as we're already doing the work in recordDao to convert the PostgreSQL info into `Records`. 