### PR TITLE
AJ-1196 Update README.md #running section to run clean

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ export WORKSPACE_ID=123e4567-e89b-12d3-a456-426614174000
 ## Running
 To just build the code, from the root directory run
 ```bash
-./gradlew build
+./gradlew build --exclude-task test
 ```
 To run the application, first a postgres database must be running:
 ```bash


### PR DESCRIPTION
The doc as authored results in a failing build because the postgres container isn't running.  Since running the tests is covered later, skipping them here allows the suggested command to run without breakage, and accomplishes the goal to "just build the code."
