### PR TITLE
[AJ-879] Update default user agent for client libraries

### DIFF
--- a/.github/workflows/release-python-client.yml
+++ b/.github/workflows/release-python-client.yml
@@ -55,7 +55,7 @@ jobs:
           -i service/src/main/resources/static/swagger/openapi-docs.yaml \
           -g python \
           -o wds-client \
-          --additional-properties=projectName=wds-client,packageName=wds_client,packageVersion=${{ inputs.new-tag }} \
+          --additional-properties=projectName=wds-client,packageName=wds_client,packageVersion=${{ inputs.new-tag }},httpUserAgent=wds-client/${{ inputs.new-tag }}/python \
           --skip-validate-spec
 
       - name: Install python package locally

--- a/client/swagger.gradle
+++ b/client/swagger.gradle
@@ -36,7 +36,8 @@ generateSwaggerCode {
 			modelPackage  : "${artifactGroup}.model",
 			apiPackage    : "${artifactGroup}.api",
 			invokerPackage: "${artifactGroup}.client",
-			dateLibrary   : 'java11'
+			dateLibrary   : 'java11',
+			httpUserAgent : "wds-client/${project.version.toString().replace('-SNAPSHOT', '')}/java"
 	]
 
 	rawOptions = ["--ignore-file-override", "${projectDir}/.swagger-codegen-ignore"]


### PR DESCRIPTION
Currently, the WDS Java client's default user agent is `Swagger-Codegen/1.0.0/java`. The Python client's default user agent is a little better, since it includes the WDS version it was published from. For example, `OpenAPI-Generator/0.2.97/python`.

This updates the default user agents for both client libraries to `wds-client/<version>/<language>`. For example, `wds-client/0.2.97/java` for the Java client and `wds-client/0.2.97/python` for the Python client.

The generated client objects allow consumers to override the default user agent.

Note: will conflict with #321.