### PR TITLE
AJ-1162: update pact libraries

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -5,7 +5,7 @@ plugins {
 	id 'org.sonarqube'
 	id 'com.gorylenko.gradle-git-properties'
 	id 'jacoco'
-	id "au.com.dius.pact" version "4.3.10"
+	id "au.com.dius.pact" version "4.6.1"
 	id 'jvm-test-suite'
 }
 
@@ -81,7 +81,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'
 	testImplementation project(':client')
-	testImplementation 'au.com.dius.pact.consumer:junit5:4.1.7'
+	testImplementation 'au.com.dius.pact.consumer:junit5:4.6.1'
 
 	constraints {
 		implementation('org.json:json:20230227') {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/pact/SamPactTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/pact/SamPactTest.java
@@ -179,7 +179,7 @@ class SamPactTest {
     }
 
     @Test
-    @PactTestFor(pactMethod = "userStatusPact")
+    @PactTestFor(pactMethod = "userStatusPact", pactVersion = PactSpecVersion.V3)
     void testSamServiceUserStatusInfo(MockServer mockServer) {
         SamClientFactory clientFactory = new HttpSamClientFactory(mockServer.getUrl());
         SamDao samDao = new HttpSamDao(clientFactory, new HttpSamClientSupport(), UUID.randomUUID().toString());
@@ -207,7 +207,7 @@ class SamPactTest {
     }
 
     @Test
-    @PactTestFor(pactMethod = "deletePermissionPact")
+    @PactTestFor(pactMethod = "deletePermissionPact", pactVersion = PactSpecVersion.V3)
     void testSamDeletePermission(MockServer mockServer) {
         SamClientFactory clientFactory = new HttpSamClientFactory(mockServer.getUrl());
         SamDao samDao = new HttpSamDao(clientFactory, new HttpSamClientSupport(), dummyResourceId);

--- a/service/src/test/java/org/databiosphere/workspacedataservice/pact/SamPactTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/pact/SamPactTest.java
@@ -5,6 +5,7 @@ import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
 import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
 import au.com.dius.pact.consumer.junit5.PactConsumerTestExt;
 import au.com.dius.pact.consumer.junit5.PactTestFor;
+import au.com.dius.pact.core.model.PactSpecVersion;
 import au.com.dius.pact.core.model.RequestResponsePact;
 import au.com.dius.pact.core.model.annotations.Pact;
 import org.broadinstitute.dsde.workbench.client.sam.model.SystemStatus;
@@ -158,7 +159,7 @@ class SamPactTest {
     }
 
     @Test
-    @PactTestFor(pactMethod = "statusApiPact")
+    @PactTestFor(pactMethod = "statusApiPact", pactVersion = PactSpecVersion.V3)
     void testSamServiceStatusCheck(MockServer mockServer) {
         SamClientFactory clientFactory = new HttpSamClientFactory(mockServer.getUrl());
         SamDao samDao = new HttpSamDao(clientFactory, new HttpSamClientSupport(), UUID.randomUUID().toString());
@@ -168,7 +169,7 @@ class SamPactTest {
     }
 
     @Test
-    @PactTestFor(pactMethod = "downStatusApiPact")
+    @PactTestFor(pactMethod = "downStatusApiPact", pactVersion = PactSpecVersion.V3)
     void testSamServiceDown(MockServer mockServer) {
         SamClientFactory clientFactory = new HttpSamClientFactory(mockServer.getUrl());
         SamDao samDao = new HttpSamDao(clientFactory, new HttpSamClientSupport(), UUID.randomUUID().toString());
@@ -187,7 +188,7 @@ class SamPactTest {
     }
 
     @Test
-    @PactTestFor(pactMethod = "noUserStatusPact")
+    @PactTestFor(pactMethod = "noUserStatusPact", pactVersion = PactSpecVersion.V3)
     void testSamServiceNoUser(MockServer mockServer) {
         SamClientFactory clientFactory = new HttpSamClientFactory(mockServer.getUrl());
         SamDao samDao = new HttpSamDao(clientFactory, new HttpSamClientSupport(), UUID.randomUUID().toString());
@@ -197,7 +198,7 @@ class SamPactTest {
     }
 
     @Test
-    @PactTestFor(pactMethod = "deleteNoPermissionPact")
+    @PactTestFor(pactMethod = "deleteNoPermissionPact", pactVersion = PactSpecVersion.V3)
     void testSamDeleteNoPermission(MockServer mockServer) {
         SamClientFactory clientFactory = new HttpSamClientFactory(mockServer.getUrl());
         SamDao samDao = new HttpSamDao(clientFactory, new HttpSamClientSupport(), dummyResourceId);
@@ -215,7 +216,7 @@ class SamPactTest {
     }
 
     @Test
-    @PactTestFor(pactMethod = "writeNoPermissionPact")
+    @PactTestFor(pactMethod = "writeNoPermissionPact", pactVersion = PactSpecVersion.V3)
     void testSamWriteNoPermission(MockServer mockServer) {
         SamClientFactory clientFactory = new HttpSamClientFactory(mockServer.getUrl());
         SamDao samDao = new HttpSamDao(clientFactory, new HttpSamClientSupport(), dummyResourceId);
@@ -224,7 +225,7 @@ class SamPactTest {
     }
 
     @Test
-    @PactTestFor(pactMethod = "writePermissionPact")
+    @PactTestFor(pactMethod = "writePermissionPact", pactVersion = PactSpecVersion.V3)
     void testSamWritePermission(MockServer mockServer) {
         SamClientFactory clientFactory = new HttpSamClientFactory(mockServer.getUrl());
         SamDao samDao = new HttpSamDao(clientFactory, new HttpSamClientSupport(), dummyResourceId);


### PR DESCRIPTION
This updates the pact libraries to latest, which requires minor changes to the pact tests. We originally did this in #262 but rolled it back because pact tests were failing. We found the failure cause, which was NOT due to the library update. Now that the pact tests are passing, let's revisit this upgrade.

This should address dependabot issues about `xercesImpl`.

---

Reminder:

PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 
