### PR TITLE
AJ-935: adjust docker file with changes from focal to jammy in base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,25 +5,8 @@
 ### Sourced from https://github.com/broadinstitute/dsp-appsec-blessed-images/blob/main/jre/Dockerfile.17-debian
 FROM us.gcr.io/broad-dsp-gcr-public/base/jre:17-debian
 
-# freshen up
-RUN apt-get update
-
-# install the prerequisites needed to use latest postgres repo and public key
-RUN apt-get install gnupg2 wget -y
-
-# use the latest postgres repository.
-# This hardcodes "focal-pgdg" instead of "$(lsb_release -cs)-pgdg" to prevent installing lsb-core
-# Note that if we change the underlying distro away from focal, this will fail
-RUN sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt focal-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-
-# install the postgres public key
-RUN wget -qO- https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-
 # refresh the repository
 RUN apt-get update
 
 # Add postgres client for pg_dump command
-RUN apt-get install postgresql-client-15 -y
-
-# remove prerequisites we no longer need
-RUN apt-get remove wget gnupg2 -y
+RUN apt-get install postgresql-client-14 -y


### PR DESCRIPTION
Base debian image is going through a change, adjust how postgres will be installed given the new base image. 

Corresponding PR for base image update: https://github.com/broadinstitute/dsp-appsec-blessed-images/pull/45

Reminder:

PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 
