### PR TITLE
AJ-1095: Add Java-PFB import and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ export LEONARDO_URL=https://leonardo.dsde-dev.broadinstitute.org/
 ```
 ##### WORKSPACE_ID
 
-WDS requires a valid workspace id to check permissions in Sam and to import snapshots from the Terra Daa Repo.
+WDS requires a valid workspace id to check permissions in Sam and to import snapshots from the Terra Data Repo.
 This is controlled by a `WORKSPACE_ID` environment variable. You should set this to the UUID
 of a workspace you own, e.g.
 ```

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -69,7 +69,7 @@ dependencies {
 	implementation 'com.squareup.okhttp3:okhttp:4.11.0' // required by Sam client
 	implementation "bio.terra:datarepo-client:1.476.0-SNAPSHOT"
 	implementation "bio.terra:workspace-manager-client:0.254.717-SNAPSHOT"
-	implementation "bio.terra:java-pfb-library:0.1.0-SNAPSHOT"
+	implementation "bio.terra:java-pfb-library:0.5.0"
 	implementation project(path: ':client')
 
 	// hk2 is required to use WSM client, but not correctly exposed by the client

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -69,6 +69,7 @@ dependencies {
 	implementation 'com.squareup.okhttp3:okhttp:4.11.0' // required by Sam client
 	implementation "bio.terra:datarepo-client:1.476.0-SNAPSHOT"
 	implementation "bio.terra:workspace-manager-client:0.254.717-SNAPSHOT"
+	implementation "bio.terra:java-pfb-library:0.1.0-SNAPSHOT"
 	implementation project(path: ':client')
 
 	// hk2 is required to use WSM client, but not correctly exposed by the client

--- a/service/src/test/java/org/databiosphere/workspacedataservice/pfb/PfbParsingTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/pfb/PfbParsingTest.java
@@ -1,0 +1,20 @@
+package org.databiosphere.workspacedataservice.pfb;
+
+import static org.springframework.test.util.AssertionErrors.assertEquals;
+
+import bio.terra.pfb.Library;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+
+
+@DirtiesContext
+@SpringBootTest
+class PfbParsingTest {
+
+    @Test
+    void testPFBHelloWorld() {
+        int valReturned = Library.getNumber5();
+        assertEquals("PFB Hello World", valReturned, 5);
+    }
+}


### PR DESCRIPTION
As a part of the work to publish the java-pfb library, this PR adds a test to prove that the library is correctly published and that we can use the methods from java-pfb in WDS!

Review Request:
-> Does the location of the test make sense?