### PR TITLE
Revert "AJ-1428 alert e2e failures to #dsde-qa"

### DIFF
--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -100,6 +100,6 @@ jobs:
   report-workflow:
     uses: broadinstitute/sherlock/.github/workflows/client-report-workflow.yaml@main
     with:
-      notify-slack-channels-upon-workflow-failure: "#dsp-analysis-journeys-alerts, #dsde-qa"
+      notify-slack-channels-upon-workflow-failure: "#dsp-analysis-journeys-alerts"
     permissions:
       id-token: write


### PR DESCRIPTION
Per Gary's request, reverting this for now - until we can report only when we run this test in staging specifically. 