### PR TITLE
AJ-1173: add sorting to python test

### DIFF
--- a/service/src/test/python/test.py
+++ b/service/src/test/python/test.py
@@ -187,7 +187,7 @@ class WdsTests(TestCase):
     # create 2 record sets, query the records back, then check record types
     def test_relation_record_creation_queryall_and_delete(self):
         records = self.generate_two_records(self.testType2_complex, self.testId1_complex, self.testType2_relation, self.testId1_relation, "testKey_complex")
-        search_request = { "offset": 0, "limit": 10};
+        search_request = { "offset": 0, "limit": 10, "sort": "asc", "sortAttribute": "testKey_complex"}
         
         recordsRetrieved = self.records_client.query_records(self.current_workspaceId, self.version, self.testType2_complex, search_request)    
         record_updated = adjust_record_to_wds(records[0], "testKey_complex", self.testId1_complex)

--- a/service/src/test/python/test.py
+++ b/service/src/test/python/test.py
@@ -190,10 +190,12 @@ class WdsTests(TestCase):
         search_request = { "offset": 0, "limit": 10, "sort": "DESC", "sortAttribute": "NumberTest3"}
         
         recordsRetrieved = self.records_client.query_records(self.current_workspaceId, self.version, self.testType2_complex, search_request)    
+        self.assertEqual("DESC", recordsRetrieved.search_request.sort)
         record_updated = adjust_record_to_wds(records[0], "testKey_complex", self.testId1_complex)
         self.assertTrue(record_updated == recordsRetrieved.records[0].attributes)
 
-        recordsRetrieved = self.records_client.query_records(self.current_workspaceId, self.version, self.testType2_relation, search_request)    
+        recordsRetrieved = self.records_client.query_records(self.current_workspaceId, self.version, self.testType2_relation, search_request)
+        self.assertEqual("DESC", recordsRetrieved.search_request.sort)
         record_updated = adjust_record_to_wds(records[1], None, self.testId1_relation)
         self.assertTrue(record_updated == recordsRetrieved.records[0].attributes)
         

--- a/service/src/test/python/test.py
+++ b/service/src/test/python/test.py
@@ -187,7 +187,7 @@ class WdsTests(TestCase):
     # create 2 record sets, query the records back, then check record types
     def test_relation_record_creation_queryall_and_delete(self):
         records = self.generate_two_records(self.testType2_complex, self.testId1_complex, self.testType2_relation, self.testId1_relation, "testKey_complex")
-        search_request = { "offset": 0, "limit": 10, "sort": "ASC", "sortAttribute": "testKey_complex"}
+        search_request = { "offset": 0, "limit": 10, "sort": "DESC", "sortAttribute": "NumberTest3"}
         
         recordsRetrieved = self.records_client.query_records(self.current_workspaceId, self.version, self.testType2_complex, search_request)    
         record_updated = adjust_record_to_wds(records[0], "testKey_complex", self.testId1_complex)

--- a/service/src/test/python/test.py
+++ b/service/src/test/python/test.py
@@ -187,7 +187,7 @@ class WdsTests(TestCase):
     # create 2 record sets, query the records back, then check record types
     def test_relation_record_creation_queryall_and_delete(self):
         records = self.generate_two_records(self.testType2_complex, self.testId1_complex, self.testType2_relation, self.testId1_relation, "testKey_complex")
-        search_request = { "offset": 0, "limit": 10, "sort": "asc", "sortAttribute": "testKey_complex"}
+        search_request = { "offset": 0, "limit": 10, "sort": "ASC", "sortAttribute": "testKey_complex"}
         
         recordsRetrieved = self.records_client.query_records(self.current_workspaceId, self.version, self.testType2_complex, search_request)    
         record_updated = adjust_record_to_wds(records[0], "testKey_complex", self.testId1_complex)


### PR DESCRIPTION
Adds an explicit sort to the Python `test_relation_record_creation_queryall_and_delete` test.

This feels like an incrementally good change overall, but I'm mostly doing it as prep for #321 so I can validate potential changes to the asc/desc enum.