### PR TITLE
AJ-1181: dont materialize process streams

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/process/LocalProcessLauncher.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/process/LocalProcessLauncher.java
@@ -59,37 +59,16 @@ public class LocalProcessLauncher {
         }
     }
 
-    /**
-     * Method to stream the child process' output to a string.
-     *
-     * @param fromStream specifies which stream will be read from
-     */
-    private String getOutputForProcessFromStream(InputStream fromStream) {
-        try (BufferedReader bufferedReader =
-                     new BufferedReader(new InputStreamReader(fromStream, StandardCharsets.UTF_8))) {
-
-            String line;
-            StringBuilder processOutput = new StringBuilder();
-            while ((line = bufferedReader.readLine()) != null) {
-                processOutput.append(line).append(System.lineSeparator());
-            }
-
-            return processOutput.toString().trim();
-        } catch (IOException ioEx) {
-            throw new LaunchProcessException("Error streaming output of child process", ioEx);
-        }
-    }
-
     /** Stream standard out/err from the child process to the CLI console.
      *
      *  @param type specifies which process stream to get data from
      * */
-    public String getOutputForProcess(Output type) {
+    public InputStream getOutputForProcess(Output type) {
         if (type == Output.ERROR) {
-            return getOutputForProcessFromStream(process.getErrorStream());
+            return process.getErrorStream();
         }
 
-        return getOutputForProcessFromStream(process.getInputStream());
+        return process.getInputStream();
     }
 
     /** Block until the child process terminates, then return its exit code. */

--- a/service/src/test/java/org/databiosphere/workspacedataservice/process/LocalProcessLaunchTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/process/LocalProcessLaunchTest.java
@@ -3,6 +3,7 @@ package org.databiosphere.workspacedataservice.process;
 import org.databiosphere.workspacedataservice.service.model.exception.LaunchProcessException;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -30,7 +31,7 @@ class LocalProcessLaunchTest {
     }
 
     @Test
-    void runSimpleCommandWithEnvs() {
+    void runSimpleCommandWithEnvs() throws IOException {
         List<String> processCommand = new ArrayList<>();
         Map<String, String> envVars = new HashMap<>();
         envVars.put("TEST_VARIABLE", "Hello World");
@@ -43,8 +44,12 @@ class LocalProcessLaunchTest {
         localProcessLauncher.launchProcess(processCommand, envVars);
 
         // stream the output to stdout/err
-        String output = localProcessLauncher.getOutputForProcess(LocalProcessLauncher.Output.OUT);
-        String error = localProcessLauncher.getOutputForProcess(LocalProcessLauncher.Output.ERROR);
+        String output = new String(
+                localProcessLauncher.getOutputForProcess(LocalProcessLauncher.Output.OUT)
+                        .readAllBytes()).trim();
+        String error = new String(
+                localProcessLauncher.getOutputForProcess(LocalProcessLauncher.Output.ERROR)
+                        .readAllBytes()).trim();
 
         // block until the child process exits
         int exitCode = localProcessLauncher.waitForTerminate();


### PR DESCRIPTION
Do not transform the entire stdout or stderr from LocalProcessLauncher into a String. Ensure the out/error streams stay as streams until we need to look at them.

In BackupRestoreService, when checking for the error output, limit the output to 1024 bytes.