### PR TITLE
AJ-1396 update java-pfb to version without snappy

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -80,7 +80,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:4.11.0' // required by Sam client
     implementation "bio.terra:datarepo-client:1.537.0-SNAPSHOT"
     implementation "bio.terra:workspace-manager-client:0.254.717-SNAPSHOT"
-    implementation "bio.terra:java-pfb-library:0.12.0"
+    implementation "bio.terra:java-pfb-library:0.13.0"
     implementation project(path: ':client')
 
     // hk2 is required to use WSM client, but not correctly exposed by the client


### PR DESCRIPTION
Snappy-java caused a [security vulnerability](https://github.com/DataBiosphere/terra-workspace-data-service/security/dependabot/38); it was removed from java-pfb in https://github.com/DataBiosphere/java-pfb/pull/14, so this PR updates java-pfb to the version without snappy or its security problems.

Reminder:

PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 
