### PR TITLE
AJ-1286: Introduce `BiStream` idioms using `com.google.mug`

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -62,6 +62,7 @@ dependencies {
 	implementation 'org.ehcache:ehcache:3.10.8'
 	implementation 'org.hashids:hashids:1.0.3'
 	implementation 'javax.ws.rs:javax.ws.rs-api:2.1.1'
+	implementation 'com.google.mug:mug:6.6'
 
 	// Terra libraries
 	implementation group: 'org.broadinstitute.dsde.workbench', name: 'sam-client_2.13', version: '0.1-08b6588'


### PR DESCRIPTION
While working on `DataTypeInferer` I noticed these stanzas of code which cried out for `BiStream` which was designed exactly for this sort of streaming logic.  See https://github.com/google/mug#bistream-streams-pairs-of-objects for many examples.

This commit is pure refactoring and is intended to demonstrate how `BiStream` can be used to simplify complex iterations by using higher-level predicates.

Note, since `BiStream` inherits from the Stream API, it also picks up the `Autocloseable` interface, which triggers some extra warnings which you can safely ignore.  For Intellij, this can be done by adding `BiStream` and `BiStream.from` to the allowlist to ignore these warnings.

![autocloseable-warnings](https://github.com/DataBiosphere/terra-workspace-data-service/assets/111856/0ee5985e-7de2-490d-8386-06ff2bff9173)
