### PR TITLE
AJ-1099: shorter request id; shorter log entries

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -54,6 +54,7 @@ dependencies {
 	implementation 'org.liquibase:liquibase-core:4.21.1'
 	implementation 'javax.cache:cache-api'
 	implementation 'org.ehcache:ehcache:3.10.8'
+	implementation 'org.hashids:hashids:1.0.3'
 
 	// Terra libraries
 	implementation group: 'org.broadinstitute.dsde.workbench', name: 'sam-client_2.13', version: '0.1-08b6588'

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/MDCServletRequestListener.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/MDCServletRequestListener.java
@@ -50,13 +50,22 @@ public class MDCServletRequestListener implements ServletRequestListener {
 
         // if we did not find an id in incoming headers, make a unique one
         if (uniqueId == null) {
-            uniqueId = hashids.encode(ThreadLocalRandom.current().nextLong(0, Integer.MAX_VALUE));
+            uniqueId = generateId();
         }
 
         // add id to MDC logging
         MDC.put(MDC_KEY, uniqueId);
     }
 
+
+    /*
+        Pseudo-random ID generation is fine here. These ids are meant to uniquely identify a
+        single request. They are not used for cryptography or anything security-sensitive.
+     */
+    @SuppressWarnings("java:S2245")
+    private String generateId() {
+        return hashids.encode(ThreadLocalRandom.current().nextLong(0, Integer.MAX_VALUE));
+    }
 
 
     @Override

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/MDCServletRequestListener.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/MDCServletRequestListener.java
@@ -1,5 +1,6 @@
 package org.databiosphere.workspacedataservice.service;
 
+import org.hashids.Hashids;
 import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
 
@@ -9,6 +10,7 @@ import javax.servlet.http.HttpServletRequest;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * Servlet request listener that sets a unique request id into the SLF4J MDC context for this request. This listener
@@ -31,6 +33,8 @@ public class MDCServletRequestListener implements ServletRequestListener {
     // we could add other headers here, such as: x-vcap-request-id, X─B3─ParentSpanId, X─B3─SpanId, X─B3─Sampled, x-amzn-trace-id
     static final List<String> INCOMING_HEADERS = Arrays.asList(RESPONSE_HEADER, "x-request-id", "trace-id");
 
+    private final Hashids hashids = new Hashids(MDCServletRequestListener.class.getName(), 8);
+
     @Override
     public void requestInitialized(ServletRequestEvent requestEvent) {
         String uniqueId = null;
@@ -47,7 +51,7 @@ public class MDCServletRequestListener implements ServletRequestListener {
 
         // if we did not find an id in incoming headers, make a unique one
         if (uniqueId == null) {
-            uniqueId = UUID.randomUUID().toString();
+            uniqueId = hashids.encode(ThreadLocalRandom.current().nextLong(0, Integer.MAX_VALUE));
         }
 
         // add id to MDC logging

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/MDCServletRequestListener.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/MDCServletRequestListener.java
@@ -9,7 +9,6 @@ import javax.servlet.ServletRequestListener;
 import javax.servlet.http.HttpServletRequest;
 import java.util.Arrays;
 import java.util.List;
-import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**

--- a/service/src/main/resources/logback-spring.xml
+++ b/service/src/main/resources/logback-spring.xml
@@ -4,7 +4,7 @@
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
 
     <!-- inspired by Spring default ${FILE_LOG_PATTERN} from defaults.xml, modified to include requestId -->
-    <property name="WDS_LOG_PATTERN" value="%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}} ${LOG_LEVEL_PATTERN:-%5p} [%36X{requestId}] [%t] %-40.40logger{39} : %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}"/>
+    <property name="WDS_LOG_PATTERN" value="%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}} ${LOG_LEVEL_PATTERN:-%5p} [%X{requestId}] [%t] %-40.40logger{39} : %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}"/>
 
     <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackMDCRequestResponseTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackMDCRequestResponseTest.java
@@ -2,6 +2,7 @@ package org.databiosphere.workspacedataservice.controller;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.databiosphere.workspacedataservice.service.MDCServletRequestListener;
+import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -17,6 +18,8 @@ import org.springframework.test.annotation.DirtiesContext;
 import java.util.List;
 import java.util.UUID;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.junit.jupiter.api.Assertions.*;
 
 @DirtiesContext
@@ -45,7 +48,7 @@ class FullStackMDCRequestResponseTest {
 		List<String> actualResponseHeaders = resp.getHeaders().get(MDCServletRequestListener.RESPONSE_HEADER);
 		assertNotNull(actualResponseHeaders);
 		assertEquals(1, actualResponseHeaders.size());
-		assertDoesNotThrow( () -> UUID.fromString(actualResponseHeaders.get(0)) );
+		assertThat(actualResponseHeaders.get(0), CoreMatchers.not(emptyOrNullString()));
 	}
 
 	// "strings" input should match MDCFilter.INCOMING_HEADERS
@@ -86,7 +89,7 @@ class FullStackMDCRequestResponseTest {
 		List<String> actualResponseHeaders = resp.getHeaders().get(MDCServletRequestListener.RESPONSE_HEADER);
 		assertNotNull(actualResponseHeaders);
 		assertEquals(1, actualResponseHeaders.size());
-		assertDoesNotThrow( () -> UUID.fromString(actualResponseHeaders.get(0)) );
+		assertThat(actualResponseHeaders.get(0), CoreMatchers.not(emptyOrNullString()));
 	}
 
 	@Test


### PR DESCRIPTION
This is a followup to https://github.com/DataBiosphere/terra-workspace-data-service/pull/264#issuecomment-1579345929.

The unique requestId in our logs was making those log lines quite long and annoying.

This PR switches the requestId from a 36-character UUID to a [hashid](https://hashids.org/) which will typically be 8 chars.

Here's what the new log entries look like:
![Screenshot 6-13-2023 at 10 33 AM](https://github.com/DataBiosphere/terra-workspace-data-service/assets/6041577/457b3361-d071-4b4f-a66d-fdd8de8fd752)


