### PR TITLE
AJ-1078 Enable Liveness and Readiness

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/logging/AvailabilityListener.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/logging/AvailabilityListener.java
@@ -1,0 +1,42 @@
+package org.databiosphere.workspacedataservice.logging;
+
+import org.springframework.boot.availability.LivenessState;
+import org.springframework.boot.availability.ReadinessState;
+import org.springframework.boot.availability.AvailabilityChangeEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Component
+public class AvailabilityListener {
+    private static Logger logger = LoggerFactory.getLogger(AvailabilityListener.class);
+
+    @EventListener
+    public void onLivenessEvent(AvailabilityChangeEvent<LivenessState> event) {
+        switch (event.getState()) {
+            case BROKEN:
+                logger.error("LivenessState: {}", event.getState());
+                break;
+            case CORRECT:
+                logger.debug("LivenessState: {}", event.getState());
+                break;
+            default:
+                logger.error("LivenessState {} is not a known state", event.getState());
+        }
+    }
+
+    @EventListener
+    public void onReadinessEvent(AvailabilityChangeEvent<ReadinessState> event) {
+        switch (event.getState()) {
+            case REFUSING_TRAFFIC:
+                logger.error("ReadinessState: {}", event.getState());
+                break;
+            case ACCEPTING_TRAFFIC:
+                logger.debug("ReadinessState: {}", event.getState());
+                break;
+            default:
+                logger.error("ReadinessState {} is not a known state", event.getState());
+        }
+    }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/logging/AvailabilityListener.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/logging/AvailabilityListener.java
@@ -19,7 +19,7 @@ public class AvailabilityListener {
                 logger.error("LivenessState: {}", event.getState());
                 break;
             case CORRECT:
-                logger.debug("LivenessState: {}", event.getState());
+                logger.info("LivenessState: {}", event.getState());
                 break;
             default:
                 logger.error("LivenessState {} is not a known state", event.getState());
@@ -33,7 +33,7 @@ public class AvailabilityListener {
                 logger.error("ReadinessState: {}", event.getState());
                 break;
             case ACCEPTING_TRAFFIC:
-                logger.debug("ReadinessState: {}", event.getState());
+                logger.info("ReadinessState: {}", event.getState());
                 break;
             default:
                 logger.error("ReadinessState {} is not a known state", event.getState());

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -17,8 +17,7 @@ management.endpoints.web.base-path=/
 management.endpoints.web.path-mapping.info=version
 management.endpoints.web.path-mapping.health=status
 management.endpoint.health.show-details=ALWAYS
-management.health.livenessstate.enabled=true
-management.health.readinessstate.enabled=true
+management.endpoint.health.group.liveness.include=livenessstate,db
 
 # additional keys to expose in the actuator info endpoint:
 management.info.env.enabled=true

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -17,7 +17,7 @@ management.endpoints.web.base-path=/
 management.endpoints.web.path-mapping.info=version
 management.endpoints.web.path-mapping.health=status
 management.endpoint.health.show-details=ALWAYS
-management.endpoint.health.group.liveness.include=livenessstate,db
+management.endpoint.health.group.liveness.include=livenessState,db
 
 # additional keys to expose in the actuator info endpoint:
 management.info.env.enabled=true

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -11,11 +11,15 @@ env.wds.db.additionalUrlParams=${ADDITIONAL_JDBC_URL_PARAMS:}
 management.endpoints.enabled-by-default=false
 management.endpoint.info.enabled=true
 management.endpoint.health.enabled=true
+management.endpoint.health.probes.enabled=true
 management.endpoints.web.exposure.include=info,health
 management.endpoints.web.base-path=/
 management.endpoints.web.path-mapping.info=version
 management.endpoints.web.path-mapping.health=status
 management.endpoint.health.show-details=ALWAYS
+management.health.livenessstate.enabled=true
+management.health.readinessstate.enabled=true
+
 # additional keys to expose in the actuator info endpoint:
 management.info.env.enabled=true
 info.app.chart-version=${HELM_CHART:unknown}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/AvailabilityTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/AvailabilityTest.java
@@ -18,7 +18,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @AutoConfigureMockMvc
-//@SpringBootTest(classes = {SpringRunner.class})
 @SpringBootTest
 public class AvailabilityTest {
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/AvailabilityTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/AvailabilityTest.java
@@ -19,7 +19,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @AutoConfigureMockMvc
 @SpringBootTest
-public class AvailabilityTest {
+class AvailabilityTest {
 
     @Autowired
     private MockMvc mvc;
@@ -30,7 +30,7 @@ public class AvailabilityTest {
 
     //Reference: https://www.baeldung.com/spring-liveness-readiness-probes
     @Test
-    public void readinessState() throws Exception {
+    void readinessState() throws Exception {
         assertThat(applicationAvailability.getReadinessState()).isEqualTo(ReadinessState.ACCEPTING_TRAFFIC);
         ResultActions readinessResult = mvc.perform(get("/status/readiness"));
         readinessResult.andExpect(status().isOk())
@@ -44,7 +44,7 @@ public class AvailabilityTest {
     }
 
     @Test
-    public void livenessState() throws Exception {
+    void livenessState() throws Exception {
         assertThat(applicationAvailability.getLivenessState()).isEqualTo(LivenessState.CORRECT);
         ResultActions result = mvc.perform(get("/status/liveness"));
         result.andExpect(status().isOk())

--- a/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/AvailabilityTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/AvailabilityTest.java
@@ -1,0 +1,63 @@
+package org.databiosphere.workspacedataservice.activitylog;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.availability.ReadinessState;
+import org.springframework.boot.availability.LivenessState;
+import org.springframework.boot.availability.ApplicationAvailability;
+import org.springframework.boot.availability.AvailabilityChangeEvent;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.context.ApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@AutoConfigureMockMvc
+//@SpringBootTest(classes = {SpringRunner.class})
+@SpringBootTest
+public class AvailabilityTest {
+
+    @Autowired
+    private MockMvc mvc;
+    @Autowired
+    private ApplicationContext context;
+    @Autowired
+    private ApplicationAvailability applicationAvailability;
+
+    //Reference: https://www.baeldung.com/spring-liveness-readiness-probes
+    @Test
+    public void readinessState() throws Exception {
+        assertThat(applicationAvailability.getReadinessState()).isEqualTo(ReadinessState.ACCEPTING_TRAFFIC);
+        ResultActions readinessResult = mvc.perform(get("/status/readiness"));
+        readinessResult.andExpect(status().isOk())
+            .andExpect(jsonPath("$.status").value("UP"));
+
+        AvailabilityChangeEvent.publish(context, ReadinessState.REFUSING_TRAFFIC);
+        assertThat(applicationAvailability.getReadinessState()).isEqualTo(ReadinessState.REFUSING_TRAFFIC);
+        mvc.perform(get("/status/readiness"))
+           .andExpect(status().isServiceUnavailable())
+            .andExpect(jsonPath("$.status").value("OUT_OF_SERVICE"));
+    }
+
+    @Test
+    public void livenessState() throws Exception {
+        assertThat(applicationAvailability.getLivenessState()).isEqualTo(LivenessState.CORRECT);
+        ResultActions result = mvc.perform(get("/status/liveness"));
+        result.andExpect(status().isOk())
+            .andExpect(jsonPath("$.status").value("UP"));
+        ResultActions livenessResult = mvc.perform(get("/status/liveness"));
+        livenessResult.andExpect(status().isOk())
+            .andExpect(jsonPath("$.status").value("UP"));
+
+        AvailabilityChangeEvent.publish(context, LivenessState.BROKEN);
+        assertThat(applicationAvailability.getLivenessState()).isEqualTo(LivenessState.BROKEN);
+        mvc.perform(get("/status/liveness"))
+            .andExpect(status().isServiceUnavailable())
+            .andExpect(jsonPath("$.status").value("DOWN"));
+    }
+}


### PR DESCRIPTION
This PR enables Liveness and Readiness built into SpringBoot to enable our app to communicate with K8. 
Listener and tests inspired by: https://github.com/DataBiosphere/jade-data-repo/pull/670
Confirmed this works in a BEE
Sister PR helm file change: https://github.com/broadinstitute/terra-helmfile/pull/4413

-----------------------
Reminder:

PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 
