### PR TITLE
[AJ-1138] Fix restore multi-replica bug

### DIFF
--- a/service/src/integrationTest/java/org/databiosphere/workspacedataservice/service/RestoreServiceIntegrationTest.java
+++ b/service/src/integrationTest/java/org/databiosphere/workspacedataservice/service/RestoreServiceIntegrationTest.java
@@ -78,4 +78,20 @@ public class RestoreServiceIntegrationTest {
         List<RecordType> actualTables = recordDao.getAllRecordTypes(destInstance);
         assertEquals(expectedTables, actualTables);
     }
+
+    @Test
+    void testRestoreWithDuplicateDestId() {
+        UUID destInstance = UUID.fromString(workspaceId);
+
+        // confirm neither source nor destination instance should exist in our list of schemas to start
+        List<UUID> instancesBefore = instanceDao.listInstanceSchemas();
+        assertThat(instancesBefore).isEmpty();
+
+        // now add the destination workspaceid to simulate a replica adding it first
+        instanceDao.createSchema(destInstance);
+
+        // perform the restore, confirm that it succeeds
+        var response = backupRestoreService.restoreAzureWDS("v0.2", "backup.sql", UUID.randomUUID(), "");
+        assertSame(JobStatus.SUCCEEDED, response.getStatus());
+    }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresInstanceDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresInstanceDao.java
@@ -52,7 +52,7 @@ public class PostgresInstanceDao implements InstanceDao {
     @WriteTransaction
     @SuppressWarnings("squid:S2077") // since instanceId must be a UUID, it is safe to use inline
     public void dropSchema(UUID instanceId) {
-        namedTemplate.getJdbcTemplate().update("drop schema " + quote(instanceId.toString()) + " cascade");
+        namedTemplate.getJdbcTemplate().update("drop schema if exists " + quote(instanceId.toString()) + " cascade");
         namedTemplate.getJdbcTemplate().update("delete from sys_wds.instance where id = ?", instanceId);
     }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/BackupRestoreService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/BackupRestoreService.java
@@ -178,6 +178,10 @@ public class BackupRestoreService {
                 If we insert rows here, we don't need the additional insert check in alterSchema.
              */
 
+            // drop schema with dest uuid if exists. this can happen if a replica sees clone mode's initiated and skips to default schema 
+            // creation, but cloning hasn't gotten to this part of restore yet.
+            instanceDao.dropSchema(UUID.fromString(workspaceId));
+
             // rename workspace schema from source to dest
             instanceDao.alterSchema(UUID.fromString(sourceWorkspaceId), UUID.fromString(workspaceId));
 


### PR DESCRIPTION
Problem: Cloning logic is currently: 
- On Initialization, check to see if we're already cloning. 
- If so, don't start in cloning mode, start regular mode.
   - Regular mode checks to see if default schema (destWorkspaceId) is created. If not, create it. 
   - Continue with normal initialization.
 - If not, start cloning mode. 
   -  Cloning mode will request a backup, and restore if that's successful.
   - Part of restore is running the pg_dump, then changing the schema name from sourceWorkspaceId to destWorkspaceId
   - CONFLICT/SQL ERROR- can't change the name because destWorkspaceId schema was created by another replica not starting in clone mode! 

Solution:
There are 2 ways to solve this, either have the other replicas wait until cloning is complete (not this PR and I don't recommend doing until cloning is Async). Or, drop the destWorkspaceId schema if it exists before renaming schema during restore. 

TODO: figure out a test for this

Reminder:

PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 
