### PR TITLE
Enable can-i-deploy in WDS CI

### DIFF
--- a/.github/workflows/publish-pacts.yml
+++ b/.github/workflows/publish-pacts.yml
@@ -12,6 +12,7 @@ on:
 env:
   WDS_RUN_ID: ${{ github.event.repository.name }}-${{ github.run_id }}
   PUBLISH_CONTRACT_RUN_NAME: 'publish-contracts-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}'
+  CAN_I_DEPLOY_RUN_NAME: 'can-i-deploy-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}'
   WDS_PACTS_ARTIFACT: wds-pacts-${{ github.event.repository.name }}-${{ github.run_id }}
   WDS_PACTS_OUTPUT_DIR: service/build/pacts/
 
@@ -161,10 +162,10 @@ jobs:
             "repo-name": "${{ github.event.repository.name }}",
             "repo-branch": "${{ needs.init-github-context.outputs.repo-branch }}",
             "release-tag": "${{ needs.regulated-tag-job.outputs.new-tag }}"
-          }'
+            }'
+
   can-i-deploy:
     runs-on: ubuntu-latest
-    if: ${{ needs.init-github-context.outputs.fork == 'false' }}
     needs:
       - init-github-context
       - publish-pacts-job
@@ -181,4 +182,4 @@ jobs:
             "run-name": "${{ env.CAN_I_DEPLOY_RUN_NAME }}",
             "pacticipant": "wds",
             "version": "${{ needs.init-github-context.outputs.repo-version }}"
-          }'
+            }'

--- a/.github/workflows/publish-pacts.yml
+++ b/.github/workflows/publish-pacts.yml
@@ -162,3 +162,23 @@ jobs:
             "repo-branch": "${{ needs.init-github-context.outputs.repo-branch }}",
             "release-tag": "${{ needs.regulated-tag-job.outputs.new-tag }}"
           }'
+  can-i-deploy:
+    runs-on: ubuntu-latest
+    if: ${{ needs.init-github-context.outputs.fork == 'false' }}
+    needs:
+      - init-github-context
+      - publish-pacts-job
+    steps:
+      - name: Dispatch to terra-github-workflows
+        uses: broadinstitute/workflow-dispatch@v4.0.0
+        with:
+          run-name: "${{ env.CAN_I_DEPLOY_RUN_NAME }}"
+          workflow: .github/workflows/can-i-deploy.yaml
+          repo: broadinstitute/terra-github-workflows
+          ref: refs/heads/main
+          token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
+          inputs: '{
+            "run-name": "${{ env.CAN_I_DEPLOY_RUN_NAME }}",
+            "pacticipant": "wds",
+            "version": "${{ needs.init-github-context.outputs.repo-version }}"
+          }'

--- a/.github/workflows/tag-0.3.0.yml
+++ b/.github/workflows/tag-0.3.0.yml
@@ -10,12 +10,12 @@ on:
         type: string
       dry-run:
         description: "Determine the next version without tagging the branch. The workflow can use the outputs new_tag and tag in subsequent steps. Possible values are true and false (default)"
-        default: false
+        default: 'false'
         required: false
         type: string
       print-tag:
         description: "Echo tag to console"
-        default: true
+        default: 'true'
         required: false
         type: string
       release-branches:


### PR DESCRIPTION
[AJ-1454](https://broadworkbench.atlassian.net/browse/AJ-1454)

This is followup to initial pact verification work to actually enable deployment protection.

This is step 6 of: https://broadworkbench.atlassian.net/wiki/spaces/IRT/pages/2660368406/Getting+Started+with+Pact+Contract+Testing

[AJ-1454]: https://broadworkbench.atlassian.net/browse/AJ-1454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Based heavily on: https://github.com/broadinstitute/rawls/blob/develop/.github/workflows/consumer_contract_tests.yml