### PR TITLE
fix status enum for BackupJob

### DIFF
--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -663,7 +663,7 @@ components:
           type: string
         status:
           type: string
-          enum: [ QUEUED, STARTED, RUNNING, SUCCEEDED, FAILED ]
+          enum: [ QUEUED, RUNNING, SUCCEEDED, ERROR, CANCELLED, UNKNOWN ]
         created:
           type: string
           format: date-time


### PR DESCRIPTION
the enum definition for `BackupJob`'s `status` field was incorrect. Specifically, this allows for `ERROR` status, which previously was not allowed and could not be deserialized.