### PR TITLE
AJ-961 - Insert instance record into sys_wds vs updating

### DIFF
--- a/service/src/integrationTest/java/org/databiosphere/workspacedataservice/service/RestoreServiceIntegrationTest.java
+++ b/service/src/integrationTest/java/org/databiosphere/workspacedataservice/service/RestoreServiceIntegrationTest.java
@@ -68,6 +68,8 @@ public class RestoreServiceIntegrationTest {
         var response = backupRestoreService.restoreAzureWDS("v0.2", "backup.sql", UUID.randomUUID(), "");
         assertSame(JobStatus.SUCCEEDED, response.getStatus());
 
+        instanceDao.dropInstanceFromSyswds(sourceInstance);
+
         // after restore, confirm destination instance exists but source does not
         List<UUID> instancesAfter = instanceDao.listInstanceSchemas();
         assertThat(instancesAfter).contains(destInstance);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/InstanceDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/InstanceDao.java
@@ -13,4 +13,5 @@ public interface InstanceDao {
     void dropSchema(UUID instanceId);
 
     void alterSchema(UUID sourceWorkspaceId, UUID workspaceId);
+    void dropInstanceFromSyswds(UUID instanceId);
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresInstanceDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresInstanceDao.java
@@ -61,6 +61,6 @@ public class PostgresInstanceDao implements InstanceDao {
     @SuppressWarnings("squid:S2077") // since instanceId must be a UUID, it is safe to use inline
     public void alterSchema(UUID sourceWorkspaceId, UUID workspaceId) {
         namedTemplate.getJdbcTemplate().update("alter schema " + quote(sourceWorkspaceId.toString()) + " rename to " + quote(workspaceId.toString()));
-        namedTemplate.getJdbcTemplate().update("update sys_wds.instance set id = ? where id = ?", workspaceId, sourceWorkspaceId);
+        namedTemplate.getJdbcTemplate().update("insert into sys_wds.instance(id) values (?)", workspaceId);
     }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresInstanceDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresInstanceDao.java
@@ -63,4 +63,8 @@ public class PostgresInstanceDao implements InstanceDao {
         namedTemplate.getJdbcTemplate().update("alter schema " + quote(sourceWorkspaceId.toString()) + " rename to " + quote(workspaceId.toString()));
         namedTemplate.getJdbcTemplate().update("insert into sys_wds.instance(id) values (?)", workspaceId);
     }
+
+    public void dropInstanceFromSyswds(UUID instanceId) {
+        namedTemplate.getJdbcTemplate().update("delete from sys_wds.instance where id = ?", instanceId);
+    }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/MockInstanceDao.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/MockInstanceDao.java
@@ -64,4 +64,8 @@ public class MockInstanceDao implements InstanceDao {
         instances.remove(sourceWorkspaceId);
         instances.add(workspaceId);
     }
+
+    public void dropInstanceFromSyswds(UUID instanceId) {
+        // doesnt really apply in the concept of mock instance dao since there is no sys-wds
+    }
 }


### PR DESCRIPTION
Slight change from ealier behavior where we were still copying sys-wds over - now that we are not, when we alter schema name, we need to insert schema record  (that UI uses to display tables) into sys_wds.instances. 

Tested in a BEE and cloning works!!! 

Reminder:

PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 
