### PR TITLE
AJ-1428: upgrade sonar plugin and task

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -79,7 +79,7 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew --build-cache sonarqube
+        run: ./gradlew --build-cache sonar
 
       - name: Upload Test Reports
         if: always()

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'org.springframework.boot' version '2.7.12' apply false
     id 'io.spring.dependency-management' version '1.1.0' apply false
     id 'com.google.cloud.tools.jib' version '3.2.1' apply false
-    id "org.sonarqube" version "4.0.0.2929" apply false
+    id "org.sonarqube" version "4.4.1.3373" apply false
     id 'idea'
     id "org.openapi.generator" version "6.6.0" apply false
     id 'java'

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -166,7 +166,7 @@ compileJava {
     }
 }
 
-sonarqube {
+sonar {
     properties {
         property "sonar.projectName", "terra-workspace-data-service"
         property "sonar.projectKey", "DataBiosphere_workspace-data-service"


### PR DESCRIPTION
This PR upgrades the [Sonarqube Gradle plugin](https://plugins.gradle.org/plugin/org.sonarqube).

It also switches from calling the `sonarqube` task to calling the `sonar` task, to address deprecation warnings:
![Screenshot 11-14-2023 at 10 00 AM](https://github.com/DataBiosphere/terra-workspace-data-service/assets/6041577/940ccc7a-88db-4b39-b323-be89cd3ad7fc)
