### PR TITLE
AJ-1429 clone failure

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/workspacemanager/WorkspaceManagerDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/workspacemanager/WorkspaceManagerDao.java
@@ -50,7 +50,12 @@ public class WorkspaceManagerDao {
       throws ApiException {
     // get a page of results from WSM
     return enumerateResources(
-        workspaceId, offset, limit, ResourceType.DATA_REPO_SNAPSHOT, StewardshipType.REFERENCED);
+        workspaceId,
+        offset,
+        limit,
+        ResourceType.DATA_REPO_SNAPSHOT,
+        StewardshipType.REFERENCED,
+        null);
   }
 
   /** Retrieves the azure storage container url and sas token for a given workspace. */
@@ -65,7 +70,8 @@ public class WorkspaceManagerDao {
         LOGGER.debug(
             "Finding storage resource for workspace {} from Workspace Manager ...", workspaceUUID);
         ResourceList resourceList =
-            enumerateResources(workspaceUUID, 0, 5, ResourceType.AZURE_STORAGE_CONTAINER, null);
+            enumerateResources(
+                workspaceUUID, 0, 5, ResourceType.AZURE_STORAGE_CONTAINER, null, authToken);
         // note: it is possible a workspace may have more than one storage container associated with
         // it
         // but currently there is no way to tell which one is the primary except for checking the
@@ -105,9 +111,10 @@ public class WorkspaceManagerDao {
       int offset,
       int limit,
       ResourceType resourceType,
-      StewardshipType stewardshipType)
+      StewardshipType stewardshipType,
+      String authToken)
       throws ApiException {
-    ResourceApi resourceApi = this.workspaceManagerClientFactory.getResourceApi(null);
+    ResourceApi resourceApi = this.workspaceManagerClientFactory.getResourceApi(authToken);
     // TODO: retries
     return resourceApi.enumerateResources(
         workspaceId, offset, limit, resourceType, stewardshipType);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/workspacemanager/WorkspaceManagerDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/workspacemanager/WorkspaceManagerDao.java
@@ -106,7 +106,7 @@ public class WorkspaceManagerDao {
     return null;
   }
 
-  private ResourceList enumerateResources(
+  ResourceList enumerateResources(
       UUID workspaceId,
       int offset,
       int limit,

--- a/service/src/test/java/org/databiosphere/workspacedataservice/sam/TokenContextUtilTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/sam/TokenContextUtilTest.java
@@ -19,6 +19,29 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 class TokenContextUtilTest {
 
   @Test
+  void nonNullInitialValueAndNoOrElse() {
+    String expected = RandomStringUtils.randomAlphanumeric(10);
+
+    // set a dummy value into request attributes
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    RequestAttributes requestAttributes = new ServletRequestAttributes(request);
+    requestAttributes.setAttribute(ATTRIBUTE_NAME_TOKEN, "dummy request value", SCOPE_REQUEST);
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+    try {
+      // and set a dummy value into job attributes
+      JobContextHolder.init();
+      JobContextHolder.setAttribute(ATTRIBUTE_NAME_TOKEN, "dummy job value");
+
+      // call getToken with a non-null initialValue
+      BearerToken actual = TokenContextUtil.getToken(expected);
+      assertEquals(BearerToken.of(expected), actual);
+    } finally {
+      JobContextHolder.destroy();
+    }
+  }
+
+  @Test
   void nonNullInitialValue() {
     BearerToken expected = BearerToken.of(RandomStringUtils.randomAlphanumeric(10));
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/workspacemanager/WorkspaceManagerDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/workspacemanager/WorkspaceManagerDaoTest.java
@@ -111,7 +111,7 @@ class WorkspaceManagerDaoTest {
 
   @Test
   void enumerateResourcesAuthTokenNull() throws ApiException {
-    // call enumerateResources
+    // call enumerateResources with authToken=null
     workspaceManagerDao.enumerateResources(
         UUID.randomUUID(),
         0,
@@ -129,7 +129,7 @@ class WorkspaceManagerDaoTest {
   @Test
   void enumerateResourcesAuthTokenPopulated() throws ApiException {
     String expected = RandomStringUtils.randomAlphanumeric(16);
-    // call enumerateResources
+    // call enumerateResources with authToken={random string value}
     workspaceManagerDao.enumerateResources(
         UUID.randomUUID(),
         0,

--- a/service/src/test/java/org/databiosphere/workspacedataservice/workspacemanager/WorkspaceManagerDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/workspacemanager/WorkspaceManagerDaoTest.java
@@ -146,7 +146,7 @@ class WorkspaceManagerDaoTest {
     String actual = argumentCaptor.getValue();
     assertEquals(expected, actual);
   }
-  
+
   @Test
   void policyOnlyProperty() throws ApiException {
     // set up inputs

--- a/service/src/test/java/org/databiosphere/workspacedataservice/workspacemanager/WorkspaceManagerDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/workspacemanager/WorkspaceManagerDaoTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -17,8 +18,10 @@ import bio.terra.workspace.model.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -51,10 +54,11 @@ class WorkspaceManagerDaoTest {
 
   @BeforeEach
   void setUp() {
-    given(mockWorkspaceManagerClientFactory.getReferencedGcpResourceApi(null))
+    given(mockWorkspaceManagerClientFactory.getReferencedGcpResourceApi(nullable(String.class)))
         .willReturn(mockReferencedGcpResourceApi);
-    given(mockWorkspaceManagerClientFactory.getResourceApi(null)).willReturn(mockResourceApi);
-    given(mockWorkspaceManagerClientFactory.getAzureResourceApi(null))
+    given(mockWorkspaceManagerClientFactory.getResourceApi(nullable(String.class)))
+        .willReturn(mockResourceApi);
+    given(mockWorkspaceManagerClientFactory.getAzureResourceApi(nullable(String.class)))
         .willReturn(mockControlledAzureResourceApi);
   }
 
@@ -103,6 +107,41 @@ class WorkspaceManagerDaoTest {
         buildResourceListObjectAndCallExtraction(
             workspaceId, "sc-" + UUID.randomUUID(), ResourceType.AZURE_STORAGE_CONTAINER);
     assertNull(resourceUUID);
+  }
+
+  @Test
+  void enumerateResourcesAuthTokenNull() throws ApiException {
+    // call enumerateResources
+    workspaceManagerDao.enumerateResources(
+        UUID.randomUUID(),
+        0,
+        10,
+        ResourceType.DATA_REPO_SNAPSHOT,
+        StewardshipType.REFERENCED,
+        null);
+    // validate argument
+    ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
+    verify(mockWorkspaceManagerClientFactory).getResourceApi(argumentCaptor.capture());
+    String actual = argumentCaptor.getValue();
+    assertNull(actual);
+  }
+
+  @Test
+  void enumerateResourcesAuthTokenPopulated() throws ApiException {
+    String expected = RandomStringUtils.randomAlphanumeric(16);
+    // call enumerateResources
+    workspaceManagerDao.enumerateResources(
+        UUID.randomUUID(),
+        0,
+        10,
+        ResourceType.DATA_REPO_SNAPSHOT,
+        StewardshipType.REFERENCED,
+        expected);
+    // validate argument
+    ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
+    verify(mockWorkspaceManagerClientFactory).getResourceApi(argumentCaptor.capture());
+    String actual = argumentCaptor.getValue();
+    assertEquals(expected, actual);
   }
 
   UUID buildResourceListObjectAndCallExtraction(UUID workspaceId, String name, ResourceType type) {


### PR DESCRIPTION
*sigh* #386 broke cloning by extracting a reusable function `WorkspaceManagerDao.enumerateResources()`.

This PR fixes that regression by ensuring the auth token is passed properly through `enumerateResources()`, plus unit tests to verify.