### PR TITLE
AJ-1186 DB Connection Pool Size

### DIFF
--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -24,6 +24,7 @@ info.app.image=${WDS_IMAGE:unknown}
 spring.datasource.jdbc-url=jdbc:postgresql://${env.wds.db.host}:${env.wds.db.port}/${env.wds.db.name}?reWriteBatchedInserts=true&${env.wds.db.additionalUrlParams}
 spring.datasource.username=${env.wds.db.user}
 spring.datasource.password=${env.wds.db.password}
+spring.datasource.maximumPoolSize=7
 
 streaming.query.jdbc-url=${spring.datasource.jdbc-url}
 streaming.query.username=${spring.datasource.username}

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -25,7 +25,7 @@ spring.datasource.jdbc-url=jdbc:postgresql://${env.wds.db.host}:${env.wds.db.por
 spring.datasource.username=${env.wds.db.user}
 spring.datasource.password=${env.wds.db.password}
 spring.datasource.maximumPoolSize=7
-spring.datasource.minimumIdle=2
+spring.datasource.minimumIdle=7
 
 streaming.query.jdbc-url=${spring.datasource.jdbc-url}
 streaming.query.username=${spring.datasource.username}

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -25,6 +25,7 @@ spring.datasource.jdbc-url=jdbc:postgresql://${env.wds.db.host}:${env.wds.db.por
 spring.datasource.username=${env.wds.db.user}
 spring.datasource.password=${env.wds.db.password}
 spring.datasource.maximumPoolSize=7
+spring.datasource.minimumIdle=2
 
 streaming.query.jdbc-url=${spring.datasource.jdbc-url}
 streaming.query.username=${spring.datasource.username}


### PR DESCRIPTION
See https://broadworkbench.atlassian.net/browse/AJ-1186
The default connection pool size for Spring/Hikari is 10.  It's not clear that WDS needs that many connections.  
Some informal testing with different pool sizes under load (greater load than we generally expect to have in real life, ~20 users all uploading files at once), I generally saw no more than 8 connections being used at a time.  (We seemed to hit limits in the relay listener before we hit limits in the DB).  Using only 6 connections seemed to result in only 1-2 pending at a time, leading me to select 7 as a rough estimate of a reasonable max pool size.


Reminder:

PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 
