### PR TITLE
AJ-1357: restrict to HTTP 1.1 for OkHttp clients

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/leonardo/HttpLeonardoClientFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/leonardo/HttpLeonardoClientFactory.java
@@ -22,7 +22,8 @@ public class HttpLeonardoClientFactory implements LeonardoClientFactory {
 
   public HttpLeonardoClientFactory(String leoUrl) {
     this.leoEndpointUrl = leoUrl;
-    // IntelliJ has a false-positive error on the following line; see https://youtrack.jetbrains.com/issue/KTIJ-26434
+    // IntelliJ has a false-positive error on the following line; see
+    // https://youtrack.jetbrains.com/issue/KTIJ-26434
     this.commonHttpClient =
         new ApiClient().getHttpClient().newBuilder().protocols(List.of(Protocol.HTTP_1_1)).build();
   }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/leonardo/HttpLeonardoClientFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/leonardo/HttpLeonardoClientFactory.java
@@ -3,8 +3,10 @@ package org.databiosphere.workspacedataservice.leonardo;
 import static org.databiosphere.workspacedataservice.sam.BearerTokenFilter.ATTRIBUTE_NAME_TOKEN;
 import static org.springframework.web.context.request.RequestAttributes.SCOPE_REQUEST;
 
+import java.util.List;
 import java.util.Objects;
 import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.dsde.workbench.client.leonardo.ApiClient;
 import org.broadinstitute.dsde.workbench.client.leonardo.api.AppsApi;
@@ -20,7 +22,9 @@ public class HttpLeonardoClientFactory implements LeonardoClientFactory {
 
   public HttpLeonardoClientFactory(String leoUrl) {
     this.leoEndpointUrl = leoUrl;
-    this.commonHttpClient = new ApiClient().getHttpClient().newBuilder().build();
+    // IntelliJ has a false-positive error on the following line; see https://youtrack.jetbrains.com/issue/KTIJ-26434
+    this.commonHttpClient =
+        new ApiClient().getHttpClient().newBuilder().protocols(List.of(Protocol.HTTP_1_1)).build();
   }
 
   private ApiClient getApiClient(String token) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamClientFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamClientFactory.java
@@ -3,8 +3,10 @@ package org.databiosphere.workspacedataservice.sam;
 import static org.databiosphere.workspacedataservice.sam.BearerTokenFilter.ATTRIBUTE_NAME_TOKEN;
 import static org.springframework.web.context.request.RequestAttributes.SCOPE_REQUEST;
 
+import java.util.List;
 import java.util.Objects;
 import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.dsde.workbench.client.sam.ApiClient;
 import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
@@ -28,7 +30,9 @@ public class HttpSamClientFactory implements SamClientFactory {
 
   public HttpSamClientFactory(String samUrl) {
     this.samUrl = samUrl;
-    this.commonHttpClient = new ApiClient().getHttpClient().newBuilder().build();
+    // IntelliJ has a false-positive error on the following line; see https://youtrack.jetbrains.com/issue/KTIJ-26434
+    this.commonHttpClient =
+        new ApiClient().getHttpClient().newBuilder().protocols(List.of(Protocol.HTTP_1_1)).build();
     // TODO: add tracing interceptor for distributed tracing to Sam.
     // this requires we import terra-common-lib
   }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamClientFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamClientFactory.java
@@ -30,7 +30,8 @@ public class HttpSamClientFactory implements SamClientFactory {
 
   public HttpSamClientFactory(String samUrl) {
     this.samUrl = samUrl;
-    // IntelliJ has a false-positive error on the following line; see https://youtrack.jetbrains.com/issue/KTIJ-26434
+    // IntelliJ has a false-positive error on the following line; see
+    // https://youtrack.jetbrains.com/issue/KTIJ-26434
     this.commonHttpClient =
         new ApiClient().getHttpClient().newBuilder().protocols(List.of(Protocol.HTTP_1_1)).build();
     // TODO: add tracing interceptor for distributed tracing to Sam.

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sourcewds/HttpWorkspaceDataServiceClientFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sourcewds/HttpWorkspaceDataServiceClientFactory.java
@@ -20,7 +20,8 @@ public class HttpWorkspaceDataServiceClientFactory implements WorkspaceDataServi
       LoggerFactory.getLogger(HttpWorkspaceDataServiceClientFactory.class);
 
   public HttpWorkspaceDataServiceClientFactory() {
-    // IntelliJ has a false-positive error on the following line; see https://youtrack.jetbrains.com/issue/KTIJ-26434
+    // IntelliJ has a false-positive error on the following line; see
+    // https://youtrack.jetbrains.com/issue/KTIJ-26434
     this.commonHttpClient =
         new ApiClient().getHttpClient().newBuilder().protocols(List.of(Protocol.HTTP_1_1)).build();
     ;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sourcewds/HttpWorkspaceDataServiceClientFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sourcewds/HttpWorkspaceDataServiceClientFactory.java
@@ -3,8 +3,10 @@ package org.databiosphere.workspacedataservice.sourcewds;
 import static org.databiosphere.workspacedataservice.sam.BearerTokenFilter.ATTRIBUTE_NAME_TOKEN;
 import static org.springframework.web.context.request.RequestAttributes.SCOPE_REQUEST;
 
+import java.util.List;
 import java.util.Objects;
 import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
 import org.apache.commons.lang3.StringUtils;
 import org.databiosphere.workspacedata.api.CloningApi;
 import org.databiosphere.workspacedata.client.ApiClient;
@@ -18,7 +20,9 @@ public class HttpWorkspaceDataServiceClientFactory implements WorkspaceDataServi
       LoggerFactory.getLogger(HttpWorkspaceDataServiceClientFactory.class);
 
   public HttpWorkspaceDataServiceClientFactory() {
-    this.commonHttpClient = new ApiClient().getHttpClient().newBuilder().build();
+    // IntelliJ has a false-positive error on the following line; see https://youtrack.jetbrains.com/issue/KTIJ-26434
+    this.commonHttpClient =
+        new ApiClient().getHttpClient().newBuilder().protocols(List.of(Protocol.HTTP_1_1)).build();
     ;
   }
 


### PR DESCRIPTION
For all our OkHttp-based client libraries (Sam, Leo, WDS), restrict to HTTP 1.1 and disallow HTTP 2.

In scale testing, we have seen intermittent/hard-to-reproduce errors like `okhttp3.internal.http2.StreamResetException: stream was reset: CANCEL`. Previous investigation hinted at HTTP 2 being a culprit here.

We don't need HTTP 2, and I don't anticipate that restricting to HTTP 1.1 will have any repercussions.

See:
* https://github.com/broadinstitute/rawls/pull/2154
* https://github.com/DataBiosphere/cbas/pull/208
* https://broadinstitute.slack.com/archives/C05BYVBM2HE/p1695916806679619