### PR TITLE
AJ-1090: swagger definition and UI tweaks

### DIFF
--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -11,8 +11,7 @@ info:
     name: BSD
     url: https://opensource.org/licenses/BSD-3-Clause
 servers:
-  - url: ../
-    description: Relative to the current swagger page
+  - url: /
 tags:
   - name: Cloning
     description: Cloning APIs including Backup and Restore

--- a/service/src/main/resources/static/swagger/swagger-ui.html
+++ b/service/src/main/resources/static/swagger/swagger-ui.html
@@ -45,9 +45,13 @@
           cleanupPlugin
         ],
         layout: 'StandaloneLayout',
-        defaultModelsExpandDepth: -1, // hide the huge list of schemas under the routes
+        displayOperationId: true,       // show generated-client method names for each endpoint
+        defaultModelsExpandDepth: -1,   // hide the huge list of schemas under the routes
         defaultModelRendering: 'model', // schema has the descriptions, unlike the example value
-        defaultModelExpandDepth: 2, // affects the schema shown for a request or response
+        defaultModelExpandDepth: 2,     // affects the schema shown for a request or response
+        displayRequestDuration: true,   // show timing
+        docExpansion: 'none',           // start with sections collapsed
+        filter: true,                   // show tag filter bar
       })
       // End Swagger UI call region
 


### PR DESCRIPTION
In this PR:
* eliminate the warning about `../` url when generating the swagger client (which also happens at bootRun). The `../` url is a leftover from when WDS was bundled with CBAS and is no longer necessary.

![Screenshot 2023-08-22 at 5 29 01 PM](https://github.com/DataBiosphere/terra-workspace-data-service/assets/6041577/1d2b9b09-a2ba-4b0c-8dfc-41de59e922c4)

I piggybacked on that fix with a few other swagger UI tweaks. These are my personal opinions; feel free to opine if you disagree!

start with each major section collapsed, making it easier to navigate quickly to the section you care about:
![Screenshot 8-22-2023 at 05 30 PM](https://github.com/DataBiosphere/terra-workspace-data-service/assets/6041577/a0dbfbf0-d79d-41d4-af25-5cf787206349)

add a filter bar to quickly filter to the main section (aka tag) you care about:
![Screenshot 8-22-2023 at 05 31 PM](https://github.com/DataBiosphere/terra-workspace-data-service/assets/6041577/8a95a1ac-08cd-496f-9d1a-91f181f02e24)

display request durations for each API invocation:
![Screenshot 8-22-2023 at 05 30 PM (1)](https://github.com/DataBiosphere/terra-workspace-data-service/assets/6041577/02c5333f-4350-457c-915d-11d13de6f57d)

display the `operationId` for each API; these ids become method names in the generated Java and Python clients:
![Screenshot 8-22-2023 at 05 31 PM (2)](https://github.com/DataBiosphere/terra-workspace-data-service/assets/6041577/83f7861c-d8c4-4ccf-9cc0-fb1d3a65108d)





