### PR TITLE
DRAFT, DO NOT MERGE: proof-of-concept JobRunr for async APIs

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -55,7 +55,8 @@ dependencies {
 	implementation 'javax.cache:cache-api'
 	implementation 'org.ehcache:ehcache:3.10.8'
 	implementation 'org.hashids:hashids:1.0.3'
-	implementation 'org.jobrunr:jobrunr-spring-boot-2-starter:6.2.1'
+	implementation 'org.jobrunr:jobrunr-spring-boot-2-starter:6.2.1'	// JobRunr
+	implementation 'com.maximeroussy.invitrode:invitrode:2.0.2'			// silly little library just for random words
 
 	// Terra libraries
 	implementation group: 'org.broadinstitute.dsde.workbench', name: 'sam-client_2.13', version: '0.1-08b6588'

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -55,6 +55,7 @@ dependencies {
 	implementation 'javax.cache:cache-api'
 	implementation 'org.ehcache:ehcache:3.10.8'
 	implementation 'org.hashids:hashids:1.0.3'
+	implementation 'org.jobrunr:jobrunr-spring-boot-2-starter:6.2.1'
 
 	// Terra libraries
 	implementation group: 'org.broadinstitute.dsde.workbench', name: 'sam-client_2.13', version: '0.1-08b6588'

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/AsyncProofController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/AsyncProofController.java
@@ -22,11 +22,18 @@ public class AsyncProofController {
         this.asyncService = asyncService;
     }
 
+    /*
+     * Start a new async SampleJob; return the job's id.
+     */
     @PostMapping("/async")
     public ResponseEntity<SampleJob> startAsyncJob() {
         SampleJob newJobId = asyncService.startAsyncJob();
         return new ResponseEntity<>(newJobId, HttpStatus.CREATED);
     }
+
+    /*
+     * Get status for a SampleJob, given the job's id. Includes the job's result if the job is complete.
+     */
     @GetMapping("/async/{jobId}")
     public ResponseEntity<SampleJob> describeAsyncJob(@PathVariable("jobId") String jobId) throws JsonProcessingException {
         SampleJob response = asyncService.describeAsyncJob(jobId);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/AsyncProofController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/AsyncProofController.java
@@ -1,0 +1,34 @@
+package org.databiosphere.workspacedataservice.controller;
+
+import org.databiosphere.workspacedataservice.service.AsyncService;
+import org.databiosphere.workspacedataservice.service.model.SampleJob;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Proof-of-concept controller for asynchronous APIs
+ */
+@RestController
+public class AsyncProofController {
+
+    private final AsyncService asyncService;
+
+    public AsyncProofController(AsyncService asyncService) {
+        this.asyncService = asyncService;
+    }
+
+    @PostMapping("/async")
+    public ResponseEntity<String> startAsyncJob() {
+        String newJobId = asyncService.startAsyncJob();
+        return new ResponseEntity<>(newJobId, HttpStatus.CREATED);
+    }
+    @GetMapping("/async/{jobId}")
+    public ResponseEntity<SampleJob> describeAsyncJob(@PathVariable("jobId") String jobId) {
+        SampleJob response = asyncService.describeAsyncJob(jobId);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/AsyncProofController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/AsyncProofController.java
@@ -1,5 +1,6 @@
 package org.databiosphere.workspacedataservice.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.databiosphere.workspacedataservice.service.AsyncService;
 import org.databiosphere.workspacedataservice.service.model.SampleJob;
 import org.springframework.http.HttpStatus;
@@ -22,12 +23,12 @@ public class AsyncProofController {
     }
 
     @PostMapping("/async")
-    public ResponseEntity<String> startAsyncJob() {
-        String newJobId = asyncService.startAsyncJob();
+    public ResponseEntity<SampleJob> startAsyncJob() {
+        SampleJob newJobId = asyncService.startAsyncJob();
         return new ResponseEntity<>(newJobId, HttpStatus.CREATED);
     }
     @GetMapping("/async/{jobId}")
-    public ResponseEntity<SampleJob> describeAsyncJob(@PathVariable("jobId") String jobId) {
+    public ResponseEntity<SampleJob> describeAsyncJob(@PathVariable("jobId") String jobId) throws JsonProcessingException {
         SampleJob response = asyncService.describeAsyncJob(jobId);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/AsyncDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/AsyncDao.java
@@ -8,8 +8,8 @@ import org.databiosphere.workspacedataservice.service.model.JobHistory;
 import org.databiosphere.workspacedataservice.service.model.SampleJob;
 import org.jobrunr.jobs.JobId;
 import org.jobrunr.jobs.lambdas.JobRequest;
-import org.jobrunr.scheduling.BackgroundJobRequest;
 import org.jobrunr.jobs.states.StateName;
+import org.jobrunr.scheduling.BackgroundJobRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.RowMapper;
@@ -19,7 +19,6 @@ import org.springframework.stereotype.Component;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
@@ -31,7 +30,6 @@ public class AsyncDao {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AsyncDao.class);
     private final NamedParameterJdbcTemplate namedTemplate;
-
     private final ObjectMapper objectMapper;
 
     public AsyncDao(NamedParameterJdbcTemplate namedTemplate, ObjectMapper objectMapper) {
@@ -39,57 +37,58 @@ public class AsyncDao {
         this.objectMapper = objectMapper;
     }
 
+    /*
+        Enqueues a new "SampleJob" asynchronous job and returns that job's id.
+     */
     public SampleJob createJob() {
         UUID uuid = UUID.randomUUID();
-        JobRequest jobRequest = new SampleJobRequest(uuid);
-
         LOGGER.info("attempting to queue job with id " + uuid + " ...");
 
+        // simplest JobRunr syntax uses a lambda:
+        // BackgroundJobRequest.enqueue(() -> someClass.doSomething());
+
+        // but in our case, we need the "doSomething()" method to have access
+        // to the job's id. Therefore, we use the more complex but more powerful
+        // JobRequest and JobRequestHandler interfaces.
+        JobRequest jobRequest = new SampleJobRequest();
         JobId jobId = BackgroundJobRequest.enqueue(uuid, jobRequest);
 
-        LOGGER.info("... job queued, actual id is " + uuid);
+        LOGGER.info("... job " + uuid + " queued.");
 
+        // create the response object
         SampleJob job = new SampleJob();
         job.setJobId(jobId.toString());
         return job;
     }
 
 
-    /**
+    /*
      * Boooo - JobRunr open-source version does NOT provide programmatic access to
-     * job status or job results.
+     * job status or job results. We need JobRunr Pro for that ($$$).
      *
      * It's pretty trivial to query the JobRunr tables directly, bypassing their API,
      * to get status of a job. That's what we're doing here.
-     *
-     * This returns an SampleJob object, which contains:
-     *  - status: the job's current state as reported by JobRunr: PROCESSING, SUCCEEDED, etc.
-     *  - signature: the Java method that was run by the job. We don't want to expose this to
-     *      end users, but we could use it internally.
-     *
-     * @param jobId
-     * @return
      */
     public SampleJob getJob(String jobId) throws JsonProcessingException {
         MapSqlParameterSource params = new MapSqlParameterSource("jobId", jobId);
 
         List<SampleJob> jobs = namedTemplate.query(
-                "select id, state, jobsignature, createdat, updatedat from sys_wds.jobrunr_jobs where id = :jobId",
+                "select id, state, jobsignature, createdat, updatedat " +
+                        "from sys_wds.jobrunr_jobs where id = :jobId",
                 params, new AsyncJobRowMapper());
 
         if (jobs.size() != 1) {
             throw new RuntimeException("found " + jobs.size() + " jobs for specified id.");
         }
-
         SampleJob job = jobs.get(0);
 
         // is this job done?
         if (job.getStatus().equals(StateName.SUCCEEDED.name())) {
-            // job is done; now, query the job's dedicated table to get the result
+            // job is done; now, query the job's dedicated table to get the results.
+            // note this is a WDS-controlled table, not a JobRunr table.
             Integer duration = namedTemplate.queryForObject(
                     "select duration from sys_wds.samplejob where id = :jobId",
                     params, Integer.class);
-
             String word = namedTemplate.queryForObject(
                     "select word from sys_wds.samplejob where id = :jobId",
                     params, String.class);
@@ -102,22 +101,20 @@ public class AsyncDao {
             response.setWord(word);
             response.setCreated(job.getCreated());
             response.setUpdated(job.getUpdated());
-
             return response;
-
-
         } else if (job.getStatus().equals(StateName.FAILED.name())) {
             // job failed. Retrieve the job history from the jobrunr table
-            String jobasjson = namedTemplate.queryForObject("select jobasjson from sys_wds.jobrunr_jobs where id = :jobId",
+            String jobasjson = namedTemplate.queryForObject(
+                    "select jobasjson from sys_wds.jobrunr_jobs where id = :jobId",
                     params, String.class);
             // deserialize the json
             JobDetails jobDetails = objectMapper.readValue(jobasjson, JobDetails.class);
-            // find the last failure (there may be multiple due to retries
+            // find the last failure (there may be multiple failures in the job history due to retries)
             List<JobHistory> failures = jobDetails.jobHistory().stream()
                     .filter(hist -> hist.state().equals(StateName.FAILED.name()))
                     .toList();
-            JobHistory lastFailure = failures.get(failures.size()-1);
-
+            JobHistory lastFailure = failures.get(failures.size() - 1);
+            // build a failure message
             String failureMsg = lastFailure.exceptionType() + ": " + lastFailure.exceptionMessage();
 
             SampleJob response = new SampleJob();
@@ -129,11 +126,10 @@ public class AsyncDao {
             response.setUpdated(job.getUpdated());
             return response;
         } else {
-            // ENQUEUED or PROCESSING
+            // SCHEDULED, ENQUEUED, PROCESSING, or DELETED (might need other handling for DELETED)
             return job;
         }
     }
-
 
 
     // rowmapper for retrieving SampleJob objects from the db

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/AsyncDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/AsyncDao.java
@@ -1,0 +1,105 @@
+package org.databiosphere.workspacedataservice.dao;
+
+import org.databiosphere.workspacedataservice.samplejob.SampleJobRequest;
+import org.databiosphere.workspacedataservice.service.AsyncService;
+import org.databiosphere.workspacedataservice.service.model.SampleJob;
+import org.databiosphere.workspacedataservice.shared.model.AttributeComparator;
+import org.jobrunr.jobs.JobId;
+import org.jobrunr.jobs.lambdas.JobRequest;
+import org.jobrunr.scheduling.BackgroundJobRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Proof-of-concept DAO for working with async jobs
+ */
+@Component
+public class AsyncDao {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AsyncDao.class);
+    private final NamedParameterJdbcTemplate namedTemplate;
+
+    public AsyncDao(NamedParameterJdbcTemplate namedTemplate) {
+        this.namedTemplate = namedTemplate;
+    }
+
+    public String createJob() {
+        UUID uuid = UUID.randomUUID();
+        JobRequest jobRequest = new SampleJobRequest(uuid);
+
+        LOGGER.info("attempting to queue job with id " + uuid + " ...");
+
+        JobId jobId = BackgroundJobRequest.enqueue(uuid, jobRequest);
+
+        LOGGER.info("... job queued, actual id is " + uuid);
+
+        return jobId.toString();
+    }
+
+
+    /**
+     * Boooo - JobRunr open-source version does NOT provide programmatic access to
+     * job status or job results.
+     *
+     * It's pretty trivial to query the JobRunr tables directly, bypassing their API,
+     * to get status of a job. That's what we're doing here.
+     *
+     * This returns an SampleJob object, which contains:
+     *  - status: the job's current state as reported by JobRunr: PROCESSING, SUCCEEDED, etc.
+     *  - signature: the Java method that was run by the job. We don't want to expose this to
+     *      end users, but we could use it internally.
+     *
+     * @param jobId
+     * @return
+     */
+    public SampleJob getJob(String jobId) {
+        MapSqlParameterSource params = new MapSqlParameterSource("jobId", jobId);
+
+        List<SampleJob> jobs = namedTemplate.query(
+                "select state, jobsignature from sys_wds.jobrunr_jobs where id = :jobId",
+                params, new AsyncJobRowMapper());
+
+        if (jobs.size() != 1) {
+            throw new RuntimeException("found " + jobs.size() + " jobs for specified id.");
+        }
+
+        SampleJob job = jobs.get(0);
+
+        // is this job done?
+        if (job.status().equals("SUCCEEDED")) {
+            // job is done; now, query the job's dedicated table to get the result
+            Integer duration = namedTemplate.queryForObject(
+                    "select duration from sys_wds.samplejob where id = :jobId",
+                    params, Integer.class);
+
+            return new SampleJob(job.status(), job.signature(), duration);
+        } else {
+            // handle different states here, like FAILED
+            return job;
+        }
+    }
+
+
+
+    // rowmapper for retrieving SampleJob objects from the db
+    private static class AsyncJobRowMapper implements RowMapper<SampleJob> {
+        @Override
+        public SampleJob mapRow(ResultSet rs, int rowNum) throws SQLException {
+            return new SampleJob(rs.getString("state"),
+                    rs.getString("jobsignature"),
+                    null);
+        }
+    }
+
+
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/samplejob/SampleJobRequest.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/samplejob/SampleJobRequest.java
@@ -4,27 +4,31 @@ import org.jobrunr.jobs.lambdas.JobRequest;
 
 import java.util.UUID;
 
+/**
+ * JobRunr-required implementation of JobRequest for SampleJobs.
+ * This doesn't do much other than pointing at the SampleJobRequestHandler.
+ */
 public class SampleJobRequest implements JobRequest {
 
-    private UUID jobId;
+//    private UUID jobId;
+//
+//    public void setJobId(UUID jobId) {
+//        this.jobId = jobId;
+//    }
 
-    public void setJobId(UUID jobId) {
-        this.jobId = jobId;
-    }
+//    public SampleJobRequest() {}
 
-    public SampleJobRequest() {}
-
-    public SampleJobRequest(UUID jobId) {
-        this.jobId = jobId;
-    }
+//    public SampleJobRequest(UUID jobId) {
+//        this.jobId = jobId;
+//    }
 
     @Override
     public Class<? extends SampleJobRequestHandler> getJobRequestHandler() {
         return SampleJobRequestHandler.class;
     }
 
-    public UUID getJobId() {
-        return jobId;
-    }
+//    public UUID getJobId() {
+//        return jobId;
+//    }
 
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/samplejob/SampleJobRequest.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/samplejob/SampleJobRequest.java
@@ -1,0 +1,30 @@
+package org.databiosphere.workspacedataservice.samplejob;
+
+import org.jobrunr.jobs.lambdas.JobRequest;
+
+import java.util.UUID;
+
+public class SampleJobRequest implements JobRequest {
+
+    private UUID jobId;
+
+    public void setJobId(UUID jobId) {
+        this.jobId = jobId;
+    }
+
+    public SampleJobRequest() {}
+
+    public SampleJobRequest(UUID jobId) {
+        this.jobId = jobId;
+    }
+
+    @Override
+    public Class<? extends SampleJobRequestHandler> getJobRequestHandler() {
+        return SampleJobRequestHandler.class;
+    }
+
+    public UUID getJobId() {
+        return jobId;
+    }
+
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/samplejob/SampleJobRequestHandler.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/samplejob/SampleJobRequestHandler.java
@@ -1,5 +1,6 @@
 package org.databiosphere.workspacedataservice.samplejob;
 
+import com.maximeroussy.invitrode.WordGenerator;
 import org.databiosphere.workspacedataservice.dao.AsyncDao;
 import org.jobrunr.jobs.annotations.Job;
 import org.jobrunr.jobs.context.JobContext;
@@ -44,12 +45,22 @@ public class SampleJobRequestHandler implements JobRequestHandler<SampleJobReque
         int randomMillis = ThreadLocalRandom.current().nextInt(5000, 60000);
         Thread.sleep(randomMillis);
 
+        // to mock real behavior, throw exceptions sometimes.
+        // jobs whose id starts with a number should succeed; those
+        // that start with a letter will fail.
+        if ("abcdef".contains(jobId.toString().substring(0,1))) {
+            throw new RuntimeException("whoops, async job hit an exception.");
+        }
+
+        WordGenerator generator = new WordGenerator();
+        String randomWord = generator.newWord(9);
+
         long duration = System.currentTimeMillis() - start;
 
         LOGGER.info("***** job " + jobId + " completed; duration was " + duration);
 
-        namedTemplate.getJdbcTemplate().update("insert into sys_wds.samplejob(id, duration) values (?, ?)",
-                jobId, duration);
+        namedTemplate.getJdbcTemplate().update("insert into sys_wds.samplejob(id, duration, word) values (?, ?, ?)",
+                jobId, duration, randomWord);
     }
 
     @Override

--- a/service/src/main/java/org/databiosphere/workspacedataservice/samplejob/SampleJobRequestHandler.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/samplejob/SampleJobRequestHandler.java
@@ -1,0 +1,59 @@
+package org.databiosphere.workspacedataservice.samplejob;
+
+import org.databiosphere.workspacedataservice.dao.AsyncDao;
+import org.jobrunr.jobs.annotations.Job;
+import org.jobrunr.jobs.context.JobContext;
+import org.jobrunr.jobs.lambdas.JobRequestHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+@Component
+public class SampleJobRequestHandler implements JobRequestHandler<SampleJobRequest> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SampleJobRequestHandler.class);
+
+    private final NamedParameterJdbcTemplate namedTemplate;
+
+    public SampleJobRequestHandler(NamedParameterJdbcTemplate namedTemplate) {
+        this.namedTemplate = namedTemplate;
+    }
+
+    /**
+     * Placeholder method for some operation that will take a long time.
+     * This placeholder just sleeps for a random time between 5 and 60 seconds,
+     * writes the actual runtime to the database, then completes.
+     *
+     * @return
+     * @throws InterruptedException
+     */
+    @Override
+    @Job(name = "My sample JobRunr job", retries = 2)
+    public void run(SampleJobRequest jobRequest) throws Exception {
+
+        UUID jobId = jobContext().getJobId();
+
+        LOGGER.info("***** starting job " + jobId + " ...");
+
+        long start = System.currentTimeMillis();
+
+        int randomMillis = ThreadLocalRandom.current().nextInt(5000, 60000);
+        Thread.sleep(randomMillis);
+
+        long duration = System.currentTimeMillis() - start;
+
+        LOGGER.info("***** job " + jobId + " completed; duration was " + duration);
+
+        namedTemplate.getJdbcTemplate().update("insert into sys_wds.samplejob(id, duration) values (?, ?)",
+                jobId, duration);
+    }
+
+    @Override
+    public JobContext jobContext() {
+        return JobRequestHandler.super.jobContext();
+    }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/samplejob/SampleJobRequestHandler.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/samplejob/SampleJobRequestHandler.java
@@ -35,6 +35,7 @@ public class SampleJobRequestHandler implements JobRequestHandler<SampleJobReque
      */
     @Override
     @Job(name = "My sample JobRunr job", retries = 2)
+    @SuppressWarnings("java:S2245")
     public void run(SampleJobRequest jobRequest) throws Exception {
 
         UUID jobId = jobContext().getJobId();

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/AsyncService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/AsyncService.java
@@ -2,16 +2,10 @@ package org.databiosphere.workspacedataservice.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.databiosphere.workspacedataservice.dao.AsyncDao;
-import org.databiosphere.workspacedataservice.samplejob.SampleJobRequest;
 import org.databiosphere.workspacedataservice.service.model.SampleJob;
-import org.jobrunr.jobs.JobId;
-import org.jobrunr.jobs.lambdas.JobRequest;
-import org.jobrunr.scheduling.BackgroundJobRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
-
-import java.util.UUID;
 
 /**
  * Proof-of-concept service for asynchronous APIs
@@ -36,7 +30,6 @@ public class AsyncService {
     public SampleJob describeAsyncJob(String jobId) throws JsonProcessingException {
         return asyncDao.getJob(jobId);
     }
-
 
 
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/AsyncService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/AsyncService.java
@@ -1,0 +1,41 @@
+package org.databiosphere.workspacedataservice.service;
+
+import org.databiosphere.workspacedataservice.dao.AsyncDao;
+import org.databiosphere.workspacedataservice.samplejob.SampleJobRequest;
+import org.databiosphere.workspacedataservice.service.model.SampleJob;
+import org.jobrunr.jobs.JobId;
+import org.jobrunr.jobs.lambdas.JobRequest;
+import org.jobrunr.scheduling.BackgroundJobRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+/**
+ * Proof-of-concept service for asynchronous APIs
+ */
+@Service
+public class AsyncService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AsyncService.class);
+
+    private final AsyncDao asyncDao;
+
+    public AsyncService(AsyncDao asyncDao) {
+        this.asyncDao = asyncDao;
+    }
+
+    // POC for starting an asynchronous job
+    public String startAsyncJob() {
+        return asyncDao.createJob();
+    }
+
+    // POC for getting status of an asynchronous job
+    public SampleJob describeAsyncJob(String jobId) {
+        return asyncDao.getJob(jobId);
+    }
+
+
+
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/AsyncService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/AsyncService.java
@@ -1,5 +1,6 @@
 package org.databiosphere.workspacedataservice.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.databiosphere.workspacedataservice.dao.AsyncDao;
 import org.databiosphere.workspacedataservice.samplejob.SampleJobRequest;
 import org.databiosphere.workspacedataservice.service.model.SampleJob;
@@ -27,12 +28,12 @@ public class AsyncService {
     }
 
     // POC for starting an asynchronous job
-    public String startAsyncJob() {
+    public SampleJob startAsyncJob() {
         return asyncDao.createJob();
     }
 
     // POC for getting status of an asynchronous job
-    public SampleJob describeAsyncJob(String jobId) {
+    public SampleJob describeAsyncJob(String jobId) throws JsonProcessingException {
         return asyncDao.getJob(jobId);
     }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/JobDetails.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/JobDetails.java
@@ -1,0 +1,9 @@
+package org.databiosphere.workspacedataservice.service.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record JobDetails(List<JobHistory> jobHistory) {
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/JobHistory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/JobHistory.java
@@ -1,0 +1,7 @@
+package org.databiosphere.workspacedataservice.service.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record JobHistory(String state, String exceptionType, String exceptionMessage) {
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/SampleJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/SampleJob.java
@@ -1,0 +1,4 @@
+package org.databiosphere.workspacedataservice.service.model;
+
+public record SampleJob(String status, String signature, Integer duration) {
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/SampleJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/SampleJob.java
@@ -1,4 +1,82 @@
 package org.databiosphere.workspacedataservice.service.model;
 
-public record SampleJob(String status, String signature, Integer duration) {
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+
+@JsonInclude(NON_NULL)
+public class SampleJob {
+
+    private String jobId, status, signature, failure, word;
+    private LocalDateTime created, updated;
+
+    public LocalDateTime getCreated() {
+        return created;
+    }
+
+    public void setCreated(LocalDateTime created) {
+        this.created = created;
+    }
+
+    public LocalDateTime getUpdated() {
+        return updated;
+    }
+
+    public void setUpdated(LocalDateTime updated) {
+        this.updated = updated;
+    }
+
+    private Integer duration;
+
+    public String getJobId() {
+        return jobId;
+    }
+
+    public void setJobId(String jobId) {
+        this.jobId = jobId;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getSignature() {
+        return signature;
+    }
+
+    public void setSignature(String signature) {
+        this.signature = signature;
+    }
+
+    public String getFailure() {
+        return failure;
+    }
+
+    public void setFailure(String failure) {
+        this.failure = failure;
+    }
+
+    public String getWord() {
+        return word;
+    }
+
+    public void setWord(String word) {
+        this.word = word;
+    }
+
+    public Integer getDuration() {
+        return duration;
+    }
+
+    public void setDuration(Integer duration) {
+        this.duration = duration;
+    }
 }

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -60,6 +60,21 @@ api.retry.backoff.multiplier=1.5
 datarepourl=${DATA_REPO_URL:}
 workspacemanagerurl=${WORKSPACE_MANAGER_URL:}
 
+org.jobrunr.background-job-server.enabled=true
+
+org.jobrunr.job-scheduler.enabled=true
+# Override JobRunr defaults so we use the wds database instead of a dedicated one,
+# and we use the sys_wds schema within the wds database.
+org.jobrunr.database.database-name=wds
+org.jobrunr.database.table-prefix=sys_wds.
+# allows to specify a DataSource specifically for JobRunr
+# org.jobrunr.database.datasource=
+# dashboard is nice, but we don't want to expose it
+org.jobrunr.dashboard.enabled=false
+# org.jobrunr.dashboard.port=8123
+# this sends the amount of succeeded jobs for marketing purposes
+org.jobrunr.miscellaneous.allow-anonymous-data-usage=false
+
 # activate the "local" profile to turn on CORS response headers,
 # which may be necessary for local development.
 # spring.profiles.active=local

--- a/service/src/main/resources/liquibase/changelog.yaml
+++ b/service/src/main/resources/liquibase/changelog.yaml
@@ -8,3 +8,7 @@ databaseChangeLog:
   - include:
       file: changesets/20230426_instance_table.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/20230613_samplejob_table.yaml
+      relativeToChangelogFile: true
+

--- a/service/src/main/resources/liquibase/changesets/20230613_samplejob_table.yaml
+++ b/service/src/main/resources/liquibase/changesets/20230613_samplejob_table.yaml
@@ -1,0 +1,17 @@
+databaseChangeLog:
+  - changeSet:
+      id: 20230613_samplejob_table
+      author: davidan
+      changes:
+        - createTable:
+            schemaName: sys_wds
+            tableName: samplejob
+            columns:
+              - column:
+                  name: id
+                  type: char(36)
+                  constraints:
+                    primaryKey: true
+              - column:
+                  name: duration
+                  type: integer

--- a/service/src/main/resources/liquibase/changesets/20230613_samplejob_table.yaml
+++ b/service/src/main/resources/liquibase/changesets/20230613_samplejob_table.yaml
@@ -15,3 +15,6 @@ databaseChangeLog:
               - column:
                   name: duration
                   type: integer
+              - column:
+                  name: word
+                  type: text

--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -14,6 +14,8 @@ servers:
   - url: ../
     description: Relative to the current swagger page
 tags:
+  - name: Async Things
+    description: POC for async APIs
   - name: Backup
     description: Backup APIs
   - name: Records
@@ -26,7 +28,36 @@ tags:
     description: Information regarding versioning, health, info, etc. for WDS
   - name: Snapshots
     description: Snapshot APIs
+
 paths:
+  /async:
+    post:
+      tags:
+        - Async Things
+      summary: start an asynchronous job
+      operationId: startAsyncJob
+      responses:
+        201:
+          description: async job created
+  /async/{jobId}:
+    get:
+      tags:
+        - Async Things
+      summary: get status and result of an asynchronous job
+      operationId: describeAsyncJob
+      parameters:
+        - name: jobId
+          in: path
+          description: job for which to get status
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: job complete
+        202:
+          description: job still running
+
   /backup/{v}:
     post:
       tags:


### PR DESCRIPTION
this shows how we'd implement async APIs using [JobRunr](https://www.jobrunr.io/en/?tab=developer).


My initial assessment of JobRunr … 

## Pros
* actively-maintained library (https://github.com/jobrunr/jobrunr)
* easy to integrate with Spring Boot
* nice property-file based config options for compatibility with our schemas
* natively understands MDC, so we can correlate async jobs to the request that spawned them
* support for retries
    * we need to make sure our jobs are idempotent if we want to use retries!
* built-in UI dashboard for local debugging
* uses our existing db for persistence
* nice features but I didn't test them:
    * distributed optimistic locking to support multiple replicas/horizontal scaling
    * jobs automatically restart if WDS restarts 
    * multiple options for persistence if we don't want to use the db

## Cons
* requires JobRunr pro ($$$) for programmatic access to job status and job results
    * workaround: query the JobRunr database tables directly. Fragile?
* using our existing db for job persistence complicates cloning a little bit. We don't want to clone job history (or do we?)
    * workaround: ensure we drop/recreate the JobRunr tables after cloning

more reading: https://www.baeldung.com/java-jobrunr-spring
