### PR TITLE
AJ-1428 alert e2e failures to #dsde-qa

### DIFF
--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -100,6 +100,6 @@ jobs:
   report-workflow:
     uses: broadinstitute/sherlock/.github/workflows/client-report-workflow.yaml@main
     with:
-      notify-slack-channels-upon-workflow-failure: "#dsp-analysis-journeys-alerts"
+      notify-slack-channels-upon-workflow-failure: "#dsp-analysis-journeys-alerts, #dsde-qa"
     permissions:
       id-token: write


### PR DESCRIPTION
Per [Gary's request](https://broadinstitute.slack.com/archives/C0475CH4ZV3/p1698944129546589?thread_ts=1698937206.372489&cid=C0475CH4ZV3), report e2e test failures to qa as well as to the AJ alerts channel