### PR TITLE
AJ-1373 use pet token instead of bearer token for import

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
@@ -54,6 +54,9 @@ public class ImportService {
       throw new AuthorizationException("Caller does not have permission to write to instance.");
     }
 
+    // get a token to execute the job
+    String petToken = samDao.getPetToken();
+
     // TODO: translate the ImportRequestServerModel into a Job
     // for now, just make an example job
     logger.debug("Data import of type {} requested", importRequest.getType());
@@ -69,9 +72,6 @@ public class ImportService {
         importRequest.getType());
 
     try {
-      // get a token to execute the job
-      String petToken = samDao.getPetToken();
-
       // create the arguments for the schedulable job
       Map<String, Serializable> arguments = new HashMap<>();
       arguments.put(ARG_TOKEN, petToken);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
@@ -16,9 +16,7 @@ import org.databiosphere.workspacedataservice.dataimport.TdrManifestSchedulable;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
 import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
 import org.databiosphere.workspacedataservice.sam.SamDao;
-import org.databiosphere.workspacedataservice.sam.TokenContextUtil;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthorizationException;
-import org.databiosphere.workspacedataservice.shared.model.BearerToken;
 import org.databiosphere.workspacedataservice.shared.model.Schedulable;
 import org.databiosphere.workspacedataservice.shared.model.job.Job;
 import org.databiosphere.workspacedataservice.shared.model.job.JobInput;
@@ -56,9 +54,6 @@ public class ImportService {
       throw new AuthorizationException("Caller does not have permission to write to instance.");
     }
 
-    // TODO AJ-1373 use this token for import
-    String petToken = samDao.getPetToken();
-
     // TODO: translate the ImportRequestServerModel into a Job
     // for now, just make an example job
     logger.debug("Data import of type {} requested", importRequest.getType());
@@ -74,15 +69,12 @@ public class ImportService {
         importRequest.getType());
 
     try {
-      // get the user's token from the current request
-      // TODO: this should actually get a pet token for the user, to ensure the token won't time out
-      BearerToken token = TokenContextUtil.getToken();
+      // get a token to execute the job
+      String petToken = samDao.getPetToken();
 
       // create the arguments for the schedulable job
       Map<String, Serializable> arguments = new HashMap<>();
-      if (token.nonEmpty()) {
-        arguments.put(ARG_TOKEN, token.getValue());
-      }
+      arguments.put(ARG_TOKEN, petToken);
       arguments.put(ARG_URL, importRequest.getUrl().toString());
       arguments.put(ARG_INSTANCE, instanceUuid.toString());
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceTest.java
@@ -52,7 +52,7 @@ class ImportServiceTest {
 
   @Autowired ImportService importService;
   @Autowired InstanceService instanceService;
-  @Autowired @SpyBean JobDao jobDao;
+  @SpyBean JobDao jobDao;
   @Autowired SamDao samDao;
   @MockBean SchedulerDao schedulerDao;
   @MockBean SamClientFactory mockSamClientFactory;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceTest.java
@@ -2,6 +2,7 @@ package org.databiosphere.workspacedataservice.service;
 
 import static org.databiosphere.workspacedataservice.generated.ImportRequestServerModel.TypeEnum;
 import static org.databiosphere.workspacedataservice.shared.model.Schedulable.ARG_INSTANCE;
+import static org.databiosphere.workspacedataservice.shared.model.Schedulable.ARG_TOKEN;
 import static org.databiosphere.workspacedataservice.shared.model.Schedulable.ARG_URL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -130,7 +131,8 @@ class ImportServiceTest {
         "scheduled job had wrong instance argument");
     assertEquals(
         importUri.toString(), actualArguments.get(ARG_URL), "scheduled job had wrong url argument");
-    // TODO: add an assertion for the pet token in the arguments, once we have pet tokens hooked up
+    // The return value of mock sam's get pet token
+    assertEquals("arbitraryToken", actualArguments.get(ARG_TOKEN), "scheduled job had wrong token");
   }
 
   // if we hit an error scheduling the job in Quartz, we should mark the job as being in ERROR

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceTest.java
@@ -64,7 +64,6 @@ class ImportServiceTest {
 
   @BeforeEach
   void setUp() throws ApiException {
-    //    jobDao = Mockito.spy(jobDao);
     // return the mock ResourcesApi from the mock SamClientFactory
     given(mockSamClientFactory.getResourcesApi(null)).willReturn(mockSamResourcesApi);
     // Sam permission check will always return true

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceTest.java
@@ -5,7 +5,10 @@ import static org.databiosphere.workspacedataservice.shared.model.Schedulable.AR
 import static org.databiosphere.workspacedataservice.shared.model.Schedulable.ARG_TOKEN;
 import static org.databiosphere.workspacedataservice.shared.model.Schedulable.ARG_URL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
@@ -15,18 +18,25 @@ import java.net.URI;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Stream;
+import org.broadinstitute.dsde.workbench.client.sam.ApiException;
+import org.broadinstitute.dsde.workbench.client.sam.api.GoogleApi;
+import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.dao.SchedulerDao;
 import org.databiosphere.workspacedataservice.dataimport.PfbQuartzJob;
 import org.databiosphere.workspacedataservice.dataimport.TdrManifestQuartzJob;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
 import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
+import org.databiosphere.workspacedataservice.sam.SamClientFactory;
+import org.databiosphere.workspacedataservice.sam.SamDao;
 import org.databiosphere.workspacedataservice.shared.model.Schedulable;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 import org.quartz.Job;
 import org.quartz.JobDataMap;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,9 +51,29 @@ class ImportServiceTest {
   @Autowired ImportService importService;
   @Autowired InstanceService instanceService;
   @Autowired JobDao jobDao;
+  @Autowired SamDao samDao;
   @MockBean SchedulerDao schedulerDao;
+  @MockBean SamClientFactory mockSamClientFactory;
+
+  ResourcesApi mockSamResourcesApi = Mockito.mock(ResourcesApi.class);
+  GoogleApi mockSamGoogleApi = Mockito.mock(GoogleApi.class);
 
   private static final String VERSION = "v0.2";
+
+  @BeforeEach
+  void setUp() throws ApiException {
+
+    // return the mock ResourcesApi from the mock SamClientFactory
+    given(mockSamClientFactory.getResourcesApi(null)).willReturn(mockSamResourcesApi);
+    // Sam permission check will always return true
+    given(mockSamResourcesApi.resourcePermissionV2(anyString(), anyString(), anyString()))
+        .willReturn(true);
+    given(mockSamClientFactory.getGoogleApi(null)).willReturn(mockSamGoogleApi);
+    // Sam permission check will always return true
+    given(mockSamGoogleApi.getArbitraryPetServiceAccountToken(any())).willReturn("arbitraryToken");
+    // clear call history for the mock
+    Mockito.clearInvocations(mockSamResourcesApi);
+  }
 
   // does createSchedulable properly store the jobId, job group, and job data map?
   @ParameterizedTest(name = "for import type {0}")
@@ -158,5 +188,26 @@ class ImportServiceTest {
     GenericJobServerModel actual = jobDao.getJob(createdJob.getJobId());
 
     assertEquals(GenericJobServerModel.StatusEnum.ERROR, actual.getStatus());
+  }
+
+  @ParameterizedTest(name = "for import type {0}")
+  @EnumSource(ImportRequestServerModel.TypeEnum.class)
+  void doesNotCreateJobWithoutPetToken(ImportRequestServerModel.TypeEnum importType)
+      throws ApiException {
+    given(mockSamClientFactory.getGoogleApi(null)).willReturn(mockSamGoogleApi);
+    // Sam permission check will always return true
+    given(mockSamGoogleApi.getArbitraryPetServiceAccountToken(any()))
+        .willThrow(new ApiException("token failure for unit test"));
+
+    // schedulerDao.schedule(), which returns void, returns successfully
+    doNothing().when(schedulerDao).schedule(any(Schedulable.class));
+    // create instance (in the MockInstanceDao)
+    UUID instanceId = UUID.randomUUID();
+    instanceService.createInstance(instanceId, VERSION);
+    // define the import request
+    URI importUri = URI.create("http://does/not/matter");
+    ImportRequestServerModel importRequest = new ImportRequestServerModel(importType, importUri);
+    // Import will fail without a pet token
+    assertThrows(Exception.class, () -> importService.createImport(instanceId, importRequest));
   }
 }


### PR DESCRIPTION
[AJ-1373](https://broadworkbench.atlassian.net/browse/AJ-1373)
This PR takes the pet token fetched in https://github.com/DataBiosphere/terra-workspace-data-service/pull/363 and passes it as the auth token for an Import Job.

Reminder:

PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 


[AJ-1373]: https://broadworkbench.atlassian.net/browse/AJ-1373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ