### PR TITLE
AJ-1011: tokens in quartz jobs

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityEventBuilder.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityEventBuilder.java
@@ -1,14 +1,12 @@
 package org.databiosphere.workspacedataservice.activitylog;
 
-import static org.databiosphere.workspacedataservice.sam.BearerTokenFilter.ATTRIBUTE_NAME_TOKEN;
-import static org.springframework.web.context.request.RequestAttributes.SCOPE_REQUEST;
 
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.sam.SamDao;
+import org.databiosphere.workspacedataservice.sam.TokenContextUtil;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.web.context.request.RequestContextHolder;
 
 /** Builder for ActivityEvent, with many convenience functions */
 public class ActivityEventBuilder {
@@ -39,12 +37,10 @@ public class ActivityEventBuilder {
   public ActivityEventBuilder currentUser() {
     try {
       // grab the current user's bearer token (see BearerTokenFilter)
-      Object token =
-          RequestContextHolder.currentRequestAttributes()
-              .getAttribute(ATTRIBUTE_NAME_TOKEN, SCOPE_REQUEST);
+      String token = TokenContextUtil.getToken();
       if (token != null) {
         // resolve the token to a user id via Sam
-        this.subject = samDao.getUserId(token.toString());
+        this.subject = samDao.getUserId(token);
       } else {
         this.subject = "anonymous";
       }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityEventBuilder.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityEventBuilder.java
@@ -1,6 +1,5 @@
 package org.databiosphere.workspacedataservice.activitylog;
 
-
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.sam.SamDao;
 import org.databiosphere.workspacedataservice.sam.TokenContextUtil;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/datarepo/HttpDataRepoClientFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/datarepo/HttpDataRepoClientFactory.java
@@ -1,16 +1,12 @@
 package org.databiosphere.workspacedataservice.datarepo;
 
-import static org.databiosphere.workspacedataservice.sam.BearerTokenFilter.ATTRIBUTE_NAME_TOKEN;
-import static org.springframework.web.context.request.RequestAttributes.SCOPE_REQUEST;
-
 import bio.terra.datarepo.api.RepositoryApi;
 import bio.terra.datarepo.client.ApiClient;
-import java.util.Objects;
 import javax.ws.rs.client.Client;
 import org.apache.commons.lang3.StringUtils;
+import org.databiosphere.workspacedataservice.sam.TokenContextUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.web.context.request.RequestContextHolder;
 
 public class HttpDataRepoClientFactory implements DataRepoClientFactory {
 
@@ -33,13 +29,11 @@ public class HttpDataRepoClientFactory implements DataRepoClientFactory {
       apiClient.setBasePath(dataRepoUrl);
     }
     // grab the current user's bearer token (see BearerTokenFilter)
-    Object token =
-        RequestContextHolder.currentRequestAttributes()
-            .getAttribute(ATTRIBUTE_NAME_TOKEN, SCOPE_REQUEST);
+    String token = TokenContextUtil.getToken();
     // add the user's bearer token to the client
-    if (!Objects.isNull(token)) {
+    if (token != null) {
       LOGGER.debug("setting access token for data repo request");
-      apiClient.setAccessToken(token.toString());
+      apiClient.setAccessToken(token);
     } else {
       LOGGER.warn("No access token found for data repo request.");
     }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/jobexec/JobContextHolder.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/jobexec/JobContextHolder.java
@@ -18,6 +18,8 @@ import java.util.concurrent.ConcurrentHashMap;
 public class JobContextHolder {
   private static final ThreadLocal<Map<String, Object>> JOB_CONTEXT = new ThreadLocal<>();
 
+  private JobContextHolder() {}
+
   /** initialize this thread's usage of JobContextHolder */
   public static void init() {
     JOB_CONTEXT.set(new ConcurrentHashMap<>());

--- a/service/src/main/java/org/databiosphere/workspacedataservice/jobexec/JobContextHolder.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/jobexec/JobContextHolder.java
@@ -1,0 +1,66 @@
+package org.databiosphere.workspacedataservice.jobexec;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Modeled after Spring's RequestContextHolder, this class manages a ThreadLocal Map<String, Object>
+ * so callers can stash values onto the thread, then later retrieve those values from the thread.
+ *
+ * <p>Callers MUST call JobContextHolder.destroy() when they are done with the underlying
+ * ThreadLocal. This should be done in a `finally` to ensure it always gets called. If callers do
+ * not reliably call destroy(), it can lead to threads receiving dangling data they should not have
+ * access to, as well as memory leaks.
+ *
+ * <p>Callers must also call init() before setting any values; this helps safeguard against dangling
+ * data.
+ */
+public class JobContextHolder {
+  private static final ThreadLocal<Map<String, Object>> JOB_CONTEXT = new ThreadLocal<>();
+
+  /** initialize this thread's usage of JobContextHolder */
+  public static void init() {
+    JOB_CONTEXT.set(new ConcurrentHashMap<>());
+  }
+
+  /**
+   * Retrieve the entire map of attributes from this context.
+   *
+   * @return all attributes
+   */
+  public static Map<String, Object> getAttributes() {
+    return JOB_CONTEXT.get();
+  }
+
+  /**
+   * Put a single value into the attributes for this context.
+   *
+   * @param key attribute name
+   * @param value attribute value
+   */
+  public static void setAttribute(String key, Object value) {
+    Map<String, Object> curr = getAttributes();
+    if (curr != null) {
+      curr.put(key, value);
+    }
+  }
+
+  /**
+   * Retrieve a single value from this context's attributes.
+   *
+   * @param key attribute name
+   * @return the attribute value, or null if the key was not found or init() has not yet been called
+   */
+  public static Object getAttribute(String key) {
+    Map<String, Object> curr = getAttributes();
+    if (curr == null) {
+      return null;
+    }
+    return curr.get(key);
+  }
+
+  /** Clean up by removing all attributes from this context. */
+  public static void destroy() {
+    JOB_CONTEXT.remove();
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/leonardo/HttpLeonardoClientFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/leonardo/HttpLeonardoClientFactory.java
@@ -35,7 +35,7 @@ public class HttpLeonardoClientFactory implements LeonardoClientFactory {
     }
 
     // grab the current user's bearer token (see BearerTokenFilter) or use parameter value
-    String token = TokenContextUtil.getToken(authToken, () -> null);
+    String token = TokenContextUtil.getToken(authToken);
     // add the user's bearer token to the client
     if (token != null) {
       LOGGER.debug("setting access token for leonardo request");

--- a/service/src/main/java/org/databiosphere/workspacedataservice/leonardo/HttpLeonardoClientFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/leonardo/HttpLeonardoClientFactory.java
@@ -1,18 +1,14 @@
 package org.databiosphere.workspacedataservice.leonardo;
 
-import static org.databiosphere.workspacedataservice.sam.BearerTokenFilter.ATTRIBUTE_NAME_TOKEN;
-import static org.springframework.web.context.request.RequestAttributes.SCOPE_REQUEST;
-
 import java.util.List;
-import java.util.Objects;
 import okhttp3.OkHttpClient;
 import okhttp3.Protocol;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.dsde.workbench.client.leonardo.ApiClient;
 import org.broadinstitute.dsde.workbench.client.leonardo.api.AppsApi;
+import org.databiosphere.workspacedataservice.sam.TokenContextUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.web.context.request.RequestContextHolder;
 
 public class HttpLeonardoClientFactory implements LeonardoClientFactory {
 
@@ -28,7 +24,7 @@ public class HttpLeonardoClientFactory implements LeonardoClientFactory {
         new ApiClient().getHttpClient().newBuilder().protocols(List.of(Protocol.HTTP_1_1)).build();
   }
 
-  private ApiClient getApiClient(String token) {
+  private ApiClient getApiClient(String authToken) {
     // create a new data repo client
     ApiClient apiClient = new ApiClient();
     apiClient.setHttpClient(commonHttpClient);
@@ -38,20 +34,14 @@ public class HttpLeonardoClientFactory implements LeonardoClientFactory {
       apiClient.setBasePath(leoEndpointUrl);
     }
 
-    // grab the current user's bearer token (see BearerTokenFilter)
-    if (token.isEmpty()) {
-      Object userToken =
-          RequestContextHolder.currentRequestAttributes()
-              .getAttribute(ATTRIBUTE_NAME_TOKEN, SCOPE_REQUEST);
-      // add the user's bearer token to the client
-      if (!Objects.isNull(userToken)) {
-        LOGGER.debug("setting access token for leonardo request");
-        apiClient.setAccessToken(userToken.toString());
-      } else {
-        LOGGER.warn("No access token found for leonardo request.");
-      }
-    } else {
+    // grab the current user's bearer token (see BearerTokenFilter) or use parameter value
+    String token = TokenContextUtil.getToken(authToken, () -> null);
+    // add the user's bearer token to the client
+    if (token != null) {
+      LOGGER.debug("setting access token for leonardo request");
       apiClient.setAccessToken(token);
+    } else {
+      LOGGER.warn("No access token found for leonardo request.");
     }
 
     // return the client

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamClientFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamClientFactory.java
@@ -44,7 +44,7 @@ public class HttpSamClientFactory implements SamClientFactory {
     }
 
     // grab the current user's bearer token (see BearerTokenFilter) or use parameter value
-    String token = TokenContextUtil.getToken(authToken, () -> null);
+    String token = TokenContextUtil.getToken(authToken);
 
     // add the user's bearer token to the client
     if (!Objects.isNull(token)) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/TokenContextUtil.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/TokenContextUtil.java
@@ -82,14 +82,12 @@ public class TokenContextUtil {
    */
   private static String tokenFromRequestContext() {
     // do any request attributes exist?
-    RequestAttributes requestAttributes;
-    try {
-      requestAttributes = RequestContextHolder.currentRequestAttributes();
-    } catch (IllegalStateException e) {
-      LOGGER.debug("No request attributes on this thread.");
-      return null;
+    RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
+    if (requestAttributes != null) {
+      return maybeToken(requestAttributes.getAttribute(ATTRIBUTE_NAME_TOKEN, SCOPE_REQUEST));
     }
-    return maybeToken(requestAttributes.getAttribute(ATTRIBUTE_NAME_TOKEN, SCOPE_REQUEST));
+    LOGGER.debug("No request attributes on this thread.");
+    return null;
   }
 
   /**

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/TokenContextUtil.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/TokenContextUtil.java
@@ -15,6 +15,8 @@ public class TokenContextUtil {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TokenContextUtil.class);
 
+  private TokenContextUtil() {}
+
   /**
    * Convenience for evaluating auth tokens.
    *

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/TokenContextUtil.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/TokenContextUtil.java
@@ -1,0 +1,116 @@
+package org.databiosphere.workspacedataservice.sam;
+
+import static org.databiosphere.workspacedataservice.sam.BearerTokenFilter.ATTRIBUTE_NAME_TOKEN;
+import static org.springframework.web.context.request.RequestAttributes.SCOPE_REQUEST;
+
+import java.util.Map;
+import java.util.function.Supplier;
+import org.databiosphere.workspacedataservice.jobexec.JobContextHolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+
+public class TokenContextUtil {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(TokenContextUtil.class);
+
+  /**
+   * Convenience for evaluating auth tokens.
+   *
+   * <p>If `initialValue` is non-null, returns the initialValue as-is.
+   *
+   * <p>If `initialValue` is null, searches request context for a non-null String value, and returns
+   * it if found.
+   *
+   * <p>If the request context has no value, searches job context for a non-null String value, and
+   * returns it if found.
+   *
+   * <p>If the job context has no value, returns the value of the `orElse` supplier.
+   *
+   * @param initialValue the first value to check for a non-null token
+   * @param orElse the value to return if the token was not found otherwise
+   * @return the final value
+   */
+  public static String getToken(String initialValue, Supplier<String> orElse) {
+    if (initialValue != null) {
+      return initialValue;
+    }
+    return getToken(orElse);
+  }
+
+  /**
+   * Look in RequestContextHolder and then JobContextHolder, in that order, for a non-null String
+   * ATTRIBUTE_NAME_TOKEN. If none found, return the value of orElse.
+   *
+   * @param orElse the value to return if the token was not found otherwise
+   * @return the final value
+   */
+  public static String getToken(Supplier<String> orElse) {
+    String foundToken = getToken();
+    if (foundToken != null) {
+      return foundToken;
+    } else {
+      return orElse.get();
+    }
+  }
+
+  /**
+   * Look in RequestContextHolder and then JobContextHolder, in that order, for a non-null String
+   * ATTRIBUTE_NAME_TOKEN
+   *
+   * @return the token if found; null otherwise
+   */
+  public static String getToken() {
+    String foundToken;
+    // look in request context; if non-null, return it
+    foundToken = tokenFromRequestContext();
+    if (foundToken != null) {
+      return foundToken;
+    }
+
+    // look in job context; return whatever we found, even if null
+    return tokenFromJobContext();
+  }
+
+  /**
+   * Look in RequestContextHolder for a non-null String ATTRIBUTE_NAME_TOKEN
+   *
+   * @return the token if found; null otherwise
+   */
+  private static String tokenFromRequestContext() {
+    // do any request attributes exist?
+    RequestAttributes requestAttributes;
+    try {
+      requestAttributes = RequestContextHolder.currentRequestAttributes();
+    } catch (IllegalStateException e) {
+      LOGGER.debug("No request attributes on this thread.");
+      return null;
+    }
+    return maybeToken(requestAttributes.getAttribute(ATTRIBUTE_NAME_TOKEN, SCOPE_REQUEST));
+  }
+
+  /**
+   * Look in JobContextHolder for a non-null String ATTRIBUTE_NAME_TOKEN
+   *
+   * @return the token if found; null otherwise
+   */
+  private static String tokenFromJobContext() {
+    // do any job attributes exist?
+    Map<String, Object> jobAttributes = JobContextHolder.getAttributes();
+    if (jobAttributes == null) {
+      LOGGER.debug("No job attributes on this thread.");
+      return null;
+    }
+
+    return maybeToken(jobAttributes.get(ATTRIBUTE_NAME_TOKEN));
+  }
+
+  /** Convenience: is the input object non-null and a String? */
+  private static String maybeToken(Object obj) {
+    if (obj instanceof String strVal) {
+      return strVal;
+    }
+    return null;
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
@@ -16,6 +16,7 @@ import org.databiosphere.workspacedataservice.dataimport.TdrManifestSchedulable;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
 import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
 import org.databiosphere.workspacedataservice.sam.SamDao;
+import org.databiosphere.workspacedataservice.sam.TokenContextUtil;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthorizationException;
 import org.databiosphere.workspacedataservice.shared.model.Schedulable;
 import org.databiosphere.workspacedataservice.shared.model.job.Job;
@@ -66,9 +67,13 @@ public class ImportService {
         createdJob.getJobId(),
         importRequest.getType());
 
+    // get the user's token from the current request
+    // TODO: this should actually get a pet token for the user, to ensure the token won't time out
+    String token = TokenContextUtil.getToken();
+
     // create the arguments for the schedulable job
     Map<String, Serializable> arguments = new HashMap<>();
-    arguments.put(ARG_TOKEN, "fake-pet-token");
+    arguments.put(ARG_TOKEN, token);
     arguments.put(ARG_URL, importRequest.getUrl().toString());
     arguments.put(ARG_INSTANCE, instanceUuid.toString());
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
@@ -73,7 +73,9 @@ public class ImportService {
 
     // create the arguments for the schedulable job
     Map<String, Serializable> arguments = new HashMap<>();
-    arguments.put(ARG_TOKEN, token);
+    if (token != null) {
+      arguments.put(ARG_TOKEN, token);
+    }
     arguments.put(ARG_URL, importRequest.getUrl().toString());
     arguments.put(ARG_INSTANCE, instanceUuid.toString());
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sourcewds/HttpWorkspaceDataServiceClientFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sourcewds/HttpWorkspaceDataServiceClientFactory.java
@@ -34,7 +34,7 @@ public class HttpWorkspaceDataServiceClientFactory implements WorkspaceDataServi
     }
 
     // grab the current user's bearer token (see BearerTokenFilter) or use parameter value
-    String token = TokenContextUtil.getToken(authToken, () -> null);
+    String token = TokenContextUtil.getToken(authToken);
 
     // add the user's bearer token to the client
     if (token != null) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sourcewds/HttpWorkspaceDataServiceClientFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sourcewds/HttpWorkspaceDataServiceClientFactory.java
@@ -1,18 +1,14 @@
 package org.databiosphere.workspacedataservice.sourcewds;
 
-import static org.databiosphere.workspacedataservice.sam.BearerTokenFilter.ATTRIBUTE_NAME_TOKEN;
-import static org.springframework.web.context.request.RequestAttributes.SCOPE_REQUEST;
-
 import java.util.List;
-import java.util.Objects;
 import okhttp3.OkHttpClient;
 import okhttp3.Protocol;
 import org.apache.commons.lang3.StringUtils;
 import org.databiosphere.workspacedata.api.CloningApi;
 import org.databiosphere.workspacedata.client.ApiClient;
+import org.databiosphere.workspacedataservice.sam.TokenContextUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.web.context.request.RequestContextHolder;
 
 public class HttpWorkspaceDataServiceClientFactory implements WorkspaceDataServiceClientFactory {
   private final OkHttpClient commonHttpClient;
@@ -24,10 +20,9 @@ public class HttpWorkspaceDataServiceClientFactory implements WorkspaceDataServi
     // https://youtrack.jetbrains.com/issue/KTIJ-26434
     this.commonHttpClient =
         new ApiClient().getHttpClient().newBuilder().protocols(List.of(Protocol.HTTP_1_1)).build();
-    ;
   }
 
-  private ApiClient getApiClient(String token, String workspaceDataServiceUrl) {
+  private ApiClient getApiClient(String authToken, String workspaceDataServiceUrl) {
     // create a new client
     ApiClient apiClient = new ApiClient();
     apiClient.setHttpClient(commonHttpClient);
@@ -38,20 +33,15 @@ public class HttpWorkspaceDataServiceClientFactory implements WorkspaceDataServi
       apiClient.setBasePath(workspaceDataServiceUrl);
     }
 
-    // grab the current user's bearer token (see BearerTokenFilter)
-    if (token.isEmpty()) {
-      Object userToken =
-          RequestContextHolder.currentRequestAttributes()
-              .getAttribute(ATTRIBUTE_NAME_TOKEN, SCOPE_REQUEST);
-      // add the user's bearer token to the client
-      if (!Objects.isNull(userToken)) {
-        LOGGER.debug("setting access token for workspace data service request");
-        apiClient.setAccessToken(userToken.toString());
-      } else {
-        LOGGER.warn("No access token found for workspace data service request.");
-      }
+    // grab the current user's bearer token (see BearerTokenFilter) or use parameter value
+    String token = TokenContextUtil.getToken(authToken, () -> null);
+
+    // add the user's bearer token to the client
+    if (token != null) {
+      LOGGER.debug("setting access token for workspace data service request");
+      apiClient.setAccessToken(token);
     } else {
-      apiClient.setBearerToken(token);
+      LOGGER.warn("No access token found for workspace data service request.");
     }
 
     return apiClient;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/workspacemanager/HttpWorkspaceManagerClientFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/workspacemanager/HttpWorkspaceManagerClientFactory.java
@@ -1,18 +1,14 @@
 package org.databiosphere.workspacedataservice.workspacemanager;
 
-import static org.databiosphere.workspacedataservice.sam.BearerTokenFilter.ATTRIBUTE_NAME_TOKEN;
-import static org.springframework.web.context.request.RequestAttributes.SCOPE_REQUEST;
-
 import bio.terra.workspace.api.ControlledAzureResourceApi;
 import bio.terra.workspace.api.ReferencedGcpResourceApi;
 import bio.terra.workspace.api.ResourceApi;
 import bio.terra.workspace.client.ApiClient;
-import java.util.Objects;
 import javax.ws.rs.client.Client;
 import org.apache.commons.lang3.StringUtils;
+import org.databiosphere.workspacedataservice.sam.TokenContextUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.web.context.request.RequestContextHolder;
 
 public class HttpWorkspaceManagerClientFactory implements WorkspaceManagerClientFactory {
 
@@ -37,16 +33,12 @@ public class HttpWorkspaceManagerClientFactory implements WorkspaceManagerClient
     }
 
     // grab the current user's bearer token (see BearerTokenFilter) or use parameter value
-    Object token =
-        StringUtils.isNotBlank(authToken)
-            ? authToken
-            : RequestContextHolder.currentRequestAttributes()
-                .getAttribute(ATTRIBUTE_NAME_TOKEN, SCOPE_REQUEST);
+    String token = TokenContextUtil.getToken(authToken, () -> null);
 
     // add the user's bearer token to the client
-    if (!Objects.isNull(token)) {
+    if (token != null) {
       LOGGER.debug("setting access token for workspace manager request");
-      apiClient.setAccessToken(token.toString());
+      apiClient.setAccessToken(token);
     } else {
       LOGGER.warn("No access token found for workspace manager request.");
     }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/workspacemanager/HttpWorkspaceManagerClientFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/workspacemanager/HttpWorkspaceManagerClientFactory.java
@@ -33,7 +33,7 @@ public class HttpWorkspaceManagerClientFactory implements WorkspaceManagerClient
     }
 
     // grab the current user's bearer token (see BearerTokenFilter) or use parameter value
-    String token = TokenContextUtil.getToken(authToken, () -> null);
+    String token = TokenContextUtil.getToken(authToken);
 
     // add the user's bearer token to the client
     if (token != null) {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/jobexec/JobContextHolderTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/jobexec/JobContextHolderTest.java
@@ -42,6 +42,7 @@ class JobContextHolderTest {
 
       // represents what a QuartzJob would do: set a JobContextHolder value; later get that value.
       @Override
+      @SuppressWarnings("java:S2925") // S2925 warns about Thread.sleep(), which is acceptable here
       public void run() {
         try {
           // init the JobContextHolder and set a randValue into it
@@ -58,7 +59,8 @@ class JobContextHolderTest {
           if (actualValue instanceof String strVal) {
             actualValues.add(strVal);
           } else {
-            fail("Failure in test thread; actualValue was [{}]", actualValue);
+            throw new RuntimeException(
+                "Failure in test thread; actualValue was [{%s}]".formatted(actualValue));
           }
           // clean up; don't leave values on the thread (memory leaks, interference with other
           // tests)
@@ -66,7 +68,7 @@ class JobContextHolderTest {
           // finally, tell the latch that this thread is done
           latch.countDown();
         } catch (InterruptedException e) {
-          fail("Failure in test thread: " + e.getMessage());
+          throw new RuntimeException("Failure in test thread: " + e.getMessage());
         }
       }
     }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/jobexec/JobContextHolderTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/jobexec/JobContextHolderTest.java
@@ -1,0 +1,93 @@
+package org.databiosphere.workspacedataservice.jobexec;
+
+import static org.assertj.core.api.Fail.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.Test;
+
+class JobContextHolderTest {
+
+  @Test
+  void threadIsolation() throws InterruptedException {
+    // how many threads should we run in this test
+    var numThreads = 5;
+    // var to hold the actual outputs from each thread
+    Set<String> actualValues = ConcurrentHashMap.newKeySet();
+    // semaphore to track when all threads are done
+    CountDownLatch latch = new CountDownLatch(numThreads);
+
+    // generate {numThreads} random String values; these are the values we'll eventually assert on
+    List<String> randomStrings =
+        IntStream.rangeClosed(1, numThreads)
+            .mapToObj(i -> RandomStringUtils.randomAlphabetic(8))
+            .toList();
+
+    /* ----- inner class: the thread to execute during the test ----- */
+    class UnitTestThread implements Runnable {
+      private final CountDownLatch latch;
+      private final String randValue;
+
+      public UnitTestThread(CountDownLatch latch, String randValue) {
+        this.latch = latch;
+        this.randValue = randValue;
+      }
+
+      // represents what a QuartzJob would do: set a JobContextHolder value; later get that value.
+      @Override
+      public void run() {
+        try {
+          // init the JobContextHolder and set a randValue into it
+          JobContextHolder.init();
+          JobContextHolder.setAttribute("unitTestKey", randValue);
+          // sleep briefly - this ensures all threads in this test have had a chance
+          // to set their values before we start retrieving values
+          Thread.sleep(500);
+          // get the value that we just set. Since this is local to the thread, this
+          // value should be exactly what we set it to above; any other threads that also
+          // called JobContextHolder.setAttribute shouldn't affect our value.
+          var actualValue = JobContextHolder.getAttribute("unitTestKey");
+          // validate the actualValue; if valid, add it to the actualValues set
+          if (actualValue instanceof String strVal) {
+            actualValues.add(strVal);
+          } else {
+            fail("Failure in test thread; actualValue was [{}]", actualValue);
+          }
+          // clean up; don't leave values on the thread (memory leaks, interference with other
+          // tests)
+          JobContextHolder.destroy();
+          // finally, tell the latch that this thread is done
+          latch.countDown();
+        } catch (InterruptedException e) {
+          fail("Failure in test thread: " + e.getMessage());
+        }
+      }
+    }
+    /* ----- end inner class ----- */
+
+    // create {numThreads} threads, each thread is a UnitTestThread
+    List<Thread> testThreads =
+        randomStrings.stream()
+            .map(randValue -> new Thread(new UnitTestThread(latch, randValue)))
+            .toList();
+
+    // start all the threads
+    testThreads.forEach(Thread::start);
+
+    // wait for all threads to finish
+    boolean finished = latch.await(60, TimeUnit.SECONDS);
+    if (!finished) {
+      fail("Threads did not complete!");
+    }
+
+    // finally, assert that the values found by the threads were the same as the inputs
+    assertEquals(new HashSet<>(randomStrings), actualValues);
+  }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/jobexec/QuartzJobTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/jobexec/QuartzJobTest.java
@@ -1,0 +1,97 @@
+package org.databiosphere.workspacedataservice.jobexec;
+
+import static org.databiosphere.workspacedataservice.shared.model.Schedulable.ARG_TOKEN;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.Map;
+import java.util.UUID;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.databiosphere.workspacedataservice.dao.JobDao;
+import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
+import org.databiosphere.workspacedataservice.sam.TokenContextUtil;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.quartz.JobDataMap;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.quartz.JobKey;
+import org.quartz.impl.JobDetailImpl;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class QuartzJobTest {
+
+  @MockBean JobDao jobDao;
+
+  @BeforeAll
+  void beforeAll() {
+    // set up the mock jobDao to return successfully on all calls except JobDao.fail()
+    GenericJobServerModel genericJobServerModel =
+        new GenericJobServerModel(
+            UUID.randomUUID(),
+            GenericJobServerModel.JobTypeEnum.DATA_IMPORT,
+            GenericJobServerModel.StatusEnum.QUEUED,
+            OffsetDateTime.now(ZoneId.of("Z")),
+            OffsetDateTime.now(ZoneId.of("Z")));
+    when(jobDao.createJob(any())).thenReturn(genericJobServerModel);
+    when(jobDao.getJob(any())).thenReturn(genericJobServerModel);
+    when(jobDao.updateStatus(any(), any())).thenReturn(genericJobServerModel);
+    when(jobDao.fail(any(), any()))
+        .thenThrow(new RuntimeException("test failed via jobDao.fail()"));
+    when(jobDao.fail(any(), any(), any()))
+        .thenThrow(new RuntimeException("test failed via jobDao.fail()"));
+  }
+
+  /**
+   * Testable extension of QuartzJob. This allows our tests to run something inside the QuartzJob
+   * shell. Specifically, this class asserts that we can retrieve a token via TokenContextUtil from
+   * within a QuartzJob's executeInternal() method.
+   */
+  class TestableQuartzJob extends QuartzJob {
+
+    private final String expectedToken;
+
+    public TestableQuartzJob(String expectedToken) {
+      this.expectedToken = expectedToken;
+    }
+
+    @Override
+    protected JobDao getJobDao() {
+      return jobDao;
+    }
+
+    @Override
+    protected void executeInternal(UUID jobId, JobExecutionContext context) {
+      assertEquals(expectedToken, TokenContextUtil.getToken());
+    }
+  }
+
+  @Test
+  void tokenIsStashedAndCleaned() throws JobExecutionException {
+    // set an example token, via mock, into the Quartz JobDataMap
+    String expectedToken = RandomStringUtils.randomAlphanumeric(10);
+    JobExecutionContext mockContext = mock(JobExecutionContext.class);
+    when(mockContext.getMergedJobDataMap())
+        .thenReturn(new JobDataMap(Map.of(ARG_TOKEN, expectedToken)));
+    JobDetailImpl jobDetail = new JobDetailImpl();
+    jobDetail.setKey(new JobKey(UUID.randomUUID().toString(), "bar"));
+    when(mockContext.getJobDetail()).thenReturn(jobDetail);
+
+    // assert that no token exists via TokenContextUtil
+    assertNull(TokenContextUtil.getToken(), "no token should exist before running the job");
+    // execute the TestableQuartzJob, which asserts that the token passed properly from the
+    // JobDataMap into job context and is therefore retrievable via TokenContextUtil
+    new TestableQuartzJob(expectedToken).execute(mockContext);
+    // assert that the token is cleaned up and no longer reachable via TokenContextUtil
+    assertNull(TokenContextUtil.getToken(), "no token should exist after running the job");
+  }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/sam/TokenContextUtilTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/sam/TokenContextUtilTest.java
@@ -14,7 +14,7 @@ import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
-public class TokenContextUtilTest {
+class TokenContextUtilTest {
 
   @Test
   void nonNullInitialValue() {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/sam/TokenContextUtilTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/sam/TokenContextUtilTest.java
@@ -2,6 +2,7 @@ package org.databiosphere.workspacedataservice.sam;
 
 import static org.databiosphere.workspacedataservice.sam.BearerTokenFilter.ATTRIBUTE_NAME_TOKEN;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.springframework.web.context.request.RequestAttributes.SCOPE_REQUEST;
 
@@ -112,5 +113,17 @@ class TokenContextUtilTest {
                     }));
 
     assertEquals("401 UNAUTHORIZED \"unit testing!\"", authenticationException.getMessage());
+  }
+
+  @Test
+  void noOrElseSpecified() {
+    String expected = RandomStringUtils.randomAlphanumeric(10);
+    // set request attributes to empty
+    RequestContextHolder.setRequestAttributes(null);
+    // ensure job attributes are empty
+    JobContextHolder.destroy();
+    // call getToken with a null initialValue and an orElse that returns the expected value
+    String actual = TokenContextUtil.getToken((String) null);
+    assertNull(actual);
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/sam/TokenContextUtilTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/sam/TokenContextUtilTest.java
@@ -1,0 +1,116 @@
+package org.databiosphere.workspacedataservice.sam;
+
+import static org.databiosphere.workspacedataservice.sam.BearerTokenFilter.ATTRIBUTE_NAME_TOKEN;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.springframework.web.context.request.RequestAttributes.SCOPE_REQUEST;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.databiosphere.workspacedataservice.jobexec.JobContextHolder;
+import org.databiosphere.workspacedataservice.service.model.exception.AuthenticationException;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+public class TokenContextUtilTest {
+
+  @Test
+  void nonNullInitialValue() {
+    String expected = RandomStringUtils.randomAlphanumeric(10);
+
+    // set a dummy value into request attributes
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    RequestAttributes requestAttributes = new ServletRequestAttributes(request);
+    requestAttributes.setAttribute(ATTRIBUTE_NAME_TOKEN, "dummy request value", SCOPE_REQUEST);
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+    try {
+      // and set a dummy value into job attributes
+      JobContextHolder.init();
+      JobContextHolder.setAttribute(ATTRIBUTE_NAME_TOKEN, "dummy job value");
+
+      // call getToken with a non-null initialValue
+      String actual = TokenContextUtil.getToken(expected, () -> "dummy orElse value");
+      assertEquals(expected, actual);
+    } finally {
+      JobContextHolder.destroy();
+    }
+  }
+
+  @Test
+  void valueInRequest() {
+    String expected = RandomStringUtils.randomAlphanumeric(10);
+
+    // set the expected token into request attributes
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    RequestAttributes requestAttributes = new ServletRequestAttributes(request);
+    requestAttributes.setAttribute(ATTRIBUTE_NAME_TOKEN, expected, SCOPE_REQUEST);
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+    try {
+      // and set a dummy value into job attributes
+      JobContextHolder.init();
+      JobContextHolder.setAttribute(ATTRIBUTE_NAME_TOKEN, "dummy job value");
+
+      // call getToken with a null initialValue
+      String actual = TokenContextUtil.getToken(null, () -> "dummy orElse value");
+      assertEquals(expected, actual);
+    } finally {
+      JobContextHolder.destroy();
+    }
+  }
+
+  @Test
+  void valueInJob() {
+    String expected = RandomStringUtils.randomAlphanumeric(10);
+
+    // set request attributes to empty
+    RequestContextHolder.setRequestAttributes(null);
+
+    try {
+      // set the expected token into job attributes
+      JobContextHolder.init();
+      JobContextHolder.setAttribute(ATTRIBUTE_NAME_TOKEN, expected);
+      // call getToken with a null initialValue
+      String actual = TokenContextUtil.getToken(null, () -> "dummy orElse value");
+      assertEquals(expected, actual);
+    } finally {
+      JobContextHolder.destroy();
+    }
+  }
+
+  @Test
+  void callOrElse() {
+    String expected = RandomStringUtils.randomAlphanumeric(10);
+    // set request attributes to empty
+    RequestContextHolder.setRequestAttributes(null);
+    // ensure job attributes are empty
+    JobContextHolder.destroy();
+    // call getToken with a null initialValue and an orElse that returns the expected value
+    String actual = TokenContextUtil.getToken(null, () -> expected);
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void throwInOrElse() {
+    // set request attributes to empty
+    RequestContextHolder.setRequestAttributes(null);
+    // ensure job attributes are empty
+    JobContextHolder.destroy();
+
+    // call getToken with a null initialValue and an orElse that throws
+    AuthenticationException authenticationException =
+        assertThrows(
+            AuthenticationException.class,
+            () ->
+                TokenContextUtil.getToken(
+                    null,
+                    () -> {
+                      throw new AuthenticationException("unit testing!");
+                    }));
+
+    assertEquals("401 UNAUTHORIZED \"unit testing!\"", authenticationException.getMessage());
+  }
+}


### PR DESCRIPTION
Reviewer: this PR has Java threading and `ThreadLocal` fun, please review that carefully as it is easy to get wrong!

In this PR:
* Add `JobContextHolder`, modeled after Spring's `RequestContextHolder`, to allow Quartz jobs to stash a token and allow that token to be retrieved from DAOs, just like we do for http requests
* Add `TokenContextUtil`, to centralize retrieval of auth tokens from either request context or job context
* Modify all REST DAOs, as well as ActivityEventBuilder, to use `TokenContextUtil` instead of their mostly copy/pasted custom logic
* Modify `ImportService` to use the current user's token for use in data import jobs (this will change to be a pet token in later PRs)
* Modify `QuartzJob` to read a token from the job's JobDataMap, stash it in job context, then clear job context after the job finishes