### PR TITLE
AJ-1075: expose chart version and docker image version in /version api

### DIFF
--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -8,11 +8,18 @@ env.wds.db.port=${WDS_DB_PORT:5432}
 # sslmode=require&authenticationPluginClassName=com.azure.identity.extensions.jdbc.postgresql.AzurePostgresqlAuthenticationPlugin
 env.wds.db.additionalUrlParams=${ADDITIONAL_JDBC_URL_PARAMS:}
 
+management.endpoints.enabled-by-default=false
+management.endpoint.info.enabled=true
+management.endpoint.health.enabled=true
 management.endpoints.web.exposure.include=info,health
 management.endpoints.web.base-path=/
 management.endpoints.web.path-mapping.info=version
 management.endpoints.web.path-mapping.health=status
 management.endpoint.health.show-details=ALWAYS
+# additional keys to expose in the actuator info endpoint:
+management.info.env.enabled=true
+info.app.chart-version=${HELM_CHART:unknown}
+info.app.image=${WDS_IMAGE:unknown}
 
 spring.datasource.jdbc-url=jdbc:postgresql://${env.wds.db.host}:${env.wds.db.port}/${env.wds.db.name}?reWriteBatchedInserts=true&${env.wds.db.additionalUrlParams}
 spring.datasource.username=${env.wds.db.user}

--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -871,6 +871,8 @@ components:
     VersionResponse:
       type: object
       properties:
+        app:
+          $ref: '#/components/schemas/app'
         git:
           $ref: '#/components/schemas/git'
         build:
@@ -908,6 +910,13 @@ components:
         version:
           type: string
         group:
+          type: string
+    app:
+      type: object
+      properties:
+        chart-version:
+          type: string
+        image:
           type: string
     git:
       type: object


### PR DESCRIPTION
part of AJ-1075 but does not complete that ticket.

This exposes the chart version and docker image version in WDS's `/version` API. It builds on previous terra-helmfile PR here: https://github.com/broadinstitute/terra-helmfile/pull/4211

AJ-1075 will require UI work to complete; this PR satisfies the backend functionality to support the UI.

See https://howtodoinjava.com/spring-boot/info-endpoint-custom-info/#4-adding-custom-information-to-info-endpoint for explanation of the code changes in this PR.

![Screenshot 7-7-2023 at 12 30 PM](https://github.com/DataBiosphere/terra-workspace-data-service/assets/6041577/ac6899de-2907-493c-b009-2b7473cc20d8)

