### PR TITLE
auth docker before pushing to GCR

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -15,7 +15,7 @@ on:
         required: true
       BROADBOT_TOKEN:
         required: true
-    
+
 env:
   SERVICE_NAME: ${{ github.event.repository.name }}
   GCR_REGISTRY: us.gcr.io
@@ -35,7 +35,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-          
+
       - name: Look for AJ (Analysis Journeys) Jira ID in the manual workflow trigger message
         id: find-jira-id
         run: |
@@ -54,38 +54,6 @@ jobs:
           git_short_sha=$(git rev-parse --short HEAD)
           echo $git_short_sha
           echo "git_short_sha=${git_short_sha}" >> $GITHUB_OUTPUT
-          
-      - name: Build WDS base Docker image 
-        run: docker build -f Dockerfile --no-cache -t wdsbase:snapshot .
-         
-      - name: Tag WDS base Docker image 
-        run: docker tag wdsbase:snapshot us.gcr.io/broad-dsp-gcr-public/base/wds-debian-pg-dump:latest
-        
-      - name: Push WDS base Docker image 
-        run: docker push us.gcr.io/broad-dsp-gcr-public/base/wds-debian-pg-dump:latest
-        
-      - name: Construct GCR docker image name
-        id: gcr-image-name
-        run: echo "name=${GCR_REGISTRY}/${GOOGLE_PROJECT}/${SERVICE_NAME}" >> $GITHUB_OUTPUT
-
-      - name: Construct ACR docker image name
-        id: acr-image-name
-        run: echo "name=${ACR_REGISTRY}/${SERVICE_NAME}" >> $GITHUB_OUTPUT
-
-      - name: Build image locally with jib
-        run: |
-          ./gradlew --build-cache jibDockerBuild \
-          --image=${{ steps.gcr-image-name.outputs.name }}:${{ steps.setHash.outputs.git_short_sha }} \
-          -Djib.console=plain
-          
-      - name: Add version tag to GCR
-        run: docker image tag ${{ steps.gcr-image-name.outputs.name }}:${{ steps.setHash.outputs.git_short_sha }} ${{ steps.gcr-image-name.outputs.name }}:${{ inputs.new-tag }}
-          
-      - name: Run Trivy vulnerability scanner
-        # Link to the github location of the action https://github.com/broadinstitute/dsp-appsec-trivy-action
-        uses: broadinstitute/dsp-appsec-trivy-action@v1
-        with:
-          image: ${{ steps.gcr-image-name.outputs.name }}:${{ steps.setHash.outputs.git_short_sha }}
 
       - name: Set up gcloud
         uses: google-github-actions/setup-gcloud@v0
@@ -100,12 +68,44 @@ jobs:
       - name: Explicitly auth Docker for GCR
         run: gcloud auth configure-docker --quiet
 
+      - name: Build WDS base Docker image 
+        run: docker build -f Dockerfile --no-cache -t wdsbase:snapshot .
+
+      - name: Tag WDS base Docker image 
+        run: docker tag wdsbase:snapshot us.gcr.io/broad-dsp-gcr-public/base/wds-debian-pg-dump:latest
+
+      - name: Push WDS base Docker image 
+        run: docker push us.gcr.io/broad-dsp-gcr-public/base/wds-debian-pg-dump:latest
+
+      - name: Construct GCR docker image name
+        id: gcr-image-name
+        run: echo "name=${GCR_REGISTRY}/${GOOGLE_PROJECT}/${SERVICE_NAME}" >> $GITHUB_OUTPUT
+
+      - name: Construct ACR docker image name
+        id: acr-image-name
+        run: echo "name=${ACR_REGISTRY}/${SERVICE_NAME}" >> $GITHUB_OUTPUT
+
+      - name: Build image locally with jib
+        run: |
+          ./gradlew --build-cache jibDockerBuild \
+          --image=${{ steps.gcr-image-name.outputs.name }}:${{ steps.setHash.outputs.git_short_sha }} \
+          -Djib.console=plain
+
+      - name: Add version tag to GCR
+        run: docker image tag ${{ steps.gcr-image-name.outputs.name }}:${{ steps.setHash.outputs.git_short_sha }} ${{ steps.gcr-image-name.outputs.name }}:${{ inputs.new-tag }}
+
+      - name: Run Trivy vulnerability scanner
+        # Link to the github location of the action https://github.com/broadinstitute/dsp-appsec-trivy-action
+        uses: broadinstitute/dsp-appsec-trivy-action@v1
+        with:
+          image: ${{ steps.gcr-image-name.outputs.name }}:${{ steps.setHash.outputs.git_short_sha }}
+
       - name: Push GCR image
         run: docker push --all-tags ${{ steps.gcr-image-name.outputs.name }}
 
       - name: Re-tag image for ACR
         run: docker tag ${{ steps.gcr-image-name.outputs.name }}:${{ steps.setHash.outputs.git_short_sha }} ${{ steps.acr-image-name.outputs.name }}:${{ steps.setHash.outputs.git_short_sha }}
-      
+
       - name: Add version tag to ACR
         run: docker image tag ${{ steps.acr-image-name.outputs.name }}:${{ steps.setHash.outputs.git_short_sha }} ${{ steps.acr-image-name.outputs.name }}:${{ inputs.new-tag }}
 
@@ -115,14 +115,14 @@ jobs:
           --username ${{ secrets.ACR_SP_USER }} \
           --password-stdin
           docker push --all-tags ${{ steps.acr-image-name.outputs.name }}
-          
+
       - name: Clone terra-helmfile
         uses: actions/checkout@v3
         with:
           repository: broadinstitute/terra-helmfile
           token: ${{ secrets.BROADBOT_TOKEN }} # Has to be set at checkout AND later when pushing to work
           path: terra-helmfile
-          
+
       - name: Create terra-helmfile PR for latest WDS version
         env:
           BROADBOT_TOKEN: ${{ secrets.BROADBOT_TOKEN }}


### PR DESCRIPTION
#212 introduced changes to `publish-docker.yml` that broke; see https://github.com/DataBiosphere/terra-workspace-data-service/actions/runs/5282685550/jobs/9557927242 for an example of the error.

This PR changes things around to ensure we auth before attempting to push to GCR.