### PR TITLE
AJ-1065: reuse http clients for Sam, WSM, TDR libraries

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/datarepo/HttpDataRepoClientFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/datarepo/HttpDataRepoClientFactory.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.context.request.RequestContextHolder;
 
+import javax.ws.rs.client.Client;
 import java.util.Objects;
 
 import static org.databiosphere.workspacedataservice.sam.BearerTokenFilter.ATTRIBUTE_NAME_TOKEN;
@@ -15,16 +16,19 @@ import static org.springframework.web.context.request.RequestAttributes.SCOPE_RE
 public class HttpDataRepoClientFactory implements DataRepoClientFactory {
 
     final String dataRepoUrl;
+    private final Client commonHttpClient;
     private static final Logger LOGGER = LoggerFactory.getLogger(HttpDataRepoClientFactory.class);
 
 
     public HttpDataRepoClientFactory(String dataRepoUrl) {
         this.dataRepoUrl = dataRepoUrl;
+        this.commonHttpClient = new ApiClient().getHttpClient();
     }
 
     private ApiClient getApiClient() {
         // create a new data repo client
         ApiClient apiClient = new ApiClient();
+        apiClient.setHttpClient(commonHttpClient);
 
         // initialize the client with the url to data repo
         if (StringUtils.isNotBlank(dataRepoUrl)) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamClientFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamClientFactory.java
@@ -1,5 +1,6 @@
 package org.databiosphere.workspacedataservice.sam;
 
+import okhttp3.OkHttpClient;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.dsde.workbench.client.sam.ApiClient;
 import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
@@ -22,16 +23,24 @@ import static org.springframework.web.context.request.RequestAttributes.SCOPE_RE
 public class HttpSamClientFactory implements SamClientFactory {
 
     private final String samUrl;
+    private final OkHttpClient commonHttpClient;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(HttpSamClientFactory.class);
 
     public HttpSamClientFactory(String samUrl) {
         this.samUrl = samUrl;
+        this.commonHttpClient = new ApiClient()
+                .getHttpClient()
+                .newBuilder()
+                .build();
+        // TODO: add tracing interceptor for distributed tracing to Sam.
+        // this requires we import terra-common-lib
     }
 
     private ApiClient getApiClient(String accessToken) {
         // create a new Sam client
         ApiClient apiClient = new ApiClient();
+        apiClient.setHttpClient(commonHttpClient);
         // initialize the client with the url to Sam
         if (StringUtils.isNotBlank(samUrl)) {
             apiClient.setBasePath(samUrl);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/workspacemanager/HttpWorkspaceManagerClientFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/workspacemanager/HttpWorkspaceManagerClientFactory.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.context.request.RequestContextHolder;
 
+import javax.ws.rs.client.Client;
 import java.util.Objects;
 
 import static org.databiosphere.workspacedataservice.sam.BearerTokenFilter.ATTRIBUTE_NAME_TOKEN;
@@ -15,16 +16,19 @@ import static org.springframework.web.context.request.RequestAttributes.SCOPE_RE
 public class HttpWorkspaceManagerClientFactory implements WorkspaceManagerClientFactory {
 
     final String workspaceManagerUrl;
+    private final Client commonHttpClient;
     private static final Logger LOGGER = LoggerFactory.getLogger(HttpWorkspaceManagerClientFactory.class);
 
 
     public HttpWorkspaceManagerClientFactory(String workspaceManagerUrl) {
         this.workspaceManagerUrl = workspaceManagerUrl;
+        this.commonHttpClient = new ApiClient().getHttpClient();
     }
 
     private ApiClient getApiClient() {
         // create a new data repo client
         ApiClient apiClient = new ApiClient();
+        apiClient.setHttpClient(commonHttpClient);
 
         // initialize the client with the url to data repo
         if (StringUtils.isNotBlank(workspaceManagerUrl)) {


### PR DESCRIPTION
See https://broadworkbench.atlassian.net/browse/AJ-1065

We want to reuse the low-level http clients for the Sam, WSM, and TDR libraries. This PR does that, following examples previously set such as:

https://github.com/DataBiosphere/terra-workspace-manager/blob/3970810228cb235d507dcdb4a3c54f33fff5c463/service/src/main/java/bio/terra/workspace/service/iam/SamService.java#L106

https://github.com/DataBiosphere/terra-data-catalog/blob/main/common/src/main/java/bio/terra/catalog/rawls/RawlsClient.java