### PR TITLE
[AJ-1243] Introduce Lock in Cloning

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'org.springframework.boot:spring-boot-starter-batch'
+    implementation 'org.springframework.integration:spring-integration-jdbc'
     implementation 'org.springframework.retry:spring-retry:1.3.4'
     implementation 'org.aspectj:aspectjweaver:1.8.9'
     // required by spring-retry, not used directly by WDS

--- a/service/src/main/java/org/databiosphere/workspacedataservice/InstanceInitializerBean.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/InstanceInitializerBean.java
@@ -201,12 +201,13 @@ public class InstanceInitializerBean {
       var finalCloneStatus = currentCloneStatus(trackingId);
       return finalCloneStatus.getStatus().equals(JobStatus.SUCCEEDED);
 
-    } catch (InterruptedException e) {
-      LOGGER.error("Error with aquiring cloning/schema initialization Lock: {}", e.getMessage());
-      Thread.currentThread().interrupt();
-      return false;
     } catch (Exception e) {
       LOGGER.error("An error occurred during clone mode. Error: {}", e.toString());
+      // handle the interrupt if lock was interrupted
+      if (e instanceof InterruptedException) {
+        LOGGER.error("Error with acquiring cloning/schema initialization Lock: {}", e.getMessage());
+        Thread.currentThread().interrupt();
+      }
       try {
         cloneDao.terminateCloneToError(
             trackingId, "Backup not successful, cannot restore.", CloneTable.RESTORE);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/InstanceInitializerBean.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/InstanceInitializerBean.java
@@ -201,6 +201,10 @@ public class InstanceInitializerBean {
       var finalCloneStatus = currentCloneStatus(trackingId);
       return finalCloneStatus.getStatus().equals(JobStatus.SUCCEEDED);
 
+    } catch (InterruptedException e) {
+      LOGGER.error("Error with aquiring cloning/schema initialization Lock: {}", e.getMessage());
+      Thread.currentThread().interrupt();
+      return false;
     } catch (Exception e) {
       LOGGER.error("An error occurred during clone mode. Error: {}", e.toString());
       try {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/InstanceInitializerConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/InstanceInitializerConfig.java
@@ -7,6 +7,7 @@ import org.databiosphere.workspacedataservice.service.BackupRestoreService;
 import org.databiosphere.workspacedataservice.sourcewds.WorkspaceDataServiceDao;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.support.locks.LockRegistry;
 
 @Configuration
 public class InstanceInitializerConfig {
@@ -17,7 +18,9 @@ public class InstanceInitializerConfig {
       LeonardoDao leoDao,
       WorkspaceDataServiceDao wdsDao,
       CloneDao cloneDao,
-      BackupRestoreService restoreService) {
-    return new InstanceInitializerBean(instanceDao, leoDao, wdsDao, cloneDao, restoreService);
+      BackupRestoreService restoreService,
+      LockRegistry lockRegistry) {
+    return new InstanceInitializerBean(
+        instanceDao, leoDao, wdsDao, cloneDao, restoreService, lockRegistry);
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/distributed/LockConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/distributed/LockConfig.java
@@ -1,0 +1,25 @@
+package org.databiosphere.workspacedataservice.distributed;
+
+import javax.sql.DataSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.jdbc.lock.DefaultLockRepository;
+import org.springframework.integration.jdbc.lock.JdbcLockRegistry;
+import org.springframework.integration.jdbc.lock.LockRepository;
+
+@Configuration
+public class LockConfig {
+
+  @Bean
+  public DefaultLockRepository defaultLockRepository(DataSource dataSource) {
+    DefaultLockRepository defaultLockRepository = new DefaultLockRepository(dataSource);
+    defaultLockRepository.setPrefix("sys_wds.INT_");
+    defaultLockRepository.setTimeToLive(10 * 60 * 1000); // 10 minutes
+    return defaultLockRepository;
+  }
+
+  @Bean
+  public JdbcLockRegistry jdbcLockRegistry(LockRepository lockRepository) {
+    return new JdbcLockRegistry(lockRepository);
+  }
+}

--- a/service/src/main/resources/liquibase/changelog.yaml
+++ b/service/src/main/resources/liquibase/changelog.yaml
@@ -17,3 +17,6 @@ databaseChangeLog:
   - include:
       file: changesets/20230714_restore_table.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/20231003_lock_table.yaml
+      relativeToChangelogFile: true

--- a/service/src/main/resources/liquibase/changesets/20231003_lock_table.yaml
+++ b/service/src/main/resources/liquibase/changesets/20231003_lock_table.yaml
@@ -1,0 +1,32 @@
+databaseChangeLog:
+  - changeSet:
+      id: 20231003_lock_table
+      author: adinas
+      changes:
+        - createTable:
+            schemaName: sys_wds
+            tableName: int_lock
+            columns:
+              - column:
+                  name: lock_key
+                  type: char(36)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: region
+                  type: varchar(100)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: client_id
+                  type: char(36)
+              - column:
+                  name: created_date
+                  type: datetime
+                  constraints:
+                    nullable: false
+        - addPrimaryKey:
+            columnNames: lock_key, region
+            constraintName: int_lock_pk
+            tableName: int_lock
+            schemaName: sys_wds

--- a/service/src/test/java/org/databiosphere/workspacedataservice/InstanceInitializerBeanTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/InstanceInitializerBeanTest.java
@@ -2,11 +2,15 @@ package org.databiosphere.workspacedataservice;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.locks.Lock;
 import org.databiosphere.workspacedataservice.activitylog.ActivityLoggerConfig;
 import org.databiosphere.workspacedataservice.dao.*;
 import org.databiosphere.workspacedataservice.leonardo.LeonardoConfig;
@@ -17,11 +21,14 @@ import org.databiosphere.workspacedataservice.sourcewds.WorkspaceDataServiceConf
 import org.databiosphere.workspacedataservice.storage.AzureBlobStorage;
 import org.databiosphere.workspacedataservice.workspacemanager.WorkspaceManagerConfig;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.integration.jdbc.lock.JdbcLockRegistry;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
@@ -56,6 +63,7 @@ import org.springframework.test.context.TestPropertySource;
 class InstanceInitializerBeanTest {
 
   @Autowired InstanceInitializerBean instanceInitializerBean;
+  @MockBean JdbcLockRegistry registry;
   @SpyBean InstanceDao instanceDao;
 
   @Value("${twds.instance.workspace-id}")
@@ -63,6 +71,16 @@ class InstanceInitializerBeanTest {
 
   // randomly generated UUID
   final UUID instanceID = UUID.fromString("90e1b179-9f83-4a6f-a8c2-db083df4cd03");
+
+  Lock mockLock = mock(Lock.class);
+
+  // JdbcLockRegistry registry = mock(JdbcLockRegistry.class);
+
+  @BeforeEach
+  void setUp() {
+    when(mockLock.tryLock()).thenReturn(true);
+    when(registry.obtain(anyString())).thenReturn(mockLock);
+  }
 
   @AfterEach
   void tearDown() {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/InstanceInitializerNoWorkspaceIdTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/InstanceInitializerNoWorkspaceIdTest.java
@@ -2,9 +2,13 @@ package org.databiosphere.workspacedataservice;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.util.concurrent.locks.Lock;
 import org.databiosphere.workspacedataservice.activitylog.ActivityLoggerConfig;
 import org.databiosphere.workspacedataservice.dao.*;
 import org.databiosphere.workspacedataservice.leonardo.LeonardoConfig;
@@ -14,10 +18,13 @@ import org.databiosphere.workspacedataservice.service.BackupRestoreService;
 import org.databiosphere.workspacedataservice.sourcewds.WorkspaceDataServiceConfig;
 import org.databiosphere.workspacedataservice.storage.AzureBlobStorage;
 import org.databiosphere.workspacedataservice.workspacemanager.WorkspaceManagerConfig;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.integration.jdbc.lock.JdbcLockRegistry;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
@@ -50,8 +57,16 @@ import org.springframework.test.context.TestPropertySource;
 class InstanceInitializerNoWorkspaceIdTest {
 
   @Autowired InstanceInitializerBean instanceInitializerBean;
-
+  @MockBean JdbcLockRegistry registry;
   @SpyBean InstanceDao instanceDao;
+
+  Lock mockLock = mock(Lock.class);
+
+  @BeforeEach
+  void setUp() {
+    when(mockLock.tryLock()).thenReturn(true);
+    when(registry.obtain(anyString())).thenReturn(mockLock);
+  }
 
   @Test
   void workspaceIDNotProvidedNoExceptionThrown() {


### PR DESCRIPTION
Currently cloning logic is not replica safe. This is due to the fact that currently if one replica initiates clone mode, another replica will see that and continue on to initialize the default schema. Problem is, cloning expects the default schema to not be created yet. 
This PR takes the first step in cloning replica safety by introducing a Lock that will prevent more than one replica from initiating cloning. Follow up work (in ticket AJ-1363) will refactor the initialization logic so a second replica won't try and create the default schema if cloning is happening. This PR **does not** mean cloning is replica safe yet. 

----------------
Reminder:

PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 
