### PR TITLE
AJ-1219: Clarify comment about disabling `sql.init.mode`

### DIFF
--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -58,8 +58,9 @@ spring:
     multipart.max-file-size: 5GB
   sql:
     init:
+      # Disable having spring-boot from automatically creating the schema for the embedded datasource
       mode: never
-  # Run Liquibase instead
+  # ... and run Liquibase instead
   liquibase:
     change-log: classpath:liquibase/changelog.yaml
 #   # activate the "local" profile to turn on CORS response headers,


### PR DESCRIPTION
Clarify why we disable `sql.init.mode`

Followup I missed from prior PR feedback: https://github.com/DataBiosphere/terra-workspace-data-service/pull/324#discussion_r1293874925