### PR TITLE
AJ-937 - Add clone status api call that terra-ui will use

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/InstanceInitializerBean.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/InstanceInitializerBean.java
@@ -110,7 +110,7 @@ public class InstanceInitializerBean {
                 var backupStatusResponse = wdsDao.checkBackupStatus(startupToken, UUID.fromString(backupResponse.getJobId()));
                 if (backupStatusResponse.getStatus().equals(Job.StatusEnum.SUCCEEDED)) {
                     backupFileName = backupStatusResponse.getResult().getFilename();
-                    cloneDao.updateCloneEntryStatus(UUID.fromString(sourceWorkspaceId), CloneStatus.BACKUPSUCCEEDED);
+                    cloneDao.updateCloneEntryStatus(trackingId, CloneStatus.BACKUPSUCCEEDED);
                 }
                 else {
                     LOGGER.error("An error occurred during clone mode - backup not complete.");

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/CloningController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/CloningController.java
@@ -45,6 +45,7 @@ public class CloningController {
     public ResponseEntity<Job<CloneResponse>> getCloningStatus(@PathVariable("version") String version) {
         validateVersion(version);
         var response = backupRestoreService.checkCloneStatus();
-        return new ResponseEntity<>(response, HttpStatus.OK);
+        var status = (response == null) ? HttpStatus.NOT_FOUND : HttpStatus.OK;
+        return new ResponseEntity<>(response, status);
     }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/CloningController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/CloningController.java
@@ -3,6 +3,7 @@ package org.databiosphere.workspacedataservice.controller;
 import org.databiosphere.workspacedataservice.service.BackupRestoreService;
 import org.databiosphere.workspacedataservice.shared.model.BackupRequest;
 import org.databiosphere.workspacedataservice.shared.model.BackupResponse;
+import org.databiosphere.workspacedataservice.shared.model.CloneResponse;
 import org.databiosphere.workspacedataservice.shared.model.job.Job;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -37,6 +38,13 @@ public class CloningController {
     public ResponseEntity<Job<BackupResponse>> getBackupStatus(@PathVariable("version") String version, @PathVariable("trackingId") UUID trackingId) {
         validateVersion(version);
         var response = backupRestoreService.checkBackupStatus(trackingId);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    @GetMapping("/clone/{version}")
+    public ResponseEntity<Job<CloneResponse>> getCloningStatus(@PathVariable("version") String version) {
+        validateVersion(version);
+        var response = backupRestoreService.checkCloneStatus();
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/CloneDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/CloneDao.java
@@ -1,6 +1,8 @@
 package org.databiosphere.workspacedataservice.dao;
 
+import org.databiosphere.workspacedataservice.shared.model.CloneResponse;
 import org.databiosphere.workspacedataservice.shared.model.CloneStatus;
+import org.databiosphere.workspacedataservice.shared.model.job.Job;
 
 import java.util.UUID;
 
@@ -8,5 +10,6 @@ public interface CloneDao {
     void createCloneEntry(UUID trackingId, UUID sourceWorkspaceId);
     void updateCloneEntryStatus(UUID trackingId, CloneStatus status);
     boolean cloneExistsForWorkspace(UUID sourceWorkspaceId);
+    Job<CloneResponse> getCloneStatus();
     void terminateCloneToError(UUID trackingId, String error);
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresCloneDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresCloneDao.java
@@ -90,7 +90,7 @@ public class PostgresCloneDao implements CloneDao {
         }
     }
 
-    // rowmapper for retrieving Job<BackupResponse> objects from the db
+    // rowmapper for retrieving Job<CloneResponse> objects from the db
     private static class CloneJobRowMapper implements RowMapper<Job<CloneResponse>> {
         @Override
         public Job<CloneResponse> mapRow(ResultSet rs, int rowNum) throws SQLException {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresCloneDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresCloneDao.java
@@ -2,20 +2,31 @@ package org.databiosphere.workspacedataservice.dao;
 
 import bio.terra.common.db.WriteTransaction;
 import org.apache.commons.lang3.StringUtils;
+import org.databiosphere.workspacedataservice.shared.model.BackupResponse;
+import org.databiosphere.workspacedataservice.shared.model.CloneResponse;
 import org.databiosphere.workspacedataservice.shared.model.CloneStatus;
+import org.databiosphere.workspacedataservice.shared.model.job.Job;
 import org.databiosphere.workspacedataservice.shared.model.job.JobStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
 
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 @Repository
 public class PostgresCloneDao implements CloneDao {
+    @Value("${twds.instance.workspace-id:}")
+    private String workspaceId;
     private final NamedParameterJdbcTemplate namedTemplate;
 
     /*
@@ -48,9 +59,9 @@ public class PostgresCloneDao implements CloneDao {
     public void updateCloneEntryStatus(UUID trackingId, CloneStatus status) {
         try {
             var jobStatus = status.equals(CloneStatus.BACKUPSUCCEEDED) ? JobStatus.SUCCEEDED.name() : JobStatus.ERROR.name();
-            namedTemplate.getJdbcTemplate().update("update sys_wds.clone SET clonestatus = ?, status = ? where id = ?",
-                    status.name(), jobStatus, trackingId);
-            LOGGER.info("Clone status is now {}", status);
+            namedTemplate.getJdbcTemplate().update("update sys_wds.clone SET clonestatus = ?, status = ?, updatedtime = ? where id = ?",
+                    status.name(), jobStatus, Timestamp.from(Instant.now()), trackingId);
+            LOGGER.info("Clone status is now {} tracknig Id", status, trackingId);
         }
         catch (Exception e){
             terminateCloneToError(trackingId, e.getMessage());
@@ -63,5 +74,52 @@ public class PostgresCloneDao implements CloneDao {
         namedTemplate.getJdbcTemplate().update("update sys_wds.clone SET error = ? where id = ?",
                 StringUtils.abbreviate(error, 2000), trackingId);
         updateCloneEntryStatus(trackingId, CloneStatus.BACKUPERROR);
+    }
+
+    @Override
+    public Job<CloneResponse> getCloneStatus() {
+        List<Job<CloneResponse>> responses = namedTemplate.query(
+                "select id, status, error, createdtime, updatedtime, sourceworkspaceid, clonestatus from sys_wds.clone",
+                 new PostgresCloneDao.CloneJobRowMapper());
+        if (responses.size() == 1) {
+            return responses.get(0);
+        } else if (responses.isEmpty()) {
+            return null;
+        } else {
+            throw new RuntimeException("Unexpected error: %s rows found for backup status query".formatted(responses.size()));
+        }
+    }
+
+    // rowmapper for retrieving Job<BackupResponse> objects from the db
+    private static class CloneJobRowMapper implements RowMapper<Job<CloneResponse>> {
+        @Override
+        public Job<CloneResponse> mapRow(ResultSet rs, int rowNum) throws SQLException {
+            UUID sourceworksapceid = rs.getObject("sourceworkspaceid", UUID.class);
+            CloneStatus cloneStatus = CloneStatus.UNKNOWN;
+            String cloneStatusString = rs.getString("clonestatus");
+
+            UUID jobId = rs.getObject("id", UUID.class);
+            JobStatus status = JobStatus.UNKNOWN;
+            String dbStatus = rs.getString("status");
+            try {
+                status = JobStatus.valueOf(dbStatus);
+            } catch (Exception e) {
+                LOGGER.warn("Unknown status for backup job {}: [{}] with error {}", jobId, dbStatus, e.getMessage());
+            }
+
+            try {
+                cloneStatus = CloneStatus.valueOf(cloneStatusString);
+            } catch (Exception e) {
+                LOGGER.warn("Unknown status for clone job {}: [{}] with error {}", jobId, cloneStatus, e.getMessage());
+            }
+
+            CloneResponse cloneResponse = new CloneResponse(sourceworksapceid, cloneStatus);
+
+            String errorMessage = rs.getString("error");
+            LocalDateTime created = rs.getTimestamp("createdtime").toLocalDateTime();
+            LocalDateTime updated = rs.getTimestamp("updatedtime").toLocalDateTime();
+
+            return new Job<>(jobId, status, errorMessage, created, updated, cloneResponse);
+        }
     }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresCloneDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresCloneDao.java
@@ -61,7 +61,7 @@ public class PostgresCloneDao implements CloneDao {
             var jobStatus = status.equals(CloneStatus.BACKUPSUCCEEDED) ? JobStatus.SUCCEEDED.name() : JobStatus.ERROR.name();
             namedTemplate.getJdbcTemplate().update("update sys_wds.clone SET clonestatus = ?, status = ?, updatedtime = ? where id = ?",
                     status.name(), jobStatus, Timestamp.from(Instant.now()), trackingId);
-            LOGGER.info("Clone status is now {} tracknig Id", status, trackingId);
+            LOGGER.info("Clone status is now {}.", status);
         }
         catch (Exception e){
             terminateCloneToError(trackingId, e.getMessage());
@@ -104,13 +104,13 @@ public class PostgresCloneDao implements CloneDao {
             try {
                 status = JobStatus.valueOf(dbStatus);
             } catch (Exception e) {
-                LOGGER.warn("Unknown status for backup job {}: [{}] with error {}", jobId, dbStatus, e.getMessage());
+                LOGGER.warn("Unknown status for clone job {}: [{}] with error {}", jobId, dbStatus, e.getMessage());
             }
 
             try {
                 cloneStatus = CloneStatus.valueOf(cloneStatusString);
             } catch (Exception e) {
-                LOGGER.warn("Unknown status for clone job {}: [{}] with error {}", jobId, cloneStatus, e.getMessage());
+                LOGGER.warn("Unknown clone status for clone job {}: [{}] with error {}", jobId, cloneStatus, e.getMessage());
             }
 
             CloneResponse cloneResponse = new CloneResponse(sourceworksapceid, cloneStatus);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresCloneDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresCloneDao.java
@@ -76,6 +76,11 @@ public class PostgresCloneDao implements CloneDao {
         updateCloneEntryStatus(trackingId, CloneStatus.BACKUPERROR);
     }
 
+    /*
+       If a workspace starts up in clone mode, its overall state will be recorded in a single row, saving the source workspace id
+       along with the status of the cloning operations. If no data is returned by this function (i.e. null) it is safe to assume
+       that the following workspace was not created from a clone.
+     */
     @Override
     public Job<CloneResponse> getCloneStatus() {
         List<Job<CloneResponse>> responses = namedTemplate.query(

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresCloneDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresCloneDao.java
@@ -2,7 +2,6 @@ package org.databiosphere.workspacedataservice.dao;
 
 import bio.terra.common.db.WriteTransaction;
 import org.apache.commons.lang3.StringUtils;
-import org.databiosphere.workspacedataservice.shared.model.BackupResponse;
 import org.databiosphere.workspacedataservice.shared.model.CloneResponse;
 import org.databiosphere.workspacedataservice.shared.model.CloneStatus;
 import org.databiosphere.workspacedataservice.shared.model.job.Job;
@@ -99,7 +98,7 @@ public class PostgresCloneDao implements CloneDao {
     private static class CloneJobRowMapper implements RowMapper<Job<CloneResponse>> {
         @Override
         public Job<CloneResponse> mapRow(ResultSet rs, int rowNum) throws SQLException {
-            UUID sourceworksapceid = rs.getObject("sourceworkspaceid", UUID.class);
+            UUID sourceWorkspaceId = rs.getObject("sourceworkspaceid", UUID.class);
             CloneStatus cloneStatus = CloneStatus.UNKNOWN;
             String cloneStatusString = rs.getString("clonestatus");
 
@@ -118,7 +117,7 @@ public class PostgresCloneDao implements CloneDao {
                 LOGGER.warn("Unknown clone status for clone job {}: [{}] with error {}", jobId, cloneStatus, e.getMessage());
             }
 
-            CloneResponse cloneResponse = new CloneResponse(sourceworksapceid, cloneStatus);
+            CloneResponse cloneResponse = new CloneResponse(sourceWorkspaceId, cloneStatus);
 
             String errorMessage = rs.getString("error");
             LocalDateTime created = rs.getTimestamp("createdtime").toLocalDateTime();

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/BackupRestoreService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/BackupRestoreService.java
@@ -85,13 +85,7 @@ public class BackupRestoreService {
     }
 
     public Job<CloneResponse> checkCloneStatus() {
-        var cloneJob = cloneDao.getCloneStatus();
-
-        if (cloneJob == null) {
-            throw new MissingObjectException("Clone job");
-        }
-
-        return cloneJob;
+        return cloneDao.getCloneStatus();
     }
 
     public Job<BackupResponse> backupAzureWDS(String version, UUID trackingId, BackupRequest backupRequest) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/CloneResponse.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/CloneResponse.java
@@ -1,0 +1,11 @@
+package org.databiosphere.workspacedataservice.shared.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.databiosphere.workspacedataservice.shared.model.job.JobResult;
+
+import java.util.UUID;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record CloneResponse(UUID sourceWorkspaceId, CloneStatus status) implements JobResult {
+
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/CloneStatus.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/CloneStatus.java
@@ -4,6 +4,7 @@ package org.databiosphere.workspacedataservice.shared.model;
  * The various states encountered during cloning.
  */
 public enum CloneStatus {
+    UNKNOWN, // in case it cant be retrieved
     BACKUPQUEUED,     // backup job has been created but not yet started
     BACKUPSUCCEEDED,  // backup job completed as expected
     BACKUPERROR      // backup job failed

--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -925,7 +925,7 @@ components:
         sourceworkspaceid:
           type: string
           format: uuid
-          description: workspace which initiated the backup
+          description: workspace which initiated the clone
         clonestatus:
           type: string
           description: description of this clone status

--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -64,6 +64,23 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BackupJob'
+  /clone/{v}:
+    get:
+      tags:
+        - Cloning
+      parameters:
+        - $ref: '#/components/parameters/versionPathParam'
+      summary: Check status of a WDS data clone
+      operationId: getCloneStatus
+      security:
+        - bearerAuth: [ ]
+      responses:
+        200:
+          description: Returns clone status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CloneJob'
   /status:
     get:
       summary: Gets health status for WDS -- generated via Spring Boot Actuator (see https://docs.spring.io/spring-boot/docs/current/actuator-api/htmlsingle/#health for details)
@@ -617,6 +634,13 @@ components:
           properties:
             result:
               $ref: '#/components/schemas/BackupResponse'
+    CloneJob:
+      allOf:
+        - $ref: '#/components/schemas/Job'
+        - type: object
+          properties:
+            result:
+              $ref: '#/components/schemas/CloneResponse'
     BatchOperation:
       type: object
       required:
@@ -895,6 +919,16 @@ components:
         description:
           type: string
           description: description of this backup
+    CloneResponse:
+      type: object
+      properties:
+        sourceworkspaceid:
+          type: string
+          format: uuid
+          description: workspace which initiated the backup
+        clonestatus:
+          type: string
+          description: description of this clone status
     build:
       type: object
       properties:

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/MockCloneDao.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/MockCloneDao.java
@@ -1,13 +1,16 @@
 package org.databiosphere.workspacedataservice.dao;
 
 import bio.terra.common.db.WriteTransaction;
+import org.databiosphere.workspacedataservice.shared.model.CloneResponse;
 import org.databiosphere.workspacedataservice.shared.model.CloneStatus;
 import org.databiosphere.workspacedataservice.shared.model.job.Job;
 import org.databiosphere.workspacedataservice.shared.model.job.JobResult;
 import org.databiosphere.workspacedataservice.shared.model.job.JobStatus;
+import org.springframework.beans.factory.annotation.Value;
 
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.Comparator;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -16,20 +19,22 @@ import java.util.concurrent.ConcurrentHashMap;
  * Mock implementation of CloneDao that is in-memory instead of requiring Postgres
  */
 public class MockCloneDao implements CloneDao {
-    private final Set<Job<CloneEntry>> clone = ConcurrentHashMap.newKeySet();
+    @Value("${twds.instance.workspace-id:}")
+    private String workspaceId;
+    private final Set<Job<CloneResponse>> clone = ConcurrentHashMap.newKeySet();
     public MockCloneDao() {
         super();
     }
     @Override
     public boolean cloneExistsForWorkspace(UUID workspaceId)  {
-        return clone.stream().anyMatch(entry -> entry.getResult().sourceWorkspaceId.equals(workspaceId));
+        return clone.stream().anyMatch(entry -> entry.getResult().sourceWorkspaceId().equals(workspaceId));
     }
 
     @Override
     public void createCloneEntry(UUID trackingId, UUID sourceWorkspaceId) {
         Timestamp now = Timestamp.from(Instant.now());
-        var cloneEntry = new CloneEntry(sourceWorkspaceId, CloneStatus.BACKUPQUEUED);
-        Job<CloneEntry> jobEntry = new Job<>(trackingId, JobStatus.QUEUED, "", now.toLocalDateTime(), now.toLocalDateTime(), cloneEntry);
+        var cloneEntry = new CloneResponse(sourceWorkspaceId, CloneStatus.BACKUPQUEUED);
+        Job<CloneResponse> jobEntry = new Job<>(trackingId, JobStatus.QUEUED, "", now.toLocalDateTime(), now.toLocalDateTime(), cloneEntry);
         clone.add(jobEntry);
     }
 
@@ -38,7 +43,7 @@ public class MockCloneDao implements CloneDao {
         try {
             var cloneEntry = clone.stream().filter(entry -> entry.getJobId().equals(trackingId)).findFirst().orElse(null);
             clone.remove(cloneEntry);
-            cloneEntry.getResult().status = status;
+            cloneEntry.setResult(new CloneResponse(cloneEntry.getResult().sourceWorkspaceId(), status));
             cloneEntry.setStatus(JobStatus.SUCCEEDED);
             clone.add(cloneEntry);
         }
@@ -60,13 +65,9 @@ public class MockCloneDao implements CloneDao {
         updateCloneEntryStatus(trackingId, CloneStatus.BACKUPERROR);
     }
 
-    class CloneEntry implements JobResult {
-        public UUID sourceWorkspaceId;
-        public CloneStatus status;
-
-        public CloneEntry(UUID workspaceId, CloneStatus jobStatus) {
-            sourceWorkspaceId = workspaceId;
-            status = jobStatus;
-        }
+    @Override
+    public Job<CloneResponse> getCloneStatus() {
+        var cloneEntry = clone.stream().max(Comparator.comparing(entry -> entry.getUpdated())).orElse(null);
+        return cloneEntry;
     }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/MockCloneDao.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/MockCloneDao.java
@@ -19,8 +19,6 @@ import java.util.concurrent.ConcurrentHashMap;
  * Mock implementation of CloneDao that is in-memory instead of requiring Postgres
  */
 public class MockCloneDao implements CloneDao {
-    @Value("${twds.instance.workspace-id:}")
-    private String workspaceId;
     private final Set<Job<CloneResponse>> clone = ConcurrentHashMap.newKeySet();
     public MockCloneDao() {
         super();


### PR DESCRIPTION
This PR adds an api call that will expose the overall clone status - this specific call will be used by the terra ui to display the overall status of the cloning process. 


Reminder:

PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 
