### PR TITLE
AJ-1359: Wire up `shell` verb for `run_postgres.sh`

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,14 @@ To run a single test, run
 ./gradlew test --tests '*RecordDaoTest.testGetSingleRecord'
 ```
 
+## Postgres
+
+When running the local docker postgres, you can access the shell directly:
+
+```bash
+./local-dev/run_posgres.sh shell
+```
+
 ## Swagger UI
 
 When running locally, a Swagger UI is available at http://localhost:8080/swagger/swagger-ui.html.

--- a/local-dev/run_postgres.sh
+++ b/local-dev/run_postgres.sh
@@ -32,12 +32,16 @@ stop() {
     exit 0
 }
 
+shell() {
+  docker exec -it $CONTAINER psql -U wds
+}
+
 CONTAINER=postgres
 COMMAND=$1
 POSTGRES_PORT=${2:-"5432"}
 
 if [ ${#@} == 0 ]; then
-    echo "Usage: $0 stop|start"
+    echo "Usage: $0 stop|start|shell"
     exit 1
 fi
 
@@ -45,6 +49,8 @@ if [ $COMMAND = "start" ]; then
     start
 elif [ $COMMAND = "stop" ]; then
     stop
+elif [ $COMMAND = "shell" ]; then
+    shell
 else
     exit 1
 fi


### PR DESCRIPTION
Quickly access local postgres prompt.

Usage:
```
./local-dev/run_postgres.sh shell
```