### PR TITLE
AJ-1162: update netty-handler and azure libs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ subprojects {
             dependency 'io.swagger.core.v3:swagger-annotations:2.1.13'
             dependency 'io.swagger.codegen.v3:swagger-codegen-cli:3.0.34'
             dependency 'org.yaml:snakeyaml:2.0'
+            dependency 'io.netty:netty-handler:4.1.94.Final'
         }
     }
 

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -38,10 +38,10 @@ ext {
 
 dependencies {
 	// Azure libraries
-	implementation 'com.microsoft.azure:applicationinsights-runtime-attach:3.4.9'
-	implementation 'com.azure:azure-storage-blob:12.18.0'
-	implementation 'com.azure:azure-identity:1.9.1' // authentication in azure environment
-	implementation 'com.azure:azure-identity-extensions:1.1.4' // postgres password plugin
+	implementation 'com.microsoft.azure:applicationinsights-runtime-attach:3.4.14'
+	implementation 'com.azure:azure-storage-blob:12.23.0'
+	implementation 'com.azure:azure-identity:1.9.2' // authentication in azure environment
+	implementation 'com.azure:azure-identity-extensions:1.1.5' // postgres password plugin
 
 	implementation 'org.springframework.boot:spring-boot-starter'
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'


### PR DESCRIPTION
This PR addresses proactive dependabot warnings on `io.netty:netty-handler`.

`io.netty:netty-handler` is a transitive dependency of our three `com.azure` libraries.

This PR updates our direct dependency on our three `com.azure` libraries to latest, then sets a [Spring Dependency Management override](`io.netty:netty-handler`) to update `io.netty:netty-handler` to the version recommended by dependabot.

Finally, this PR also updates `com.microsoft.azure:applicationinsights-runtime-attach` to latest. Even though this lib does NOT have `netty-handler` as a transitive dependency, since I was updating the other Azure libs I figured I'd update this one too.

---

Reminder:

PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 
