### PR TITLE
AJ-1187: use Hikari properties; bean initialization

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/DataSourceConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/DataSourceConfig.java
@@ -17,15 +17,15 @@ public class DataSourceConfig {
 
     @Bean
     @Primary
-    @ConfigurationProperties("spring.datasource")
+    @ConfigurationProperties("spring.datasource.hikari")
     public DataSource mainDb() {
         return DataSourceBuilder.create().build();
     }
 
     @Bean
     @Primary
-    public NamedParameterJdbcTemplate namedParameterJdbcTemplate() {
-        return new NamedParameterJdbcTemplate(mainDb());
+    public NamedParameterJdbcTemplate namedParameterJdbcTemplate(DataSource dataSource) {
+        return new NamedParameterJdbcTemplate(dataSource);
     }
 
 }

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -21,11 +21,11 @@ management.info.env.enabled=true
 info.app.chart-version=${HELM_CHART:unknown}
 info.app.image=${WDS_IMAGE:unknown}
 
-spring.datasource.jdbc-url=jdbc:postgresql://${env.wds.db.host}:${env.wds.db.port}/${env.wds.db.name}?reWriteBatchedInserts=true&${env.wds.db.additionalUrlParams}
-spring.datasource.username=${env.wds.db.user}
-spring.datasource.password=${env.wds.db.password}
-spring.datasource.maximumPoolSize=7
-spring.datasource.minimumIdle=7
+spring.datasource.hikari.jdbc-url=jdbc:postgresql://${env.wds.db.host}:${env.wds.db.port}/${env.wds.db.name}?reWriteBatchedInserts=true&${env.wds.db.additionalUrlParams}
+spring.datasource.hikari.username=${env.wds.db.user}
+spring.datasource.hikari.password=${env.wds.db.password}
+spring.datasource.hikari.maximum-pool-size=7
+spring.datasource.hikari.minimum-idle=7
 
 # Ensure data.sql is NOT run on startup
 spring.sql.init.mode=never

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -27,6 +27,10 @@ spring.datasource.hikari.password=${env.wds.db.password}
 spring.datasource.hikari.maximum-pool-size=7
 spring.datasource.hikari.minimum-idle=7
 
+# set hikari logging to DEBUG or even TRACE to troubleshoot connection pool issues
+logging.level.com.zaxxer.hikari.HikariConfig=INFO
+logging.level.com.zaxxer.hikari=INFO
+
 # Ensure data.sql is NOT run on startup
 spring.sql.init.mode=never
 # Run Liquibase instead


### PR DESCRIPTION
A bit of cleanup after #317 and #313 ...

* Use `spring.datasource.hikari.*` properties instead of `spring.datasource.*` properties. This should have no impact to WDS runtime, but it makes inspection via IntelliJ easier since IntelliJ recognizes `spring.datasource.hikari.*`.
* Change initialization of the NamedParameterJdbcTemplate bean to use Spring-managed injection for its datasource, instead of bypassing injection and calling `mainDb()` directly.
* add logging properties for the Hikari connection pool, but set the properties to defaults; this is a developer convenience for anyone who needs to change them later