### PR TITLE
AJ-1011: snapshot import via Quartz

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -78,7 +78,7 @@ dependencies {
     implementation group: 'org.broadinstitute.dsde.workbench', name: 'sam-client_2.13', version: '0.1-08b6588'
     implementation group: 'org.broadinstitute.dsde.workbench', name: 'leonardo-client_2.13', version: '1.3.6-22ee00b'
     implementation 'com.squareup.okhttp3:okhttp:4.11.0' // required by Sam client
-    implementation "bio.terra:datarepo-client:1.476.0-SNAPSHOT"
+    implementation "bio.terra:datarepo-client:1.537.0-SNAPSHOT"
     implementation "bio.terra:workspace-manager-client:0.254.717-SNAPSHOT"
     implementation "bio.terra:java-pfb-library:0.5.0"
     implementation project(path: ':client')

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresJobDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresJobDao.java
@@ -141,6 +141,8 @@ public class PostgresJobDao implements JobDao {
     // execute the update
     namedTemplate.update(sb.toString(), params);
 
+    logger.debug("Job {} is now in status {}", jobId, status);
+
     // return the updated job
     return getJob(jobId);
   }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/QuartzSchedulerDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/QuartzSchedulerDao.java
@@ -23,7 +23,7 @@ public class QuartzSchedulerDao implements SchedulerDao {
   }
 
   public void schedule(Schedulable schedulable) {
-    JobKey jobKey = new JobKey(schedulable.getName(), schedulable.getGroup());
+    JobKey jobKey = new JobKey(schedulable.getId(), schedulable.getGroup());
 
     // TODO: read JobData from the Job's inputs, instead of hardcoding it here
     // TODO: choose the implementing class based on the job's type, instead of hardcoding

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/QuartzSchedulerDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/QuartzSchedulerDao.java
@@ -25,9 +25,6 @@ public class QuartzSchedulerDao implements SchedulerDao {
   public void schedule(Schedulable schedulable) {
     JobKey jobKey = new JobKey(schedulable.getId(), schedulable.getGroup());
 
-    // TODO: read JobData from the Job's inputs, instead of hardcoding it here
-    // TODO: choose the implementing class based on the job's type, instead of hardcoding
-    // ImportQuartzJob.class
     JobDetail jobDetail =
         JobBuilder.newJob()
             .ofType(schedulable.getImplementation())

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/QuartzSchedulerDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/QuartzSchedulerDao.java
@@ -2,10 +2,7 @@ package org.databiosphere.workspacedataservice.dao;
 
 import static org.quartz.TriggerBuilder.newTrigger;
 
-import org.databiosphere.workspacedataservice.dataimport.ImportQuartzJob;
-import org.databiosphere.workspacedataservice.shared.model.job.Job;
-import org.databiosphere.workspacedataservice.shared.model.job.JobInput;
-import org.databiosphere.workspacedataservice.shared.model.job.JobResult;
+import org.databiosphere.workspacedataservice.shared.model.Schedulable;
 import org.quartz.JobBuilder;
 import org.quartz.JobDetail;
 import org.quartz.JobKey;
@@ -25,19 +22,19 @@ public class QuartzSchedulerDao implements SchedulerDao {
     this.scheduler = scheduler;
   }
 
-  public void schedule(Job<JobInput, JobResult> job) {
-    JobKey jobKey = new JobKey(job.getJobId().toString(), job.getJobType().name());
+  public void schedule(Schedulable schedulable) {
+    JobKey jobKey = new JobKey(schedulable.getName(), schedulable.getGroup());
 
     // TODO: read JobData from the Job's inputs, instead of hardcoding it here
     // TODO: choose the implementing class based on the job's type, instead of hardcoding
     // ImportQuartzJob.class
     JobDetail jobDetail =
         JobBuilder.newJob()
-            .ofType(ImportQuartzJob.class)
+            .ofType(schedulable.getImplementation())
             .withIdentity(jobKey)
-            .usingJobData("token", "proof-of-concept-token")
+            .setJobData(schedulable.getArgumentsAsJobDataMap())
             .storeDurably(false) // delete from the quartz table after the job finishes
-            .withDescription("Import for job " + job.getJobId().toString())
+            .withDescription(schedulable.getDescription())
             .build();
 
     // tell Quartz to run the job: run only once, start immediately

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/SchedulerDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/SchedulerDao.java
@@ -1,10 +1,8 @@
 package org.databiosphere.workspacedataservice.dao;
 
-import org.databiosphere.workspacedataservice.shared.model.job.Job;
-import org.databiosphere.workspacedataservice.shared.model.job.JobInput;
-import org.databiosphere.workspacedataservice.shared.model.job.JobResult;
+import org.databiosphere.workspacedataservice.shared.model.Schedulable;
 
 public interface SchedulerDao {
 
-  void schedule(Job<JobInput, JobResult> job);
+  void schedule(Schedulable schedulable);
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportJobInput.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportJobInput.java
@@ -1,0 +1,30 @@
+package org.databiosphere.workspacedataservice.dataimport;
+
+import java.net.URI;
+import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
+import org.databiosphere.workspacedataservice.shared.model.job.JobInput;
+
+public class ImportJobInput implements JobInput {
+
+  private final URI uri;
+  private final ImportRequestServerModel.TypeEnum importType;
+
+  public ImportJobInput(URI uri, ImportRequestServerModel.TypeEnum importType) {
+    this.uri = uri;
+    this.importType = importType;
+  }
+
+  public static ImportJobInput from(ImportRequestServerModel importRequest) {
+    // if/when data imports need to include anything from importRequest.getOptions(), will need to
+    // add them here, so they are persisted to the db
+    return new ImportJobInput(importRequest.getUrl(), importRequest.getType());
+  }
+
+  public URI getUri() {
+    return uri;
+  }
+
+  public ImportRequestServerModel.TypeEnum getImportType() {
+    return importType;
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportJobInput.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportJobInput.java
@@ -4,6 +4,7 @@ import java.net.URI;
 import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
 import org.databiosphere.workspacedataservice.shared.model.job.JobInput;
 
+/** User-supplied input arguments for a data import job */
 public class ImportJobInput implements JobInput {
 
   private final URI uri;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportQuartzJob.java
@@ -1,58 +1,8 @@
 package org.databiosphere.workspacedataservice.dataimport;
 
-import java.util.UUID;
-import java.util.concurrent.ThreadLocalRandom;
-import org.databiosphere.workspacedataservice.dao.JobDao;
-import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
-import org.quartz.Job;
-import org.quartz.JobExecutionContext;
-import org.quartz.JobExecutionException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Component;
+import org.databiosphere.workspacedataservice.jobexec.QuartzJob;
 
-/**
- * Quartz-executable job definition for data imports.
- *
- * <p>As of this writing, the job can be queued and executed by Quartz, but the execution itself
- * will do nothing but sleep for a random time between 5 and 15 seconds
- */
-@Component
-// note this implements Quartz's `Job`, not WDS's own `Job`
-public class ImportQuartzJob implements Job {
-
-  private final JobDao jobDao;
-  private final Logger logger = LoggerFactory.getLogger(this.getClass());
-
-  public ImportQuartzJob(JobDao jobDao) {
-    this.jobDao = jobDao;
-  }
-
-  @Override
-  public void execute(JobExecutionContext context) throws JobExecutionException {
-    UUID jobId = UUID.fromString(context.getJobDetail().getKey().getName());
-
-    // as the first step when this kicks off, set status to running
-    jobDao.updateStatus(jobId, GenericJobServerModel.StatusEnum.RUNNING);
-
-    // retrieve the token from job data, so we can execute as the user
-    String token = context.getJobDetail().getJobDataMap().getString("token");
-    logger.info("executing async job with token '{}'", token);
-
-    // TODO: implement the actual data-import business logic! Or delegate to other
-    // classes that do that.
-
-    @SuppressWarnings("java:S2245") // RNG here is fine if it's insecure
-    long sleepMillis = ThreadLocalRandom.current().nextLong(5000, 15000);
-    try {
-      Thread.sleep(sleepMillis);
-      // the business logic for this job has completed; mark it as successful
-      jobDao.updateStatus(jobId, GenericJobServerModel.StatusEnum.SUCCEEDED);
-    } catch (InterruptedException e) {
-      // ensure the thread is actually interrupted
-      Thread.currentThread().interrupt();
-      jobDao.fail(jobId, e.getMessage());
-      throw new JobExecutionException(e);
-    }
-  }
+/** Base class for data-import Quartz jobs, containing constants and utilities for data imports. */
+public abstract class ImportQuartzJob extends QuartzJob {
+  public static final String ARG_URL = "url";
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportQuartzJob.java
@@ -1,8 +1,0 @@
-package org.databiosphere.workspacedataservice.dataimport;
-
-import org.databiosphere.workspacedataservice.jobexec.QuartzJob;
-
-/** Base class for data-import Quartz jobs, containing constants and utilities for data imports. */
-public abstract class ImportQuartzJob extends QuartzJob {
-  public static final String ARG_URL = "url";
-}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbQuartzJob.java
@@ -1,0 +1,20 @@
+package org.databiosphere.workspacedataservice.dataimport;
+
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PfbQuartzJob implements Job {
+
+  private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+  @Override
+  public void execute(JobExecutionContext context) throws JobExecutionException {
+    // TODO: implement PFB import.
+    logger.info("TODO: implement PFB import.");
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbQuartzJob.java
@@ -11,13 +11,18 @@ import org.springframework.stereotype.Component;
 @Component
 public class PfbQuartzJob extends ImportQuartzJob {
 
-  final JobDao jobDao;
+  private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+  private final JobDao jobDao;
 
   public PfbQuartzJob(JobDao jobDao) {
     this.jobDao = jobDao;
   }
 
-  private final Logger logger = LoggerFactory.getLogger(this.getClass());
+  @Override
+  protected JobDao getJobDao() {
+    return this.jobDao;
+  }
 
   @Override
   protected void executeInternal(UUID jobId, JobExecutionContext context) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbQuartzJob.java
@@ -1,19 +1,26 @@
 package org.databiosphere.workspacedataservice.dataimport;
 
-import org.quartz.Job;
+import java.util.UUID;
+import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.quartz.JobExecutionContext;
-import org.quartz.JobExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+/** Shell/starting point for PFB import via Quartz. */
 @Component
-public class PfbQuartzJob implements Job {
+public class PfbQuartzJob extends ImportQuartzJob {
+
+  final JobDao jobDao;
+
+  public PfbQuartzJob(JobDao jobDao) {
+    this.jobDao = jobDao;
+  }
 
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
   @Override
-  public void execute(JobExecutionContext context) throws JobExecutionException {
+  protected void executeInternal(UUID jobId, JobExecutionContext context) {
     // TODO: implement PFB import.
     logger.info("TODO: implement PFB import.");
   }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbQuartzJob.java
@@ -2,6 +2,7 @@ package org.databiosphere.workspacedataservice.dataimport;
 
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.dao.JobDao;
+import org.databiosphere.workspacedataservice.jobexec.QuartzJob;
 import org.quartz.JobExecutionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -9,7 +10,7 @@ import org.springframework.stereotype.Component;
 
 /** Shell/starting point for PFB import via Quartz. */
 @Component
-public class PfbQuartzJob extends ImportQuartzJob {
+public class PfbQuartzJob extends QuartzJob {
 
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbSchedulable.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbSchedulable.java
@@ -1,0 +1,14 @@
+package org.databiosphere.workspacedataservice.dataimport;
+
+import static org.databiosphere.workspacedataservice.generated.ImportRequestServerModel.TypeEnum.PFB;
+
+import java.io.Serializable;
+import java.util.Map;
+import org.databiosphere.workspacedataservice.shared.model.Schedulable;
+
+public class PfbSchedulable extends Schedulable {
+
+  public PfbSchedulable(String name, String description, Map<String, Serializable> arguments) {
+    super(PFB.name(), name, PfbQuartzJob.class, description, arguments);
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/TdrManifestQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/TdrManifestQuartzJob.java
@@ -1,26 +1,25 @@
 package org.databiosphere.workspacedataservice.dataimport;
 
+import static org.databiosphere.workspacedataservice.shared.model.Schedulable.ARG_INSTANCE;
+
 import bio.terra.datarepo.model.SnapshotExportResponseModel;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.dao.JobDao;
-import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
+import org.databiosphere.workspacedataservice.jobexec.JobExecutionException;
 import org.databiosphere.workspacedataservice.service.DataRepoService;
-import org.quartz.Job;
 import org.quartz.JobDataMap;
 import org.quartz.JobExecutionContext;
-import org.quartz.JobExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 @Component
-public class TdrManifestQuartzJob implements Job {
+public class TdrManifestQuartzJob extends ImportQuartzJob {
 
-  private final JobDao jobDao;
+  final JobDao jobDao;
   private final ObjectMapper mapper;
   private final DataRepoService dataRepoService;
 
@@ -33,48 +32,30 @@ public class TdrManifestQuartzJob implements Job {
   }
 
   @Override
-  public void execute(JobExecutionContext context) throws JobExecutionException {
-    // retrieve jobId and mark this job as running
-    JobDataMap jobDataMap = context.getJobDetail().getJobDataMap();
-    UUID jobId = UUID.fromString(context.getJobDetail().getKey().getName());
-    jobDao.updateStatus(jobId, GenericJobServerModel.StatusEnum.RUNNING);
-
-    // get url to manifest from job data
-    URL url;
-    try {
-      url = new URL(jobDataMap.getString("url"));
-    } catch (MalformedURLException e) {
-      jobDao.fail(jobId, e.getMessage(), e.getStackTrace());
-      // TODO: dedicated exceptions for problems inside jobs
-      throw new RuntimeException(e);
-    }
+  protected void executeInternal(UUID jobId, JobExecutionContext context) {
+    // retrieve the Quartz JobDataMap, which contains arguments for this execution
+    JobDataMap jobDataMap = context.getMergedJobDataMap();
 
     // get instanceid from job data
-    UUID instanceId;
-    try {
-      instanceId = UUID.fromString(jobDataMap.getString("instanceId"));
-    } catch (Exception e) {
-      // TODO: make a fail() method that accepts an Exception
-      // TODO: fail() methods should log
-      jobDao.fail(jobId, e.getMessage(), e.getStackTrace());
-      // TODO: dedicated exceptions for problems inside jobs
-      throw new RuntimeException(e);
-    }
+    UUID instanceId = getJobDataUUID(jobDataMap, ARG_INSTANCE);
+
+    // get the TDR manifest url from job data
+    URL url = getJobDataUrl(jobDataMap, ARG_URL);
 
     // read manifest
     SnapshotExportResponseModel snapshotExportResponseModel;
     try {
       snapshotExportResponseModel = mapper.readValue(url, SnapshotExportResponseModel.class);
     } catch (IOException e) {
-      // TODO: dedicated exceptions for problems inside jobs
-      jobDao.fail(jobId, e.getMessage(), e.getStackTrace());
-      throw new RuntimeException(e);
+      throw new JobExecutionException(
+          "Error reading TDR snapshot manifest: %s".formatted(e.getMessage()), e);
     }
 
+    // get the snapshot id from the manifest
     UUID snapshotId = snapshotExportResponseModel.getSnapshot().getId();
     logger.info("Starting import of snapshot {} to instance {}", snapshotId, instanceId);
+    // perform the import via DataRepoService
     // TODO: pass token to dataRepoService, or possibly stash it on the thread
     dataRepoService.importSnapshot(instanceId, snapshotId);
-    jobDao.updateStatus(jobId, GenericJobServerModel.StatusEnum.SUCCEEDED);
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/TdrManifestQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/TdrManifestQuartzJob.java
@@ -73,6 +73,7 @@ public class TdrManifestQuartzJob implements Job {
 
     UUID snapshotId = snapshotExportResponseModel.getSnapshot().getId();
     logger.info("Starting import of snapshot {} to instance {}", snapshotId, instanceId);
+    // TODO: pass token to dataRepoService, or possibly stash it on the thread
     dataRepoService.importSnapshot(instanceId, snapshotId);
     jobDao.updateStatus(jobId, GenericJobServerModel.StatusEnum.SUCCEEDED);
   }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/TdrManifestQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/TdrManifestQuartzJob.java
@@ -19,7 +19,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class TdrManifestQuartzJob extends ImportQuartzJob {
 
-  final JobDao jobDao;
+  private final JobDao jobDao;
   private final ObjectMapper mapper;
   private final DataRepoService dataRepoService;
 
@@ -29,6 +29,11 @@ public class TdrManifestQuartzJob extends ImportQuartzJob {
     this.jobDao = jobDao;
     this.mapper = mapper;
     this.dataRepoService = dataRepoService;
+  }
+
+  @Override
+  protected JobDao getJobDao() {
+    return this.jobDao;
   }
 
   @Override

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/TdrManifestQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/TdrManifestQuartzJob.java
@@ -1,6 +1,7 @@
 package org.databiosphere.workspacedataservice.dataimport;
 
 import static org.databiosphere.workspacedataservice.shared.model.Schedulable.ARG_INSTANCE;
+import static org.databiosphere.workspacedataservice.shared.model.Schedulable.ARG_URL;
 
 import bio.terra.datarepo.model.SnapshotExportResponseModel;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -9,6 +10,7 @@ import java.net.URL;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.jobexec.JobExecutionException;
+import org.databiosphere.workspacedataservice.jobexec.QuartzJob;
 import org.databiosphere.workspacedataservice.service.DataRepoService;
 import org.quartz.JobDataMap;
 import org.quartz.JobExecutionContext;
@@ -17,7 +19,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 @Component
-public class TdrManifestQuartzJob extends ImportQuartzJob {
+public class TdrManifestQuartzJob extends QuartzJob {
 
   private final JobDao jobDao;
   private final ObjectMapper mapper;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/TdrManifestQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/TdrManifestQuartzJob.java
@@ -1,0 +1,79 @@
+package org.databiosphere.workspacedataservice.dataimport;
+
+import bio.terra.datarepo.model.SnapshotExportResponseModel;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.UUID;
+import org.databiosphere.workspacedataservice.dao.JobDao;
+import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
+import org.databiosphere.workspacedataservice.service.DataRepoService;
+import org.quartz.Job;
+import org.quartz.JobDataMap;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TdrManifestQuartzJob implements Job {
+
+  private final JobDao jobDao;
+  private final ObjectMapper mapper;
+  private final DataRepoService dataRepoService;
+
+  private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+  public TdrManifestQuartzJob(JobDao jobDao, ObjectMapper mapper, DataRepoService dataRepoService) {
+    this.jobDao = jobDao;
+    this.mapper = mapper;
+    this.dataRepoService = dataRepoService;
+  }
+
+  @Override
+  public void execute(JobExecutionContext context) throws JobExecutionException {
+    // retrieve jobId and mark this job as running
+    JobDataMap jobDataMap = context.getJobDetail().getJobDataMap();
+    UUID jobId = UUID.fromString(context.getJobDetail().getKey().getName());
+    jobDao.updateStatus(jobId, GenericJobServerModel.StatusEnum.RUNNING);
+
+    // get url to manifest from job data
+    URL url;
+    try {
+      url = new URL(jobDataMap.getString("url"));
+    } catch (MalformedURLException e) {
+      jobDao.fail(jobId, e.getMessage(), e.getStackTrace());
+      // TODO: dedicated exceptions for problems inside jobs
+      throw new RuntimeException(e);
+    }
+
+    // get instanceid from job data
+    UUID instanceId;
+    try {
+      instanceId = UUID.fromString(jobDataMap.getString("instanceId"));
+    } catch (Exception e) {
+      // TODO: make a fail() method that accepts an Exception
+      // TODO: fail() methods should log
+      jobDao.fail(jobId, e.getMessage(), e.getStackTrace());
+      // TODO: dedicated exceptions for problems inside jobs
+      throw new RuntimeException(e);
+    }
+
+    // read manifest
+    SnapshotExportResponseModel snapshotExportResponseModel;
+    try {
+      snapshotExportResponseModel = mapper.readValue(url, SnapshotExportResponseModel.class);
+    } catch (IOException e) {
+      // TODO: dedicated exceptions for problems inside jobs
+      jobDao.fail(jobId, e.getMessage(), e.getStackTrace());
+      throw new RuntimeException(e);
+    }
+
+    UUID snapshotId = snapshotExportResponseModel.getSnapshot().getId();
+    logger.info("Starting import of snapshot {} to instance {}", snapshotId, instanceId);
+    dataRepoService.importSnapshot(instanceId, snapshotId);
+    jobDao.updateStatus(jobId, GenericJobServerModel.StatusEnum.SUCCEEDED);
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/TdrManifestSchedulable.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/TdrManifestSchedulable.java
@@ -1,0 +1,15 @@
+package org.databiosphere.workspacedataservice.dataimport;
+
+import static org.databiosphere.workspacedataservice.generated.ImportRequestServerModel.TypeEnum.TDRMANIFEST;
+
+import java.io.Serializable;
+import java.util.Map;
+import org.databiosphere.workspacedataservice.shared.model.Schedulable;
+
+public class TdrManifestSchedulable extends Schedulable {
+
+  public TdrManifestSchedulable(
+      String name, String description, Map<String, Serializable> arguments) {
+    super(TDRMANIFEST.name(), name, TdrManifestQuartzJob.class, description, arguments);
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/jobexec/JobExecutionException.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/jobexec/JobExecutionException.java
@@ -1,0 +1,12 @@
+package org.databiosphere.workspacedataservice.jobexec;
+
+/** Exception thrown by asynchronous background jobs, i.e. Quartz jobs */
+public class JobExecutionException extends RuntimeException {
+  public JobExecutionException(String message) {
+    super(message);
+  }
+
+  public JobExecutionException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/jobexec/QuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/jobexec/QuartzJob.java
@@ -28,7 +28,7 @@ import org.quartz.JobExecutionContext;
 public abstract class QuartzJob implements Job {
 
   /** implementing classes are expected to be beans that inject a JobDao */
-  JobDao jobDao;
+  protected abstract JobDao getJobDao();
 
   @Override
   public void execute(JobExecutionContext context) throws org.quartz.JobExecutionException {
@@ -36,14 +36,14 @@ public abstract class QuartzJob implements Job {
     UUID jobId = UUID.fromString(context.getJobDetail().getKey().getName());
     try {
       // mark this job as running
-      jobDao.updateStatus(jobId, GenericJobServerModel.StatusEnum.RUNNING);
+      getJobDao().updateStatus(jobId, GenericJobServerModel.StatusEnum.RUNNING);
       // execute the specifics of this job
       executeInternal(jobId, context);
       // if we reached here, mark this job as successful
-      jobDao.updateStatus(jobId, GenericJobServerModel.StatusEnum.SUCCEEDED);
+      getJobDao().updateStatus(jobId, GenericJobServerModel.StatusEnum.SUCCEEDED);
     } catch (Exception e) {
       // on any otherwise-unhandled exception, mark the job as failed
-      jobDao.fail(jobId, e.getMessage(), e.getStackTrace());
+      getJobDao().fail(jobId, e.getMessage(), e.getStackTrace());
     }
   }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/jobexec/QuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/jobexec/QuartzJob.java
@@ -1,0 +1,107 @@
+package org.databiosphere.workspacedataservice.jobexec;
+
+import java.net.URL;
+import java.util.UUID;
+import org.databiosphere.workspacedataservice.dao.JobDao;
+import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
+import org.quartz.Job;
+import org.quartz.JobDataMap;
+import org.quartz.JobExecutionContext;
+
+/**
+ * WDS's base class for asynchronous Quartz jobs. Contains convenience methods and an overridable
+ * best-practice implementation of `execute()`. This implementation:
+ *
+ * <p>- retrieves the job id as a UUID (Quartz stores it as a String)
+ *
+ * <p>- sets the WDS job to RUNNING
+ *
+ * <p>- calls the implementing class's `executeInternal()` method
+ *
+ * <p>- sets the WDS job to SUCCEEDED once `executeInternal()` finishes
+ *
+ * <p>- sets the WDS job to FAILED on any Exception from `executeInternal()`
+ *
+ * <p>Note this implements Quartz's `Job` interface, not WDS's own `Job` model.
+ */
+// note this implements Quartz's `Job`, not WDS's own `Job`
+public abstract class QuartzJob implements Job {
+
+  /** implementing classes are expected to be beans that inject a JobDao */
+  JobDao jobDao;
+
+  @Override
+  public void execute(JobExecutionContext context) throws org.quartz.JobExecutionException {
+    // retrieve jobId
+    UUID jobId = UUID.fromString(context.getJobDetail().getKey().getName());
+    try {
+      // mark this job as running
+      jobDao.updateStatus(jobId, GenericJobServerModel.StatusEnum.RUNNING);
+      // execute the specifics of this job
+      executeInternal(jobId, context);
+      // if we reached here, mark this job as successful
+      jobDao.updateStatus(jobId, GenericJobServerModel.StatusEnum.SUCCEEDED);
+    } catch (Exception e) {
+      // on any otherwise-unhandled exception, mark the job as failed
+      jobDao.fail(jobId, e.getMessage(), e.getStackTrace());
+    }
+  }
+
+  protected abstract void executeInternal(UUID jobId, JobExecutionContext context);
+
+  /**
+   * Retrieve a String value from a JobDataMap. Throws a JobExecutionException if the value is not
+   * found/null or not a String.
+   *
+   * @param jobDataMap the map from which to retrieve the String
+   * @param key where to find the String in the map
+   * @return value from the JobDataMap
+   */
+  protected String getJobDataString(JobDataMap jobDataMap, String key) {
+    String returnValue;
+    try {
+      returnValue = jobDataMap.getString(key);
+      if (returnValue == null) {
+        throw new JobExecutionException("Key '%s' was null in JobDataMap".formatted(key));
+      }
+      return returnValue;
+    } catch (Exception e) {
+      throw new JobExecutionException(
+          "Error retrieving key %s from JobDataMap: %s".formatted(key, e.getMessage()), e);
+    }
+  }
+
+  /**
+   * Retrieve a UUID value from a JobDataMap. Throws a JobExecutionException if the value is not
+   * found/null or not a UUID.
+   *
+   * @param jobDataMap the map from which to retrieve the UUID
+   * @param key where to find the UUID in the map
+   * @return value from the JobDataMap
+   */
+  protected UUID getJobDataUUID(JobDataMap jobDataMap, String key) {
+    try {
+      return UUID.fromString(jobDataMap.getString(key));
+    } catch (Exception e) {
+      throw new JobExecutionException(
+          "Error retrieving key %s as UUID from JobDataMap: %s".formatted(key, e.getMessage()), e);
+    }
+  }
+
+  /**
+   * Retrieve a URL value from a JobDataMap. Throws a JobExecutionException if the value is not
+   * found/null or cannot be parsed into a URL.
+   *
+   * @param jobDataMap the map from which to retrieve the URL
+   * @param key where to find the URL in the map
+   * @return value from the JobDataMap
+   */
+  protected URL getJobDataUrl(JobDataMap jobDataMap, String key) {
+    try {
+      return new URL(jobDataMap.getString(key));
+    } catch (Exception e) {
+      throw new JobExecutionException(
+          "Error retrieving key %s as URL from JobDataMap: %s".formatted(key, e.getMessage()), e);
+    }
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
@@ -1,8 +1,8 @@
 package org.databiosphere.workspacedataservice.service;
 
-import static org.databiosphere.workspacedataservice.dataimport.ImportQuartzJob.ARG_URL;
 import static org.databiosphere.workspacedataservice.shared.model.Schedulable.ARG_INSTANCE;
 import static org.databiosphere.workspacedataservice.shared.model.Schedulable.ARG_TOKEN;
+import static org.databiosphere.workspacedataservice.shared.model.Schedulable.ARG_URL;
 
 import java.io.Serializable;
 import java.util.HashMap;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
@@ -1,13 +1,19 @@
 package org.databiosphere.workspacedataservice.service;
 
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
-import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.dao.SchedulerDao;
+import org.databiosphere.workspacedataservice.dataimport.ImportJobInput;
+import org.databiosphere.workspacedataservice.dataimport.PfbSchedulable;
+import org.databiosphere.workspacedataservice.dataimport.TdrManifestSchedulable;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
 import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
 import org.databiosphere.workspacedataservice.sam.SamDao;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthorizationException;
+import org.databiosphere.workspacedataservice.shared.model.Schedulable;
 import org.databiosphere.workspacedataservice.shared.model.job.Job;
 import org.databiosphere.workspacedataservice.shared.model.job.JobInput;
 import org.databiosphere.workspacedataservice.shared.model.job.JobResult;
@@ -23,19 +29,13 @@ public class ImportService {
   private final SamDao samDao;
   private final JobDao jobDao;
   private final SchedulerDao schedulerDao;
-  private final ActivityLogger activityLogger;
 
   public ImportService(
-      InstanceService instanceService,
-      SamDao samDao,
-      JobDao jobDao,
-      SchedulerDao schedulerDao,
-      ActivityLogger activityLogger) {
+      InstanceService instanceService, SamDao samDao, JobDao jobDao, SchedulerDao schedulerDao) {
     this.instanceService = instanceService;
     this.samDao = samDao;
     this.jobDao = jobDao;
     this.schedulerDao = schedulerDao;
-    this.activityLogger = activityLogger;
   }
 
   public GenericJobServerModel createImport(
@@ -50,20 +50,46 @@ public class ImportService {
       throw new AuthorizationException("Caller does not have permission to write to instance.");
     }
 
-    // TODO: translate the ImportRequestServerModel into a Job
-    // for now, just make an example job
-    Job<JobInput, JobResult> job = Job.newJob(JobType.DATA_IMPORT, JobInput.empty());
+    logger.debug("Data import of type {} requested", importRequest.getType());
 
-    // persist the job
+    ImportJobInput importJobInput = ImportJobInput.from(importRequest);
+    Job<JobInput, JobResult> job = Job.newJob(JobType.DATA_IMPORT, importJobInput);
+
+    // persist the full job to WDS's db
     GenericJobServerModel createdJob = jobDao.createJob(job);
+    logger.debug(
+        "Job {} created for data import of type {}",
+        createdJob.getJobId(),
+        importRequest.getType());
+
+    // create the arguments for the schedulable job
+    // TODO: create some constants for map keys
+    Map<String, Serializable> arguments = new HashMap<>();
+    arguments.put("token", "fake-pet-token");
+    arguments.put("url", importRequest.getUrl().toString());
+    arguments.put("instanceId", instanceUuid.toString());
+
+    // create the executable job to be scheduled
+    Schedulable schedulable =
+        createSchedulable(importRequest.getType(), createdJob.getJobId(), arguments);
 
     // schedule the job. after successfully scheduling, mark the job as queued
-    schedulerDao.schedule(job);
+    schedulerDao.schedule(schedulable);
+    logger.debug("Job {} scheduled", createdJob.getJobId());
     jobDao.updateStatus(job.getJobId(), GenericJobServerModel.StatusEnum.QUEUED);
-
-    // TODO: activity log? Or is that part of the job itself?
 
     // return the queued job
     return createdJob;
+  }
+
+  protected Schedulable createSchedulable(
+      ImportRequestServerModel.TypeEnum importType,
+      UUID jobId,
+      Map<String, Serializable> arguments) {
+    return switch (importType) {
+      case TDRMANIFEST -> new TdrManifestSchedulable(
+          jobId.toString(), "TDR manifest import", arguments);
+      case PFB -> new PfbSchedulable(jobId.toString(), "TODO: PFB import", arguments);
+    };
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
@@ -1,5 +1,9 @@
 package org.databiosphere.workspacedataservice.service;
 
+import static org.databiosphere.workspacedataservice.dataimport.ImportQuartzJob.ARG_URL;
+import static org.databiosphere.workspacedataservice.shared.model.Schedulable.ARG_INSTANCE;
+import static org.databiosphere.workspacedataservice.shared.model.Schedulable.ARG_TOKEN;
+
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
@@ -63,11 +67,10 @@ public class ImportService {
         importRequest.getType());
 
     // create the arguments for the schedulable job
-    // TODO: create some constants for map keys
     Map<String, Serializable> arguments = new HashMap<>();
-    arguments.put("token", "fake-pet-token");
-    arguments.put("url", importRequest.getUrl().toString());
-    arguments.put("instanceId", instanceUuid.toString());
+    arguments.put(ARG_TOKEN, "fake-pet-token");
+    arguments.put(ARG_URL, importRequest.getUrl().toString());
+    arguments.put(ARG_INSTANCE, instanceUuid.toString());
 
     // create the executable job to be scheduled
     Schedulable schedulable =

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/JobService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/JobService.java
@@ -3,6 +3,8 @@ package org.databiosphere.workspacedataservice.service;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
+import org.databiosphere.workspacedataservice.service.model.exception.MissingObjectException;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -20,6 +22,10 @@ public class JobService {
     // validate instance exists
     instanceService.validateInstance(instanceUuid);
 
-    return jobDao.getJob(jobId);
+    try {
+      return jobDao.getJob(jobId);
+    } catch (EmptyResultDataAccessException e) {
+      throw new MissingObjectException("Job");
+    }
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/Schedulable.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/Schedulable.java
@@ -10,6 +10,7 @@ public class Schedulable {
   // keys for job data arguments likely to be used by all/most Schedulables
   public static final String ARG_TOKEN = "authToken";
   public static final String ARG_INSTANCE = "instanceId";
+  public static final String ARG_URL = "url";
 
   // classifier for types of schedulable jobs; feeds into Quartz's JobKey
   private final String group;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/Schedulable.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/Schedulable.java
@@ -7,6 +7,10 @@ import org.quartz.JobDataMap;
 
 public class Schedulable {
 
+  // keys for job data arguments likely to be used by all/most Schedulables
+  public static final String ARG_TOKEN = "authToken";
+  public static final String ARG_INSTANCE = "instanceId";
+
   // classifier for types of schedulable jobs; feeds into Quartz's JobKey
   private final String group;
   // id for a single schedulable job; feeds into Quartz's JobKey

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/Schedulable.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/Schedulable.java
@@ -1,0 +1,59 @@
+package org.databiosphere.workspacedataservice.shared.model;
+
+import java.io.Serializable;
+import java.util.Map;
+import org.quartz.Job;
+import org.quartz.JobDataMap;
+
+public class Schedulable {
+
+  // classifier for types of schedulable jobs; feeds into Quartz's JobKey
+  private final String group;
+  // id for a single schedulable job; feeds into Quartz's JobKey
+  private final String name;
+  // for human-readable debugging
+  private final String description;
+  // Class to execute for this schedulable job
+  private final Class<? extends Job> implementation;
+  // inputs to the schedulable job
+  private final Map<String, Serializable> arguments;
+
+  public Schedulable(
+      String group,
+      String name,
+      Class<? extends Job> implementation,
+      String description,
+      Map<String, Serializable> arguments) {
+    this.group = group;
+    this.name = name;
+    this.implementation = implementation;
+    this.description = description;
+    this.arguments = arguments;
+  }
+
+  public String getGroup() {
+    return group;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public Class<? extends Job> getImplementation() {
+    return implementation;
+  }
+
+  public Map<String, Serializable> getArguments() {
+    return arguments;
+  }
+
+  public JobDataMap getArgumentsAsJobDataMap() {
+    JobDataMap jobDataMap = new JobDataMap();
+    jobDataMap.putAll(arguments);
+    return jobDataMap;
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/Schedulable.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/Schedulable.java
@@ -14,7 +14,7 @@ public class Schedulable {
   // classifier for types of schedulable jobs; feeds into Quartz's JobKey
   private final String group;
   // id for a single schedulable job; feeds into Quartz's JobKey
-  private final String name;
+  private final String id;
   // for human-readable debugging
   private final String description;
   // Class to execute for this schedulable job
@@ -24,12 +24,12 @@ public class Schedulable {
 
   public Schedulable(
       String group,
-      String name,
+      String id,
       Class<? extends Job> implementation,
       String description,
       Map<String, Serializable> arguments) {
     this.group = group;
-    this.name = name;
+    this.id = id;
     this.implementation = implementation;
     this.description = description;
     this.arguments = arguments;
@@ -39,8 +39,8 @@ public class Schedulable {
     return group;
   }
 
-  public String getName() {
-    return name;
+  public String getId() {
+    return id;
   }
 
   public String getDescription() {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/ImportJobInputTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/ImportJobInputTest.java
@@ -1,0 +1,24 @@
+package org.databiosphere.workspacedataservice.dataimport;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class ImportJobInputTest {
+
+  @ParameterizedTest(name = "with type {0}")
+  @EnumSource(ImportRequestServerModel.TypeEnum.class)
+  void from(ImportRequestServerModel.TypeEnum type) throws URISyntaxException {
+    URI testUri = new URI("https://example.com/?rand=" + RandomStringUtils.randomAlphanumeric(10));
+    ImportRequestServerModel importRequest = new ImportRequestServerModel(type, testUri);
+
+    ImportJobInput actual = ImportJobInput.from(importRequest);
+    assertEquals(testUri, actual.getUri());
+    assertEquals(type, actual.getImportType());
+  }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceTest.java
@@ -1,0 +1,67 @@
+package org.databiosphere.workspacedataservice.service;
+
+import static org.databiosphere.workspacedataservice.generated.ImportRequestServerModel.TypeEnum;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.databiosphere.workspacedataservice.dataimport.PfbQuartzJob;
+import org.databiosphere.workspacedataservice.dataimport.TdrManifestQuartzJob;
+import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
+import org.databiosphere.workspacedataservice.shared.model.Schedulable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.quartz.Job;
+import org.quartz.JobDataMap;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class ImportServiceTest {
+
+  @Autowired ImportService importService;
+
+  // does createSchedulable properly store the jobId, job group, and job data map?
+  @ParameterizedTest(name = "for import type {0}")
+  @EnumSource(ImportRequestServerModel.TypeEnum.class)
+  void createSchedulableValues(ImportRequestServerModel.TypeEnum importType) {
+    UUID jobId = UUID.randomUUID();
+    Map<String, Serializable> arguments = Map.of("foo", "bar", "twenty-three", 23);
+
+    Schedulable actual = importService.createSchedulable(importType, jobId, arguments);
+
+    JobDataMap expectedJobDataMap = new JobDataMap();
+    expectedJobDataMap.put("foo", "bar");
+    expectedJobDataMap.put("twenty-three", 23);
+
+    assertEquals(jobId.toString(), actual.getName());
+    assertEquals(importType.name(), actual.getGroup());
+    assertEquals(expectedJobDataMap, actual.getArgumentsAsJobDataMap());
+  }
+
+  private static Stream<Arguments> provideImplementationClasses() {
+    return Stream.of(
+        Arguments.of(TypeEnum.TDRMANIFEST, TdrManifestQuartzJob.class),
+        Arguments.of(TypeEnum.PFB, PfbQuartzJob.class));
+  }
+
+  // does createSchedulable use the correct implementation class for TDRMANIFEST?
+  @ParameterizedTest(name = "for import type {0}, should use {1}")
+  @MethodSource("provideImplementationClasses")
+  void createSchedulableImplementationClasses(
+      TypeEnum importType, Class<? extends Job> expectedClass) {
+    UUID jobId = UUID.randomUUID();
+    Schedulable actual = importService.createSchedulable(importType, jobId, Map.of());
+    assertEquals(expectedClass, actual.getImplementation());
+  }
+
+  // TODO: add test coverage
+  //    - writes a row to sys_wds.job as CREATED
+  //    - with Quartz mock, schedules a job
+  //    - saves token, url, and instance to the scheduled job
+  //    - updates row in sys_wds.job to QUEUED
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceTest.java
@@ -38,7 +38,7 @@ class ImportServiceTest {
     expectedJobDataMap.put("foo", "bar");
     expectedJobDataMap.put("twenty-three", 23);
 
-    assertEquals(jobId.toString(), actual.getName());
+    assertEquals(jobId.toString(), actual.getId());
     assertEquals(importType.name(), actual.getGroup());
     assertEquals(expectedJobDataMap, actual.getArgumentsAsJobDataMap());
   }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceTest.java
@@ -21,7 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-public class ImportServiceTest {
+class ImportServiceTest {
 
   @Autowired ImportService importService;
 


### PR DESCRIPTION
connects the dots and performs async snapshot import via Quartz. Well, as of this PR the import fails because we're not properly passing a token. But you can see that it's trying, and token work will be a follow-on PR ([Slack thread](https://broadinstitute.slack.com/archives/C02SJQ0FKHQ/p1697205316686489))

To test this locally:
1. Export a snapshot from TDR via the [exportSnapshot API](https://jade.datarepo-dev.broadinstitute.org/swagger-ui.html#/snapshots/exportSnapshot) and copy the url to the exported manifest
2. Call WDS's `importV1` API with a payload of `{"type": "TDRMANIFEST", "url": "url-to-manifest-from-previous-step"}` and make note of the jobId it returns
3. Call WDS's `jobStatusV1` API, passing the jobId from the previous step
4. View the WDS logs to see progress of the job

For future PRs:
* Properly pass an auth token from the Quartz job to the WSM and TDR API calls
* return some kind of response payload from the import, such as the number of rows affected
* Update the OpenAPI spec to define the expected response payloads
* always can use more test coverage