### PR TITLE
Add local profile to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,15 @@ of a workspace you own, e.g.
 export WORKSPACE_ID=123e4567-e89b-12d3-a456-426614174000
 ```
 
+##### SPRING_PROFILES_ACTIVE
+
+Terra's Azure Relay sends CORS headers. When running locally, there is no Azure Relay, so WDS
+needs to send CORS headers itself. This can be done by activating the `local` Spring profile.
+
+```
+export SPRING_PROFILES_ACTIVE=local
+```
+
 ## Running
 
 To just build the code, from the root directory run


### PR DESCRIPTION
I was very confused as to why my local WDS was claiming "No bearer token in incoming request" when I could see that the UI was sending a token.

It ended up being a CORS issue. When running locally / not behind the Terra Azure Relay, WDS needs to have the "local" Spring profile active. This adds `SPRING_PROFILES_ACTIVE` to the list of environment variables for running WDS locally.