### PR TITLE
AJ-1234: Make WDS publish multiple pacts.

### DIFF
--- a/.github/workflows/publish-pacts.yml
+++ b/.github/workflows/publish-pacts.yml
@@ -9,6 +9,11 @@ on:
       - main
     paths-ignore: [ '**.md' ]
 
+env:
+  WDS_PACTS_ARTIFACT: wds-pacts-${{ github.event.repository.name }}-${{ github.run_id }}
+  WDS_PACTS_OUTPUT_DIR: service/build/pacts/
+  PUBLISH_CONTRACT_RUN_NAME: 'publish-contracts-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}'
+
 jobs:
   init-github-context:
     runs-on: ubuntu-latest
@@ -49,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ init-github-context ]
     outputs:
-      pact-b64: ${{ steps.encode-pact.outputs.pact-b64 }}
+      pact-paths: ${{ steps.locate-pacts.outputs.pact-paths }}
 
     steps:
       - name: Checkout current code
@@ -62,24 +67,68 @@ jobs:
           distribution: 'temurin'
       - name: Run consumer tests
         run: ./gradlew pactTests
-      - name: Output consumer contract as non-breaking base64 string
-        id: encode-pact
-        run: |
-          NON_BREAKING_B64=$(cat service/build/pacts/wds-sam.json | base64 -w 0)
-          echo "pact-b64=${NON_BREAKING_B64}" >> $GITHUB_OUTPUT
 
-  publish-pact-job:
+      - name: Locate all pact json files and output Base64-encoded pacts
+        id: locate-pacts
+        run: |
+          # Locate .json pact files in $pactOutputDir
+          pactPaths=($(find "${{ env.WDS_PACTS_OUTPUT_DIR }}" -type f -name "*.json"))
+
+          # Put the Base64-encoded pacts in JSON string
+          pactPathsJson="["
+
+          # Loop through $pactPaths and encode the corresponding pact
+          for path in "${pactPaths[@]}"; do
+            pactPathsJson="${pactPathsJson}\"$path\", "
+          done
+
+          pactPathsJson="${pactPathsJson%, }]"
+
+          echo "pact-paths=$pactPathsJson" >> $GITHUB_OUTPUT
+
+      - name: Upload pact files to artifact
+        id: upload-pacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.WDS_PACTS_ARTIFACT }}
+          path: |
+            ${{ env.WDS_PACTS_OUTPUT_DIR }}
+          retention-days: 1
+
+  publish-pacts-job:
     runs-on: ubuntu-latest
     needs: [ init-github-context, run-consumer-contract-tests ]
-    permissions:
-      contents: 'read'
-      id-token: 'write'
+    strategy:
+      matrix:
+        pact_path: ${{ fromJson(needs.run-consumer-contract-tests.outputs.pact-paths) }}
+
     steps:
-      - name: Dispatch to terra-github-workflows
-        uses: broadinstitute/workflow-dispatch@v3
+      - name: Download pact files from artifact
+        id: download-pacts
+        uses: actions/download-artifact@v3
         with:
+          name: ${{ env.WDS_PACTS_ARTIFACT }}
+          path: |
+            ${{ env.WDS_PACTS_OUTPUT_DIR }}
+
+      - name: Encode pact as non-breaking base64 string
+        id: encode-pact
+        run: |
+          nonBreakingB64=$(cat "${{ matrix.pact_path }}" | base64 -w 0)
+          echo "pact-b64=${nonBreakingB64}" >> $GITHUB_OUTPUT
+
+      - name: Dispatch to terra-github-workflows
+        uses: broadinstitute/workflow-dispatch@v4.0.0
+        with:
+          run-name: '${{ env.PUBLISH_CONTRACT_RUN_NAME }}-${{ matrix.pact_path }}'
           workflow: .github/workflows/publish-contracts.yaml
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
-          inputs: '{ "pact-b64": "${{ needs.run-consumer-contract-tests.outputs.pact-b64 }}", "repo-owner": "${{ github.repository_owner }}", "repo-name": "${{ github.event.repository.name }}", "repo-branch": "${{ needs.init-github-context.outputs.repo-branch }}" }'
+          inputs: '{
+            "run-name": "${{ env.PUBLISH_CONTRACT_RUN_NAME }}-${{ matrix.pact_path }}",
+            "pact-b64": "${{ steps.encode-pact.outputs.pact-b64 }}",
+            "repo-owner": "${{ github.repository_owner }}",
+            "repo-name": "${{ github.event.repository.name }}",
+            "repo-branch": "${{ needs.init-github-context.outputs.repo-branch }}"
+          }'


### PR DESCRIPTION
Make `publish_pacts` work with multiple pacts.

This is based on https://github.com/DataBiosphere/terra-workspace-data-service/pull/397

Co-authored-by: ichengchang
Co-authored-by: calypsomatic