### PR TITLE
AJ-1289: Add optional `pre-commit` hook to enforce style guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,11 @@ Intellij:
 VSCode:
 1. VSCode will work out of the box and is configured by [.vscode/settings.json](.vscode/settings.json).  The formatter will run automatically whenever you save a file.
 
+## (Optional) Install pre-commit hooks
+1. [scripts/git-hooks/pre-commit] has been provided to help ensure all submitted changes are formatted correctly.  To install all hooks in [scripts/git-hooks], run:
+```bash
+git config core.hooksPath scripts/git-hooks
+```
 ## Before You Open a Pull Request
 
 You most likely want to do your work on a feature branch based on develop. There is no explicit naming convention; we usually use some combination of the JIRA issue number and something alluding to the work we're doing.

--- a/scripts/git-hooks/README.md
+++ b/scripts/git-hooks/README.md
@@ -1,0 +1,1 @@
+To enable hooks in this directory run: `git config core.hooksPath scripts/git-hooks`

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# Based on: https://medium.com/@mmessell/apply-spotless-formatting-with-git-pre-commit-hook-1c484ea68c34
+# Note: running git add in pre-commit is not recommended, which is why this pre-commit hook isn't enabled
+# by default.
+stagedFiles=$(git diff --staged --name-only)
+
+echo "Running spotlessApply. Formatting code..."
+./gradlew spotlessApply
+
+for file in $stagedFiles; do
+  if test -f "$file"; then
+    git add $file
+  fi
+done


### PR DESCRIPTION
Run the following command to pick up all provided hooks (as of this writing, only includes the `pre-commit` hook for applying the style guide).

```
git config core.hooksPath scripts/git-hooks
```