### PR TITLE
AJ-1234: Use helmchart name for pact identifiers.

### DIFF
--- a/.github/workflows/publish-pacts.yml
+++ b/.github/workflows/publish-pacts.yml
@@ -11,15 +11,15 @@ on:
 
 jobs:
   init-github-context:
-      runs-on: ubuntu-latest
-      outputs:
-        sha-short: ${{ steps.extract-branch.outputs.sha-short }}
-        repo-branch: ${{ steps.extract-branch.outputs.repo-branch }}
-        repo-version: ${{ steps.extract-branch.outputs.repo-version }}
-        
-      steps:
+    runs-on: ubuntu-latest
+    outputs:
+      sha-short: ${{ steps.extract-branch.outputs.sha-short }}
+      repo-branch: ${{ steps.extract-branch.outputs.repo-branch }}
+      repo-version: ${{ steps.extract-branch.outputs.repo-version }}
+
+    steps:
       - uses: actions/checkout@v3
-      
+
       - name: Extract branch
         id: extract-branch
         run: |
@@ -44,17 +44,17 @@ jobs:
           echo "repo-name=${{ github.event.repository.name }}"
           echo "repo-branch=${{ steps.extract-branch.outputs.repo-branch }}"
           echo "repo-version=${{ steps.extract-branch.outputs.repo-version }}"
-        
+
   run-consumer-contract-tests:
     runs-on: ubuntu-latest
-    needs: [init-github-context]
+    needs: [ init-github-context ]
     outputs:
       pact-b64: ${{ steps.encode-pact.outputs.pact-b64 }}
 
     steps:
       - name: Checkout current code
         uses: actions/checkout@v3
-        
+
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:
@@ -65,12 +65,12 @@ jobs:
       - name: Output consumer contract as non-breaking base64 string
         id: encode-pact
         run: |
-          NON_BREAKING_B64=$(cat service/build/pacts/wds-consumer-sam-provider.json | base64 -w 0)
+          NON_BREAKING_B64=$(cat service/build/pacts/wds-sam.json | base64 -w 0)
           echo "pact-b64=${NON_BREAKING_B64}" >> $GITHUB_OUTPUT
 
   publish-pact-job:
     runs-on: ubuntu-latest
-    needs: [init-github-context, run-consumer-contract-tests]
+    needs: [ init-github-context, run-consumer-contract-tests ]
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/service/src/test/java/org/databiosphere/workspacedataservice/pact/SamPactTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/pact/SamPactTest.java
@@ -37,7 +37,7 @@ class SamPactTest {
     RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
   }
 
-  @Pact(consumer = "wds-consumer", provider = "sam-provider")
+  @Pact(consumer = "wds", provider = "sam")
   public RequestResponsePact statusApiPact(PactDslWithProvider builder) {
     return builder
         .given("Sam is ok")
@@ -50,7 +50,7 @@ class SamPactTest {
         .toPact();
   }
 
-  @Pact(consumer = "wds-consumer", provider = "sam-provider")
+  @Pact(consumer = "wds", provider = "sam")
   public RequestResponsePact downStatusApiPact(PactDslWithProvider builder) {
     return builder
         .given("Sam is not ok")
@@ -63,7 +63,7 @@ class SamPactTest {
         .toPact();
   }
 
-  @Pact(consumer = "wds-consumer", provider = "sam-provider")
+  @Pact(consumer = "wds", provider = "sam")
   public RequestResponsePact writeNoPermissionPact(PactDslWithProvider builder) {
     return builder
         .given("user does not have write permission", Map.of("dummyResourceId", dummyResourceId))
@@ -78,7 +78,7 @@ class SamPactTest {
         .toPact();
   }
 
-  @Pact(consumer = "wds-consumer", provider = "sam-provider")
+  @Pact(consumer = "wds", provider = "sam")
   public RequestResponsePact writePermissionPact(PactDslWithProvider builder) {
     return builder
         .given("user has write permission", Map.of("dummyResourceId", dummyResourceId))
@@ -93,7 +93,7 @@ class SamPactTest {
         .toPact();
   }
 
-  @Pact(consumer = "wds-consumer", provider = "sam-provider")
+  @Pact(consumer = "wds", provider = "sam")
   public RequestResponsePact deletePermissionPact(PactDslWithProvider builder) {
     return builder
         .given("user has delete permission", Map.of("dummyResourceId", dummyResourceId))
@@ -108,7 +108,7 @@ class SamPactTest {
         .toPact();
   }
 
-  @Pact(consumer = "wds-consumer", provider = "sam-provider")
+  @Pact(consumer = "wds", provider = "sam")
   public RequestResponsePact deleteNoPermissionPact(PactDslWithProvider builder) {
     return builder
         .given("user does not have delete permission", Map.of("dummyResourceId", dummyResourceId))
@@ -123,7 +123,7 @@ class SamPactTest {
         .toPact();
   }
 
-  @Pact(consumer = "wds-consumer", provider = "sam-provider")
+  @Pact(consumer = "wds", provider = "sam")
   public RequestResponsePact userStatusPact(PactDslWithProvider builder) {
     var userResponseShape =
         new PactDslJsonBody()
@@ -142,7 +142,7 @@ class SamPactTest {
         .toPact();
   }
 
-  @Pact(consumer = "wds-consumer", provider = "sam-provider")
+  @Pact(consumer = "wds", provider = "sam")
   public RequestResponsePact noUserStatusPact(PactDslWithProvider builder) {
     return builder
         .given("user status info request without access token")
@@ -154,7 +154,7 @@ class SamPactTest {
         .toPact();
   }
 
-  @Pact(consumer = "wds-consumer", provider = "sam-provider")
+  @Pact(consumer = "wds", provider = "sam")
   public RequestResponsePact petTokenPact(PactDslWithProvider builder) {
     PactDslJsonRootValue responseBody = PactDslJsonRootValue.stringType("aToken");
 


### PR DESCRIPTION
This is prefactoring work for [AJ-1234](https://broadworkbench.atlassian.net/browse/AJ-1234)

This pairs with https://github.com/broadinstitute/sam/pull/1234, where `sam` also renames its reference from `sam-consumer` to just `sam`.

* See [thread](https://broadinstitute.slack.com/archives/C043YJ40719/p1698068076950019) discussing the `-consumer` and `-provider` suffix anti-pattern.
* See [thread](https://broadinstitute.slack.com/archives/C043YJ40719/p1698241095600099) discussing the recommendation to use the helmchart name.

[AJ-1234]: https://broadworkbench.atlassian.net/browse/AJ-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ