### PR TITLE
AJ-955 - Add source WDS Api client to enable trigger of backup from one WDS to another

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -62,6 +62,7 @@ dependencies {
 	implementation 'com.squareup.okhttp3:okhttp:4.10.0' // required by Sam client
 	implementation "bio.terra:datarepo-client:1.476.0-SNAPSHOT"
 	implementation "bio.terra:workspace-manager-client:0.254.717-SNAPSHOT"
+	implementation project(path: ':client')
 
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	runtimeOnly 'org.webjars.npm:swagger-ui-dist:4.12.0'

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sourcewds/HttpWorkspaceDataServiceClientFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sourcewds/HttpWorkspaceDataServiceClientFactory.java
@@ -18,7 +18,7 @@ public class HttpWorkspaceDataServiceClientFactory implements WorkspaceDataServi
     private static final Logger LOGGER = LoggerFactory.getLogger(HttpWorkspaceDataServiceClientFactory.class);
 
     public HttpWorkspaceDataServiceClientFactory() {
-        this.commonHttpClient = new bio.terra.workspace.client.ApiClient().getHttpClient();
+        this.commonHttpClient = new ApiClient().getHttpClient();
     }
 
     private ApiClient getApiClient(String token, String workspaceDataServiceUrl) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sourcewds/HttpWorkspaceDataServiceClientFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sourcewds/HttpWorkspaceDataServiceClientFactory.java
@@ -1,0 +1,57 @@
+package org.databiosphere.workspacedataservice.sourcewds;
+
+import org.databiosphere.workspacedata.api.CloningApi;
+import org.databiosphere.workspacedata.client.ApiClient;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.context.request.RequestContextHolder;
+
+import javax.ws.rs.client.Client;
+import java.util.Objects;
+
+import static org.databiosphere.workspacedataservice.sam.BearerTokenFilter.ATTRIBUTE_NAME_TOKEN;
+import static org.springframework.web.context.request.RequestAttributes.SCOPE_REQUEST;
+
+public class HttpWorkspaceDataServiceClientFactory implements WorkspaceDataServiceClientFactory {
+    private final Client commonHttpClient;
+    private static final Logger LOGGER = LoggerFactory.getLogger(HttpWorkspaceDataServiceClientFactory.class);
+
+    public HttpWorkspaceDataServiceClientFactory() {
+        this.commonHttpClient = new bio.terra.workspace.client.ApiClient().getHttpClient();
+    }
+
+    private ApiClient getApiClient(String token, String workspaceDataServiceUrl) {
+        // create a new client
+        ApiClient apiClient = new ApiClient();
+        apiClient.setHttpClient(commonHttpClient);
+
+        // initialize the client with the url to wds endpoint
+        if (StringUtils.isNotBlank(workspaceDataServiceUrl)) {
+            LOGGER.info("Setting Wds endpoint url to: {}", workspaceDataServiceUrl);
+            apiClient.setBasePath(workspaceDataServiceUrl);
+        }
+
+        // grab the current user's bearer token (see BearerTokenFilter)
+        if(token.isEmpty()) {
+            Object userToken = RequestContextHolder.currentRequestAttributes()
+                    .getAttribute(ATTRIBUTE_NAME_TOKEN, SCOPE_REQUEST);
+            // add the user's bearer token to the client
+            if (!Objects.isNull(userToken)) {
+                LOGGER.debug("setting access token for workspace data service request");
+                apiClient.setAccessToken(userToken.toString());
+            } else {
+                LOGGER.warn("No access token found for workspace data service request.");
+            }
+        }
+        else {
+            apiClient.setAccessToken(token);
+        }
+
+        return apiClient;
+    }
+
+    public CloningApi getBackupClient(String token, String wdsUrl) {
+        return new CloningApi(getApiClient(token, wdsUrl));
+    }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sourcewds/WorkspaceDataServiceClientFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sourcewds/WorkspaceDataServiceClientFactory.java
@@ -1,0 +1,7 @@
+package org.databiosphere.workspacedataservice.sourcewds;
+
+import org.databiosphere.workspacedata.api.CloningApi;
+
+public interface WorkspaceDataServiceClientFactory {
+    CloningApi getBackupClient(String token, String wdsUrl);
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sourcewds/WorkspaceDataServiceConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sourcewds/WorkspaceDataServiceConfig.java
@@ -1,0 +1,18 @@
+package org.databiosphere.workspacedataservice.sourcewds;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class WorkspaceDataServiceConfig {
+
+        @Bean
+        public WorkspaceDataServiceClientFactory getWorkspaceDataServiceClientFactory() {
+                return new HttpWorkspaceDataServiceClientFactory();
+        }
+
+        @Bean
+        public WorkspaceDataServiceDao workspaceDataServiceDao(WorkspaceDataServiceClientFactory workspaceDataServiceClientFactory) {
+                return new WorkspaceDataServiceDao(workspaceDataServiceClientFactory);
+        }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sourcewds/WorkspaceDataServiceDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sourcewds/WorkspaceDataServiceDao.java
@@ -1,0 +1,48 @@
+package org.databiosphere.workspacedataservice.sourcewds;
+
+
+import org.databiosphere.workspacedata.client.ApiException;
+import org.databiosphere.workspacedata.model.BackupJob;
+import org.databiosphere.workspacedata.model.BackupRequest;
+
+import java.util.UUID;
+
+
+public class WorkspaceDataServiceDao {
+  private final WorkspaceDataServiceClientFactory workspaceDataServiceClientFactory;
+
+  private String workspaceDataServiceUrl;
+
+  public WorkspaceDataServiceDao(WorkspaceDataServiceClientFactory workspaceDataServiceClientFactory) {
+    this.workspaceDataServiceClientFactory = workspaceDataServiceClientFactory;
+  }
+
+  public void setWorkspaceDataServiceUrl(String endpointUrl) {
+    this.workspaceDataServiceUrl = endpointUrl;
+  }
+  /**
+   * Triggers a backup in source workspace data service.
+   */
+  public BackupJob triggerBackup(String token, UUID requesterWorkspaceId) {
+    try {
+      var backupClient = this.workspaceDataServiceClientFactory.getBackupClient(token, workspaceDataServiceUrl);
+      BackupRequest body = new BackupRequest();
+      body.setRequestingWorkspaceId(requesterWorkspaceId);
+      return backupClient.createBackup(body,"v0.2");
+    } catch (ApiException e) {
+      throw new WorkspaceDataServiceException(e);
+    }
+  }
+
+  /**
+   * Checks status of a backup in source workspace data service.
+   */
+  public BackupJob checkBackupStatus(String token, UUID trackingId) {
+    var backupClient = this.workspaceDataServiceClientFactory.getBackupClient(token, workspaceDataServiceUrl);
+    try {
+      return backupClient.getBackupStatus("v0.2", trackingId);
+    } catch (ApiException e) {
+      throw new WorkspaceDataServiceException(e);
+    }
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sourcewds/WorkspaceDataServiceException.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sourcewds/WorkspaceDataServiceException.java
@@ -1,0 +1,13 @@
+package org.databiosphere.workspacedataservice.sourcewds;
+
+import org.databiosphere.workspacedata.client.ApiException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Optional;
+
+public class WorkspaceDataServiceException extends ResponseStatusException {
+  public WorkspaceDataServiceException(ApiException cause) {
+    super(Optional.ofNullable(HttpStatus.resolve(cause.getCode())).orElse(HttpStatus.INTERNAL_SERVER_ERROR), null, cause);
+  }
+}


### PR DESCRIPTION
This is a split out PR in hopes to make https://github.com/DataBiosphere/terra-workspace-data-service/pull/280 smaller. This PR adds the wds client that will be used for destination WDS to trigger backup on a source WDS (where the clone was initiated). 

Reminder:

PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 
