### PR TITLE
AJ-1396: allow cloning earlier versions of WDS

### DIFF
--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -889,7 +889,6 @@ components:
       type: object
       required:
         - jobId
-        - jobType
         - status
         - created
         - updated

--- a/service/src/test/java/org/databiosphere/workspacedataservice/sourcewds/CloneOlderWdsTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/sourcewds/CloneOlderWdsTest.java
@@ -1,0 +1,36 @@
+package org.databiosphere.workspacedataservice.sourcewds;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.databiosphere.workspacedata.model.BackupJob;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class CloneOlderWdsTest {
+
+  @Autowired ObjectMapper objectMapper;
+
+  @Test
+  void deserializeBackupResponse() {
+    // this is the response from a WDS v0.2.100 or earlier, prior to
+    // the `jobType` field being required
+    String backupResponse =
+        """
+          {
+            "jobId": "e0e9341a-7e5d-4e1d-8410-ea242e91399f",
+            "status": "SUCCEEDED",
+            "created": "2023-10-30T19:33:36.22421",
+            "updated": "2023-10-30T19:33:42.819065",
+            "result": {
+              "filename": "wdsservice/cloning/backup/ed0b4126-e607-4b03-8a01-c65334e98a4c-2023-10-30_19-33-36.sql",
+              "requester": "f2fcc10d-fee3-409a-bdba-6a92bf201f40"
+            }
+          }""";
+
+    // can we parse such a response into the generated BackupJob class?
+    assertDoesNotThrow(() -> BackupJob.fromJson(backupResponse));
+  }
+}


### PR DESCRIPTION
Resolves an error when cloning earlier versions of WDS. The error is `BACKUPERROR (The required field `jobType` is not found in the JSON string`:
![Screenshot 10-30-2023 at 04 04 PM](https://github.com/DataBiosphere/terra-workspace-data-service/assets/6041577/fc427acd-63ff-44b0-a4dc-4f0e3ac51585)

And is caused by https://github.com/DataBiosphere/terra-workspace-data-service/pull/358, which added `jobType` as a required field in the `BackupJob` model.

This PR makes `jobType` not required. 