### PR TITLE
AJ-1162: update okhttp and okio

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -65,7 +65,7 @@ dependencies {
 	// Terra libraries
 	implementation group: 'org.broadinstitute.dsde.workbench', name: 'sam-client_2.13', version: '0.1-08b6588'
 	implementation group: 'org.broadinstitute.dsde.workbench', name: 'leonardo-client_2.11', version: '1.3.5-1be4da6-SNAP'
-	implementation 'com.squareup.okhttp3:okhttp:4.10.0' // required by Sam client
+	implementation 'com.squareup.okhttp3:okhttp:4.11.0' // required by Sam client
 	implementation "bio.terra:datarepo-client:1.476.0-SNAPSHOT"
 	implementation "bio.terra:workspace-manager-client:0.254.717-SNAPSHOT"
 	implementation project(path: ':client')
@@ -86,6 +86,9 @@ dependencies {
 	constraints {
 		implementation('org.json:json:20230227') {
 			because("CVE-2022-45688")
+		}
+		implementation('com.squareup.okio:okio:3.4.0') {
+			because("CVE-2023-3635")
 		}
 	}
 }


### PR DESCRIPTION
This PR addresses proactive dependabot warnings on `com.squareup.okio:okio`.

`com.squareup.okio:okio` is a transitive dependency of `com.squareup.okhttp3:okhttp`.

This PR updates our direct dependency on `com.squareup.okhttp3:okhttp` to latest, then sets a transitive constraint to update `com.squareup.okio:okio` to the version recommended by dependabot.

---

Reminder:

PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 
