### PR TITLE
AJ-1069: JsonStreamWriteHandler features-enabled unit test

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/JsonStreamWriteHandler.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/JsonStreamWriteHandler.java
@@ -27,8 +27,7 @@ public class JsonStreamWriteHandler implements StreamingWriteHandler {
 
 	public JsonStreamWriteHandler(InputStream inputStream, ObjectMapper objectMapper) throws IOException {
 		this.inputStream = inputStream;
-		JsonFactory factory = new JsonFactory(objectMapper.copy());
-		parser = factory.createParser(inputStream);
+		parser = objectMapper.copy().tokenStreamFactory().createParser(inputStream);
 		if (parser.nextToken() != JsonToken.START_ARRAY) {
 			throw new IllegalArgumentException("Expected content to be an array");
 		}
@@ -75,5 +74,9 @@ public class JsonStreamWriteHandler implements StreamingWriteHandler {
 		inputStream.close();
 	}
 
+	// Exposed (as protected, not public) to assist with unit tests.
+	protected JsonParser getParser() {
+		return this.parser;
+	}
 
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/JsonStreamWriteHandlerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/JsonStreamWriteHandlerTest.java
@@ -1,0 +1,47 @@
+package org.databiosphere.workspacedataservice.service;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DirtiesContext
+@SpringBootTest(classes = { JsonConfig.class })
+public class JsonStreamWriteHandlerTest {
+
+    @Autowired
+    ObjectMapper objectMapper; // as defined in JsonConfig
+
+    private static Stream<Arguments> parserFeatures() {
+        return Arrays.stream(JsonParser.Feature.values()).map(Arguments::of);
+    }
+
+    // test that JsonStreamWriteHandler has the same JsonParser features enabled
+    // as the main ObjectMapper from JsonConfig
+    @ParameterizedTest(name = "JsonParser feature {0} should be same in ObjectMapper and JsonParser")
+    @MethodSource("parserFeatures")
+    void parserConfig(JsonParser.Feature feature) throws IOException {
+        // fake json input needs to start with "[", or creating the JsonStreamWriteHandler will fail
+        String streamContents = "[]";
+        InputStream is = new ByteArrayInputStream(streamContents.getBytes());
+
+        JsonStreamWriteHandler handler = new JsonStreamWriteHandler(is, objectMapper);
+
+        boolean expected = objectMapper.isEnabled(feature);
+        boolean actual = handler.getParser().isEnabled(feature);
+        assertEquals(expected, actual, "for feature " + feature.name());
+    }
+
+}


### PR DESCRIPTION
part of AJ-1069 but does not complete that ticket.

While evaluating AJ-1069 as a good ramp-up ticket for new developers, I found an inconsistency in our JSON batch-write API: the `JsonParser` used for batch-write does not fully inherit its configuration from the `ObjectMapper` definition in `JsonConfig`. This PR fixes that, so it inherits features correctly.

I am pushing this PR through to make AJ-1069 easier and more focused on ramp-up instead of digging through ugly Jackson internals.