### PR TITLE
AJ-1011: add openapi validation to build

### DIFF
--- a/client/swagger.gradle
+++ b/client/swagger.gradle
@@ -6,6 +6,10 @@ dependencies {
 	api 'com.squareup.okhttp3:logging-interceptor:4.10.0'
 }
 
+openApiValidate {
+    inputSpec = "$rootDir/service/src/main/resources/static/swagger/openapi-docs.yaml".toString()
+}
+
 openApiGenerate {
 	inputSpec = "$rootDir/service/src/main/resources/static/swagger/openapi-docs.yaml".toString()
 	outputDir = "$buildDir/generated".toString()
@@ -71,7 +75,8 @@ tasks.register('patchSources', Copy) {
 	}
 }
 
-// control task order: openApiGenerate -> backUpSources -> patchSources
+// control task order: openApiValidate -> openApiGenerate -> backUpSources -> patchSources
+tasks.getByName('openApiGenerate').dependsOn 'openApiValidate'
 tasks.register('fixOpenApiGenerate') {
 	doFirst {
 		logger.lifecycle("")


### PR DESCRIPTION
More prefactoring work for AJ-1011. This adds validation of our OpenAPI spec to the gradle build.

If the spec is invalid, we'll get a build failure:
![Screenshot 2023-09-29 at 3 36 55 PM](https://github.com/DataBiosphere/terra-workspace-data-service/assets/6041577/956f1ca5-bb0f-4f4a-983e-0e0d0da31793)

Note that we also get non-fatal recommendations on how to clean up the spec!
