### PR TITLE
[AJ-1069] Reject records containing duplicate keys

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/JsonConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/JsonConfig.java
@@ -1,6 +1,7 @@
 package org.databiosphere.workspacedataservice.service;
 
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -21,6 +22,7 @@ public class JsonConfig {
             .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
             .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
             .configure(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN, true)
+            .configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION, true)
             .configure(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS, true)
             .configure(DeserializationFeature.USE_BIG_INTEGER_FOR_INTS, true)
             .findAndAddModules()

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/BadStreamingWriteRequestException.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/BadStreamingWriteRequestException.java
@@ -1,5 +1,6 @@
 package org.databiosphere.workspacedataservice.service.model.exception;
 
+import com.fasterxml.jackson.databind.JsonMappingException;
 import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,8 +15,12 @@ public class BadStreamingWriteRequestException extends IllegalArgumentException 
 
   public BadStreamingWriteRequestException(IOException ex) {
     super(
-        "The server doesn't understand the request. Please verify you are using "
-            + "the proper format.");
-    LOGGER.error("Error parsing request stream as json ", ex);
+        // If the original exception was a JsonMappingException, forward the original message
+        // describing the issue to the user.
+        // Otherwise, send a generic error message.
+        (ex instanceof JsonMappingException)
+            ? ((JsonMappingException) ex).getOriginalMessage()
+            : "The server doesn't understand the request. Please verify you are using the proper format.");
+    LOGGER.error("Error parsing request stream ", ex);
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/BatchWriteServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/BatchWriteServiceTest.java
@@ -1,0 +1,58 @@
+package org.databiosphere.workspacedataservice.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+import org.databiosphere.workspacedataservice.dao.InstanceDao;
+import org.databiosphere.workspacedataservice.service.model.exception.BadStreamingWriteRequestException;
+import org.databiosphere.workspacedataservice.shared.model.RecordType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+
+@DirtiesContext
+@SpringBootTest
+public class BatchWriteServiceTest {
+
+  @Autowired private BatchWriteService batchWriteService;
+  @Autowired private InstanceDao instanceDao;
+
+  private static final UUID INSTANCE = UUID.fromString("aaaabbbb-cccc-dddd-1111-222233334444");
+  private static final RecordType THING_TYPE = RecordType.valueOf("thing");
+
+  @BeforeEach
+  void setUp() {
+    if (!instanceDao.instanceSchemaExists(INSTANCE)) {
+      instanceDao.createSchema(INSTANCE);
+    }
+  }
+
+  @AfterEach
+  void tearDown() {
+    instanceDao.dropSchema(INSTANCE);
+  }
+
+  @Test
+  void testRejectsDuplicateKeys() throws IOException {
+    String streamContents =
+        "[{\"operation\": \"upsert\", \"record\": {\"id\": \"1\", \"type\": \"thing\", \"attributes\": {\"key\": \"value1\", \"key\": \"value2\"}}}]";
+    InputStream is = new ByteArrayInputStream(streamContents.getBytes());
+
+    Exception ex =
+        assertThrows(
+            BadStreamingWriteRequestException.class,
+            () ->
+                batchWriteService.batchWriteJsonStream(
+                    is, INSTANCE, THING_TYPE, java.util.Optional.<String>empty()));
+
+    String errorMessage = ex.getMessage();
+    assertEquals(errorMessage, "Duplicate field 'key'");
+  }
+}


### PR DESCRIPTION
Currently, WDS' batchWriteRecords API accepts records containing duplicate keys.

For example, this request
```json
[
  {
    "operation": "upsert",
    "record": {
      "id": "1",
      "type": "thing",
      "attributes": {
        "key": "value1",
        "key": "value2"
      }
    }
  }
]
```

Results in a record:
```json
{
  "id": "1",
  "type": "thing",
  "attributes": {
    "sys_name": "1",
    "key": "value2",
    "stringAttr": null
  }
}
```

The first value for the duplicated key is silently dropped.

With this change, that same request returns a 400 response with a "Duplicate field 'key'" message.