### PR TITLE
AJ-1011: update TODO comments

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/JobDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/JobDao.java
@@ -8,7 +8,7 @@ import org.databiosphere.workspacedataservice.shared.model.job.JobResult;
 
 public interface JobDao {
 
-  // TODO: awkward that this API accepts `Job` but returns `GenericJobServerModel`;
+  // TODO: AJ-1011 awkward that this API accepts `Job` but returns `GenericJobServerModel`;
   // we should standardize on one model
   GenericJobServerModel createJob(Job<JobInput, JobResult> job);
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresJobDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresJobDao.java
@@ -44,7 +44,7 @@ public class PostgresJobDao implements JobDao {
       } catch (JsonProcessingException e) {
         // for now, fail silently. If/when we have any inputs that are required,
         // this should rethrow an exception instead of swallowing it
-        // TODO: this will soon need to be a failure
+        // TODO: AJ-1011 this will soon need to be a failure
         logger.error(
             "Error serializing inputs to jsonb for job {}: {}", job.getJobId(), e.getMessage());
       }
@@ -131,7 +131,7 @@ public class PostgresJobDao implements JobDao {
       } catch (JsonProcessingException e) {
         logger.error(
             "Error serializing stack trace to jsonb for job {}: {}", jobId, e.getMessage());
-        // TODO: should this be fatal?
+        // TODO: AJ-1011 should this be fatal?
       }
     }
 
@@ -188,7 +188,7 @@ public class PostgresJobDao implements JobDao {
 
       job.errorMessage(rs.getString("error"));
 
-      // TODO: also return stacktrace, input, result.
+      // TODO: AJ-1011 also return stacktrace, input, result.
       return job;
     }
   }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbQuartzJob.java
@@ -27,7 +27,7 @@ public class PfbQuartzJob extends QuartzJob {
 
   @Override
   protected void executeInternal(UUID jobId, JobExecutionContext context) {
-    // TODO: implement PFB import.
+    // TODO: AJ-1227? implement PFB import.
     logger.info("TODO: implement PFB import.");
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/TdrManifestQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/TdrManifestQuartzJob.java
@@ -62,7 +62,7 @@ public class TdrManifestQuartzJob extends QuartzJob {
     UUID snapshotId = snapshotExportResponseModel.getSnapshot().getId();
     logger.info("Starting import of snapshot {} to instance {}", snapshotId, instanceId);
     // perform the import via DataRepoService
-    // TODO: pass token to dataRepoService, or possibly stash it on the thread
+    // TODO: AJ-1011 pass token to dataRepoService, or possibly stash it on the thread
     dataRepoService.importSnapshot(instanceId, snapshotId);
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/PostgresJobDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/PostgresJobDaoTest.java
@@ -187,7 +187,7 @@ class PostgresJobDaoTest {
         "should properly update the job with an error message and a stack trace");
   }
 
-  // TODO: get job, does it deserialize correctly?
+  // TODO: AJ-1011 get job, does it deserialize correctly?
   @Test
   void getJob() {
     JobType jobType = JobType.DATA_IMPORT;
@@ -195,6 +195,6 @@ class PostgresJobDaoTest {
 
     assertEquals(JobTypeEnum.DATA_IMPORT, actual.getJobType());
     assertEquals(StatusEnum.CREATED, actual.getStatus());
-    // TODO: as PostgresJobDao.mapRow evolves, add more assertions here
+    // TODO: AJ-1011 as PostgresJobDao.mapRow evolves, add more assertions here
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceTest.java
@@ -59,7 +59,7 @@ class ImportServiceTest {
     assertEquals(expectedClass, actual.getImplementation());
   }
 
-  // TODO: add test coverage
+  // TODO: AJ-1011 add test coverage
   //    - writes a row to sys_wds.job as CREATED
   //    - with Quartz mock, schedules a job
   //    - saves token, url, and instance to the scheduled job


### PR DESCRIPTION
a quickie: tag a bunch of TODO comments with their associated Jira tickets, to make it easier to search the codebase for specific TODOs.

I have not tried to tag all the TODOs in the codebase.