### PR TITLE
AJ-1122: update artifactory plugin

### DIFF
--- a/client/build.gradle
+++ b/client/build.gradle
@@ -3,7 +3,7 @@ plugins {
 	id 'java-library'
 	id 'maven-publish'
 
-	id 'com.jfrog.artifactory' version '4.18.2'
+	id 'com.jfrog.artifactory' version '4.32.0'
 	id 'org.hidetake.swagger.generator'
 }
 


### PR DESCRIPTION
first discovered in #284.

At least one of the transitive dependencies of the artifactory gradle plugin version 4.18.2 have been removed from the internet. This caused builds/tests to fail.

This PR updates the plugin to latest, which fixes those failures.

