### PR TITLE
Tidy up setup and teardown methods.

### DIFF
--- a/service/src/integrationTest/java/org/databiosphere/workspacedataservice/InstanceInitializerCloneTest.java
+++ b/service/src/integrationTest/java/org/databiosphere/workspacedataservice/InstanceInitializerCloneTest.java
@@ -24,7 +24,7 @@ import org.databiosphere.workspacedataservice.shared.model.job.Job;
 import org.databiosphere.workspacedataservice.shared.model.job.JobStatus;
 import org.databiosphere.workspacedataservice.sourcewds.WorkspaceDataServiceClientFactory;
 import org.databiosphere.workspacedataservice.workspacemanager.WorkspaceManagerDao;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -69,8 +69,8 @@ class InstanceInitializerCloneTest {
   @Value("${twds.instance.source-workspace-id}")
   String sourceWorkspaceId;
 
-  @BeforeEach
-  void beforeEach() {
+  @AfterEach
+  void tearDown() {
     // clean up any instances left in the db
     List<UUID> allInstances = instanceDao.listInstanceSchemas();
     allInstances.forEach(instanceId -> instanceDao.dropSchema(instanceId));

--- a/service/src/integrationTest/java/org/databiosphere/workspacedataservice/service/RestoreServiceIntegrationTest.java
+++ b/service/src/integrationTest/java/org/databiosphere/workspacedataservice/service/RestoreServiceIntegrationTest.java
@@ -10,7 +10,7 @@ import org.databiosphere.workspacedataservice.dao.InstanceDao;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 import org.databiosphere.workspacedataservice.shared.model.job.JobStatus;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -40,8 +40,8 @@ public class RestoreServiceIntegrationTest {
   @Value("${twds.instance.workspace-id:}")
   private String workspaceId;
 
-  @BeforeEach
-  void beforeEach() {
+  @AfterEach
+  void tearDown() {
     // clean up any instances left in the db
     List<UUID> allInstances = instanceDao.listInstanceSchemas();
     allInstances.forEach(instanceId -> instanceDao.dropSchema(instanceId));

--- a/service/src/test/java/org/databiosphere/workspacedataservice/InstanceInitializerBeanTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/InstanceInitializerBeanTest.java
@@ -16,7 +16,7 @@ import org.databiosphere.workspacedataservice.service.BackupRestoreService;
 import org.databiosphere.workspacedataservice.sourcewds.WorkspaceDataServiceConfig;
 import org.databiosphere.workspacedataservice.storage.AzureBlobStorage;
 import org.databiosphere.workspacedataservice.workspacemanager.WorkspaceManagerConfig;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -64,8 +64,8 @@ class InstanceInitializerBeanTest {
   // randomly generated UUID
   final UUID instanceID = UUID.fromString("90e1b179-9f83-4a6f-a8c2-db083df4cd03");
 
-  @BeforeEach
-  void beforeEach() {
+  @AfterEach
+  void tearDown() {
     // clean up any instances left in the db
     List<UUID> allInstances = instanceDao.listInstanceSchemas();
     allInstances.forEach(instanceId -> instanceDao.dropSchema(instanceId));

--- a/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/ActivityEventBuilderTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/ActivityEventBuilderTest.java
@@ -44,7 +44,7 @@ public class ActivityEventBuilderTest {
   final ResourcesApi mockResourcesApi = Mockito.mock(ResourcesApi.class);
 
   @BeforeEach
-  void beforeEach() {
+  void setUp() {
     given(mockSamClientFactory.getUsersApi(any())).willReturn(mockUsersApi);
     given(mockSamClientFactory.getResourcesApi(any())).willReturn(mockResourcesApi);
   }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/LogStatementTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/LogStatementTest.java
@@ -65,7 +65,7 @@ public class LogStatementTest {
   final RepositoryApi mockRepositoryApi = Mockito.mock(RepositoryApi.class);
 
   @AfterEach
-  void afterEach() {
+  void tearDown() {
     List<UUID> allInstances = instanceService.listInstances(VERSION);
     for (UUID id : allInstances) {
       instanceService.deleteInstance(id, VERSION);

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/ConcurrentDataTypeChangesTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/ConcurrentDataTypeChangesTest.java
@@ -33,15 +33,15 @@ import org.springframework.test.context.ActiveProfiles;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class ConcurrentDataTypeChangesTest {
   @Autowired private TestRestTemplate restTemplate;
-  private static HttpHeaders headers;
-  private static UUID instanceId;
+  private HttpHeaders headers;
+  private UUID instanceId;
 
   private static final String recordId = "concurrent-changes";
   private static final RecordType recordType = RecordType.valueOf("concurrency");
   private static final String versionId = "v0.2";
 
   @BeforeEach
-  void beforeEach() {
+  void setUp() {
     headers = new HttpHeaders();
     headers.setContentType(MediaType.APPLICATION_JSON);
     instanceId = UUID.randomUUID();
@@ -57,7 +57,7 @@ class ConcurrentDataTypeChangesTest {
   }
 
   @AfterEach
-  void afterEach() {
+  void tearDown() {
     ResponseEntity<String> response =
         restTemplate.exchange(
             "/instances/{v}/{instanceid}",

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/DataRepoControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/DataRepoControllerMockMvcTest.java
@@ -58,12 +58,12 @@ class DataRepoControllerMockMvcTest {
   final ReferencedGcpResourceApi mockReferencedGcpResourceApi =
       Mockito.mock(ReferencedGcpResourceApi.class);
 
-  private static UUID instanceId;
+  private UUID instanceId;
 
   private static final String versionId = "v0.2";
 
   @BeforeEach
-  void beforeEach() throws Exception {
+  void setUp() throws Exception {
     given(mockDataRepoClientFactory.getRepositoryApi()).willReturn(mockRepositoryApi);
     given(mockWorkspaceManagerClientFactory.getReferencedGcpResourceApi(null))
         .willReturn(mockReferencedGcpResourceApi);
@@ -74,7 +74,7 @@ class DataRepoControllerMockMvcTest {
   }
 
   @AfterEach
-  void afterEach() {
+  void tearDown() {
     try {
       mockMvc
           .perform(delete("/instances/{v}/{instanceid}", versionId, instanceId).content(""))

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
@@ -31,7 +31,6 @@ import org.databiosphere.workspacedataservice.shared.model.RecordType;
 import org.databiosphere.workspacedataservice.shared.model.SearchRequest;
 import org.databiosphere.workspacedataservice.shared.model.SortDirection;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -62,20 +61,17 @@ import org.springframework.transaction.annotation.Transactional;
 @Import(SmallBatchWriteTestConfig.class)
 class FullStackRecordControllerTest {
   @Autowired private TestRestTemplate restTemplate;
-  private static HttpHeaders headers;
-  private static UUID instanceId;
+  private HttpHeaders headers;
+  private UUID instanceId;
   private static final String versionId = "v0.2";
   @Autowired private ObjectMapper mapper;
 
-  @BeforeAll
-  static void setUp() {
+  @BeforeEach
+  void setUp() {
     headers = new HttpHeaders();
     headers.setContentType(MediaType.APPLICATION_JSON);
     instanceId = UUID.randomUUID();
-  }
 
-  @BeforeEach
-  void beforeEach() {
     ResponseEntity<String> response =
         restTemplate.exchange(
             "/instances/{v}/{instanceid}",
@@ -88,7 +84,7 @@ class FullStackRecordControllerTest {
   }
 
   @AfterEach
-  void afterEach() {
+  void tearDown() {
     ResponseEntity<String> response =
         restTemplate.exchange(
             "/instances/{v}/{instanceid}",

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -62,14 +62,14 @@ class RecordControllerMockMvcTest {
   @Autowired private ObjectMapper mapper;
   @Autowired private MockMvc mockMvc;
 
-  private static UUID instanceId;
+  private UUID instanceId;
 
   private static final String versionId = "v0.2";
 
   @Autowired TestDao testDao;
 
   @BeforeEach
-  void beforeEach() throws Exception {
+  void setUp() throws Exception {
     instanceId = UUID.randomUUID();
     mockMvc
         .perform(post("/instances/{v}/{instanceid}", versionId, instanceId).content(""))
@@ -77,7 +77,7 @@ class RecordControllerMockMvcTest {
   }
 
   @AfterEach
-  void afterEach() {
+  void tearDown() {
     try {
       mockMvc
           .perform(delete("/instances/{v}/{instanceid}", versionId, instanceId).content(""))
@@ -88,7 +88,7 @@ class RecordControllerMockMvcTest {
   }
 
   @AfterAll
-  void afterAll() throws Exception {
+  void deleteAllInstances() throws Exception {
     MvcResult response = mockMvc.perform(get("/instances/{v}", versionId)).andReturn();
     UUID[] allInstances =
         mapper.readValue(response.getResponse().getContentAsString(), UUID[].class);

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
@@ -69,7 +69,7 @@ class TsvDownloadTest {
   }
 
   @AfterEach
-  void afterEach() {
+  void tearDown() {
     recordController.deleteInstance(instanceId, version);
   }
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvInputFormatsTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvInputFormatsTest.java
@@ -37,12 +37,12 @@ class TsvInputFormatsTest {
   @Autowired private MockMvc mockMvc;
   @Autowired RecordDao recordDao;
 
-  private static UUID instanceId;
+  private UUID instanceId;
 
   private static final String versionId = "v0.2";
 
   @BeforeEach
-  void beforeEach() throws Exception {
+  void setUp() throws Exception {
     instanceId = UUID.randomUUID();
     mockMvc
         .perform(post("/instances/{v}/{instanceid}", versionId, instanceId).content(""))
@@ -50,7 +50,7 @@ class TsvInputFormatsTest {
   }
 
   @AfterEach
-  void afterEach() {
+  void tearDown() {
     try {
       mockMvc
           .perform(delete("/instances/{v}/{instanceid}", versionId, instanceId).content(""))

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
@@ -77,7 +77,7 @@ class RecordDaoTest {
   }
 
   @AfterEach
-  void cleanUp() {
+  void tearDown() {
     instanceDao.dropSchema(instanceId);
   }
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/datarepo/DataRepoDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/datarepo/DataRepoDaoTest.java
@@ -38,7 +38,7 @@ class DataRepoDaoTest {
   private static final UUID INSTANCE = UUID.fromString("111e9999-e89b-12d3-a456-426614174000");
 
   @BeforeEach
-  void beforeEach() {
+  void setUp() {
     given(mockDataRepoClientFactory.getRepositoryApi()).willReturn(mockRepositoryApi);
     if (!instanceDao.instanceSchemaExists(INSTANCE)) {
       instanceDao.createSchema(INSTANCE);
@@ -46,7 +46,7 @@ class DataRepoDaoTest {
   }
 
   @AfterEach
-  void afterEach() {
+  void tearDown() {
     if (instanceDao.instanceSchemaExists(INSTANCE)) {
       instanceDao.dropSchema(INSTANCE);
     }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/datarepo/DataRepoServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/datarepo/DataRepoServiceTest.java
@@ -59,7 +59,7 @@ class DataRepoServiceTest {
   private static final UUID INSTANCE = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
 
   @BeforeEach
-  void beforeEach() {
+  void setUp() {
     given(mockDataRepoClientFactory.getRepositoryApi()).willReturn(mockRepositoryApi);
     given(mockWorkspaceManagerClientFactory.getReferencedGcpResourceApi(null))
         .willReturn(mockReferencedGcpResourceApi);
@@ -69,7 +69,7 @@ class DataRepoServiceTest {
   }
 
   @AfterEach
-  void afterEach() {
+  void tearDown() {
     if (instanceDao.instanceSchemaExists(INSTANCE)) {
       instanceDao.dropSchema(INSTANCE);
     }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/leonardo/LeonardoDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/leonardo/LeonardoDaoTest.java
@@ -35,7 +35,7 @@ class LeonardoDaoTest {
   final AppsApi mockAppsApi = mock(AppsApi.class);
 
   @BeforeEach
-  void beforeEach() {
+  void setUp() {
     given(leonardoClientFactory.getAppsV2Api(any())).willReturn(mockAppsApi);
   }
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/pact/SamPactTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/pact/SamPactTest.java
@@ -28,8 +28,8 @@ class SamPactTest {
 
   static final String dummyResourceId = "92276398-fbe4-414a-9304-e7dcf18ac80e";
 
-  @BeforeAll
-  static void setup() {
+  @BeforeEach
+  void setUp() {
     // Without this setup, the HttpClient throws a "No thread-bound request found" error
     MockHttpServletRequest request = new MockHttpServletRequest();
     // Set the mock request as the current request context

--- a/service/src/test/java/org/databiosphere/workspacedataservice/retry/TransactionRetryTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/retry/TransactionRetryTest.java
@@ -30,7 +30,7 @@ class TransactionRetryTest {
   @Autowired TransactionRetryTestBean transactionRetryTestBean;
 
   @BeforeEach
-  public void beforeEach() {
+  public void setUp() {
     transactionRetryTestBean.resetCount();
   }
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceNoPermissionSamTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceNoPermissionSamTest.java
@@ -48,7 +48,7 @@ class InstanceServiceNoPermissionSamTest {
   final ResourcesApi mockResourcesApi = Mockito.mock(ResourcesApi.class);
 
   @BeforeEach
-  void beforeEach() {
+  void setUp() {
     instanceService = new InstanceService(instanceDao, samDao, activityLogger);
   }
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamExceptionTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamExceptionTest.java
@@ -80,7 +80,7 @@ class InstanceServiceSamExceptionTest {
   String containingWorkspaceId;
 
   @BeforeEach
-  void beforeEach() {
+  void setUp() {
     instanceService = new InstanceService(instanceDao, samDao, activityLogger);
 
     // return the mock ResourcesApi from the mock SamClientFactory
@@ -88,7 +88,7 @@ class InstanceServiceSamExceptionTest {
   }
 
   @AfterEach
-  void afterEach() {
+  void tearDown() {
     // clean up any instances left in the db
     List<UUID> allInstances = instanceDao.listInstanceSchemas();
     allInstances.forEach(instanceId -> instanceDao.dropSchema(instanceId));

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamTest.java
@@ -56,7 +56,7 @@ class InstanceServiceSamTest {
   String parentWorkspaceId;
 
   @BeforeEach
-  void beforeEach() throws ApiException {
+  void setUp() throws ApiException {
     instanceService = new InstanceService(instanceDao, samDao, activityLogger);
 
     // return the mock ResourcesApi from the mock SamClientFactory

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceTest.java
@@ -14,6 +14,7 @@ import org.databiosphere.workspacedataservice.sam.MockSamClientFactoryConfig;
 import org.databiosphere.workspacedataservice.sam.SamConfig;
 import org.databiosphere.workspacedataservice.sam.SamDao;
 import org.databiosphere.workspacedataservice.service.model.exception.MissingObjectException;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,6 +43,10 @@ class InstanceServiceTest {
   @BeforeEach
   void setUp() {
     instanceService = new InstanceService(instanceDao, samDao, activityLogger);
+  }
+
+  @AfterEach
+  void tearDown() {
     // Delete all instances
     instanceDao.listInstanceSchemas().forEach(instance -> instanceDao.dropSchema(instance));
   }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/PermissionsStatusServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/PermissionsStatusServiceTest.java
@@ -43,7 +43,7 @@ class PermissionsStatusServiceTest {
   final Health.Builder mockHealthBuilder = Mockito.mock(Health.Builder.class);
 
   @BeforeEach
-  void beforeEach() {
+  void setUp() {
     // return the mock StatusApi from the mock SamClientFactory
     given(mockSamClientFactory.getStatusApi()).willReturn(mockStatusApi);
     Mockito.clearInvocations(mockStatusApi);

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorSamTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorSamTest.java
@@ -57,7 +57,7 @@ class RecordOrchestratorSamTest {
   }
 
   @AfterEach
-  void cleanUp() {
+  void tearDown() {
     instanceDao.dropSchema(INSTANCE);
   }
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
@@ -51,7 +51,7 @@ class RecordOrchestratorServiceTest {
   }
 
   @AfterEach
-  void cleanUp() {
+  void tearDown() {
     instanceDao.dropSchema(INSTANCE);
   }
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvErrorMessageTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvErrorMessageTest.java
@@ -33,18 +33,18 @@ public class TsvErrorMessageTest {
   @Autowired InstanceService instanceService;
   @Autowired RecordOrchestratorService recordOrchestratorService;
 
-  private static UUID instanceId;
+  private UUID instanceId;
 
   private static final String VERSION = "v0.2";
 
   @BeforeEach
-  void beforeEach() {
+  void setUp() {
     instanceId = UUID.randomUUID();
     instanceService.createInstance(instanceId, VERSION);
   }
 
   @AfterEach
-  void afterEach() {
+  void tearDown() {
     List<UUID> allInstances = instanceService.listInstances(VERSION);
     for (UUID id : allInstances) {
       instanceService.deleteInstance(id, VERSION);

--- a/service/src/test/java/org/databiosphere/workspacedataservice/workspacemanager/WorkspaceManagerDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/workspacemanager/WorkspaceManagerDaoTest.java
@@ -1,6 +1,7 @@
 package org.databiosphere.workspacedataservice.workspacemanager;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -49,7 +50,7 @@ class WorkspaceManagerDaoTest {
       Mockito.mock(ControlledAzureResourceApi.class);
 
   @BeforeEach
-  void beforeEach() {
+  void setUp() {
     given(mockWorkspaceManagerClientFactory.getReferencedGcpResourceApi(null))
         .willReturn(mockReferencedGcpResourceApi);
     given(mockWorkspaceManagerClientFactory.getResourceApi(null)).willReturn(mockResourceApi);
@@ -101,7 +102,7 @@ class WorkspaceManagerDaoTest {
     var resourceUUID =
         buildResourceListObjectAndCallExtraction(
             workspaceId, "sc-" + UUID.randomUUID(), ResourceType.AZURE_STORAGE_CONTAINER);
-    assertEquals(null, resourceUUID);
+    assertNull(resourceUUID);
   }
 
   UUID buildResourceListObjectAndCallExtraction(UUID workspaceId, String name, ResourceType type) {


### PR DESCRIPTION
Tidy up `setUp` and `tearDown` methods and improve test isolation.

* Rename generally to `setUp` and `tearDown`.  This is just for consistency.
* Where possible, prefer `@BeforeEach` and `@AfterEach` over `@BeforeAll` and `@AfterAll`.  This is to improve test isolation within test suites.
* Prefer to do cleanup in `tearDown` rather than pre-emptively in `setUp`.  Tests should be responsible for cleaning up after themselves, rather than other tests.
* Drop the `static` modifier from `private` but non-`final` instance variables in test cases.  This is to make each test manage its own instance state rather than share across invocations within the test file.