### PR TITLE
AJ-1364 - Draft PR to represent how metrics can be added to WDS

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -53,6 +53,17 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-batch'
     implementation 'org.springframework.integration:spring-integration-jdbc'
     implementation 'org.springframework.retry:spring-retry:1.3.4'
+
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'io.opentelemetry:opentelemetry-api:1.30.1'
+    implementation 'io.opentelemetry:opentelemetry-sdk:1.30.1'
+    implementation 'io.opentelemetry:opentelemetry-sdk-metrics:1.30.1'
+    implementation 'io.opentelemetry:opentelemetry-exporter-logging:1.30.1'
+    implementation 'io.opentelemetry:opentelemetry-semconv:1.30.1-alpha'
+    implementation 'io.opentelemetry:opentelemetry-sdk-extension-autoconfigure'
+    implementation 'io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.30.1'
+    implementation 'io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi:1.30.1'
+
     implementation 'org.aspectj:aspectjweaver:1.8.9'
     // required by spring-retry, not used directly by WDS
     implementation 'org.apache.commons:commons-lang3'

--- a/service/src/main/java/org/databiosphere/workspacedataservice/WorkspaceDataServiceApplication.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/WorkspaceDataServiceApplication.java
@@ -1,9 +1,12 @@
 package org.databiosphere.workspacedataservice;
 
 import com.microsoft.applicationinsights.attach.ApplicationInsights;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
@@ -22,5 +25,10 @@ public class WorkspaceDataServiceApplication {
   public static void main(String[] args) {
     ApplicationInsights.attach();
     SpringApplication.run(WorkspaceDataServiceApplication.class, args);
+  }
+
+  @Bean
+  public OpenTelemetry openTelemetry() {
+    return AutoConfiguredOpenTelemetrySdk.initialize().getOpenTelemetrySdk();
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -27,8 +27,6 @@ import org.databiosphere.workspacedataservice.shared.model.RecordResponse;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 import org.databiosphere.workspacedataservice.shared.model.SearchRequest;
 import org.databiosphere.workspacedataservice.shared.model.TsvUploadResponse;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -48,7 +48,6 @@ import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBo
 
 @RestController
 public class RecordController {
-  private static final Logger LOGGER = LoggerFactory.getLogger(RecordOrchestratorService.class);
   private final InstanceService instanceService;
   private final RecordOrchestratorService recordOrchestratorService;
 


### PR DESCRIPTION
This PR includes setting up Otel in WDS application and the following otel examples: 
- tracking a successful http request
- tracking an error http request
- metrics for how often an api call is executed
- metrics for how long an api call takes

Each otel event can have up to 128 attributes, I have only included 3 at this time. Clearly a lot more can be done when it comes to thinking through exactly what event info we would want to capture in each event. A lot of this would driven by exactly how and what we want to track. 

if you want to pull and run on your own: OTEL_TRACES_EXPORTER=logging OTEL_METRICS_EXPORTER=logging OTEL_LOGS_EXPORTER=logging ./gradlew bootRun

(execute get Single Record or add/update Single records apis to see events)

example of what events look like: 

- simpler trace metric with success
 i.o.e.logging.LoggingSpanExporter        : 'getSingleRecord' : 798f4020b751e569680cbc187147ffec 0dd4ec511121f69f INTERNAL [tracer: org.springframework.web.servlet.mvc.Controller:] AttributesMap{data={http.apicall=getSingleRecord, http.recordTypeName=test2, http.result=400 BAD_REQUEST}, capacity=128, totalAddedValues=3}

- simpler trace metric with error
i.o.e.logging.LoggingSpanExporter        : 'getSingleRecord' : 9742cbf8477520d2b63664ea5ed19abb f0afec76527fd0bd INTERNAL [tracer: org.springframework.web.servlet.mvc.Controller:] AttributesMap{data={http.result=200 OK, http.apicall=getSingleRecord, http.recordTypeName=test}, capacity=128, totalAddedValues=3}

- metric for tracking how often something is called 
 i.o.e.logging.LoggingMetricExporter      : metric: ImmutableMetricData{resource=Resource{schemaUrl=https://opentelemetry.io/schemas/1.21.0, attributes={service.name="unknown_service:java", telemetry.sdk.language="java", telemetry.sdk.name="opentelemetry", telemetry.sdk.version="1.30.1"}}, instrumentationScopeInfo=InstrumentationScopeInfo{name=org.springframework.web.servlet.mvc.Controller, version=null, schemaUrl=null, attributes={}}, name=record.invocations_service, description=Measures the number of times an api is invoked., unit=, type=LONG_SUM, data=ImmutableSumData{points=[ImmutableLongPointData{startEpochNanos=1696964190796739796, epochNanos=1696968090774494039, attributes={record.upsertSingleRecord=false}, value=10, exemplars=[]}, ImmutableLongPointData{startEpochNanos=1696964190796739796, epochNanos=1696968090774494039, attributes={record.upsertSingleRecord=true}, value=1, exemplars=[]}], monotonic=true, aggregationTemporality=CUMULATIVE}}

- metric for tracking how long something takes  
i.o.e.logging.LoggingMetricExporter      : metric: ImmutableMetricData{resource=Resource{schemaUrl=https://opentelemetry.io/schemas/1.21.0, attributes={service.name="unknown_service:java", telemetry.sdk.language="java", telemetry.sdk.name="opentelemetry", telemetry.sdk.version="1.30.1"}}, instrumentationScopeInfo=InstrumentationScopeInfo{name=org.springframework.web.servlet.mvc.Controller, version=null, schemaUrl=null, attributes={}}, name=record.requestTime, description=Measures how long a given records request takes. , unit=ms, type=HISTOGRAM, data=ImmutableHistogramData{aggregationTemporality=CUMULATIVE, points=[ImmutableHistogramPointData{getStartEpochNanos=1696964190796739796, getEpochNanos=1696968090774494039, getAttributes={ATTR_APICALL="getSingleRecord"}, getSum=10113.0, getCount=2, hasMin=true, getMin=5054.0, hasMax=true, getMax=5059.0, getBoundaries=[0.0, 5.0, 10.0, 25.0, 50.0, 75.0, 100.0, 250.0, 500.0, 750.0, 1000.0, 2500.0, 5000.0, 7500.0, 10000.0], getCounts=[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0], getExemplars=[ImmutableDoubleExemplarData{filteredAttributes={}, epochNanos=1696968079191791357, spanContext=ImmutableSpanContext{traceId=9742cbf8477520d2b63664ea5ed19abb, spanId=f0afec76527fd0bd, traceFlags=01, traceState=ArrayBasedTraceState{entries=[]}, remote=false, valid=true}, value=5059.0}]}]}}

Reminder:

PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 
