### PR TITLE
[AJ-1166] Configure CORS for Actuator endpoints

### DIFF
--- a/service/src/main/resources/application-local-cors.yml
+++ b/service/src/main/resources/application-local-cors.yml
@@ -1,0 +1,7 @@
+management:
+  endpoints:
+    web:
+      cors:
+        allowed-origins: ["*"]
+        allowed-methods: ["*"]
+        allowed-headers: ["*"]


### PR DESCRIPTION
When using the `local-cors` profile, WDS configures all controllers to allow CORS requests from any origin.

https://github.com/DataBiosphere/terra-workspace-data-service/blob/2b64d5afc105673c20024bb2a8aa51d88d53a644/service/src/main/java/org/databiosphere/workspacedataservice/controller/ControllerConfig.java#L25-L36

This allows using a local WDS with a local Terra UI.

However, the `status` and `version` endpoints are backed by Spring Boot Actuator and are not configured by this method. Thus, those two endpoints return CORS errors when requested by a local Terra UI.

This adds CORS configuration for Spring Boot Actuator endpoints to the `local-cors` profile.