### PR TITLE
AJ-1011: setup for async snapshot api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ config/
 gha-creds-*.json
 
 service/backup.sql
+/service/.openapi-generator/
+/service/src/main/java/org/databiosphere/workspacedataservice/generated/

--- a/README.md
+++ b/README.md
@@ -257,10 +257,8 @@ their implementations are hand-coded.
 APIs at `v1` or later use code generation. To create or update an API, you must:
 
 1. Define the API using OpenAPI syntax
-   at `service/src/main/resources/static/swagger/openapi-docs.yaml`
-2. Update the `generateApiInterfaces` Gradle task in `service/build.gradle` as necessary.
-  1. Add your APIs to `apiFilesConstrainedTo`
-  2. Add your API's models to `modelFilesConstrainedTo`
+   at `service/src/main/resources/static/swagger/apis-v1.yaml`
+2. Include the API, via `$ref:`, in `service/src/main/resources/static/swagger/openapi-docs.yaml`
 3. Run the `generateApiInterfaces` Gradle task
 4. Note the new/updated Java interfaces and models under the `o.d.w.generated` package
 5. Create or update a controller class that implements the new Java interface

--- a/README.md
+++ b/README.md
@@ -1,15 +1,23 @@
 # Workspace Data Service
+
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=DataBiosphere_workspace-data-service&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=DataBiosphere_workspace-data-service)
 
 Workspace Data Service provides an API to manage records in Terra.
 
-Design docs and other references may be found [here](https://broadworkbench.atlassian.net/wiki/spaces/AS/pages/2437742606/Workspace+Data+Service).
+Design docs and other references may be
+found [here](https://broadworkbench.atlassian.net/wiki/spaces/AS/pages/2437742606/Workspace+Data+Service).
 
 ## Setup
-### Prerequisites
-Make sure you have Java 17 installed.  Our favorite way to do this is with [SDKMAN](https://sdkman.io/jdks).  Once it is installed , use `sdk list java` to see available versions, and `sdk install java 17.0.2-tem` to install, for example, the Temurin version of Java 17.
 
-[jenv](https://www.jenv.be/) is also helpful for managing active versions.  On a Mac,jenv can be installed and used like so:
+### Prerequisites
+
+Make sure you have Java 17 installed. Our favorite way to do this is
+with [SDKMAN](https://sdkman.io/jdks). Once it is installed , use `sdk list java` to see available
+versions, and `sdk install java 17.0.2-tem` to install, for example, the Temurin version of Java 17.
+
+[jenv](https://www.jenv.be/) is also helpful for managing active versions. On a Mac,jenv can be
+installed and used like so:
+
 ```
 brew install jenv
 # follow postinstall instructions to activate jenv...
@@ -24,7 +32,7 @@ brew install homebrew/cask-versions/temurin17
 jenv add /Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home
 ```
 
-We are using Postgres 14.  You do not need to have postgres installed on your system.
+We are using Postgres 14. You do not need to have postgres installed on your system.
 Instead use the `run_postgres.sh` script to set up a docker container running postgres (see below).
 
 #### Environment Variables
@@ -37,6 +45,7 @@ You may want to add them to your `~/.zshrc` or similar shell profile.
 
 WDS contacts Sam for permission checks. You will need to configure Sam's URL by setting an
 environment variable, such as:
+
 ```
 export SAM_URL=https://sam.dsde-dev.broadinstitute.org/
 ```
@@ -45,61 +54,85 @@ export SAM_URL=https://sam.dsde-dev.broadinstitute.org/
 
 For importing snapshots from the Terra Data Repo, WDS will need the TDR URL configured as an
 environment variable, such as:
+
 ```
 export DATA_REPO_URL=https://jade.datarepo-dev.broadinstitute.org/
 ```
+
 ##### WORKSPACE_MANAGER_URL
 
-Importing snapshots from the Terra Data Repo also requires the Workspace Manager configured as an environment variable, such as:
+Importing snapshots from the Terra Data Repo also requires the Workspace Manager configured as an
+environment variable, such as:
+
 ```
 export WORKSPACE_MANAGER_URL=https://workspace.dsde-dev.broadinstitute.org/
 ```
+
 ##### LEONARDO_URL
 
-Starting WDS in clone mode (your WDS is attempting to clone some other WDS) requires contacting Leo. Set a Leo env var such as:
+Starting WDS in clone mode (your WDS is attempting to clone some other WDS) requires contacting Leo.
+Set a Leo env var such as:
+
 ```
 export LEONARDO_URL=https://leonardo.dsde-dev.broadinstitute.org/
 ```
+
 ##### WORKSPACE_ID
 
-WDS requires a valid workspace id to check permissions in Sam and to import snapshots from the Terra Data Repo.
+WDS requires a valid workspace id to check permissions in Sam and to import snapshots from the Terra
+Data Repo.
 This is controlled by a `WORKSPACE_ID` environment variable. You should set this to the UUID
 of a workspace you own, e.g.
+
 ```
 export WORKSPACE_ID=123e4567-e89b-12d3-a456-426614174000
 ```
 
 ## Running
+
 To just build the code, from the root directory run
+
 ```bash
 ./gradlew build --exclude-task test
 ```
+
 To run the application, first a postgres database must be running:
+
 ```bash
 ./local-dev/run_postgres.sh start
 ```
 
-To run the application against a local SAM_URL instead of dev, you can run the following commands (path has to be absolute, replace with path of where your wds repo exists) to set up nginx in a docker container locally:
+To run the application against a local SAM_URL instead of dev, you can run the following commands (
+path has to be absolute, replace with path of where your wds repo exists) to set up nginx in a
+docker container locally:
+
 ```bash
 docker run -v /{absolute path}/service/src/test/resources/nginx.conf:/etc/nginx/nginx.conf -p 9889:80 -d nginx:1.23.3
 export SAM_URL=http://localhost:9889
 ```
 
 To run WDS locally, you can either use the command line:
+
 ```bash
 ./gradlew bootRun
 ```
-Or, from Intellij, go to `src/main/java/org.databiosphere.workspacedataservice/WorkspaceDataServiceApplication` and click the green play button.
+
+Or, from Intellij, go
+to `src/main/java/org.databiosphere.workspacedataservice/WorkspaceDataServiceApplication` and click
+the green play button.
 This will launch the service on port 8080.
 
-At the moment, WDS is only available through this port.  It can be reached from the command line:
+At the moment, WDS is only available through this port. It can be reached from the command line:
 
 To query for a single record:
+
 ```bash
 curl http://localhost:8080/<instanceid>/records/v0.2/<table/type>/<record_id>
 ```
 
-To add new attribute or update values for existing attributes (this won't create a new record however):
+To add new attribute or update values for existing attributes (this won't create a new record
+however):
+
 ``` bash
 curl -H "Content-type: application/json" -X PATCH "http://localhost:8080/<instanceid guid>/records/v0.2/<table/type>/<record_id>" -d '{
 "id": "<record_name>",
@@ -112,56 +145,78 @@ curl -H "Content-type: application/json" -X PATCH "http://localhost:8080/<instan
 }
 }'
 ```
-Note that attribute and record type names are subject to the logic in [validateName](https://github.com/DataBiosphere/terra-workspace-data-service/blob/5375c8c846ad163e38a5540c4487ea05fb292f45/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java#L80)
+
+Note that attribute and record type names are subject to the logic
+in [validateName](https://github.com/DataBiosphere/terra-workspace-data-service/blob/5375c8c846ad163e38a5540c4487ea05fb292f45/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java#L80)
 
 When done, stop postgres:
+
 ```bash
 ./local-dev/run_postgres.sh stop
 ```
 
 ## Tests
+
 To run unit tests locally, first make sure your local postgres is up and running:
+
 ```bash
 ./local-dev/run_postgres.sh start
 ```
+
 From the command line, run
+
 ```bash
 ./gradlew test
 ```
+
 To run one test suite, run
+
 ```bash
 ./gradlew test --tests '*RecordDaoTest'
 ```
+
 To run a single test, run
+
 ```bash
 ./gradlew test --tests '*RecordDaoTest.testGetSingleRecord'
 ```
 
 ## Swagger UI
+
 When running locally, a Swagger UI is available at http://localhost:8080/swagger/swagger-ui.html.
 
-You can also view the swagger definitions via this third-party hosted UI: https://petstore.swagger.io/?url=https://raw.githubusercontent.com/DataBiosphere/terra-workspace-data-service/main/service/src/main/resources/static/swagger/openapi-docs.yaml.
-Note that in this third-party UI, the APIs are not active; this is only valuable for viewing the definitions.
+You can also view the swagger definitions via this third-party hosted
+UI: https://petstore.swagger.io/?url=https://raw.githubusercontent.com/DataBiosphere/terra-workspace-data-service/main/service/src/main/resources/static/swagger/openapi-docs.yaml.
+Note that in this third-party UI, the APIs are not active; this is only valuable for viewing the
+definitions.
 
 ## Docker
+
 To build the WDS docker image _(replace "wdsdocker" with your desired image name)_:
+
 ```bash
 ./gradlew --build-cache jibDockerBuild --image=wdsdocker -Djib.console=plain
 ```
 
 To run the built docker image (_replace "wdsdocker" the image name specified during build_):
+
 * Docker for Mac:
+
 ```bash
 docker run -e WDS_DB_HOST='host.docker.internal' -p 8080:8080 wdsdocker
 ```
+
 * Docker on Linux:
+
 ```bash
 docker run --network=host -e WDS_DB_HOST='127.0.0.1' -p 8080:8080 wdsdocker
 ```
 
-
 ## Using Workspace Data Service
-A client of WDS is published in the Broad Artifactory.  To include it in your Gradle project, add the following to your `build.gradle` file:
+
+A client of WDS is published in the Broad Artifactory. To include it in your Gradle project, add the
+following to your `build.gradle` file:
+
 ```
 repositories {
     maven {
@@ -172,16 +227,45 @@ repositories {
 dependencies {
     implementation(group: 'org.databiosphere', name: 'workspacedataservice-client', version: 'x.x.x')
 ```
-The latest version can be seen under [Tags](https://github.com/DataBiosphere/terra-workspace-data-service/tags).
+
+The latest version can be seen
+under [Tags](https://github.com/DataBiosphere/terra-workspace-data-service/tags).
 
 ## For Developers
+
 ### Code Style
 
-We use follow the [Google Java style guide](https://google.github.io/styleguide/javaguide.html) and implement it with a combination of the [spotless](https://github.com/diffplug/spotless) plugin and IDE tooling.
+We use follow the [Google Java style guide](https://google.github.io/styleguide/javaguide.html) and
+implement it with a combination of the [spotless](https://github.com/diffplug/spotless) plugin and
+IDE tooling.
 
 To run spotless from the CLI:
+
 ```bash
 ./gradlew spotlessApply
 ```
 
-For details on how to make the most of your IDE to apply the style guide automatically, see [CONTRIBUTING.md](CONTRIBUTING.md).
+For details on how to make the most of your IDE to apply the style guide automatically,
+see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+### API Definitions and Code Generation
+
+WDS's `v0.2` APIs are documented in `service/src/main/resources/static/swagger/openapi-docs.yaml`
+and
+their implementations are hand-coded.
+
+APIs at `v1` or later use code generation. To create or update an API, you must:
+
+1. Define the API using OpenAPI syntax
+   at `service/src/main/resources/static/swagger/openapi-docs.yaml`
+2. Update the `generateApiInterfaces` Gradle task in `service/build.gradle` as necessary.
+  1. Add your APIs to `apiFilesConstrainedTo`
+  2. Add your API's models to `modelFilesConstrainedTo`
+3. Run the `generateApiInterfaces` Gradle task
+4. Note the new/updated Java interfaces and models under the `o.d.w.generated` package
+5. Create or update a controller class that implements the new Java interface
+
+The `generateApiInterfaces` Gradle task is configured to run as a dependency of other
+important Gradle tasks, such as `compileJava`. You should not have to run it manually
+in the course of most development; however, if you are actively changing definitions for
+an API you may need to run it to see your changes.

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -137,11 +137,12 @@ spotless {
 }
 spotlessJavaCheck.onlyIf( { spotlessEnabled } )
 
-// Don't run spotless on generated code
+// Don't run spotless on generated code, but generate code before compiling
 generateApiInterfaces.mustRunAfter(spotlessJava)
+compileJava.dependsOn(generateApiInterfaces)
+processResources.dependsOn(generateApiInterfaces)
 
 // Run spotless check when running in github actions, otherwise run spotless apply.
-// Run generateApiInterfaces after spotless; then compile.
 compileJava {
   if (spotlessEnabled) {
     if (isCiServer) {
@@ -150,7 +151,6 @@ compileJava {
         dependsOn(spotlessApply)
     }
   }
-  dependsOn(generateApiInterfaces)
 }
 
 sonarqube {

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -143,6 +143,7 @@ spotlessJava.dependsOn(generateApiInterfaces)
 compileJava.dependsOn(generateApiInterfaces)
 processResources.dependsOn(generateApiInterfaces)
 processTestResources.dependsOn(generateApiInterfaces)
+processIntegrationTestResources.dependsOn(generateApiInterfaces)
 
 // Run spotless check when running in github actions, otherwise run spotless apply.
 compileJava {

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -141,8 +141,9 @@ spotlessJavaCheck.onlyIf( { spotlessEnabled } )
 // multiple gradle tasks need generateApiInterfaces to run before they do
 spotlessJava.dependsOn(generateApiInterfaces)
 compileJava.dependsOn(generateApiInterfaces)
-processResources.dependsOn(generateApiInterfaces)
-processTestResources.dependsOn(generateApiInterfaces)
+tasks.withType(ProcessResources).configureEach {
+  it.dependsOn(generateApiInterfaces)
+}
 
 // Run spotless check when running in github actions, otherwise run spotless apply.
 compileJava {

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -1,122 +1,127 @@
 import org.openapitools.generator.gradle.plugin.tasks.GenerateTask
 
 plugins {
-	id 'org.springframework.boot'
-	id 'com.google.cloud.tools.jib'
-	id 'org.sonarqube'
-	id 'com.gorylenko.gradle-git-properties'
-	id 'org.openapi.generator'
-	id 'com.diffplug.spotless' version '6.21.0'
-	id 'jacoco'
-	id "au.com.dius.pact" version "4.6.1"
-	id 'jvm-test-suite'
+    id 'org.springframework.boot'
+    id 'com.google.cloud.tools.jib'
+    id 'org.sonarqube'
+    id 'com.gorylenko.gradle-git-properties'
+    id 'org.openapi.generator'
+    id 'com.diffplug.spotless' version '6.21.0'
+    id 'jacoco'
+    id "au.com.dius.pact" version "4.6.1"
+    id 'jvm-test-suite'
 }
 
 springBoot {
-	buildInfo()
+    buildInfo()
 }
 
 repositories {
-	maven { url 'https://broadinstitute.jfrog.io/artifactory/maven-central' }
-	mavenCentral()
-	maven { url 'https://broadinstitute.jfrog.io/artifactory/libs-snapshot' }
-	maven { url 'https://broadinstitute.jfrog.io/artifactory/libs-release' }
+    maven { url 'https://broadinstitute.jfrog.io/artifactory/maven-central' }
+    mavenCentral()
+    maven { url 'https://broadinstitute.jfrog.io/artifactory/libs-snapshot' }
+    maven { url 'https://broadinstitute.jfrog.io/artifactory/libs-release' }
 }
 
 jib {
-	from {
-		// see https://github.com/broadinstitute/dsp-appsec-blessed-images/tree/main/jre
-		image = "us.gcr.io/broad-dsp-gcr-public/debian/wds-debian-pg-dump:latest"
-	}
+    from {
+        // see https://github.com/broadinstitute/dsp-appsec-blessed-images/tree/main/jre
+        image = "us.gcr.io/broad-dsp-gcr-public/debian/wds-debian-pg-dump:latest"
+    }
 
-	container {
-		mainClass = 'org.databiosphere.workspacedataservice.WorkspaceDataServiceApplication'
-		creationTime = "USE_CURRENT_TIMESTAMP"
-	}
+    container {
+        mainClass = 'org.databiosphere.workspacedataservice.WorkspaceDataServiceApplication'
+        creationTime = "USE_CURRENT_TIMESTAMP"
+    }
 }
 
 ext {
-	jersey_version = "2.36"
+    jersey_version = "2.36"
 }
 
 dependencies {
-	// Azure libraries
-	implementation 'com.microsoft.azure:applicationinsights-runtime-attach:3.4.14'
-	implementation 'com.azure:azure-storage-blob:12.23.0'
-	implementation 'com.azure:azure-identity:1.9.2' // authentication in azure environment
-	implementation 'com.azure:azure-identity-extensions:1.1.5' // postgres password plugin
+    // Azure libraries
+    implementation 'com.microsoft.azure:applicationinsights-runtime-attach:3.4.14'
+    implementation 'com.azure:azure-storage-blob:12.23.0'
+    implementation 'com.azure:azure-identity:1.9.2' // authentication in azure environment
+    implementation 'com.azure:azure-identity-extensions:1.1.5' // postgres password plugin
 
-	implementation 'org.springframework.boot:spring-boot-starter'
-	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-cache'
-	implementation 'org.springframework.boot:spring-boot-starter-batch'
-	implementation 'org.springframework.retry:spring-retry:1.3.4'
-	implementation 'org.aspectj:aspectjweaver:1.8.9' // required by spring-retry, not used directly by WDS
-	implementation 'org.apache.commons:commons-lang3'
-	implementation 'com.google.guava:guava:32.1.1-jre'
-	implementation 'org.postgresql:postgresql'
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	implementation 'org.webjars:webjars-locator-core:0.52'
-	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.13.5'
-	implementation 'io.sentry:sentry-logback:6.12.1'
-	implementation 'org.liquibase:liquibase-core:4.21.1'
-	implementation 'javax.cache:cache-api'
-	implementation 'org.ehcache:ehcache:3.10.8'
-	implementation 'org.hashids:hashids:1.0.3'
-	implementation 'javax.ws.rs:javax.ws.rs-api:2.1.1'
-	implementation 'com.google.mug:mug:6.6'
+    implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'org.springframework.boot:spring-boot-starter-batch'
+    implementation 'org.springframework.retry:spring-retry:1.3.4'
+    implementation 'org.aspectj:aspectjweaver:1.8.9'
+    // required by spring-retry, not used directly by WDS
+    implementation 'org.apache.commons:commons-lang3'
+    implementation 'com.google.guava:guava:32.1.1-jre'
+    implementation 'org.postgresql:postgresql'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.webjars:webjars-locator-core:0.52'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.13.5'
+    implementation 'io.sentry:sentry-logback:6.12.1'
+    implementation 'org.liquibase:liquibase-core:4.21.1'
+    implementation 'javax.cache:cache-api'
+    implementation 'org.ehcache:ehcache:3.10.8'
+    implementation 'org.hashids:hashids:1.0.3'
+    implementation 'javax.ws.rs:javax.ws.rs-api:2.1.1'
+    implementation 'com.google.mug:mug:6.6'
 
-	// required by openapi-generated models and api interfaces
-	implementation 'javax.validation:validation-api'
-	implementation 'io.swagger.core.v3:swagger-annotations:2.2.16'
+    // required by openapi-generated models and api interfaces
+    implementation 'javax.validation:validation-api'
+    implementation 'io.swagger.core.v3:swagger-annotations:2.2.16'
 
-	// Terra libraries
-	implementation group: 'org.broadinstitute.dsde.workbench', name: 'sam-client_2.13', version: '0.1-08b6588'
-	implementation group: 'org.broadinstitute.dsde.workbench', name: 'leonardo-client_2.13', version: '1.3.6-22ee00b'
-	implementation 'com.squareup.okhttp3:okhttp:4.11.0' // required by Sam client
-	implementation "bio.terra:datarepo-client:1.476.0-SNAPSHOT"
-	implementation "bio.terra:workspace-manager-client:0.254.717-SNAPSHOT"
-	implementation "bio.terra:java-pfb-library:0.5.0"
-	implementation project(path: ':client')
+    // Terra libraries
+    implementation group: 'org.broadinstitute.dsde.workbench', name: 'sam-client_2.13', version: '0.1-08b6588'
+    implementation group: 'org.broadinstitute.dsde.workbench', name: 'leonardo-client_2.13', version: '1.3.6-22ee00b'
+    implementation 'com.squareup.okhttp3:okhttp:4.11.0' // required by Sam client
+    implementation "bio.terra:datarepo-client:1.476.0-SNAPSHOT"
+    implementation "bio.terra:workspace-manager-client:0.254.717-SNAPSHOT"
+    implementation "bio.terra:java-pfb-library:0.5.0"
+    implementation project(path: ':client')
 
-	// hk2 is required to use WSM client, but not correctly exposed by the client
-	implementation "org.glassfish.jersey.inject:jersey-hk2:$jersey_version"
-	implementation "org.glassfish.jersey.core:jersey-client:$jersey_version"
-	implementation "org.glassfish.jersey.core:jersey-common:$jersey_version"
+    // hk2 is required to use WSM client, but not correctly exposed by the client
+    implementation "org.glassfish.jersey.inject:jersey-hk2:$jersey_version"
+    implementation "org.glassfish.jersey.core:jersey-client:$jersey_version"
+    implementation "org.glassfish.jersey.core:jersey-common:$jersey_version"
 
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
-	runtimeOnly 'org.webjars.npm:swagger-ui-dist:4.12.0'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'
-	testImplementation project(':client')
-	testImplementation 'au.com.dius.pact.consumer:junit5:4.6.1'
+    runtimeOnly 'org.webjars.npm:swagger-ui-dist:4.12.0'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'
+    testImplementation project(':client')
+    testImplementation 'au.com.dius.pact.consumer:junit5:4.6.1'
 
-	constraints {
-		implementation('org.json:json:20230227') {
-			because("CVE-2022-45688")
-		}
-		implementation('com.squareup.okio:okio:3.4.0') {
-			because("CVE-2023-3635")
-		}
-	}
+    constraints {
+        implementation('org.json:json:20230227') {
+            because("CVE-2022-45688")
+        }
+        implementation('com.squareup.okio:okio:3.4.0') {
+            because("CVE-2023-3635")
+        }
+    }
 }
 
+// generate server stubs, for WDS's v1 APIs only
 tasks.register('generateApiInterfaces', GenerateTask) {
-	generatorName = "spring"
-	library = "spring-boot"
-	inputSpec = "$rootDir/service/src/main/resources/static/swagger/openapi-docs.yaml"
-	outputDir = "$rootDir/service"
-	cleanupOutput = false // else would delete the /service directory
-	apiPackage = "org.databiosphere.workspacedataservice.generated.api"
-	modelPackage = "org.databiosphere.workspacedataservice.generated.model"
-	apiFilesConstrainedTo.set(["Import"]) // seems to respect the tag value instead of the filename
-	modelFilesConstrainedTo.set(["ImportRequest"])
-	supportingFilesConstrainedTo.set(["ApiUtil.java"])
-	configOptions.set([
-		interfaceOnly: "true", // Java interfaces only; no controllers or implementation classes
-		useTags      : "true" // use the OpenAPI tag to classify apis, not the first segment of the api path
-	])
+    generatorName = "spring"
+    library = "spring-boot"
+    inputSpec = "$rootDir/service/src/main/resources/static/swagger/apis-v1.yaml"
+    outputDir = "$rootDir/service"
+    cleanupOutput = false // else would delete the /service directory
+    apiPackage = "org.databiosphere.workspacedataservice.generated.api"
+    // apiNameSuffix does not work; see https://github.com/OpenAPITools/openapi-generator/issues/8822
+    // apiNameSuffix = "Server" // disambiguate from classes in the generated client
+    modelPackage = "org.databiosphere.workspacedataservice.generated.model"
+    modelNameSuffix = "ServerModel"   // disambiguate from classes in the generated client
+    apiFilesConstrainedTo.set([""])   // empty string means generate all apis
+    modelFilesConstrainedTo.set([""]) // empty string means generate all models
+    supportingFilesConstrainedTo.set(["ApiUtil.java"])
+    configOptions.set([
+        interfaceOnly: "true", // Java interfaces only; no controllers or implementation classes
+        useTags      : "true" // use the OpenAPI tag to classify apis, not the first segment of the api path
+    ])
 }
 
 
@@ -128,96 +133,96 @@ boolean isCiServer = System.getenv().containsKey("CI") && System.getenv().get("C
 boolean spotlessEnabled = true
 
 spotless {
-  java {
-    targetExclude "${buildDir}/**"
-    targetExclude "**/swagger-code/**"
-    targetExclude "**/generated/**"
-    googleJavaFormat()
-    toggleOffOn() // allow spotless:off & spotless:on to protect code from formatting
-  }
+    java {
+        targetExclude "${buildDir}/**"
+        targetExclude "**/swagger-code/**"
+        targetExclude "**/generated/**"
+        googleJavaFormat()
+        toggleOffOn() // allow spotless:off & spotless:on to protect code from formatting
+    }
 }
-spotlessJavaCheck.onlyIf( { spotlessEnabled } )
+spotlessJavaCheck.onlyIf({ spotlessEnabled })
 
 // multiple gradle tasks need generateApiInterfaces to run before they do
 spotlessJava.dependsOn(generateApiInterfaces)
 compileJava.dependsOn(generateApiInterfaces)
 tasks.withType(ProcessResources).configureEach {
-  it.dependsOn(generateApiInterfaces)
+    it.dependsOn(generateApiInterfaces)
 }
 
 // Run spotless check when running in github actions, otherwise run spotless apply.
 compileJava {
-  if (spotlessEnabled) {
-    if (isCiServer) {
-        dependsOn(spotlessCheck)
-    } else {
-        dependsOn(spotlessApply)
+    if (spotlessEnabled) {
+        if (isCiServer) {
+            dependsOn(spotlessCheck)
+        } else {
+            dependsOn(spotlessApply)
+        }
     }
-  }
 }
 
 sonarqube {
-	properties {
-		property "sonar.projectName", "terra-workspace-data-service"
-		property "sonar.projectKey", "DataBiosphere_workspace-data-service"
-		property "sonar.organization", "broad-databiosphere"
-		property "sonar.host.url", "https://sonarcloud.io"
-	}
+    properties {
+        property "sonar.projectName", "terra-workspace-data-service"
+        property "sonar.projectKey", "DataBiosphere_workspace-data-service"
+        property "sonar.organization", "broad-databiosphere"
+        property "sonar.host.url", "https://sonarcloud.io"
+    }
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
-	testLogging {
-		events = ["passed", "failed", "skipped", "started"]
-		exceptionFormat = "full"
-		// should command-line test output show stdout/stderr?
-		showStandardStreams = false
-	}
+    useJUnitPlatform()
+    testLogging {
+        events = ["passed", "failed", "skipped", "started"]
+        exceptionFormat = "full"
+        // should command-line test output show stdout/stderr?
+        showStandardStreams = false
+    }
 }
 
 jacocoTestReport {
-	reports {
-		// sonarqube requires XML coverage output to upload coverage data
-		xml.required = true
-	}
+    reports {
+        // sonarqube requires XML coverage output to upload coverage data
+        xml.required = true
+    }
 }
 
 test {
-	systemProperties['pact.rootDir'] = "$buildDir/pacts"
-	systemProperties['pact.provider.version'] = "$project.version"
+    systemProperties['pact.rootDir'] = "$buildDir/pacts"
+    systemProperties['pact.provider.version'] = "$project.version"
 }
 
 tasks.register("pactTests", Test) {
-	useJUnitPlatform {
-		includeTags "pact-test"
-	}
-	testLogging {
-		showStandardStreams = true
-	}
+    useJUnitPlatform {
+        includeTags "pact-test"
+    }
+    testLogging {
+        showStandardStreams = true
+    }
 }
 
 testing {
     suites {
         integrationTest(JvmTestSuite) {
             dependencies {
-				implementation project(':service')
-				implementation project(':client')
-				implementation 'org.springframework.boot:spring-boot-starter-test'
-				implementation 'org.springframework.boot:spring-boot-starter-jdbc'
-				implementation 'org.liquibase:liquibase-core:4.21.1'
-				implementation "org.glassfish.jersey.core:jersey-client:$jersey_version"
-				implementation "org.glassfish.jersey.core:jersey-common:$jersey_version"
-				implementation "org.glassfish.jersey.inject:jersey-hk2:$jersey_version"
+                implementation project(':service')
+                implementation project(':client')
+                implementation 'org.springframework.boot:spring-boot-starter-test'
+                implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+                implementation 'org.liquibase:liquibase-core:4.21.1'
+                implementation "org.glassfish.jersey.core:jersey-client:$jersey_version"
+                implementation "org.glassfish.jersey.core:jersey-common:$jersey_version"
+                implementation "org.glassfish.jersey.inject:jersey-hk2:$jersey_version"
             }
         }
     }
 }
 
 tasks.named('integrationTest') {
-	testLogging {
-		events = ["passed", "failed", "skipped", "started"]
-		exceptionFormat = "full"
-		// should command-line test output show stdout/stderr?
-		showStandardStreams = false
-	}
+    testLogging {
+        events = ["passed", "failed", "skipped", "started"]
+        exceptionFormat = "full"
+        // should command-line test output show stdout/stderr?
+        showStandardStreams = false
+    }
 }

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -110,10 +110,10 @@ tasks.register('generateApiInterfaces', GenerateTask) {
     inputSpec = "$rootDir/service/src/main/resources/static/swagger/apis-v1.yaml"
     outputDir = "$rootDir/service"
     cleanupOutput = false // else would delete the /service directory
-    apiPackage = "org.databiosphere.workspacedataservice.generated.api"
+    apiPackage = "org.databiosphere.workspacedataservice.generated"
     // apiNameSuffix does not work; see https://github.com/OpenAPITools/openapi-generator/issues/8822
     // apiNameSuffix = "Server" // disambiguate from classes in the generated client
-    modelPackage = "org.databiosphere.workspacedataservice.generated.model"
+    modelPackage = "org.databiosphere.workspacedataservice.generated"
     modelNameSuffix = "ServerModel"   // disambiguate from classes in the generated client
     apiFilesConstrainedTo.set([""])   // empty string means generate all apis
     modelFilesConstrainedTo.set([""]) // empty string means generate all models

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -107,7 +107,7 @@ tasks.register('generateApiInterfaces', GenerateTask) {
 	library = "spring-boot"
 	inputSpec = "$rootDir/service/src/main/resources/static/swagger/openapi-docs.yaml"
 	outputDir = "$rootDir/service"
-	cleanupOutput = false // set to true to delete the output directory before regenerating
+	cleanupOutput = false // else would delete the /service directory
 	apiPackage = "org.databiosphere.workspacedataservice.generated.api"
 	modelPackage = "org.databiosphere.workspacedataservice.generated.model"
 	apiFilesConstrainedTo.set(["Import"]) // seems to respect the tag value instead of the filename
@@ -143,7 +143,6 @@ spotlessJava.dependsOn(generateApiInterfaces)
 compileJava.dependsOn(generateApiInterfaces)
 processResources.dependsOn(generateApiInterfaces)
 processTestResources.dependsOn(generateApiInterfaces)
-processIntegrationTestResources.dependsOn(generateApiInterfaces)
 
 // Run spotless check when running in github actions, otherwise run spotless apply.
 compileJava {

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -117,7 +117,7 @@ tasks.register('generateApiInterfaces', GenerateTask) {
     modelNameSuffix = "ServerModel"   // disambiguate from classes in the generated client
     apiFilesConstrainedTo.set([""])   // empty string means generate all apis
     modelFilesConstrainedTo.set([""]) // empty string means generate all models
-    supportingFilesConstrainedTo.set(["ApiUtil.java"])
+    supportingFilesConstrainedTo.set([]) // empty array means generate none
     configOptions.set([
         interfaceOnly: "true", // Java interfaces only; no controllers or implementation classes
         useTags      : "true" // use the OpenAPI tag to classify apis, not the first segment of the api path

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -1,8 +1,11 @@
+import org.openapitools.generator.gradle.plugin.tasks.GenerateTask
+
 plugins {
 	id 'org.springframework.boot'
 	id 'com.google.cloud.tools.jib'
 	id 'org.sonarqube'
 	id 'com.gorylenko.gradle-git-properties'
+	id 'org.openapi.generator'
 	id 'com.diffplug.spotless' version '6.21.0'
 	id 'jacoco'
 	id "au.com.dius.pact" version "4.6.1"
@@ -64,6 +67,10 @@ dependencies {
 	implementation 'javax.ws.rs:javax.ws.rs-api:2.1.1'
 	implementation 'com.google.mug:mug:6.6'
 
+	// required by openapi-generated models and api interfaces
+	implementation 'javax.validation:validation-api'
+	implementation 'io.swagger.core.v3:swagger-annotations:2.2.16'
+
 	// Terra libraries
 	implementation group: 'org.broadinstitute.dsde.workbench', name: 'sam-client_2.13', version: '0.1-08b6588'
 	implementation group: 'org.broadinstitute.dsde.workbench', name: 'leonardo-client_2.13', version: '1.3.6-22ee00b'
@@ -95,6 +102,24 @@ dependencies {
 	}
 }
 
+tasks.register('generateApiInterfaces', GenerateTask) {
+	generatorName = "spring"
+	library = "spring-boot"
+	inputSpec = "$rootDir/service/src/main/resources/static/swagger/openapi-docs.yaml"
+	outputDir = "$rootDir/service"
+	cleanupOutput = false // set to true to delete the output directory before regenerating
+	apiPackage = "org.databiosphere.workspacedataservice.generated.api"
+	modelPackage = "org.databiosphere.workspacedataservice.generated.model"
+	apiFilesConstrainedTo.set(["Import"]) // seems to respect the tag value instead of the filename
+	modelFilesConstrainedTo.set(["ImportRequest"])
+	supportingFilesConstrainedTo.set(["ApiUtil.java"])
+	configOptions.set([
+		interfaceOnly: "true", // Java interfaces only; no controllers or implementation classes
+		useTags      : "true" // use the OpenAPI tag to classify apis, not the first segment of the api path
+	])
+}
+
+
 boolean isCiServer = System.getenv().containsKey("CI") && System.getenv().get("CI").toBoolean()
 
 // kill switch for spotless, intended for one-off contingencies only, like when
@@ -112,7 +137,11 @@ spotless {
 }
 spotlessJavaCheck.onlyIf( { spotlessEnabled } )
 
+// Don't run spotless on generated code
+generateApiInterfaces.mustRunAfter(spotlessJava)
+
 // Run spotless check when running in github actions, otherwise run spotless apply.
+// Run generateApiInterfaces after spotless; then compile.
 compileJava {
   if (spotlessEnabled) {
     if (isCiServer) {
@@ -121,6 +150,7 @@ compileJava {
         dependsOn(spotlessApply)
     }
   }
+  dependsOn(generateApiInterfaces)
 }
 
 sonarqube {

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -141,6 +141,7 @@ spotlessJavaCheck.onlyIf( { spotlessEnabled } )
 generateApiInterfaces.mustRunAfter(spotlessJava)
 compileJava.dependsOn(generateApiInterfaces)
 processResources.dependsOn(generateApiInterfaces)
+processTestResources.dependsOn(generateApiInterfaces)
 
 // Run spotless check when running in github actions, otherwise run spotless apply.
 compileJava {

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -131,14 +131,15 @@ spotless {
   java {
     targetExclude "${buildDir}/**"
     targetExclude "**/swagger-code/**"
+    targetExclude "**/generated/**"
     googleJavaFormat()
     toggleOffOn() // allow spotless:off & spotless:on to protect code from formatting
   }
 }
 spotlessJavaCheck.onlyIf( { spotlessEnabled } )
 
-// Don't run spotless on generated code, but generate code before compiling
-generateApiInterfaces.mustRunAfter(spotlessJava)
+// multiple gradle tasks need generateApiInterfaces to run before they do
+spotlessJava.dependsOn(generateApiInterfaces)
 compileJava.dependsOn(generateApiInterfaces)
 processResources.dependsOn(generateApiInterfaces)
 processTestResources.dependsOn(generateApiInterfaces)

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/ImportController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/ImportController.java
@@ -1,6 +1,5 @@
 package org.databiosphere.workspacedataservice.controller;
 
-import java.util.List;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.generated.api.ImportApi;
 import org.databiosphere.workspacedataservice.generated.model.ImportRequest;
@@ -12,7 +11,8 @@ import org.springframework.web.bind.annotation.RestController;
 public class ImportController implements ImportApi {
 
   @Override
-  public ResponseEntity<Void> importV1(UUID instanceUuid, List<ImportRequest> importRequest) {
+  public ResponseEntity<Void> importV1(UUID instanceUuid, ImportRequest importRequest) {
+    // TODO: implementation for imports
     return new ResponseEntity<>(HttpStatus.TOO_EARLY);
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/ImportController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/ImportController.java
@@ -13,6 +13,8 @@ public class ImportController implements ImportApi {
   @Override
   public ResponseEntity<Void> importV1(UUID instanceUuid, ImportRequest importRequest) {
     // TODO: implementation for imports
+    // return TOO_EARLY here as a proof-of-concept that we can override the implementation
+    // in ImportApi (which returns NOT_IMPLEMENTED)
     return new ResponseEntity<>(HttpStatus.TOO_EARLY);
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/ImportController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/ImportController.java
@@ -2,7 +2,7 @@ package org.databiosphere.workspacedataservice.controller;
 
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.generated.api.ImportApi;
-import org.databiosphere.workspacedataservice.generated.model.ImportRequest;
+import org.databiosphere.workspacedataservice.generated.model.ImportRequestServerModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ImportController implements ImportApi {
 
   @Override
-  public ResponseEntity<Void> importV1(UUID instanceUuid, ImportRequest importRequest) {
+  public ResponseEntity<Void> importV1(UUID instanceUuid, ImportRequestServerModel importRequest) {
     // TODO: implementation for imports
     // return TOO_EARLY here as a proof-of-concept that we can override the implementation
     // in ImportApi (which returns NOT_IMPLEMENTED)

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/ImportController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/ImportController.java
@@ -1,0 +1,18 @@
+package org.databiosphere.workspacedataservice.controller;
+
+import java.util.List;
+import java.util.UUID;
+import org.databiosphere.workspacedataservice.generated.api.ImportApi;
+import org.databiosphere.workspacedataservice.generated.model.ImportRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ImportController implements ImportApi {
+
+  @Override
+  public ResponseEntity<Void> importV1(UUID instanceUuid, List<ImportRequest> importRequest) {
+    return new ResponseEntity<>(HttpStatus.TOO_EARLY);
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/ImportController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/ImportController.java
@@ -1,8 +1,8 @@
 package org.databiosphere.workspacedataservice.controller;
 
 import java.util.UUID;
-import org.databiosphere.workspacedataservice.generated.api.ImportApi;
-import org.databiosphere.workspacedataservice.generated.model.ImportRequestServerModel;
+import org.databiosphere.workspacedataservice.generated.ImportApi;
+import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;

--- a/service/src/main/resources/static/swagger/apis-v1.yaml
+++ b/service/src/main/resources/static/swagger/apis-v1.yaml
@@ -1,0 +1,79 @@
+# This file contains only the v1 WDS APIs.
+# Our server-stub generator can target this file and this file only, to avoid generating
+# v0.2 stubs we aren't using.externalDocs:
+#
+# The APIs and models in this file **must** also be included, via $ref, in openapi-docs.yaml
+# to present both the v0.2 and v1 APIs to the swagger-ui.
+
+openapi: 3.0.3
+
+info:
+  title: Workspace Data Service
+  version: v1
+
+tags:
+  # Tags should be listed in the order they should appear in the UI
+  - name: Import
+    description: Import APIs
+
+paths:
+  ##############################
+  # Import APIs
+  ##############################
+  /{instanceUuid}/import/v1:
+    post:
+      summary: Import from a file
+      description: Imports records from the specified URL.
+      operationId: importV1
+      tags:
+        - Import
+      parameters:
+        - $ref: '#/components/parameters/instanceUuidPathParam'
+      requestBody:
+        description: A request to import records from a file
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              title: ImportRequest
+              required:
+                - type
+                - url
+              properties:
+                type:
+                  type: string
+                  enum: [ PFB, TDRMANIFEST ]
+                  description: format of file to import
+                url:
+                  type: string
+                  format: uri
+                  description: url from which to import
+                options:
+                  type: object
+                  additionalProperties: true
+                  description: key-value pairs to configure this import. Options vary based on the import file type.
+      responses:
+        202:
+          description: Import accepted.
+
+components:
+  # within each group, components should be listed alphabetically.
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+
+  parameters:
+    # instanceUuidPathParam is very close to duplicating instanceIdPathParam from v0.2,
+    # but this one specifies format: uuid, which creates Java UUID objects in generated
+    # code instead of a String.
+    instanceUuidPathParam:
+      name: instanceUuid
+      in: path
+      description: WDS instance id; by convention equal to workspace id
+      required: true
+      schema:
+        type: string
+        format: uuid
+

--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -334,19 +334,8 @@ paths:
   # Import APIs
   ##############################
   /{instanceUuid}/import/v1:
-    post:
-      summary: Import from a file
-      description: Imports records from the specified URL.
-      operationId: importV1
-      tags:
-        - Import
-      parameters:
-        - $ref: '#/components/parameters/instanceUuidPathParam'
-      requestBody:
-        $ref: '#/components/requestBodies/ImportRequestBody'
-      responses:
-        202:
-          description: Import accepted.
+    # OpenApi requires "/" to be replaced with "~1" in the path being referenced
+    $ref: 'apis-v1.yaml#/paths/~1{instanceUuid}~1import~1v1'
 
   ##############################
   # Instances APIs
@@ -647,13 +636,6 @@ components:
             type: array
             items:
               $ref: '#/components/schemas/BatchOperation'
-    ImportRequestBody:
-      description: A request to import records from a file
-      required: true
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ImportRequest'
     RecordRequestBody:
       description: A record's attributes to upload
       required: true
@@ -889,24 +871,6 @@ components:
           type: string
         commit:
           $ref: '#/components/schemas/commit'
-    ImportRequest:
-      type: object
-      required:
-        - type
-        - url
-      properties:
-        type:
-          type: string
-          enum: [ PFB, TDRMANIFEST ]
-          description: format of file to import
-        url:
-          type: string
-          format: uri
-          description: url from which to import
-        options:
-          type: object
-          additionalProperties: true
-          description: key-value pairs to configure this import. Options vary based on the import file type.
     Job:
       type: object
       required:

--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -333,7 +333,7 @@ paths:
   ##############################
   # Import APIs
   ##############################
-  /{instanceid}/import/v1:
+  /{instanceUuid}/import/v1:
     post:
       summary: Import from a file
       description: Imports records from the specified URL.
@@ -341,7 +341,7 @@ paths:
       tags:
         - Import
       parameters:
-        - $ref: '#/components/parameters/instanceIdPathParam'
+        - $ref: '#/components/parameters/instanceUuidPathParam'
       requestBody:
         $ref: '#/components/requestBodies/ImportRequestBody'
       responses:
@@ -556,6 +556,14 @@ components:
       required: true
       schema:
         type: string
+    instanceUuidPathParam:
+      name: instanceUuid
+      in: path
+      description: WDS instance id; by convention equal to workspace id
+      required: true
+      schema:
+        type: string
+        format: uuid
     recordIdPathParam:
       name: id
       in: path

--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -653,9 +653,7 @@ components:
       content:
         application/json:
           schema:
-            type: array
-            items:
-              $ref: '#/components/schemas/ImportRequest'
+            $ref: '#/components/schemas/ImportRequest'
     RecordRequestBody:
       description: A record's attributes to upload
       required: true

--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -20,6 +20,8 @@ tags:
     description: Cloning APIs including Backup and Restore
   - name: Records
     description: Record APIs
+  - name: Import
+    description: Import APIs
   - name: Instances
     description: Instance APIs
   - name: Schema
@@ -329,6 +331,24 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
 
   ##############################
+  # Import APIs
+  ##############################
+  /{instanceid}/import/v1:
+    post:
+      summary: Import from a file
+      description: Imports records from the specified URL.
+      operationId: importV1
+      tags:
+        - Import
+      parameters:
+        - $ref: '#/components/parameters/instanceIdPathParam'
+      requestBody:
+        $ref: '#/components/requestBodies/ImportRequestBody'
+      responses:
+        202:
+          description: Import accepted.
+
+  ##############################
   # Instances APIs
   ##############################
   /instances/{v}:
@@ -494,7 +514,11 @@ paths:
   ##############################
   /{instanceid}/snapshots/{v}/{snapshotid}:
     post:
+      deprecated: true
       summary: Import a snapshot from Terra Data Repo
+      description: |
+        This API will be removed on or after Jan 1 2024.
+        Use the POST /{instanceid}/import/v1 API instead.
       operationId: importSnapshot
       security:
         - bearerAuth: [ ]
@@ -615,6 +639,15 @@ components:
             type: array
             items:
               $ref: '#/components/schemas/BatchOperation'
+    ImportRequestBody:
+      description: A request to import records from a file
+      required: true
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/ImportRequest'
     RecordRequestBody:
       description: A record's attributes to upload
       required: true
@@ -850,6 +883,24 @@ components:
           type: string
         commit:
           $ref: '#/components/schemas/commit'
+    ImportRequest:
+      type: object
+      required:
+        - type
+        - url
+      properties:
+        type:
+          type: string
+          enum: [ PFB, TDRMANIFEST ]
+          description: format of file to import
+        url:
+          type: string
+          format: uri
+          description: url from which to import
+        options:
+          type: object
+          additionalProperties: true
+          description: key-value pairs to configure this import. Options vary based on the import file type.
     Job:
       type: object
       required:


### PR DESCRIPTION
This PR introduces a bunch of concepts to WDS; I'm putting this out for debate and discussion.

Note that this PR does not actually implement a new/async snapshot API yet. I will do that in follow-on PRs; I wanted to get this out for discussion before then.

In this PR:

## We can and should bump the version for individual APIs
Or, bump groups of APIs together. We don't have to version all WDS APIs at once. This PR adds a new `importV1` API as a successor to the v0.2 `importSnapshot` API.

## We can deprecate old APIs
In this PR, I've marked the `importSnapshot` API as deprecated and given it a 3-month time to live. Admittedly, this is an easy deprecation since we're not using that API anywhere yet.

## We should generate API interface definitions programmatically
And then hand-code implementation classes on top of those interfaces. This forces attention to detail on our OpenAPI spec. Since that spec is used to create our Java and Python clients, it's really important to get the spec right and name things in a friendly manner. By dogfooding our server-side API interfaces, we improve our clients as well. This PR introduces a `generateApiInterfaces` gradle task which generates the `ImportApi` interface at build time; `ImportController` then implements that interface. It also generates the `ImportRequest` model class.


