### PR TITLE
AJ-1289: Ignore large reformatting commit from `git blame`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# To configure git to use this file when using `git blame`:
+# $ git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# AJ-1289: Reformat code using spotless to match Google style guide.
+c795c46f2ce4bf30fce829979bcfc40ec12eef0c

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,13 @@ VSCode:
 ```bash
 git config core.hooksPath scripts/git-hooks
 ```
+
+## Ignoring code formatting changes from `git blame`
+The style guide formatting changes can make it difficult to use `git blame` to find the original author of a line of code after https://github.com/DataBiosphere/terra-workspace-data-service/commit/c795c46f2ce4bf30fce829979bcfc40ec12eef0c.  To ignore these (and any other similarly obfuscating) changes, run the following command to add the appropriate commits to the blame ignore list:
+```bash
+git config blame.ignoreRevsFile .git-blame-ignore-revs
+```
+
 ## Before You Open a Pull Request
 
 You most likely want to do your work on a feature branch based on develop. There is no explicit naming convention; we usually use some combination of the JIRA issue number and something alluding to the work we're doing.


### PR DESCRIPTION
To enable git to ignore this commit run:
```
$ git config blame.ignoreRevsFile .git-blame-ignore-revs
```

This ignores the large commit produced from merging: https://github.com/DataBiosphere/terra-workspace-data-service/pull/336