### PR TITLE
AJ-1187: WDS only needs one connection pool

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -47,6 +47,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-cache'
+	implementation 'org.springframework.boot:spring-boot-starter-batch'
 	implementation 'org.springframework.retry:spring-retry:1.3.4'
 	implementation 'org.aspectj:aspectjweaver:1.8.9' // required by spring-retry, not used directly by WDS
 	implementation 'org.apache.commons:commons-lang3'

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/DataSourceConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/DataSourceConfig.java
@@ -28,25 +28,4 @@ public class DataSourceConfig {
         return new NamedParameterJdbcTemplate(mainDb());
     }
 
-    @Bean
-    @Qualifier("streamingDs")
-    @ConfigurationProperties("streaming.query")
-    public DataSource streamingDs() {
-        DataSource ds = DataSourceBuilder.create().build();
-        HikariDataSource hikariDataSource = (HikariDataSource) ds;
-        // https://jdbc.postgresql.org/documentation/query/#getting-results-based-on-a-cursor
-        hikariDataSource.setAutoCommit(false);
-        return hikariDataSource;
-    }
-
-    @Bean
-    @Qualifier("streamingDs")
-    public NamedParameterJdbcTemplate templateForStreaming(@Qualifier("streamingDs") DataSource ds,
-                                                           @Value("${twds.streaming.fetch.size:5000}") int fetchSize) {
-        NamedParameterJdbcTemplate jdbcTemplate = new NamedParameterJdbcTemplate(ds);
-        // https://jdbc.postgresql.org/documentation/query/#getting-results-based-on-a-cursor
-        jdbcTemplate.getJdbcTemplate().setFetchSize(fetchSize);
-        return jdbcTemplate;
-    }
-
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -394,8 +394,7 @@ public class RecordDao {
 		// 		- the connection must have autocommit=off
 		//		- the statement must use forward-only fetching (which is the default)
 		//		- the statement must have a positive fetch size
-		JdbcCursorItemReaderBuilder<Record> builder = new JdbcCursorItemReaderBuilder<>();
-		JdbcCursorItemReader<Record> itemReader = builder
+		JdbcCursorItemReader<Record> itemReader = new JdbcCursorItemReaderBuilder<Record>()
 				.dataSource(mainDb)
 				.connectionAutoCommit(false)
 				.fetchSize(fetchSize)

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -804,5 +804,4 @@ public class RecordDao {
 			throw e;
 		}
 	}
-
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -372,6 +372,7 @@ public class RecordDao {
 	}
 
 
+	@SuppressWarnings("squid:S2077") // sql statement has been manually reviewed
 	public Stream<Record> streamAllRecordsForType(UUID instanceId, RecordType recordType) {
 		// return a Stream of all records of a given type.
 		// this implementation MUST stream, to avoid materializing large result sets and

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -25,10 +25,6 @@ spring.datasource.jdbc-url=jdbc:postgresql://${env.wds.db.host}:${env.wds.db.por
 spring.datasource.username=${env.wds.db.user}
 spring.datasource.password=${env.wds.db.password}
 
-streaming.query.jdbc-url=${spring.datasource.jdbc-url}
-streaming.query.username=${spring.datasource.username}
-streaming.query.password=${spring.datasource.password}
-
 # Ensure data.sql is NOT run on startup
 spring.sql.init.mode=never
 # Run Liquibase instead

--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -976,8 +976,6 @@ components:
           $ref: '#/components/schemas/component'
         mainDb:
           $ref: '#/components/schemas/dbValidationcomponent'
-        streamingDs:
-          $ref: '#/components/schemas/dbValidationcomponent'
     component:
       type: object
       properties:

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -58,10 +57,6 @@ class RecordDaoTest {
 
 	@Autowired
 	NamedParameterJdbcTemplate namedTemplate;
-
-	@Autowired
-	@Qualifier("streamingDs")
-	NamedParameterJdbcTemplate templateForStreaming;
 
 	@Autowired
 	DataTypeInferer dataTypeInferer;


### PR DESCRIPTION
Combine WDS's two connection pools into one, thereby halving the number of db connections WDS requires. Preserve the capability to stream TSV downloads from Postgres to the end user.

I verified that WDS still uses cursors/streams to query Postgres by setting `-c log_statement=all` on my local Postgres docker image and watching what queries were actually executed. I also verified that the autocommit value was set back to true by cranking up logging levels for `com.zaxxer.hikari.HikariConfig` and `com.zaxxer.hikari`.

I cannot figure out how to unit test the low-level cursor behavior of the JDBC driver. This PR turns on features that are implemented in libraries. I would love to hear ideas on how to test!

High-level changes in this PR:
* add Spring Batch for its `JdbcCursorItemReader`, which manages the Postgres cursor query
* remove the "streamingDs" datasource and connection pool
* reimplement `RecordDao.streamAllRecordsForType()` using Spring Batch


