### PR TITLE
AJ-1122: Rename Backup to Cloning

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/CloningController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/CloningController.java
@@ -8,11 +8,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-public class BackupController {
+public class CloningController {
 
     private final BackupService backupService;
     private final AzureBlobStorage storage;
-    public BackupController(BackupService backupService) {
+    public CloningController(BackupService backupService) {
         this.storage = new AzureBlobStorage();
         this.backupService = backupService;
     }

--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -14,8 +14,8 @@ servers:
   - url: ../
     description: Relative to the current swagger page
 tags:
-  - name: Backup
-    description: Backup APIs
+  - name: Cloning
+    description: Cloning APIs including Backup and Restore
   - name: Records
     description: Record APIs
   - name: Instances
@@ -30,7 +30,7 @@ paths:
   /backup/{v}:
     post:
       tags:
-        - Backup
+        - Cloning
       parameters:
         - $ref: '#/components/parameters/versionPathParam'
       summary: Create a backup of a PostgreSQL instance and upload it to Azure Blob Storage


### PR DESCRIPTION
Work in #212 included functionality to backup our database using pg_dump. Now that we want to add the restore functionality, we should aggregate those APIs under the name Cloning instead of Backup to be inclusive. 