### PR TITLE
AJ-1011: include in-memory Quartz in WDS

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'org.springframework.boot:spring-boot-starter-batch'
+    implementation 'org.springframework.boot:spring-boot-starter-quartz'
     implementation 'org.springframework.integration:spring-integration-jdbc'
     implementation 'org.springframework.retry:spring-retry:1.3.4'
     implementation 'org.aspectj:aspectjweaver:1.8.9'

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -63,6 +63,15 @@ spring:
   # ... and run Liquibase instead
   liquibase:
     change-log: classpath:liquibase/changelog.yaml
+  quartz:
+    # Quartz will persist all its information in memory. This is simple and performant and
+    # allows Quartz to use sensitive data such as auth tokens as input to jobs. However,
+    # it is not restart-safe; if WDS restarts or dies before a Quartz job completes, that
+    # job will be lost and appear to the end user as if it hung.
+    # It is also not cluster-aware; when WDS runs as a multi-replica cluster, Quartz jobs will
+    # always run on the replica where they were created.
+    job-store-type: memory
+
 #   # activate the "local" profile to turn on CORS response headers,
 #   # which may be necessary for local development.
 #   profiles:


### PR DESCRIPTION
Spun off from #353 and #355

This PR brings Quartz into WDS, but doesn't yet use Quartz for anything. This is a setup PR to make future PRs smaller. In this PR:
* Add the Quartz starter dependency for Spring Boot
* Configure Quartz to run in-memory via `application.yml`

See the code comments for the drawbacks of running Quartz in-memory, as opposed to database-backed. #355 configures Quartz to be database-backed, but there [is debate](https://docs.google.com/document/d/1one0ouQmGC4ymKaPSb0DLHWrf3mewCJ-ZWxBgQcSuTA/edit
) on whether this is a good idea or not, because Quartz can write sensitive data to the db temporarily.

I would like to push this in-memory PR through to unblock async development, while continuing the debate over how to handle sensitive data. We can always adjust Quartz from in-memory to database-backed later, if we decide that's the right idea.



