### PR TITLE
AJ-1142: json, array datatypes in TSV download

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/TsvSupport.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/TsvSupport.java
@@ -70,6 +70,7 @@ public class TsvSupport {
 
 			if (dataType.isArrayType() || JSON.equals(dataType)) {
 				try {
+					// TODO: handle nulls/empties
 					row.add(objectMapper.writeValueAsString(attr));
 				} catch (JsonProcessingException e) {
 					row.add(attr.toString());

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/TsvSupport.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/TsvSupport.java
@@ -72,7 +72,6 @@ public class TsvSupport {
 			if (attr == null) {
 				// TODO: output [] for arrays and {} for json?
 				row.add("");
-
 			// handle arrays and json objects
 			} else if (dataType.isArrayType() || JSON.equals(dataType)) {
 				try {
@@ -81,15 +80,12 @@ public class TsvSupport {
 					logger.error("Could not create TSV: " + e.getMessage(), e);
 					throw new UnexpectedTsvException("Could not create TSV: " + e.getMessage());
 				}
-
 			// all other data types
 			} else {
 				row.add(attr.toString());
 			}
-
 		});
 		return row;
 	}
-
 
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/TsvSupport.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/TsvSupport.java
@@ -70,13 +70,8 @@ public class TsvSupport {
 
 			// handle null/empty values
 			if (attr == null) {
-				if (dataType.isArrayType()) {
-					row.add("[]");
-				} else if (JSON.equals(dataType)) {
-					row.add("{}");
-				} else {
-					row.add("");
-				}
+				// TODO: output [] for arrays and {} for json?
+				row.add("");
 
 			// handle arrays and json objects
 			} else if (dataType.isArrayType() || JSON.equals(dataType)) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/TsvSupport.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/TsvSupport.java
@@ -1,59 +1,87 @@
 package org.databiosphere.workspacedataservice.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SequenceWriter;
 import com.fasterxml.jackson.dataformat.csv.CsvGenerator;
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
+import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
 import org.databiosphere.workspacedataservice.service.model.exception.UnexpectedTsvException;
 import org.databiosphere.workspacedataservice.shared.model.Record;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.ArrayList;
+import java.util.Map;
 import java.util.stream.Stream;
 
+import static org.databiosphere.workspacedataservice.service.model.DataTypeMapping.JSON;
 
+@Component
 public class TsvSupport {
 
-	private TsvSupport() {
+	private final ObjectMapper objectMapper;
+
+	private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+	private TsvSupport(ObjectMapper objectMapper) {
+		this.objectMapper = objectMapper;
 	}
 
-	public static void writeTsvToStream (Stream<Record> records, OutputStream stream, List<String> headers) throws IOException {
+	public void writeTsvToStream (Stream<Record> records, Map<String, DataTypeMapping> typeSchema, OutputStream stream, List<String> headers) throws IOException {
 
 		CsvSchema tsvHeaderSchema = CsvSchema.emptySchema()
-		.withEscapeChar('\\')
-		.withColumnSeparator('\t');
+				.withEscapeChar('\\')
+				.withColumnSeparator('\t');
 
 		final CsvMapper tsvMapper = CsvMapper.builder()
-		.enable(CsvGenerator.Feature.STRICT_CHECK_FOR_QUOTING)
-		.build();
+				.enable(CsvGenerator.Feature.STRICT_CHECK_FOR_QUOTING)
+				.build();
 
 		SequenceWriter seqW = tsvMapper.writer(tsvHeaderSchema)
-			.writeValues(stream);
+				.writeValues(stream);
 		seqW.write(headers);
 		// First header is Primary Key, and value is stored in rcd.id. Remove header here and add rcd.id manually.
 		headers.remove(0);
-		records.forEach(rcd -> writeRowToTsv(seqW, rcd, headers));
-		seqW.close();		
+		records.forEach(rcd -> writeRowToTsv(seqW, rcd, typeSchema, headers));
+		seqW.close();
 	}
 
-	private static void writeRowToTsv(SequenceWriter seqW, Record rcd, List<String> headers) {
+	private void writeRowToTsv(SequenceWriter seqW, Record rcd, Map<String, DataTypeMapping> typeSchema, List<String> headers) {
 		try {
-			List<String> row = recordToRow(rcd, headers);
+			List<String> row = recordToRow(rcd, typeSchema, headers);
 			seqW.write(row);
 		} catch (Exception e) {
 			throw new UnexpectedTsvException("Error writing TSV: " + e.getMessage());
 		}
 	}
 
-	private static List<String> recordToRow(Record rcd, List<String> headers) {
+	private List<String> recordToRow(Record rcd, Map<String, DataTypeMapping> typeSchema, List<String> headers) {
 		List<String> row = new ArrayList<>();
 		row.add(rcd.getId());
 		headers.forEach(h -> {
 			Object attr = rcd.getAttributeValue(h);
-			row.add(attr == null ? "" : attr.toString());
+			DataTypeMapping dataType = typeSchema.get(h);
+
+			if (dataType.isArrayType() || JSON.equals(dataType)) {
+				try {
+					row.add(objectMapper.writeValueAsString(attr));
+				} catch (JsonProcessingException e) {
+					row.add(attr.toString());
+					logger.warn("Failed to properly serialize value of type {} to TSV: {}", dataType.name(), e.getMessage());
+				}
+			} else {
+				row.add(attr == null ? "" : attr.toString());
+			}
+
 		});
 		return row;
 	}
+
+
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
@@ -145,6 +145,8 @@ class TsvDownloadTest {
 						DATE_TIME, "2021-10-03T19:01:23"),
 				Arguments.of(BigDecimal.valueOf(789),
 						NUMBER, "789"),
+				Arguments.of(BigDecimal.valueOf(25.5),
+						NUMBER, "25.5"),
 				Arguments.of("https://accountname.blob.core.windows.net/container-1/blob1",
 						FILE, "https://accountname.blob.core.windows.net/container-1/blob1"),
 				Arguments.of("terra-wds:/target/1",

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectReader;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
+import org.databiosphere.workspacedataservice.service.model.Relation;
 import org.databiosphere.workspacedataservice.shared.model.BatchResponse;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
 import org.databiosphere.workspacedataservice.shared.model.RecordRequest;
@@ -37,6 +38,8 @@ import java.io.InputStreamReader;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -138,32 +141,34 @@ class TsvDownloadTest {
 						STRING, "hello"),
 				Arguments.of("embedded\ttab",
 						STRING, "\"embedded\ttab\""),
+				Arguments.of("2021-10-03",
+						DATE, "2021-10-03"),
+				Arguments.of("2021-10-03T19:01:23",
+						DATE_TIME, "2021-10-03T19:01:23"),
 				Arguments.of(BigDecimal.valueOf(789),
 						NUMBER, "789"),
+//				Arguments.of("https://account_name.blob.core.windows.net/container-1/blob1",
+//						FILE, "https://account_name.blob.core.windows.net/container-1/blob1"),
+//				Arguments.of("terra-wds:/type/id",
+//						RELATION, "terra-wds:/type/id"),
 				Arguments.of("{\"foo\": \"bar\", \"arr\": [2,4,6]}",
 						JSON, "\"{\"\"arr\"\":[2,4,6],\"\"foo\"\":\"\"bar\"\"}\""),
+//				Arguments.of(new String[]{},
+//						EMPTY_ARRAY, "[]"),
 				Arguments.of(List.of("foo", "bar", "baz"),
 						ARRAY_OF_STRING, "\"[\"\"foo\"\",\"\"bar\"\",\"\"baz\"\"]\""),
 				Arguments.of(List.of(BigDecimal.valueOf(1), BigDecimal.valueOf(3), BigDecimal.valueOf(5)),
-						ARRAY_OF_NUMBER, "[1,3,5]")
-
-
-//				Arguments.of("2021-10-03",          "2021-10-03",           true),
-//				Arguments.of("2021-10-03T19:01:23", "2021-10-03T19:01:23",  true),
-//				Arguments.of("terra-wds:/type/id",  "terra-wds:/type/id",   true),
-//				Arguments.of("[]", Collections.EMPTY_LIST, false),
-//
-//				// arrays of booleans
-//				Arguments.of("[true,false,true]",       List.of(true, false, true),     false),
-
-//				Arguments.of("[\"2021-10-03\", \"2022-11-04\"]",                    List.of("2021-10-03", "2022-11-04"),                    false),
-//				Arguments.of("[\"2021-10-03T19:01:23\", \"2021-11-04T20:02:24\"]",  List.of("2021-10-03T19:01:23", "2021-11-04T20:02:24"),  false),
-//				Arguments.of("[\"terra-wds:/type/id\", \"terra-wds:/type/id2\"]",   List.of("terra-wds:/type/id", "terra-wds:/type/id2"),   false),
-//
-//				// mixed array (these deserialize as mixed lists, will be coerced to a single data type later in processing)
-//				Arguments.of("[\"hello\", 123, true]",  List.of("hello", BigInteger.valueOf(123), true),    false),
-
-
+						ARRAY_OF_NUMBER, "[1,3,5]"),
+				Arguments.of(List.of(Boolean.TRUE, Boolean.FALSE, Boolean.TRUE),
+						ARRAY_OF_BOOLEAN, "[true,false,true]"),
+				Arguments.of(List.of(LocalDate.parse("2021-10-03"), LocalDate.parse("2022-11-04")),
+						ARRAY_OF_DATE, "\"[\"\"2021-10-03\"\",\"\"2022-11-04\"\"]\""),
+				Arguments.of(List.of(LocalDateTime.parse("2021-10-03T19:01:23"), LocalDateTime.parse("2021-11-04T20:02:24")),
+						ARRAY_OF_DATE_TIME, "\"[\"\"2021-10-03T19:01:23\"\",\"\"2021-11-04T20:02:24\"\"]\"")
+//				Arguments.of("[\"drs://drs.example.org/file_id_1\", \"https://account_name.blob.core.windows.net/container-2/blob2\"]",
+//						ARRAY_OF_FILE, "[\"drs://drs.example.org/file_id_1\", \"https://account_name.blob.core.windows.net/container-2/blob2\"]")
+//				Arguments.of("[\"terra-wds:/type/id\", \"terra-wds:/type/id2\"]",
+//						ARRAY_OF_RELATION, "[\"terra-wds:/type/id\", \"terra-wds:/type/id2\"]")
 				);
 	}
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
@@ -1,14 +1,21 @@
 package org.databiosphere.workspacedataservice.controller;
 
-import org.databiosphere.workspacedataservice.shared.model.BatchResponse;
-import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
-import org.databiosphere.workspacedataservice.shared.model.RecordType;
 import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.databind.ObjectReader;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.databiosphere.workspacedataservice.dao.RecordDao;
+import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
+import org.databiosphere.workspacedataservice.shared.model.BatchResponse;
+import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
+import org.databiosphere.workspacedataservice.shared.model.RecordRequest;
+import org.databiosphere.workspacedataservice.shared.model.RecordResponse;
+import org.databiosphere.workspacedataservice.shared.model.RecordType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -23,14 +30,20 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.databiosphere.workspacedataservice.service.model.DataTypeMapping.*;
 
 @ActiveProfiles(profiles = "mock-sam")
 @DirtiesContext
@@ -42,6 +55,8 @@ class TsvDownloadTest {
 
 	@Autowired
 	private RecordController recordController;
+	@Autowired
+	private RecordDao recordDao;
 	private String version;
 	private UUID instanceId;
 
@@ -80,6 +95,7 @@ class TsvDownloadTest {
 		assertThat(tsvIterator.hasNext()).isFalse();
 		reader.close();
 	}
+
 	@Test
 	void batchWriteFollowedByTsvDownload() throws IOException {
 		RecordType recordType = RecordType.valueOf("tsv-test");
@@ -103,4 +119,73 @@ class TsvDownloadTest {
 		assertThat(tsvIterator.hasNext()).isFalse();
 		reader.close();
 	}
+
+
+	private static Stream<Arguments> tsvDownloadValues() {
+        /* Arguments are sets:
+            - first value is the Object to insert as an attribute
+            - second value is the expected data type that the object creates
+            - third value is the text that would be contained in a TSV cell when downloading the attribute
+         */
+		return Stream.of(
+				Arguments.of(Boolean.TRUE,
+						BOOLEAN, "true"),
+				Arguments.of(Boolean.FALSE,
+						BOOLEAN, "false"),
+				Arguments.of("hello",
+						STRING, "hello"),
+				Arguments.of("embedded\ttab",
+						STRING, "\"embedded\ttab\""),
+				Arguments.of(BigDecimal.valueOf(789),
+						NUMBER, "789"),
+				Arguments.of("{\"foo\": \"bar\", \"arr\": [2,4,6]}",
+						JSON, "\"{\"\"arr\"\":[2,4,6],\"\"foo\"\":\"\"bar\"\"}\""),
+				Arguments.of(List.of("foo", "bar", "baz"),
+						ARRAY_OF_STRING, "\"[\"\"foo\"\",\"\"bar\"\",\"\"baz\"\"]\""),
+				Arguments.of(List.of(BigDecimal.valueOf(1), BigDecimal.valueOf(3), BigDecimal.valueOf(5)),
+						ARRAY_OF_NUMBER, "[1,3,5]")
+		);
+	}
+
+
+	@ParameterizedTest(name = "TSV download for a {1} should be correct")
+	@MethodSource("tsvDownloadValues")
+	void tsvDownloadVariousDataTypes(Object toUpload, DataTypeMapping expectedDataType, String expectedCellValue) throws IOException {
+		RecordType recordType = RecordType.valueOf(RandomStringUtils.randomAlphabetic(8));
+		String recordId = "123";
+		String attrName = RandomStringUtils.randomAlphabetic(8);
+
+		// upload a record containing the attribute in question
+		RecordAttributes uploadAttrs = new RecordAttributes(Map.of(attrName, toUpload));
+		RecordRequest recordRequest = new RecordRequest(uploadAttrs);
+
+		ResponseEntity<RecordResponse> response = recordController.upsertSingleRecord(instanceId, version, recordType, recordId, Optional.empty(), recordRequest);
+		assertThat(response.getStatusCodeValue()).isEqualTo(201);
+
+		// verify the backend datatype
+		Map<String, DataTypeMapping> tableSchema = recordDao.getExistingTableSchema(instanceId, recordType);
+		assertThat(tableSchema.keySet()).contains(attrName);
+		DataTypeMapping actualDataType = tableSchema.get(attrName);
+		assertThat(actualDataType).isEqualTo(expectedDataType);
+
+		// get the TSV
+		HttpHeaders headers = new HttpHeaders();
+		ResponseEntity<Resource> stream = restTemplate.exchange("/{instanceId}/tsv/{version}/{recordType}",
+				HttpMethod.GET, new HttpEntity<>(headers), Resource.class, instanceId, version, recordType);
+
+		// read the TSV contents. Note that this test intentionally reads the TSV as strings - we don't use
+		// a MappingIterator<RecordAttributes>, for example. This allows us to assert on the string representation
+		// of values within the TSV.
+		try (
+				InputStream inputStream = stream.getBody().getInputStream();
+				BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))
+		) {
+			String firstLine = reader.readLine();
+			assertThat(firstLine).isEqualTo("sys_name\t" + attrName);
+
+			String secondLine = reader.readLine();
+			assertThat(secondLine).isEqualTo(recordId + "\t" + expectedCellValue);
+		}
+	}
+
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
@@ -35,7 +35,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -144,7 +146,25 @@ class TsvDownloadTest {
 						ARRAY_OF_STRING, "\"[\"\"foo\"\",\"\"bar\"\",\"\"baz\"\"]\""),
 				Arguments.of(List.of(BigDecimal.valueOf(1), BigDecimal.valueOf(3), BigDecimal.valueOf(5)),
 						ARRAY_OF_NUMBER, "[1,3,5]")
-		);
+
+
+//				Arguments.of("2021-10-03",          "2021-10-03",           true),
+//				Arguments.of("2021-10-03T19:01:23", "2021-10-03T19:01:23",  true),
+//				Arguments.of("terra-wds:/type/id",  "terra-wds:/type/id",   true),
+//				Arguments.of("[]", Collections.EMPTY_LIST, false),
+//
+//				// arrays of booleans
+//				Arguments.of("[true,false,true]",       List.of(true, false, true),     false),
+
+//				Arguments.of("[\"2021-10-03\", \"2022-11-04\"]",                    List.of("2021-10-03", "2022-11-04"),                    false),
+//				Arguments.of("[\"2021-10-03T19:01:23\", \"2021-11-04T20:02:24\"]",  List.of("2021-10-03T19:01:23", "2021-11-04T20:02:24"),  false),
+//				Arguments.of("[\"terra-wds:/type/id\", \"terra-wds:/type/id2\"]",   List.of("terra-wds:/type/id", "terra-wds:/type/id2"),   false),
+//
+//				// mixed array (these deserialize as mixed lists, will be coerced to a single data type later in processing)
+//				Arguments.of("[\"hello\", 123, true]",  List.of("hello", BigInteger.valueOf(123), true),    false),
+
+
+				);
 	}
 
 


### PR DESCRIPTION
Reviewer: the github diff is easier to see if you ignore whitespace.

This PR addresses [AJ-1142](https://broadworkbench.atlassian.net/browse/AJ-1142): it properly handles arrays and JSON objects in TSV downloads.

At the implementation level, this PR includes:
* change `TsvSupport` from a class of static methods to a Spring `@Component`; this makes it easy to give that class an `ObjectMapper` for serialization.
* When serializing the TSV, first get the `DataTypeMapping` schema for the record type. Make serialization decisions based on the datatype of the column in question:
    * for arrays and JSON objects, serialize the value as JSON
    * for scalars, continue using the `.toString()` for that value
* Add unit tests to fix the missing coverage

NOTE: While working on this PR, I discovered additional TSV bugs. I am NOT fixing these additional bugs here; let's get this PR through and fix those bugs in follow-on work. These are not regressions in the move from Apache->Jackson; they were present before that move. I will file these in Jira.
1. if the TSV contains nulls in a `RELATION` column, the TSV fails to upload. Need to see if this is true for arrays-of-relations too


---

Reminder:

PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 


[AJ-1142]: https://broadworkbench.atlassian.net/browse/AJ-1142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ