### PR TITLE
AJ-1322 - Set source wds client token using SetBearerToken

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/sourcewds/HttpWorkspaceDataServiceClientFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sourcewds/HttpWorkspaceDataServiceClientFactory.java
@@ -48,7 +48,7 @@ public class HttpWorkspaceDataServiceClientFactory implements WorkspaceDataServi
             }
         }
         else {
-            apiClient.setAccessToken(token);
+            apiClient.setBearerToken(token);
         }
 
         return apiClient;


### PR DESCRIPTION
Currently WDS during cloning is complaining that "No OAuth2 authentication configured!" - use SetBearerToken instead to fix this. It appears that this is a difference in implementation between jersey library (that we used previously) that didnt cause issues, but is different since we have made the move to okhttp. 

Reminder:

PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 
