### PR TITLE
Re-enable `hideGenerationTimestamp`

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -123,7 +123,7 @@ tasks.register('generateApiInterfaces', GenerateTask) {
     configOptions.set([
         interfaceOnly          : "true", // Java interfaces only; no controllers or implementation classes
         useTags                : "true", // use the OpenAPI tag to classify apis, not the first segment of the api path
-        hideGenerationTimestamp: "false" // if we need to omit timestamp from generated code, so we can track it via git
+        hideGenerationTimestamp: "true"  // hidden to prevent unnecessary diff noise on unrelated changes
     ])
 }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/generated/ImportApi.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/generated/ImportApi.java
@@ -33,7 +33,7 @@ import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Generated;
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2023-10-05T15:39:06.900914-04:00[America/New_York]")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
 @Tag(name = "Import", description = "Import APIs")
 public interface ImportApi {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/generated/ImportRequestServerModel.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/generated/ImportRequestServerModel.java
@@ -24,7 +24,7 @@ import javax.annotation.Generated;
  */
 
 @JsonTypeName("ImportRequest")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2023-10-05T15:39:06.900914-04:00[America/New_York]")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class ImportRequestServerModel {
 
   /**


### PR DESCRIPTION
This is to eliminate diff noise for unrelated changes.

Ideally we could use the timestamp, but we need to solve the problem of having it only run when there are relevant changes first.