### PR TITLE
AJ-1359: exclude generated files from Sonar scans

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -170,6 +170,8 @@ sonarqube {
         property "sonar.projectKey", "DataBiosphere_workspace-data-service"
         property "sonar.organization", "broad-databiosphere"
         property "sonar.host.url", "https://sonarcloud.io"
+        // exclude generated files from Sonar scans
+        property "sonar.exclusions", "service/src/main/java/org/databiosphere/workspacedataservice/generated/**/*"
     }
 }
 


### PR DESCRIPTION
Excludes the autogenerated API interfaces and models from Sonar scans.

These files are created by openapi-generator automatically, and they trigger a bunch of noise in Sonar. We don't need that noise.

See Sonar results on #361 for an example of all the noise.