### PR TITLE
[ AJ-1363] Make Cloning/startup multi-replica safe

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/InstanceInitializerBean.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/InstanceInitializerBean.java
@@ -86,7 +86,7 @@ public class InstanceInitializerBean {
           workspaceId);
       // Initialize default schema if initCloneMode() returns false.
       if (initCloneMode()) {
-        LOGGER.info("Exited cloning.");
+        LOGGER.info("Cloning complete.");
         return;
       }
       LOGGER.info("Cloning failed, falling back to initialize default schema.");
@@ -165,7 +165,9 @@ public class InstanceInitializerBean {
       // If there's a clone entry and no default schema, another replica errored before completing.
       // If there's a clone entry and a default schema there's nothing for us to do here.
       if (cloningStarted(UUID.fromString(sourceWorkspaceId))) {
-        return instanceDao.instanceSchemaExists(UUID.fromString(workspaceId)) ? true : false;
+        boolean instanceExists =  instanceDao.instanceSchemaExists(UUID.fromString(workspaceId));
+        LOGGER.info("Previous clone entry found. Instance schema exists: {}.", instanceExists);
+        return instanceExists;
       }
 
       // First, create an entry in the clone table to mark cloning has started

--- a/service/src/main/java/org/databiosphere/workspacedataservice/InstanceInitializerBean.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/InstanceInitializerBean.java
@@ -127,8 +127,7 @@ public class InstanceInitializerBean {
         UUID.fromString(sourceWorkspaceId);
       } catch (IllegalArgumentException e) {
         LOGGER.warn(
-            "SourceWorkspaceId could not be parsed, unable to clone DB. Provided SourceWorkspaceId: {}.",
-            sourceWorkspaceId);
+            "SourceWorkspaceId {} could not be parsed, unable to clone DB.", sourceWorkspaceId);
         return false;
       }
 
@@ -138,7 +137,7 @@ public class InstanceInitializerBean {
       }
       return true;
     }
-    LOGGER.info("No SourceWorkspaceId found, initializing default schema.");
+    LOGGER.info("No SourceWorkspaceId found, unable to proceed with cloning.");
     return false;
   }
 
@@ -165,7 +164,7 @@ public class InstanceInitializerBean {
       // If there's a clone entry and no default schema, another replica errored before completing.
       // If there's a clone entry and a default schema there's nothing for us to do here.
       if (cloningStarted(UUID.fromString(sourceWorkspaceId))) {
-        boolean instanceExists =  instanceDao.instanceSchemaExists(UUID.fromString(workspaceId));
+        boolean instanceExists = instanceDao.instanceSchemaExists(UUID.fromString(workspaceId));
         LOGGER.info("Previous clone entry found. Instance schema exists: {}.", instanceExists);
         return instanceExists;
       }
@@ -303,7 +302,6 @@ public class InstanceInitializerBean {
           cloneJobId, restoreResponse.getErrorMessage(), CloneTable.RESTORE);
     } else {
       LOGGER.info("Restore Successful");
-      LOGGER.info("Cloning Complete");
       cloneDao.updateCloneEntryStatus(cloneJobId, CloneStatus.RESTORESUCCEEDED);
     }
   }
@@ -325,8 +323,7 @@ public class InstanceInitializerBean {
 
     } catch (IllegalArgumentException e) {
       LOGGER.warn(
-          "Workspace id could not be parsed, a default schema won't be created. Provided id: {}.",
-          workspaceId);
+          "Workspace id {} could not be parsed, a default schema won't be created.", workspaceId);
     } catch (DataAccessException e) {
       LOGGER.error("Failed to create default schema id for workspaceId {}.", workspaceId);
     }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/InstanceInitializerBean.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/InstanceInitializerBean.java
@@ -85,7 +85,7 @@ public class InstanceInitializerBean {
           sourceWorkspaceId,
           workspaceId);
       // Initialize default schema if initCloneMode() returns false.
-      if (initCloneMode()) {
+      if (initCloneMode(sourceWorkspaceId)) {
         LOGGER.info("Cloning complete.");
         return;
       }
@@ -148,7 +148,7 @@ public class InstanceInitializerBean {
   starting WDS was initiated via a clone operation and will contain the WorkspaceId of the original workspace where the cloning
   was triggered. This function returns false for an incomplete clone.
   */
-  private boolean initCloneMode() {
+  protected boolean initCloneMode(String sourceWorkspaceId) {
     LOGGER.info("Starting in clone mode...");
     UUID trackingId = UUID.randomUUID();
     Lock lock = lockRegistry.obtain(sourceWorkspaceId);

--- a/service/src/test/java/org/databiosphere/workspacedataservice/InstanceInitializerBeanTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/InstanceInitializerBeanTest.java
@@ -113,42 +113,42 @@ class InstanceInitializerBeanTest {
   }
 
   @Test
-  void blankSourceWorkspaceID() {
-    boolean cloneMode = instanceInitializerBean.cloningArgumentsSafe("");
-    assertFalse(cloneMode);
-
-    cloneMode = instanceInitializerBean.cloningArgumentsSafe(" ");
+  void sourceWorkspaceIDNotProvided() {
+    boolean cloneMode = instanceInitializerBean.isInCloneMode(null);
     assertFalse(cloneMode);
   }
 
   @Test
-  void sourceWorkspaceSchemaNotExists() {
-    boolean cloneMode = instanceInitializerBean.cloningStartedOrCompleted(UUID.randomUUID());
+  void blankSourceWorkspaceID() {
+    boolean cloneMode = instanceInitializerBean.isInCloneMode("");
+    assertFalse(cloneMode);
+
+    cloneMode = instanceInitializerBean.isInCloneMode(" ");
     assertFalse(cloneMode);
   }
 
   @Test
   void sourceWorkspaceSchemaExists() {
     instanceDao.createSchema(instanceID);
-    boolean cloneMode = instanceInitializerBean.cloningStartedOrCompleted(instanceID);
+    boolean cloneMode = instanceDao.instanceSchemaExists(instanceID);
     assertTrue(cloneMode);
   }
 
   @Test
   void sourceWorkspaceIDCorrect() {
-    boolean cloneMode = instanceInitializerBean.cloningArgumentsSafe(UUID.randomUUID().toString());
+    boolean cloneMode = instanceInitializerBean.isInCloneMode(UUID.randomUUID().toString());
     assert (cloneMode);
   }
 
   @Test
   void sourceWorkspaceIDInvalid() {
-    boolean cloneMode = instanceInitializerBean.cloningArgumentsSafe("invalidUUID");
+    boolean cloneMode = instanceInitializerBean.isInCloneMode("invalidUUID");
     assertFalse(cloneMode);
   }
 
   @Test
   void sourceAndCurrentWorkspaceIdsMatch() {
-    boolean cloneMode = instanceInitializerBean.cloningArgumentsSafe(workspaceId);
+    boolean cloneMode = instanceInitializerBean.isInCloneMode(workspaceId);
     assertFalse(cloneMode);
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/InstanceInitializerBeanTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/InstanceInitializerBeanTest.java
@@ -113,42 +113,42 @@ class InstanceInitializerBeanTest {
   }
 
   @Test
-  void sourceWorkspaceIDNotProvided() {
-    boolean cloneMode = instanceInitializerBean.isInCloneMode(null);
+  void blankSourceWorkspaceID() {
+    boolean cloneMode = instanceInitializerBean.cloningArgumentsSafe("");
+    assertFalse(cloneMode);
+
+    cloneMode = instanceInitializerBean.cloningArgumentsSafe(" ");
     assertFalse(cloneMode);
   }
 
   @Test
-  void blankSourceWorkspaceID() {
-    boolean cloneMode = instanceInitializerBean.isInCloneMode("");
-    assertFalse(cloneMode);
-
-    cloneMode = instanceInitializerBean.isInCloneMode(" ");
+  void sourceWorkspaceSchemaNotExists() {
+    boolean cloneMode = instanceInitializerBean.cloningStartedOrCompleted(UUID.randomUUID());
     assertFalse(cloneMode);
   }
 
   @Test
   void sourceWorkspaceSchemaExists() {
     instanceDao.createSchema(instanceID);
-    boolean cloneMode = instanceInitializerBean.isInCloneMode(UUID.randomUUID().toString());
-    assertFalse(cloneMode);
+    boolean cloneMode = instanceInitializerBean.cloningStartedOrCompleted(instanceID);
+    assertTrue(cloneMode);
   }
 
   @Test
   void sourceWorkspaceIDCorrect() {
-    boolean cloneMode = instanceInitializerBean.isInCloneMode(UUID.randomUUID().toString());
+    boolean cloneMode = instanceInitializerBean.cloningArgumentsSafe(UUID.randomUUID().toString());
     assert (cloneMode);
   }
 
   @Test
   void sourceWorkspaceIDInvalid() {
-    boolean cloneMode = instanceInitializerBean.isInCloneMode("invalidUUID");
+    boolean cloneMode = instanceInitializerBean.cloningArgumentsSafe("invalidUUID");
     assertFalse(cloneMode);
   }
 
   @Test
   void sourceAndCurrentWorkspaceIdsMatch() {
-    boolean cloneMode = instanceInitializerBean.isInCloneMode(workspaceId);
+    boolean cloneMode = instanceInitializerBean.cloningArgumentsSafe(workspaceId);
     assertFalse(cloneMode);
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/InstanceInitializerNoWorkspaceIdTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/InstanceInitializerNoWorkspaceIdTest.java
@@ -2,6 +2,7 @@ package org.databiosphere.workspacedataservice;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -63,8 +64,8 @@ class InstanceInitializerNoWorkspaceIdTest {
   Lock mockLock = mock(Lock.class);
 
   @BeforeEach
-  void setUp() {
-    when(mockLock.tryLock()).thenReturn(true);
+  void setUp() throws InterruptedException {
+    when(mockLock.tryLock(anyLong(), any())).thenReturn(true);
     when(registry.obtain(anyString())).thenReturn(mockLock);
   }
 


### PR DESCRIPTION
This PR makes cloning replica safe by refactoring our initialization logic to follow the flowchart below:

![image](https://github.com/DataBiosphere/terra-workspace-data-service/assets/9140651/e17b5b2c-43d6-487f-ab06-b8f17983ad17)


Ultimately, in code `initCloneMode()` returning false will have us create the default schema and returning true has us "do nothing" (ie just start WDS). 

Here is what the logs will look like. 
**Non-Cloning Replica**: 
```
2023-10-11 18:40:51.780  INFO [] [main] o.d.w.InstanceInitializerBean            : Default workspace id loaded as e28ba126-6d7a-4046-993f-a0e73512078b.
2023-10-11 18:40:51.785  INFO [] [main] o.d.w.InstanceInitializerBean            : SourceWorkspaceId found, checking validity
2023-10-11 18:40:51.785  INFO [] [main] o.d.w.InstanceInitializerBean            : Cloning mode enabled, attempting to clone from 5d8e8691-75a1-4c76-99ad-8263d29c58c1 into e28ba126-6d7a-4046-993f-a0e73512078b.
2023-10-11 18:40:51.785  INFO [] [main] o.d.w.InstanceInitializerBean            : Starting in clone mode...
2023-10-11 18:40:51.897  INFO [] [main] o.d.w.InstanceInitializerBean            : clone entry in database: true
2023-10-11 18:40:51.906  INFO [] [main] o.d.w.InstanceInitializerBean            : Previous clone entry found. Instance schema exists: true.
2023-10-11 18:40:51.912  INFO [] [main] o.d.w.InstanceInitializerBean            : Cloning complete.
2023-10-11 18:40:51.918  INFO [] [main] o.d.w.WorkspaceDataServiceApplication    : Started WorkspaceDataServiceApplication in 76.778 seconds (JVM running for 95.266)
2023-10-11 18:40:51.985  INFO [] [main] o.d.w.logging.AvailabilityListener       : LivenessState: CORRECT
2023-10-11 18:40:51.987  INFO [] [main] o.d.w.logging.AvailabilityListener       : ReadinessState: ACCEPTING_TRAFFIC
```
**Cloning Replica** (filtered): 
```
2023-10-11 18:40:25.379  INFO [] [main] o.d.w.InstanceInitializerBean            : Default workspace id loaded as e28ba126-6d7a-4046-993f-a0e73512078b.
2023-10-11 18:40:25.394  INFO [] [main] o.d.w.InstanceInitializerBean            : SourceWorkspaceId found, checking validity
2023-10-11 18:40:25.394  INFO [] [main] o.d.w.InstanceInitializerBean            : Cloning mode enabled, attempting to clone from 5d8e8691-75a1-4c76-99ad-8263d29c58c1 into e28ba126-6d7a-4046-993f-a0e73512078b.
2023-10-11 18:40:25.394  INFO [] [main] o.d.w.InstanceInitializerBean            : Starting in clone mode...
2023-10-11 18:40:25.592  INFO [] [main] o.d.w.InstanceInitializerBean            : clone entry in database: false
2023-10-11 18:40:25.592  INFO [] [main] o.d.w.InstanceInitializerBean            : Creating entry to track cloning process.
2023-10-11 18:40:26.794  INFO [] [main] o.d.w.InstanceInitializerBean            : Retrieved source wds endpoint url https://lz73d73b0c51c86d3f3f84cf157194cb1167472d4e243f3a56.servicebus.windows.net/wds-5d8e8691-75a1-4c76-99ad-8263d29c58c1-5d8e8691-75a1-4c76-99ad-8263d29c58c1/
2023-10-11 18:40:26.802  INFO [] [main] o.d.w.InstanceInitializerBean            : Requesting a backup file from the remote source WDS in workspace 5d8e8691-75a1-4c76-99ad-8263d29c58c1
2023-10-11 18:40:26.830  INFO [] [main] o.d.w.dao.PostgresCloneDao               : Clone status is now BACKUPQUEUED.
2023-10-11 18:40:28.183  INFO [] [main] o.d.w.dao.PostgresCloneDao               : Clone status is now BACKUPSUCCEEDED.
2023-10-11 18:40:28.195  INFO [] [main] o.d.w.InstanceInitializerBean            : Re-checking clone job status after backup request
2023-10-11 18:40:28.213  INFO [] [main] o.d.w.InstanceInitializerBean            : Restore from the following path on the source workspace storage container: wdsservice/cloning/backup/5d8e8691-75a1-4c76-99ad-8263d29c58c1-2023-10-11_18-40-27.sql
2023-10-11 18:40:28.235  INFO [] [main] o.d.w.dao.PostgresCloneDao               : Clone status is now RESTOREQUEUED.
2023-10-11 18:40:28.243  INFO [] [main] o.d.w.service.BackupRestoreService       : Starting restore.
2023-10-11 18:40:28.271  INFO [] [main] o.d.w.dao.AbstractBackupRestoreDao       : Restore job abdd42fd-e033-418d-a907-6ac35732ab6c is now QUEUED
2023-10-11 18:40:28.707  INFO [] [main] o.d.w.dao.AbstractBackupRestoreDao       : Job abdd42fd-e033-418d-a907-6ac35732ab6c is now RUNNING
2023-10-11 18:40:28.779  INFO [] [main] o.d.w.service.BackupRestoreService       : Grabbing data from the backup file.
2023-10-11 18:40:32.311  INFO [] [main] o.d.w.dao.AbstractBackupRestoreDao       : Job abdd42fd-e033-418d-a907-6ac35732ab6c is now SUCCEEDED
2023-10-11 18:40:32.691  INFO [] [main] o.d.w.InstanceInitializerBean            : Restore Successful
2023-10-11 18:40:32.703  INFO [] [main] o.d.w.dao.PostgresCloneDao               : Clone status is now RESTORESUCCEEDED.
2023-10-11 18:40:32.711  INFO [] [main] o.d.w.InstanceInitializerBean            : Re-checking clone job status after restore request
2023-10-11 18:40:32.723  INFO [] [main] o.d.w.InstanceInitializerBean            : Cloning complete.
2023-10-11 18:40:32.729  INFO [] [main] o.d.w.WorkspaceDataServiceApplication    : Started WorkspaceDataServiceApplication in 60.199 seconds (JVM running for 77.275)
```

-----------------------
Reminder:

PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 
