### PR TITLE
AJ-1162: use Java 17 for dependency submissions

### DIFF
--- a/.github/workflows/submit-dependencies.yml
+++ b/.github/workflows/submit-dependencies.yml
@@ -14,6 +14,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'gradle'
+
       - name: Submit Dependencies
         uses: mikepenz/gradle-dependency-submission@v0.9.0
         with:


### PR DESCRIPTION
I think I know why our dependency submission action is failing (example [here](https://github.com/DataBiosphere/terra-workspace-data-service/actions/runs/5556695260/jobs/10149531709)):

* the new pact libraries from #300 require Java 17
* the dependency submission action was running on Java 11 and thus can't inspect the new pact libraries.

The key line in the error message is "The consumer was configured to find a library for use during runtime, **_compatible with Java 11_**…"

This PR runs the dependency submission action using Java 17.


---

Reminder:

PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 
