### PR TITLE
AJ-1465 - Add landing zone attach retry to e2e tests

### DIFF
--- a/.github/actions/landing-zone-attach/action.yml
+++ b/.github/actions/landing-zone-attach/action.yml
@@ -1,0 +1,32 @@
+name: 'create bee'
+description: 'Creates a bee for the wds e2e test'
+inputs:
+  token:
+    description: 'The auth token to use for bee creation'
+    required: true
+    type: string
+  bee_name:
+    description: 'The name of the bee to create'
+    required: true
+    type: string
+  project_name:
+    description: 'The name of billing project'
+    required: true
+    type: string
+
+runs:
+  using: 'composite'
+  steps:
+    - name: dispatch to terra-github-workflows
+      uses: broadinstitute/workflow-dispatch@v3
+      with:
+        workflow: attach-billing-project-to-landing-zone.yaml
+        repo: broadinstitute/terra-github-workflows
+        ref: refs/heads/main
+        token: '${{ inputs.token }}'
+        inputs: >-
+          {
+          "bee-name": "${{ inputs.bee_name }}",
+          "billing-project": "${{ inputs.project_name }}",
+          "service-account": "firecloud-qa@broad-dsde-qa.iam.gserviceaccount.com"
+          }

--- a/.github/actions/landing-zone-attach/action.yml
+++ b/.github/actions/landing-zone-attach/action.yml
@@ -1,16 +1,16 @@
 name: 'create bee'
-description: 'Creates a bee for the wds e2e test'
+description: 'Attaches landing zone to an existing bee'
 inputs:
   token:
-    description: 'The auth token to use for bee creation'
+    description: 'The auth token to use for connecting to bee'
     required: true
     type: string
   bee_name:
-    description: 'The name of the bee to create'
+    description: 'The name of the bee to connect to'
     required: true
     type: string
   project_name:
-    description: 'The name of billing project'
+    description: 'The name of billing project to attach to'
     required: true
     type: string
 

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v3
         
       - name: dispatch to terra-github-workflows
-        id: FirstAttempt
+        id: FirstAttemptCreateBee
         continue-on-error: true
         uses: ./.github/actions/create-bee
         with:
@@ -50,7 +50,7 @@ jobs:
             token: '${{ env.TOKEN }}'
 
       - name: retry dispatch to terra-github-workflows in case of failure
-        if: steps.FirstAttempt.outcome == 'failure'
+        if: steps.FirstAttemptCreateBee.outcome == 'failure'
         uses: ./.github/actions/create-bee
         with:
             bee_name: ${{ env.BEE_NAME }}, 
@@ -60,19 +60,26 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ init-github-context, create-bee-workflow, params-gen ]
     steps:
+      - name: Get actions
+        uses: actions/checkout@v3
+        
       - name: dispatch to terra-github-workflows
-        uses: broadinstitute/workflow-dispatch@v3
+        id: FirstAttemptLandingZone
+        continue-on-error: true
+        uses: ./.github/actions/landing-zone-attach
         with:
-          workflow: attach-billing-project-to-landing-zone.yaml
-          repo: broadinstitute/terra-github-workflows
-          ref: refs/heads/main
-          token: '${{ env.TOKEN }}'
-          inputs: >-
-            {
-            "bee-name": "${{ env.BEE_NAME }}",
-            "billing-project": "${{needs.params-gen.outputs.project-name }}",
-            "service-account": "firecloud-qa@broad-dsde-qa.iam.gserviceaccount.com"
-            }
+            bee_name: ${{ env.BEE_NAME }}
+            token: '${{ env.TOKEN }}'
+            project_name: ${{needs.params-gen.outputs.project-name }}
+
+      - name: retry dispatch to terra-github-workflows in case of failure
+        if: steps.FirstAttemptLandingZone.outcome == 'failure'
+        uses: ./.github/actions/landing-zone-attach
+        with:
+            bee_name: ${{ env.BEE_NAME }}
+            token: '${{ env.TOKEN }}'
+            project_name: ${{needs.params-gen.outputs.project-name }}
+            
   run-e2e-test-job:
     needs:
       - attach-landing-zone-to-bee-workflow

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -110,6 +110,7 @@ jobs:
           inputs: '{ "bee-name": "${{ env.BEE_NAME }}" }'
   report-workflow:
     uses: broadinstitute/sherlock/.github/workflows/client-report-workflow.yaml@main
+    if: github.ref == 'refs/heads/main'
     with:
       notify-slack-channels-upon-workflow-failure: "#dsp-analysis-journeys-alerts"
     permissions:


### PR DESCRIPTION
After chatting more with dev ops, it seems like it would be useful to have a landing zone attach retry immediately after failure. 

Reminder:

PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 
