### PR TITLE
AJ-1234: Relax regex matching conflict message.

### DIFF
--- a/service/src/test/java/org/databiosphere/workspacedataservice/pact/WsmPactTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/pact/WsmPactTest.java
@@ -102,7 +102,9 @@ public class WsmPactTest {
             newJsonBody(
                     body ->
                         body.stringMatcher(
-                            "message", "^(.*)policy conflict(.*)$", "unexpected policy conflict"))
+                            "message",
+                            "^(.*)(policy|policies)(.*)conflict(.*)$",
+                            "Workspace policies conflict with source"))
                 .build())
         .toPact();
   }


### PR DESCRIPTION
The actual message differed slightly from expectation, so I've adjusted the regex to allow both forms of pluralization; what matters most is that the conflict was due to something relating to policies (and not one of the other myriad ways a 409 can be returned).