### PR TITLE
AJ-1162: update guava

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -50,7 +50,7 @@ dependencies {
 	implementation 'org.springframework.retry:spring-retry:1.3.4'
 	implementation 'org.aspectj:aspectjweaver:1.8.9' // required by spring-retry, not used directly by WDS
 	implementation 'org.apache.commons:commons-lang3'
-	implementation 'com.google.guava:guava:31.1-jre'
+	implementation 'com.google.guava:guava:32.1.1-jre'
 	implementation 'org.postgresql:postgresql'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.webjars:webjars-locator-core:0.52'


### PR DESCRIPTION
updates our `guava` dependency to latest. This should address dependabot warnings.

---

Reminder:

PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 
