### PR TITLE
AJ-1173: clarify 'allOf' composed schema name

### DIFF
--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -627,6 +627,7 @@ components:
           type: string
           description: User-friendly description to associate with this backup. Optional.
     BackupJob:
+      x-all-of-name: BackupJob
       allOf:
         - $ref: '#/components/schemas/Job'
         - type: object
@@ -634,6 +635,7 @@ components:
             result:
               $ref: '#/components/schemas/BackupResponse'
     CloneJob:
+      x-all-of-name: CloneJob
       allOf:
         - $ref: '#/components/schemas/Job'
         - type: object


### PR DESCRIPTION
This eliminates spurious "allOf with multiple schemas defined. Using only the first one: Job" warnings when generating the Java client.

The issue is described here: https://github.com/OpenAPITools/openapi-generator/issues/11841

I have diff-ed the generated code before and after this PR, and do not see any difference.


## Before:
```shell
➜  terra-workspace-data-service git:(da_AJ-1173_allOfSchemaNames) ✗ gw :client:openApiGenerate

> Task :client:openApiGenerate
allOf with multiple schemas defined. Using only the first one: Job
allOf with multiple schemas defined. Using only the first one: Job
allOf with multiple schemas defined. Using only the first one: Job
allOf with multiple schemas defined. Using only the first one: Job
allOf with multiple schemas defined. Using only the first one: Job
################################################################################
# Thanks for using OpenAPI Generator.                                          #
# Please consider donation to help us maintain this project 🙏                 #
# https://opencollective.com/openapi_generator/donate                          #
################################################################################
Successfully generated code to /Users/davidan/work/src/terra-workspace-data-service/client/build/generated
```

## After:
```shell
➜  terra-workspace-data-service git:(da_AJ-1173_allOfSchemaNames) gw :client:openApiGenerate

> Task :client:openApiGenerate
################################################################################
# Thanks for using OpenAPI Generator.                                          #
# Please consider donation to help us maintain this project 🙏                 #
# https://opencollective.com/openapi_generator/donate                          #
################################################################################
Successfully generated code to /Users/davidan/work/src/terra-workspace-data-service/client/build/generated
```