### PR TITLE
AJ-1285: remove Spring Boot Dev Tools

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -79,7 +79,6 @@ dependencies {
 
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	runtimeOnly 'org.webjars.npm:swagger-ui-dist:4.12.0'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'
 	testImplementation project(':client')


### PR DESCRIPTION
nobody on the team seems to be relying on [devtools](https://docs.spring.io/spring-boot/docs/2.7.x/reference/html/using.html#using.devtools): 
https://broadinstitute.slack.com/archives/C02SJQ0FKHQ/p1693341056309169

so, let's get it out of our stack entirely instead of figuring out how to remove it only from prod.