### PR TITLE
AJ-1101 include resourceId as key in contract test

### DIFF
--- a/service/src/test/java/org/databiosphere/workspacedataservice/pact/SamPactTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/pact/SamPactTest.java
@@ -17,6 +17,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
+import java.util.Map;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -80,9 +81,9 @@ class SamPactTest {
     @Pact(consumer = "wds-consumer", provider = "sam-provider")
     public RequestResponsePact writePermissionPact(PactDslWithProvider builder) {
         return builder
-                .given("user has write permission")
-                .uponReceiving("a request for write permission on workspace", Map.of("dummyResourceId",
-                        dummyResourceId))
+                .given("user has write permission", Map.of("dummyResourceId",
+                                dummyResourceId))
+                .uponReceiving("a request for write permission on workspace")
                 .pathFromProviderState(
                         "/api/resources/v2/workspace/${dummyResourceId}/action/write",
                         String.format("/api/resources/v2/workspace/%s/action/write", dummyResourceId))
@@ -96,9 +97,9 @@ class SamPactTest {
     @Pact(consumer = "wds-consumer", provider = "sam-provider")
     public RequestResponsePact deletePermissionPact(PactDslWithProvider builder) {
         return builder
-                .given("user has delete permission")
-                .uponReceiving("a request for delete permission on workspace", Map.of("dummyResourceId",
+                .given("user has delete permission", Map.of("dummyResourceId",
                         dummyResourceId))
+                .uponReceiving("a request for delete permission on workspace")
                 .pathFromProviderState(
                         "/api/resources/v2/workspace/${dummyResourceId}/action/delete",
                         String.format("/api/resources/v2/workspace/%s/action/delete", dummyResourceId))
@@ -112,9 +113,9 @@ class SamPactTest {
     @Pact(consumer = "wds-consumer", provider = "sam-provider")
     public RequestResponsePact deleteNoPermissionPact(PactDslWithProvider builder) {
         return builder
-                .given("user does not have delete permission")
-                .uponReceiving("a request for delete permission on workspace", Map.of("dummyResourceId",
+                .given("user does not have delete permission", Map.of("dummyResourceId",
                         dummyResourceId))
+                .uponReceiving("a request for delete permission on workspace")
                 .pathFromProviderState(
                         "/api/resources/v2/workspace/${dummyResourceId}/action/delete",
                         String.format("/api/resources/v2/workspace/%s/action/delete", dummyResourceId))

--- a/service/src/test/java/org/databiosphere/workspacedataservice/pact/SamPactTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/pact/SamPactTest.java
@@ -64,7 +64,8 @@ class SamPactTest {
     @Pact(consumer = "wds-consumer", provider = "sam-provider")
     public RequestResponsePact writeNoPermissionPact(PactDslWithProvider builder) {
         return builder
-                .given("user does not have write permission")
+                .given("user does not have write permission", Map.of("dummyResourceId",
+                        dummyResourceId))
                 .uponReceiving("a request for write permission on workspace")
                 .pathFromProviderState(
                         "/api/resources/v2/workspace/${dummyResourceId}/action/write",
@@ -80,7 +81,8 @@ class SamPactTest {
     public RequestResponsePact writePermissionPact(PactDslWithProvider builder) {
         return builder
                 .given("user has write permission")
-                .uponReceiving("a request for write permission on workspace")
+                .uponReceiving("a request for write permission on workspace", Map.of("dummyResourceId",
+                        dummyResourceId))
                 .pathFromProviderState(
                         "/api/resources/v2/workspace/${dummyResourceId}/action/write",
                         String.format("/api/resources/v2/workspace/%s/action/write", dummyResourceId))
@@ -95,7 +97,8 @@ class SamPactTest {
     public RequestResponsePact deletePermissionPact(PactDslWithProvider builder) {
         return builder
                 .given("user has delete permission")
-                .uponReceiving("a request for delete permission on workspace")
+                .uponReceiving("a request for delete permission on workspace", Map.of("dummyResourceId",
+                        dummyResourceId))
                 .pathFromProviderState(
                         "/api/resources/v2/workspace/${dummyResourceId}/action/delete",
                         String.format("/api/resources/v2/workspace/%s/action/delete", dummyResourceId))
@@ -110,7 +113,8 @@ class SamPactTest {
     public RequestResponsePact deleteNoPermissionPact(PactDslWithProvider builder) {
         return builder
                 .given("user does not have delete permission")
-                .uponReceiving("a request for delete permission on workspace")
+                .uponReceiving("a request for delete permission on workspace", Map.of("dummyResourceId",
+                        dummyResourceId))
                 .pathFromProviderState(
                         "/api/resources/v2/workspace/${dummyResourceId}/action/delete",
                         String.format("/api/resources/v2/workspace/%s/action/delete", dummyResourceId))


### PR DESCRIPTION
[AJ-1101](https://broadworkbench.atlassian.net/browse/AJ-1101)
For provider-side contract tests to work properly, we need to let them know what path we're expecting.
See https://broadworkbench.atlassian.net/wiki/spaces/IRT/pages/2787672065/Demystifying+Provider+States+Callbacks+-+pathFromProviderState for explanation.

[AJ-1101]: https://broadworkbench.atlassian.net/browse/AJ-1101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ