### PR TITLE
AJ-955 - Adding Leonardo Client to WDS to extract source WDS Url during cloning

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -56,9 +56,11 @@ dependencies {
 	implementation 'javax.cache:cache-api'
 	implementation 'org.ehcache:ehcache:3.10.8'
 	implementation 'org.hashids:hashids:1.0.3'
+	implementation 'javax.ws.rs:javax.ws.rs-api:2.1.1'
 
 	// Terra libraries
 	implementation group: 'org.broadinstitute.dsde.workbench', name: 'sam-client_2.13', version: '0.1-08b6588'
+	implementation group: 'org.broadinstitute.dsde.workbench', name: 'leonardo-client_2.11', version: '1.3.5-1be4da6-SNAP'
 	implementation 'com.squareup.okhttp3:okhttp:4.10.0' // required by Sam client
 	implementation "bio.terra:datarepo-client:1.476.0-SNAPSHOT"
 	implementation "bio.terra:workspace-manager-client:0.254.717-SNAPSHOT"

--- a/service/src/main/java/org/databiosphere/workspacedataservice/leonardo/HttpLeonardoClientFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/leonardo/HttpLeonardoClientFactory.java
@@ -1,0 +1,64 @@
+package org.databiosphere.workspacedataservice.leonardo;
+
+import okhttp3.OkHttpClient;
+import org.apache.commons.lang3.StringUtils;
+import org.broadinstitute.dsde.workbench.client.leonardo.ApiClient;
+import org.broadinstitute.dsde.workbench.client.leonardo.api.AppsV2Api;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.context.request.RequestContextHolder;
+
+import java.util.Objects;
+
+import static org.databiosphere.workspacedataservice.sam.BearerTokenFilter.ATTRIBUTE_NAME_TOKEN;
+import static org.springframework.web.context.request.RequestAttributes.SCOPE_REQUEST;
+
+public class HttpLeonardoClientFactory implements LeonardoClientFactory {
+
+    final String leoEndpointUrl;
+    private final OkHttpClient commonHttpClient;
+    private static final Logger LOGGER = LoggerFactory.getLogger(HttpLeonardoClientFactory.class);
+
+
+    public HttpLeonardoClientFactory(String leoUrl) {
+        this.leoEndpointUrl = leoUrl;
+        this.commonHttpClient = new org.broadinstitute.dsde.workbench.client.sam.ApiClient()
+                .getHttpClient()
+                .newBuilder()
+                .build();
+    }
+
+    private ApiClient getApiClient(String token) {
+        // create a new data repo client
+        ApiClient apiClient = new ApiClient();
+        apiClient.setHttpClient(commonHttpClient);
+
+        // initialize the client with the url to leo endpoint
+        if (StringUtils.isNotBlank(leoEndpointUrl)) {
+            apiClient.setBasePath(leoEndpointUrl);
+        }
+
+        // grab the current user's bearer token (see BearerTokenFilter)
+        if(token.isEmpty()) {
+            Object userToken = RequestContextHolder.currentRequestAttributes()
+                    .getAttribute(ATTRIBUTE_NAME_TOKEN, SCOPE_REQUEST);
+            // add the user's bearer token to the client
+            if (!Objects.isNull(userToken)) {
+                LOGGER.debug("setting access token for leonardo request");
+                apiClient.setAccessToken(userToken.toString());
+            } else {
+                LOGGER.warn("No access token found for leonardo request.");
+            }
+        }
+        else {
+            apiClient.setAccessToken(token);
+        }
+
+        // return the client
+        return apiClient;
+    }
+
+    public AppsV2Api getAppsV2Api(String token) {
+        return new AppsV2Api(getApiClient(token));
+    }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/leonardo/HttpLeonardoClientFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/leonardo/HttpLeonardoClientFactory.java
@@ -22,7 +22,7 @@ public class HttpLeonardoClientFactory implements LeonardoClientFactory {
 
     public HttpLeonardoClientFactory(String leoUrl) {
         this.leoEndpointUrl = leoUrl;
-        this.commonHttpClient = new org.broadinstitute.dsde.workbench.client.sam.ApiClient()
+        this.commonHttpClient = new ApiClient()
                 .getHttpClient()
                 .newBuilder()
                 .build();

--- a/service/src/main/java/org/databiosphere/workspacedataservice/leonardo/HttpLeonardoClientFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/leonardo/HttpLeonardoClientFactory.java
@@ -19,7 +19,6 @@ public class HttpLeonardoClientFactory implements LeonardoClientFactory {
     private final OkHttpClient commonHttpClient;
     private static final Logger LOGGER = LoggerFactory.getLogger(HttpLeonardoClientFactory.class);
 
-
     public HttpLeonardoClientFactory(String leoUrl) {
         this.leoEndpointUrl = leoUrl;
         this.commonHttpClient = new ApiClient()

--- a/service/src/main/java/org/databiosphere/workspacedataservice/leonardo/LeonardoClientFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/leonardo/LeonardoClientFactory.java
@@ -1,0 +1,7 @@
+package org.databiosphere.workspacedataservice.leonardo;
+
+import org.broadinstitute.dsde.workbench.client.leonardo.api.AppsV2Api;
+
+public interface LeonardoClientFactory {
+    AppsV2Api getAppsV2Api(String token);
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/leonardo/LeonardoConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/leonardo/LeonardoConfig.java
@@ -1,0 +1,30 @@
+package org.databiosphere.workspacedataservice.leonardo;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class LeonardoConfig {
+
+        @Value("${leoUrl:}")
+        private String leonardoUrl;
+
+        @Value("${twds.instance.workspace-id:}")
+        private String workspaceId;
+
+        private static final Logger LOGGER = LoggerFactory.getLogger(LeonardoConfig.class);
+
+        @Bean
+        public LeonardoClientFactory getLeonardoClientFactory() {
+                LOGGER.info("Using leonardo url: '{}'", leonardoUrl);
+                return new HttpLeonardoClientFactory(leonardoUrl);
+        }
+
+        @Bean
+        public LeonardoDao leonardoDao(LeonardoClientFactory leonardoClientFactory) {
+                return new LeonardoDao(leonardoClientFactory, workspaceId);
+        }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/leonardo/LeonardoDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/leonardo/LeonardoDao.java
@@ -1,0 +1,77 @@
+package org.databiosphere.workspacedataservice.leonardo;
+
+import com.nimbusds.oauth2.sdk.util.StringUtils;
+import org.broadinstitute.dsde.workbench.client.leonardo.ApiException;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.AppStatus;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.AppType;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.ListAppResponse;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class LeonardoDao {
+  private final LeonardoClientFactory leonardoClientFactory;
+  private final String workspaceId;
+
+  public LeonardoDao(LeonardoClientFactory leonardoClientFactory, String workspaceId) {
+    this.leonardoClientFactory = leonardoClientFactory;
+    this.workspaceId = workspaceId;
+  }
+
+  /**
+   * Asks leo to return apps running in a given workspace setting.
+   */
+  public String getWdsEndpointUrl(String token) {
+    var workspaceApps = this.leonardoClientFactory.getAppsV2Api(token);
+    try {
+      var response = workspaceApps.listAppsV2(workspaceId, null, false, null);
+      // unsure what the key would be if there is more than 1 wds present in the listed apps, but in this case our assumption is
+      // it is acceptable to fail if we cant find a single RUNNING wds in the proxy urls
+      var url = extractWdsUrl(response);
+      if (url != null) {
+        return url;
+      }
+
+      throw new ApiException("Did not locate an app running WDS.");
+    } catch (ApiException e) {
+      throw new LeonardoServiceException(e);
+    }
+  }
+
+  class AppCreationDateComparator implements Comparator<ListAppResponse> {
+    @Override
+    public int compare(ListAppResponse o1, ListAppResponse o2) {
+      return o1.getAuditInfo().getCreatedDate().compareTo(o2.getAuditInfo().getCreatedDate());
+    }
+    @Override
+    public boolean equals(Object obj) {
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      // sonar is complaining that hashCode has to be overwritten as well if equals is
+      // since we are not using any object instances in this class, returning a default value 
+      return -1;
+    }
+  }
+  public String extractWdsUrl(List<ListAppResponse> response) {
+    // look for apps of type "WDS" which are in "RUNNING" status.
+    // if more than one, choose the earliest-created. This matches Terra UI logic.
+    Optional<ListAppResponse> maybeApp = response.stream()
+            .filter(app -> AppType.WDS.equals(app.getAppType()) && AppStatus.RUNNING.equals(app.getStatus()))
+            .min(new AppCreationDateComparator());
+    if (maybeApp.isPresent()) {
+      Map<String, String> proxyUrls = ((Map<String, String>) maybeApp.get().getProxyUrls());
+      if (proxyUrls != null) {
+        String url = proxyUrls.getOrDefault("wds", "");
+        if (StringUtils.isNotBlank(url)) {
+          return url;
+        }
+      }
+    }
+    return null;
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/leonardo/LeonardoServiceException.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/leonardo/LeonardoServiceException.java
@@ -1,0 +1,13 @@
+package org.databiosphere.workspacedataservice.leonardo;
+
+import org.broadinstitute.dsde.workbench.client.leonardo.ApiException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Optional;
+
+public class LeonardoServiceException extends ResponseStatusException {
+  public LeonardoServiceException(ApiException cause) {
+    super(Optional.ofNullable(HttpStatus.resolve(cause.getCode())).orElse(HttpStatus.INTERNAL_SERVER_ERROR), null, cause);
+  }
+}

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -72,6 +72,7 @@ api.retry.backoff.multiplier=1.5
 
 datarepourl=${DATA_REPO_URL:}
 workspacemanagerurl=${WORKSPACE_MANAGER_URL:}
+leoUrl=${LEONARDO_URL:}
 
 # activate the "local" profile to turn on CORS response headers,
 # which may be necessary for local development.

--- a/service/src/test/java/org/databiosphere/workspacedataservice/leonardo/LeonardoDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/leonardo/LeonardoDaoTest.java
@@ -1,0 +1,106 @@
+package org.databiosphere.workspacedataservice.leonardo;
+
+import org.broadinstitute.dsde.workbench.client.leonardo.ApiException;
+import org.broadinstitute.dsde.workbench.client.leonardo.api.AppsV2Api;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.AppStatus;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.AppType;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.AuditInfo;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.ListAppResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+
+import java.text.SimpleDateFormat;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DirtiesContext
+@SpringBootTest(classes = {LeonardoConfig.class})
+@TestPropertySource(properties = {"twds.instance.workspace-id=90e1b179-9f83-4a6f-a8c2-db083df4cd03"})
+class LeonardoDaoTest {
+    @Autowired
+    LeonardoDao leonardoDao;
+
+    @MockBean
+    LeonardoClientFactory leonardoClientFactory;
+
+    final AppsV2Api mockAppsApi = mock(AppsV2Api.class);
+
+    @BeforeEach
+    void beforeEach() {
+        given(leonardoClientFactory.getAppsV2Api(any())).willReturn(mockAppsApi);
+    }
+
+    final String expectedUrl = "https://lz28e3b6da2a7f727cae07c307f6c7c11d96da0d1fde444216.servicebus.windows.net/wds-e433ab84-1725-4666-b07e-4ee7ca";
+    @Test
+    void testWdsUrlNotReturned() throws ApiException {
+        final int statusCode = HttpStatus.INTERNAL_SERVER_ERROR.value();
+        given(mockAppsApi.listAppsV2(String.valueOf(UUID.randomUUID()), "things", null, null))
+                .willThrow(new org.broadinstitute.dsde.workbench.client.leonardo.ApiException(statusCode, "Intentional error thrown for unit test"));
+        var exception = assertThrows(LeonardoServiceException.class, () -> leonardoDao.getWdsEndpointUrl(any()));
+        assertEquals(statusCode, exception.getRawStatusCode());
+    }
+
+    @Test
+    void testWdsUrlReturned() throws ApiException {
+        var url = buildAppResponseAndCallExtraction(generateListAppResponse("wds", AppStatus.RUNNING,1));
+        assertEquals(expectedUrl, url);
+    }
+
+    @Test
+    void testWdsUrlNotFoundWrongStatus() throws ApiException {
+        var url = buildAppResponseAndCallExtraction(generateListAppResponse("wds", AppStatus.DELETED, 1));
+        assertEquals(null, url);
+    }
+
+    @Test
+    void testWdsUrlNotFoundWrongKey() throws ApiException {
+        var url = buildAppResponseAndCallExtraction(generateListAppResponse("not-wds", AppStatus.RUNNING, 1));
+        assertEquals(null, url);
+    }
+
+    @Test
+    void testWdsUrlMultiple() throws ApiException {
+        // tests the case if there are 2 running wds apps
+        var url = buildAppResponseAndCallExtraction(generateListAppResponse("wds", AppStatus.RUNNING,2));
+        assertEquals(expectedUrl, url);
+    }
+
+    String buildAppResponseAndCallExtraction(List<ListAppResponse> responses ){
+        var url = leonardoDao.extractWdsUrl(responses);
+        return url;
+    }
+
+    List<ListAppResponse> generateListAppResponse(String wdsKey, AppStatus wdsStatus, int count) {
+        List<ListAppResponse> responseList = new ArrayList<>();
+        var url = expectedUrl;
+        while(count != 0) {
+            ListAppResponse response = mock(ListAppResponse.class);
+            Map<String, String> proxyUrls = new HashMap<String, String>();
+            proxyUrls.put(wdsKey, url);
+            when(response.getProxyUrls()).thenReturn(proxyUrls);
+            when(response.getStatus()).thenReturn(wdsStatus);
+            when(response.getAppType()).thenReturn(AppType.WDS);
+            when(response.getAuditInfo()).thenReturn(mock(AuditInfo.class));
+            when(response.getAuditInfo().getCreatedDate()).thenReturn(new SimpleDateFormat("yyyyMMdd_HHmmss").format(Calendar.getInstance().getTime()));
+            responseList.add(response);
+            count--;
+
+            // only one wds entry will have a valid url, so mark url to be an empty string for all but the first loop through
+            url = "";
+        }
+
+        return responseList;
+    }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/leonardo/LeonardoDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/leonardo/LeonardoDaoTest.java
@@ -85,7 +85,7 @@ class LeonardoDaoTest {
         var url = expectedUrl;
         while(count != 0) {
             ListAppResponse response = mock(ListAppResponse.class);
-            Map<String, String> proxyUrls = new HashMap<String, String>();
+            Map<String, String> proxyUrls = new HashMap<>();
             proxyUrls.put(wdsKey, url);
             when(response.getProxyUrls()).thenReturn(proxyUrls);
             when(response.getStatus()).thenReturn(wdsStatus);

--- a/service/src/test/java/org/databiosphere/workspacedataservice/leonardo/LeonardoDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/leonardo/LeonardoDaoTest.java
@@ -18,8 +18,7 @@ import org.springframework.test.context.TestPropertySource;
 import java.text.SimpleDateFormat;
 import java.util.*;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -53,33 +52,32 @@ class LeonardoDaoTest {
     }
 
     @Test
-    void testWdsUrlReturned() throws ApiException {
+    void testWdsUrlReturned() {
         var url = buildAppResponseAndCallExtraction(generateListAppResponse("wds", AppStatus.RUNNING,1));
         assertEquals(expectedUrl, url);
     }
 
     @Test
-    void testWdsUrlNotFoundWrongStatus() throws ApiException {
+    void testWdsUrlNotFoundWrongStatus() {
         var url = buildAppResponseAndCallExtraction(generateListAppResponse("wds", AppStatus.DELETED, 1));
-        assertEquals(null, url);
+        assertNull(url);
     }
 
     @Test
-    void testWdsUrlNotFoundWrongKey() throws ApiException {
+    void testWdsUrlNotFoundWrongKey() {
         var url = buildAppResponseAndCallExtraction(generateListAppResponse("not-wds", AppStatus.RUNNING, 1));
-        assertEquals(null, url);
+        assertNull(url);
     }
 
     @Test
-    void testWdsUrlMultiple() throws ApiException {
+    void testWdsUrlMultiple() {
         // tests the case if there are 2 running wds apps
         var url = buildAppResponseAndCallExtraction(generateListAppResponse("wds", AppStatus.RUNNING,2));
         assertEquals(expectedUrl, url);
     }
 
     String buildAppResponseAndCallExtraction(List<ListAppResponse> responses ){
-        var url = leonardoDao.extractWdsUrl(responses);
-        return url;
+        return leonardoDao.extractWdsUrl(responses);
     }
 
     List<ListAppResponse> generateListAppResponse(String wdsKey, AppStatus wdsStatus, int count) {


### PR DESCRIPTION
This is a split out PR in hopes to make https://github.com/DataBiosphere/terra-workspace-data-service/pull/280 smaller. This PR adds the leonardo client that will be used to request the source WDS url to enable cloning. 

Reminder:

PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 
