### PR TITLE
AJ-1263 Fix `IllegalStateException` on startup while polling SAM status.

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/PermissionsStatusService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/PermissionsStatusService.java
@@ -28,6 +28,7 @@ public class PermissionsStatusService extends AbstractHealthIndicator {
         try {
             Boolean samStatus = samDao.getSystemStatusOk();
             builder.withDetail("samOK", samStatus);
+            LOGGER.info("SAM is currently signaled as UP.");
         } catch (Exception e) {
             LOGGER.warn("SAM is currently signaled as DOWN.");
             builder.withDetail("samConnectionError", e.getMessage());

--- a/service/src/test/java/org/databiosphere/workspacedataservice/pact/SamPactTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/pact/SamPactTest.java
@@ -12,11 +12,9 @@ import org.broadinstitute.dsde.workbench.client.sam.model.SystemStatus;
 import org.databiosphere.workspacedataservice.sam.*;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthenticationException;
 import org.databiosphere.workspacedataservice.service.model.exception.SamServerException;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 
 import java.util.Map;
 import java.util.UUID;
@@ -28,14 +26,6 @@ import static org.junit.jupiter.api.Assertions.*;
 class SamPactTest {
 
     static final String dummyResourceId = "92276398-fbe4-414a-9304-e7dcf18ac80e";
-
-    @BeforeAll
-    static void setup() {
-        //Without this setup, the HttpClient throws a "No thread-bound request found" error
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        // Set the mock request as the current request context
-        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
-    }
 
     @Pact(consumer = "wds-consumer", provider = "sam-provider")
     public RequestResponsePact statusApiPact(PactDslWithProvider builder) {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/sam/HttpSamClientFactoryTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/sam/HttpSamClientFactoryTest.java
@@ -1,0 +1,59 @@
+package org.databiosphere.workspacedataservice.sam;
+
+import org.broadinstitute.dsde.workbench.client.sam.auth.OAuth;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import javax.servlet.ServletException;
+import java.io.IOException;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class HttpSamClientFactoryTest {
+
+    @Test
+    void getStatusApiWorksOutsideOfRequest() {
+        var factory = new HttpSamClientFactory("http://localhost/sam");
+        var statusApi = factory.getStatusApi();
+        assertThat(statusApi).isNotNull();
+
+        var apiClient = statusApi.getApiClient();
+        assertThat(apiClient).isNotNull();
+        assertThat(apiClient.getBasePath()).isEqualTo("http://localhost/sam");
+
+        var oauths = apiClient.getAuthentications().values().stream().filter(auth -> auth instanceof OAuth).toList();
+        assertThat(oauths.isEmpty()).isFalse();
+
+        oauths.forEach(auth -> assertThat(((OAuth) auth).getAccessToken()).isNull());
+    }
+
+    @Test
+    void getStatusApiWorksWithinARequest() throws ServletException, IOException {
+        var request = new MockHttpServletRequest();
+        request.addHeader(HttpHeaders.AUTHORIZATION, "fancytoken");
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain filterChain = new MockFilterChain();
+
+        new BearerTokenFilter().doFilter(request, response, filterChain);
+
+        var factory = new HttpSamClientFactory("http://localhost/sam");
+        var statusApi = factory.getStatusApi();
+        assertThat(statusApi).isNotNull();
+
+        var apiClient = statusApi.getApiClient();
+        assertThat(apiClient).isNotNull();
+        assertThat(apiClient.getBasePath()).isEqualTo("http://localhost/sam");
+
+        var oauths = apiClient.getAuthentications().values().stream().filter(auth -> auth instanceof OAuth).toList();
+        assertThat(oauths.isEmpty()).isFalse();
+
+        oauths.forEach(auth -> assertThat(((OAuth) auth).getAccessToken()).isEqualTo("fancytoken"));
+    }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceNoPermissionSamTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceNoPermissionSamTest.java
@@ -23,6 +23,7 @@ import org.springframework.test.context.ActiveProfiles;
 import java.util.List;
 import java.util.UUID;
 
+import static org.databiosphere.workspacedataservice.sam.HttpSamClientFactory.USE_BEARER_TOKEN_IF_PRESENT;
 import static org.databiosphere.workspacedataservice.service.RecordUtils.VERSION;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -56,7 +57,7 @@ class InstanceServiceNoPermissionSamTest {
     void testCreateInstanceNoPermission() throws ApiException {
 
         // return the mock ResourcesApi from the mock SamClientFactory
-        given(mockSamClientFactory.getResourcesApi(null))
+        given(mockSamClientFactory.getResourcesApi(USE_BEARER_TOKEN_IF_PRESENT))
                 .willReturn(mockResourcesApi);
 
         // Call to check permissions in Sam does not throw an exception, but returns false -
@@ -77,7 +78,7 @@ class InstanceServiceNoPermissionSamTest {
     void testDeleteInstanceNoPermission() throws ApiException {
 
         // return the mock ResourcesApi from the mock SamClientFactory
-        given(mockSamClientFactory.getResourcesApi(null))
+        given(mockSamClientFactory.getResourcesApi(USE_BEARER_TOKEN_IF_PRESENT))
                 .willReturn(mockResourcesApi);
 
         // Call to check permissions in Sam does not throw an exception, but returns false -

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamExceptionTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamExceptionTest.java
@@ -33,6 +33,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.UUID;
 
+import static org.databiosphere.workspacedataservice.sam.HttpSamClientFactory.USE_BEARER_TOKEN_IF_PRESENT;
 import static org.databiosphere.workspacedataservice.service.RecordUtils.VERSION;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -81,7 +82,7 @@ class InstanceServiceSamExceptionTest {
         instanceService = new InstanceService(instanceDao, samDao, activityLogger);
 
         // return the mock ResourcesApi from the mock SamClientFactory
-        given(mockSamClientFactory.getResourcesApi(null))
+        given(mockSamClientFactory.getResourcesApi(USE_BEARER_TOKEN_IF_PRESENT))
                 .willReturn(mockResourcesApi);
     }
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamTest.java
@@ -25,6 +25,7 @@ import org.springframework.test.context.TestPropertySource;
 
 import java.util.UUID;
 
+import static org.databiosphere.workspacedataservice.sam.HttpSamClientFactory.USE_BEARER_TOKEN_IF_PRESENT;
 import static org.databiosphere.workspacedataservice.service.RecordUtils.VERSION;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
@@ -57,7 +58,7 @@ class InstanceServiceSamTest {
         instanceService = new InstanceService(instanceDao, samDao, activityLogger);
 
         // return the mock ResourcesApi from the mock SamClientFactory
-        given(mockSamClientFactory.getResourcesApi(null))
+        given(mockSamClientFactory.getResourcesApi(USE_BEARER_TOKEN_IF_PRESENT))
                 .willReturn(mockResourcesApi);
         // Sam permission check will always return true
         given(mockResourcesApi.resourcePermissionV2(anyString(), anyString(), anyString()))

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorSamTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorSamTest.java
@@ -19,6 +19,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 import java.util.UUID;
 
+import static org.databiosphere.workspacedataservice.sam.HttpSamClientFactory.USE_BEARER_TOKEN_IF_PRESENT;
 import static org.databiosphere.workspacedataservice.service.RecordUtils.VERSION;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -51,7 +52,7 @@ class RecordOrchestratorSamTest {
         if (!instanceDao.instanceSchemaExists(INSTANCE)) {
             instanceDao.createSchema(INSTANCE);
         }
-        given(mockSamClientFactory.getResourcesApi(null))
+        given(mockSamClientFactory.getResourcesApi(USE_BEARER_TOKEN_IF_PRESENT))
                 .willReturn(mockResourcesApi);
 
         // clear call history for the mock


### PR DESCRIPTION
AJ-1263 Fix `IllegalStateException` on startup while polling SAM status.

When starting WDS locally, the startup process attempts to poll SAM status outside the context of a user request.  Spring throws an error when `RequestContextHolder.currentRequestAttributes` is called outside the context of a web request, which caused the below crash indicating SAM was down.

This fix adds a check to only use `currentRequestAttributes` in the context of a request.  Otherwise the reqeust will be treated as unauthenticated via an access token.

```
2023-08-10 11:32:16.535  INFO [] [restartedMain] o.d.w.logging.AvailabilityListener       : ReadinessState: ACCEPTING_TRAFFIC
2023-08-10 11:32:16.946 DEBUG [] [RMI TCP Connection(2)-10.1.7.98] o.d.w.sam.HttpSamClientSupport           : Sending getSystemStatus request to Sam ...
2023-08-10 11:32:16.951 ERROR [] [RMI TCP Connection(2)-10.1.7.98] o.d.w.sam.HttpSamClientSupport           : getSystemStatus Sam request resulted in No thread-bound request found: Are you referring to request attributes outside of an actual web request, or processing a request outside of the originally receiving thread? If you are actually operating within a web request and still receive this message, your code is probably running outside of DispatcherServlet: In this case, use RequestContextListener or RequestContextFilter to expose the current request.

java.lang.IllegalStateException: No thread-bound request found: Are you referring to request attributes outside of an actual web request, or processing a request outside of the originally receiving thread? If you are actually operating within a web request and still receive this message, your code is probably running outside of DispatcherServlet: In this case, use RequestContextListener or RequestContextFilter to expose the current request.
	at org.springframework.web.context.request.RequestContextHolder.currentRequestAttributes(RequestContextHolder.java:131)
	at org.databiosphere.workspacedataservice.sam.HttpSamClientFactory.getApiClient(HttpSamClientFactory.java:50)
	at org.databiosphere.workspacedataservice.sam.HttpSamClientFactory.getStatusApi(HttpSamClientFactory.java:85)
	at org.databiosphere.workspacedataservice.sam.HttpSamDao.lambda$getSystemStatus$2(HttpSamDao.java:111)
	at org.databiosphere.workspacedataservice.sam.HttpSamClientSupport.withRetryAndErrorHandling(HttpSamClientSupport.java:57)
	at org.databiosphere.workspacedataservice.sam.HttpSamClientSupport$$FastClassBySpringCGLIB$$92d51fe7.invoke(<generated>)
	at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218)
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:793)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763)
	at org.springframework.retry.interceptor.RetryOperationsInterceptor$1.doWithRetry(RetryOperationsInterceptor.java:97)
	at org.springframework.retry.support.RetryTemplate.doExecute(RetryTemplate.java:329)
	at org.springframework.retry.support.RetryTemplate.execute(RetryTemplate.java:209)
	at org.springframework.retry.interceptor.RetryOperationsInterceptor.invoke(RetryOperationsInterceptor.java:133)
	at org.springframework.retry.annotation.AnnotationAwareRetryOperationsInterceptor.invoke(AnnotationAwareRetryOperationsInterceptor.java:159)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763)
	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:708)
	at org.databiosphere.workspacedataservice.sam.HttpSamClientSupport$$EnhancerBySpringCGLIB$$5e50f93b.withRetryAndErrorHandling(<generated>)
	at org.databiosphere.workspacedataservice.sam.HttpSamDao.getSystemStatus(HttpSamDao.java:112)
	at org.databiosphere.workspacedataservice.sam.HttpSamDao.getSystemStatusOk(HttpSamDao.java:107)
	at org.databiosphere.workspacedataservice.sam.HttpSamDao$$FastClassBySpringCGLIB$$dca659b5.invoke(<generated>)
	at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218)
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:793)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763)
	at org.springframework.cache.interceptor.CacheInterceptor.lambda$invoke$0(CacheInterceptor.java:54)
	at org.springframework.cache.interceptor.CacheAspectSupport.invokeOperation(CacheAspectSupport.java:366)
	at org.springframework.cache.interceptor.CacheAspectSupport.execute(CacheAspectSupport.java:421)
	at org.springframework.cache.interceptor.CacheAspectSupport.execute(CacheAspectSupport.java:345)
	at org.springframework.cache.interceptor.CacheInterceptor.invoke(CacheInterceptor.java:64)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763)
	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:708)
	at org.databiosphere.workspacedataservice.sam.HttpSamDao$$EnhancerBySpringCGLIB$$f9be12c4.getSystemStatusOk(<generated>)
	at org.databiosphere.workspacedataservice.sam.PermissionsStatusService.doHealthCheck(PermissionsStatusService.java:29)
	at org.springframework.boot.actuate.health.AbstractHealthIndicator.health(AbstractHealthIndicator.java:82)
	at org.springframework.boot.actuate.health.HealthIndicator.getHealth(HealthIndicator.java:37)
	at org.springframework.boot.actuate.health.HealthEndpoint.getHealth(HealthEndpoint.java:94)
	at org.springframework.boot.actuate.health.HealthEndpoint.getHealth(HealthEndpoint.java:41)
	at org.springframework.boot.actuate.health.HealthEndpointSupport.getLoggedHealth(HealthEndpointSupport.java:172)
	at org.springframework.boot.actuate.health.HealthEndpointSupport.getContribution(HealthEndpointSupport.java:145)
	at org.springframework.boot.actuate.health.HealthEndpointSupport.getAggregateContribution(HealthEndpointSupport.java:156)
	at org.springframework.boot.actuate.health.HealthEndpointSupport.getContribution(HealthEndpointSupport.java:141)
	at org.springframework.boot.actuate.health.HealthEndpointSupport.getHealth(HealthEndpointSupport.java:110)
	at org.springframework.boot.actuate.health.HealthEndpointSupport.getHealth(HealthEndpointSupport.java:81)
	at org.springframework.boot.actuate.health.HealthEndpoint.health(HealthEndpoint.java:88)
	at org.springframework.boot.actuate.health.HealthEndpoint.health(HealthEndpoint.java:78)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.springframework.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:282)
	at org.springframework.boot.actuate.endpoint.invoke.reflect.ReflectiveOperationInvoker.invoke(ReflectiveOperationInvoker.java:74)
	at org.springframework.boot.actuate.endpoint.annotation.AbstractDiscoveredOperation.invoke(AbstractDiscoveredOperation.java:60)
	at org.springframework.boot.actuate.endpoint.jmx.EndpointMBean.invoke(EndpointMBean.java:124)
	at org.springframework.boot.actuate.endpoint.jmx.EndpointMBean.invoke(EndpointMBean.java:97)
	at java.management/com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.invoke(DefaultMBeanServerInterceptor.java:814)
	at java.management/com.sun.jmx.mbeanserver.JmxMBeanServer.invoke(JmxMBeanServer.java:802)
	at java.management.rmi/javax.management.remote.rmi.RMIConnectionImpl.doOperation(RMIConnectionImpl.java:1472)
	at java.management.rmi/javax.management.remote.rmi.RMIConnectionImpl$PrivilegedOperation.run(RMIConnectionImpl.java:1310)
	at java.management.rmi/javax.management.remote.rmi.RMIConnectionImpl.doPrivilegedOperation(RMIConnectionImpl.java:1405)
	at java.management.rmi/javax.management.remote.rmi.RMIConnectionImpl.invoke(RMIConnectionImpl.java:829)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at java.rmi/sun.rmi.server.UnicastServerRef.dispatch(UnicastServerRef.java:360)
	at java.rmi/sun.rmi.transport.Transport$1.run(Transport.java:200)
	at java.rmi/sun.rmi.transport.Transport$1.run(Transport.java:197)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:712)
	at java.rmi/sun.rmi.transport.Transport.serviceCall(Transport.java:196)
	at java.rmi/sun.rmi.transport.tcp.TCPTransport.handleMessages(TCPTransport.java:587)
	at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run0(TCPTransport.java:828)
	at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.lambda$run$0(TCPTransport.java:705)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
	at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run(TCPTransport.java:704)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)

2023-08-10 11:32:16.951  WARN [] [RMI TCP Connection(2)-10.1.7.98] o.d.w.retry.RetryLoggingListener         : Retryable method public <T> T org.databiosphere.workspacedataservice.sam.HttpSamClientSupport.withRetryAndErrorHandling(org.databiosphere.workspacedataservice.sam.HttpSamClientSupport$SamFunction<T>,java.lang.String) throws org.databiosphere.workspacedataservice.service.model.exception.SamException,org.databiosphere.workspacedataservice.service.model.exception.AuthenticationException,org.databiosphere.workspacedataservice.service.model.exception.AuthorizationException threw 1th exception org.databiosphere.workspacedataservice.service.model.exception.SamException: 500 INTERNAL_SERVER_ERROR "Error from Sam: No thread-bound request found: Are you referring to request attributes outside of an actual web request, or processing a request outside of the originally receiving thread? If you are actually operating within a web request and still receive this message, your code is probably running outside of DispatcherServlet: In this case, use RequestContextListener or RequestContextFilter to expose the current request."
2023-08-10 11:32:16.951  WARN [] [RMI TCP Connection(2)-10.1.7.98] o.d.w.sam.PermissionsStatusService       : SAM is currently signaled as DOWN.
```