### PR TITLE
AJ-1109: more helpful TSV errors

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/BadStreamingWriteRequestException.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/BadStreamingWriteRequestException.java
@@ -12,7 +12,7 @@ public class BadStreamingWriteRequestException extends IllegalArgumentException 
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(BadStreamingWriteRequestException.class);
 	public BadStreamingWriteRequestException(IOException ex) {
-		super("The server doesn't understand the request. Please check swagger to make sure you use"
+		super("The server doesn't understand the request. Please verify you are using "
 				+ "the proper format.");
 		LOGGER.error("Error parsing request stream as json ", ex);
 	}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvErrorMessageTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvErrorMessageTest.java
@@ -56,7 +56,7 @@ public class TsvErrorMessageTest {
 
     @ParameterizedTest(name = "The malformed TSV file '{0}' should throw a helpful error")
     @ValueSource(strings = {"tsv-errors/column-separator.tsv", "tsv-errors/empty-header-line.tsv",
-            "tsv-errors/invalid-middle-byte.tsv", "tsv-errors/too-man-entries.tsv",})
+            "tsv-errors/invalid-middle-byte.tsv", "tsv-errors/too-many-entries.tsv"})
     void testBadTsvFile(String badTsvFile) throws Exception {
         try (InputStream inputStream = ClassLoader.getSystemResourceAsStream(badTsvFile)) {
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvErrorMessageTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvErrorMessageTest.java
@@ -1,0 +1,77 @@
+package org.databiosphere.workspacedataservice.tsv;
+
+import org.databiosphere.workspacedataservice.service.InstanceService;
+import org.databiosphere.workspacedataservice.service.RecordOrchestratorService;
+import org.databiosphere.workspacedataservice.service.model.exception.InvalidTsvException;
+import org.databiosphere.workspacedataservice.shared.model.RecordType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ActiveProfiles(profiles = "mock-sam")
+@DirtiesContext
+@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class TsvErrorMessageTest {
+
+    @Autowired
+    InstanceService instanceService;
+    @Autowired
+    RecordOrchestratorService recordOrchestratorService;
+
+    private static UUID instanceId;
+
+    private static final String VERSION = "v0.2";
+
+    @BeforeEach
+    void beforeEach() {
+        instanceId = UUID.randomUUID();
+        instanceService.createInstance(instanceId, VERSION);
+    }
+
+    @AfterEach
+    void afterEach() {
+        List<UUID> allInstances = instanceService.listInstances(VERSION);
+        for (UUID id : allInstances) {
+            instanceService.deleteInstance(id, VERSION);
+        }
+    }
+
+    @ParameterizedTest(name = "The malformed TSV file '{0}' should throw a helpful error")
+    @ValueSource(strings = {"tsv-errors/column-separator.tsv", "tsv-errors/empty-header-line.tsv",
+            "tsv-errors/invalid-middle-byte.tsv", "tsv-errors/too-man-entries.tsv",})
+    void testBadTsvFile(String badTsvFile) throws Exception {
+        try (InputStream inputStream = ClassLoader.getSystemResourceAsStream(badTsvFile)) {
+
+            MockMultipartFile tsvUpload = new MockMultipartFile("some_file", "some_file",
+                    MediaType.TEXT_PLAIN_VALUE, inputStream);
+
+            Exception actual = assertThrows(InvalidTsvException.class, () ->
+                    recordOrchestratorService.tsvUpload(instanceId, VERSION,
+                            RecordType.valueOf("will_error"), Optional.empty(),
+                            tsvUpload)
+            );
+
+            assertThat(actual.getMessage(),
+                    startsWith("Error reading TSV. Please check the format of your upload. Underlying error is"));
+        }
+    }
+
+}

--- a/service/src/test/resources/tsv-errors/column-separator.tsv
+++ b/service/src/test/resources/tsv-errors/column-separator.tsv
@@ -1,0 +1,3 @@
+header1,header2
+"baz","qux"
+"one","two"

--- a/service/src/test/resources/tsv-errors/empty-header-line.tsv
+++ b/service/src/test/resources/tsv-errors/empty-header-line.tsv
@@ -1,0 +1,3 @@
+	
+something
+blah

--- a/service/src/test/resources/tsv-errors/invalid-middle-byte.tsv
+++ b/service/src/test/resources/tsv-errors/invalid-middle-byte.tsv
@@ -1,0 +1,4 @@
+id	value
+1	hello
+2	funké
+	

--- a/service/src/test/resources/tsv-errors/too-many-entries.tsv
+++ b/service/src/test/resources/tsv-errors/too-many-entries.tsv
@@ -1,0 +1,2 @@
+header1
+foo	bar	baz


### PR DESCRIPTION
We already have error trapping for specific TSV problems, like duplicate column names. But, we didn't have catch-all error trapping for the exceptions we didn't expect; this PR adds that. Plus, some new known-bad TSVs for use in unit tests.