### PR TITLE
AJ-1452: pfb data types

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -80,7 +80,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:4.11.0' // required by Sam client
     implementation "bio.terra:datarepo-client:1.537.0-SNAPSHOT"
     implementation "bio.terra:workspace-manager-client:0.254.717-SNAPSHOT"
-    implementation "bio.terra:java-pfb-library:0.13.0"
+    implementation "bio.terra:java-pfb-library:0.14.0"
     implementation project(path: ':client')
 
     // hk2 is required to use WSM client, but not correctly exposed by the client

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbRecordConverter.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbRecordConverter.java
@@ -1,8 +1,11 @@
 package org.databiosphere.workspacedataservice.dataimport;
 
+import java.math.BigDecimal;
 import java.util.List;
+import java.util.Map;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
+import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
@@ -14,24 +17,36 @@ public class PfbRecordConverter {
   public static final String TYPE_FIELD = "name";
   public static final String OBJECT_FIELD = "object";
 
+  private final Map<String, Map<String, DataTypeMapping>> recordTypeSchemas;
+
+  public PfbRecordConverter(Map<String, Map<String, DataTypeMapping>> recordTypeSchemas) {
+    this.recordTypeSchemas = recordTypeSchemas;
+  }
+
   public Record genericRecordToRecord(GenericRecord genRec) {
+    // create the WDS record shell (id, record type, empty attributes)
     Record converted =
         new Record(
             genRec.get(ID_FIELD).toString(),
             RecordType.valueOf(genRec.get(TYPE_FIELD).toString()),
             RecordAttributes.empty());
 
-    // contains attributes
+    // retrieve the expected schema for this record type
+    Map<String, DataTypeMapping> wdsTypeSchema =
+        recordTypeSchemas.getOrDefault(genRec.get(TYPE_FIELD).toString(), Map.of());
+
+    // loop over all Avro fields and add to the record's attributes
     if (genRec.get(OBJECT_FIELD) instanceof GenericRecord objectAttributes) {
       Schema schema = objectAttributes.getSchema();
       List<Schema.Field> fields = schema.getFields();
       RecordAttributes attributes = RecordAttributes.empty();
       for (Schema.Field field : fields) {
         String fieldName = field.name();
-        Object value =
-            objectAttributes.get(fieldName) == null
-                ? null
-                : convertAttributeType(objectAttributes.get(fieldName));
+        Object value = null;
+        if (objectAttributes.get(fieldName) != null) {
+          DataTypeMapping targetDataType = wdsTypeSchema.get(fieldName);
+          value = convertAttributeType(objectAttributes.get(fieldName), targetDataType);
+        }
         attributes.putAttribute(fieldName, value);
       }
       converted.setAttributes(attributes);
@@ -40,16 +55,43 @@ public class PfbRecordConverter {
     return converted;
   }
 
-  // TODO AJ-1452: respect the datatypes returned by the PFB. For now, we make no guarantee that
-  //    about datatypes; many values are just toString()-ed. This allows us to commit incremental
-  //    progress and save some complicated work for later.
-  Object convertAttributeType(Object attribute) {
+  // TODO AJ-1452: This only handles scalar numbers, booleans and strings. We need to add support
+  //     for other datatypes later.
+  Object convertAttributeType(Object attribute, DataTypeMapping targetDataType) {
+
     if (attribute == null) {
       return null;
     }
-    if (attribute instanceof Long /*or other number*/) {
-      return attribute;
+    if (targetDataType == null) {
+      return attribute.toString();
     }
-    return attribute.toString(); // easier for the datatype inferer to parse
+    Object returnValue = null;
+    switch (targetDataType) {
+      case NUMBER:
+        // Avro numbers - see
+        // https://avro.apache.org/docs/current/api/java/org/apache/avro/generic/package-summary.html#package_description
+        if (attribute instanceof Long longAttr) {
+          returnValue = BigDecimal.valueOf(longAttr);
+        } else if (attribute instanceof Integer intAttr) {
+          returnValue = BigDecimal.valueOf(intAttr);
+        } else if (attribute instanceof Float floatAttr) {
+          returnValue = BigDecimal.valueOf(floatAttr);
+        } else if (attribute instanceof Double doubleAttr) {
+          returnValue = BigDecimal.valueOf(doubleAttr);
+        }
+        break;
+      case BOOLEAN:
+        if (attribute instanceof Boolean boolAttr) {
+          returnValue = boolAttr;
+        }
+        break;
+      default:
+        returnValue = attribute.toString();
+    }
+    if (returnValue == null) {
+      returnValue = attribute.toString();
+    }
+
+    return returnValue;
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbRecordConverter.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbRecordConverter.java
@@ -9,6 +9,8 @@ import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Logic to convert a PFB's GenericRecord to WDS's Record */
 public class PfbRecordConverter {
@@ -18,6 +20,8 @@ public class PfbRecordConverter {
   public static final String OBJECT_FIELD = "object";
 
   private final Map<String, Map<String, DataTypeMapping>> recordTypeSchemas;
+
+  private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
   public PfbRecordConverter(Map<String, Map<String, DataTypeMapping>> recordTypeSchemas) {
     this.recordTypeSchemas = recordTypeSchemas;
@@ -89,6 +93,14 @@ public class PfbRecordConverter {
         returnValue = attribute.toString();
     }
     if (returnValue == null) {
+      // If we reach here, it means that the actual object returned by Avro did not
+      // match the expected WDS data type, and the "instanceof" clauses in the cases above
+      // don't satisfy. This should only happen if our logic is faulty.
+      logger.warn(
+          "mismatched attribute datatype: expected "
+              + targetDataType
+              + " but found "
+              + attribute.getClass().getSimpleName());
       returnValue = attribute.toString();
     }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbRecordConverter.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbRecordConverter.java
@@ -97,10 +97,9 @@ public class PfbRecordConverter {
       // match the expected WDS data type, and the "instanceof" clauses in the cases above
       // don't satisfy. This should only happen if our logic is faulty.
       logger.warn(
-          "mismatched attribute datatype: expected "
-              + targetDataType
-              + " but found "
-              + attribute.getClass().getSimpleName());
+          "mismatched attribute datatype: expected {} but found {}",
+          targetDataType,
+          attribute.getClass().getSimpleName());
       returnValue = attribute.toString();
     }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbSchemaConverter.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbSchemaConverter.java
@@ -52,7 +52,7 @@ public class PfbSchemaConverter {
   /** return the PfbDataType for a single field within the PFB's "object" column */
   PfbDataType getFieldSchema(Schema fieldSchema) {
     if (!fieldSchema.isUnion()) {
-      Boolean isArray = fieldSchema.getType() == Schema.Type.ARRAY;
+      boolean isArray = fieldSchema.getType() == Schema.Type.ARRAY;
       Schema.Type schemaType =
           isArray ? fieldSchema.getElementType().getType() : fieldSchema.getType();
       return new PfbDataType(isArray, schemaType);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbSchemaConverter.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbSchemaConverter.java
@@ -1,0 +1,93 @@
+package org.databiosphere.workspacedataservice.dataimport;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.avro.Schema;
+import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
+import org.databiosphere.workspacedataservice.service.model.exception.PfbParsingException;
+
+/** Logic to translate PFB/Avro schema definitions to WDS schema definitions. */
+public class PfbSchemaConverter {
+
+  /** Utility class to ease handling of array types */
+  record PfbDataType(Boolean isArray, Schema.Type schemaType) {}
+
+  // ENUM datatype should be treated as a string
+  // FIXED and BYTE datatypes will be treated as string, but unlikely to give decent output
+  private static final Map<Schema.Type, DataTypeMapping> SCALAR_CONVERSIONS =
+      Map.of(
+          Schema.Type.BOOLEAN, DataTypeMapping.BOOLEAN,
+          Schema.Type.DOUBLE, DataTypeMapping.NUMBER,
+          Schema.Type.FLOAT, DataTypeMapping.NUMBER,
+          Schema.Type.INT, DataTypeMapping.NUMBER,
+          Schema.Type.LONG, DataTypeMapping.NUMBER,
+          Schema.Type.MAP, DataTypeMapping.JSON,
+          Schema.Type.RECORD, DataTypeMapping.JSON);
+
+  // arrays of ENUM datatype should be treated as arrays of strings
+  // arrays of FIXED or BYTE will be treated as arrays of string, but unlikely to give decent output
+  // arrays of MAP or RECORD will be treated as arrays of string, but should be treated as array of
+  //     json (AJ-1366)
+  private static final Map<Schema.Type, DataTypeMapping> ARRAY_CONVERSIONS =
+      Map.of(
+          Schema.Type.BOOLEAN, DataTypeMapping.ARRAY_OF_BOOLEAN,
+          Schema.Type.DOUBLE, DataTypeMapping.ARRAY_OF_NUMBER,
+          Schema.Type.FLOAT, DataTypeMapping.ARRAY_OF_NUMBER,
+          Schema.Type.INT, DataTypeMapping.ARRAY_OF_NUMBER,
+          Schema.Type.LONG, DataTypeMapping.ARRAY_OF_NUMBER);
+
+  /** return the WDS DataTypeMapping to use for a given PfbDataType */
+  DataTypeMapping mapTypes(PfbDataType pfbDataType) {
+    if (pfbDataType.isArray) {
+      return ARRAY_CONVERSIONS.getOrDefault(
+          pfbDataType.schemaType, DataTypeMapping.ARRAY_OF_STRING);
+    } else {
+      return SCALAR_CONVERSIONS.getOrDefault(pfbDataType.schemaType, DataTypeMapping.STRING);
+    }
+  }
+
+  /** return the PfbDataType for a single field within the PFB's "object" column */
+  PfbDataType getFieldSchema(Schema fieldSchema) {
+    if (!fieldSchema.isUnion()) {
+      Boolean isArray = fieldSchema.getType() == Schema.Type.ARRAY;
+      Schema.Type schemaType =
+          isArray ? fieldSchema.getElementType().getType() : fieldSchema.getType();
+      return new PfbDataType(isArray, schemaType);
+    } else {
+      // PFB types are often a union of NULL and some other type.
+      // Ignore the nulls and just grab the type.
+      Set<PfbDataType> nonNulls =
+          fieldSchema.getTypes().stream()
+              .filter(s -> s.getType() != Schema.Type.NULL)
+              .map(this::getFieldSchema) // recurse
+              .collect(Collectors.toSet());
+
+      if (nonNulls.size() == 1) {
+        return nonNulls.iterator().next();
+      } else {
+        throw new PfbParsingException(
+            "found multiple schema types for field '" + fieldSchema + "': " + nonNulls);
+      }
+    }
+  }
+
+  /**
+   * For a given record type within a PFB, return the WDS datatypes for all fields of that record
+   * type
+   */
+  public Map<String, DataTypeMapping> pfbSchemaToWdsSchema(Schema pfbSchema) {
+    Map<String, DataTypeMapping> result = new HashMap<>();
+
+    List<Schema.Field> fields = pfbSchema.getFields();
+    fields.forEach(
+        fld -> {
+          PfbDataType pfbDataType = getFieldSchema(fld.schema());
+          result.put(fld.name(), mapTypes(pfbDataType));
+        });
+
+    return result;
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbSchemaConverter.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbSchemaConverter.java
@@ -13,7 +13,7 @@ import org.databiosphere.workspacedataservice.service.model.exception.PfbParsing
 public class PfbSchemaConverter {
 
   /** Utility class to ease handling of array types */
-  record PfbDataType(Boolean isArray, Schema.Type schemaType) {}
+  record PfbDataType(boolean isArray, Schema.Type schemaType) {}
 
   // ENUM datatype should be treated as a string
   // FIXED and BYTE datatypes will be treated as string, but unlikely to give decent output
@@ -41,7 +41,7 @@ public class PfbSchemaConverter {
 
   /** return the WDS DataTypeMapping to use for a given PfbDataType */
   DataTypeMapping mapTypes(PfbDataType pfbDataType) {
-    if (pfbDataType.isArray()) {
+    if (pfbDataType.isArray) {
       return ARRAY_CONVERSIONS.getOrDefault(
           pfbDataType.schemaType, DataTypeMapping.ARRAY_OF_STRING);
     } else {
@@ -52,7 +52,7 @@ public class PfbSchemaConverter {
   /** return the PfbDataType for a single field within the PFB's "object" column */
   PfbDataType getFieldSchema(Schema fieldSchema) {
     if (!fieldSchema.isUnion()) {
-      boolean isArray = fieldSchema.getType() == Schema.Type.ARRAY;
+      boolean isArray = Schema.Type.ARRAY.equals(fieldSchema.getType());
       Schema.Type schemaType =
           isArray ? fieldSchema.getElementType().getType() : fieldSchema.getType();
       return new PfbDataType(isArray, schemaType);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbSchemaConverter.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbSchemaConverter.java
@@ -41,7 +41,7 @@ public class PfbSchemaConverter {
 
   /** return the WDS DataTypeMapping to use for a given PfbDataType */
   DataTypeMapping mapTypes(PfbDataType pfbDataType) {
-    if (pfbDataType.isArray) {
+    if (pfbDataType.isArray()) {
       return ARRAY_CONVERSIONS.getOrDefault(
           pfbDataType.schemaType, DataTypeMapping.ARRAY_OF_STRING);
     } else {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/BatchWriteService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/BatchWriteService.java
@@ -184,8 +184,12 @@ public class BatchWriteService {
    */
   @WriteTransaction
   public BatchWriteResult batchWritePfbStream(
-      DataFileStream<GenericRecord> is, UUID instanceId, Optional<String> primaryKey) {
-    try (PfbStreamWriteHandler streamingWriteHandler = new PfbStreamWriteHandler(is)) {
+      DataFileStream<GenericRecord> is,
+      UUID instanceId,
+      Optional<String> primaryKey,
+      Map<String, Map<String, DataTypeMapping>> recordTypeSchemas) {
+    try (PfbStreamWriteHandler streamingWriteHandler =
+        new PfbStreamWriteHandler(is, recordTypeSchemas)) {
       return consumeWriteStream(streamingWriteHandler, instanceId, null, primaryKey);
     } catch (IOException e) {
       throw new BadStreamingWriteRequestException(e);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/PfbParsingException.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/PfbParsingException.java
@@ -6,6 +6,10 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 @ResponseStatus(code = HttpStatus.BAD_REQUEST)
 public class PfbParsingException extends IllegalArgumentException {
 
+  public PfbParsingException(String message) {
+    super(message);
+  }
+
   public PfbParsingException(String message, Exception e) {
     super(message, e);
   }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/PfbQuartzJobTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/PfbQuartzJobTest.java
@@ -155,7 +155,7 @@ class PfbQuartzJobTest {
     when(wsmDao.enumerateDataRepoSnapshotReferences(any(), anyInt(), anyInt()))
         .thenReturn(new ResourceList());
     // We're not testing this, so it doesn't matter what returns
-    when(batchWriteService.batchWritePfbStream(any(), any(), any()))
+    when(batchWriteService.batchWritePfbStream(any(), any(), any(), any()))
         .thenReturn(BatchWriteResult.empty());
 
     buildQuartzJob().execute(mockContext);
@@ -175,7 +175,7 @@ class PfbQuartzJobTest {
     when(wsmDao.enumerateDataRepoSnapshotReferences(any(), anyInt(), anyInt()))
         .thenReturn(new ResourceList());
     // We're not testing this, so it doesn't matter what returns
-    when(batchWriteService.batchWritePfbStream(any(), any(), any()))
+    when(batchWriteService.batchWritePfbStream(any(), any(), any(), any()))
         .thenReturn(BatchWriteResult.empty());
 
     buildQuartzJob().execute(mockContext);

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/PfbRecordConverterTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/PfbRecordConverterTest.java
@@ -3,6 +3,7 @@ package org.databiosphere.workspacedataservice.dataimport;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -11,6 +12,7 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.junit.jupiter.api.Test;
 
@@ -23,7 +25,7 @@ class PfbRecordConverterTest {
     String inputName = RandomStringUtils.randomAlphanumeric(16);
     GenericRecord input = PfbTestUtils.makeRecord(inputId, inputName);
 
-    Record actual = new PfbRecordConverter().genericRecordToRecord(input);
+    Record actual = new PfbRecordConverter(Map.of()).genericRecordToRecord(input);
 
     assertEquals(inputId, actual.getId());
     assertEquals(inputName, actual.getRecordTypeName());
@@ -33,7 +35,7 @@ class PfbRecordConverterTest {
   @Test
   void emptyObjectAttributes() {
     GenericRecord input = PfbTestUtils.makeRecord("my-id", "my-name");
-    Record actual = new PfbRecordConverter().genericRecordToRecord(input);
+    Record actual = new PfbRecordConverter(Map.of()).genericRecordToRecord(input);
 
     assertThat(actual.attributeSet()).isEmpty();
   }
@@ -43,7 +45,7 @@ class PfbRecordConverterTest {
   void nullObjectAttributes() {
     GenericRecord input =
         PfbTestUtils.makeRecord("this-record-has", "a-null-for-the-object-field", null);
-    Record actual = new PfbRecordConverter().genericRecordToRecord(input);
+    Record actual = new PfbRecordConverter(Map.of()).genericRecordToRecord(input);
 
     assertThat(actual.attributeSet()).isEmpty();
   }
@@ -54,34 +56,124 @@ class PfbRecordConverterTest {
   void valuesInObjectAttributes() {
     Schema myObjSchema =
         Schema.createRecord(
-            "objectSchema",
+            "mytype",
             "doc",
             "namespace",
             false,
             List.of(
                 new Schema.Field("marco", Schema.create(Schema.Type.STRING)),
                 new Schema.Field("pi", Schema.create(Schema.Type.LONG)),
-                new Schema.Field("afile", Schema.create(Schema.Type.STRING))));
+                new Schema.Field("afile", Schema.create(Schema.Type.STRING)),
+                new Schema.Field("booly", Schema.create(Schema.Type.BOOLEAN))));
 
     GenericData.Record objectAttributes = new GenericData.Record(myObjSchema);
     objectAttributes.put("marco", "polo");
     objectAttributes.put("pi", 3.14159);
     objectAttributes.put("afile", "https://some/path/to/a/file");
+    objectAttributes.put("booly", Boolean.TRUE);
 
-    GenericRecord input =
-        PfbTestUtils.makeRecord("this-record-has", "a-null-for-the-object-field", objectAttributes);
-    Record actual = new PfbRecordConverter().genericRecordToRecord(input);
+    // translate the object schema to WDS schema
+    PfbSchemaConverter pfbSchemaConverter = new PfbSchemaConverter();
+    Map<String, Map<String, DataTypeMapping>> wdsSchema =
+        Map.of("mytype", pfbSchemaConverter.pfbSchemaToWdsSchema(myObjSchema));
+
+    GenericRecord input = PfbTestUtils.makeRecord("my-id", "mytype", objectAttributes);
+    Record actual = new PfbRecordConverter(wdsSchema).genericRecordToRecord(input);
 
     Set<Map.Entry<String, Object>> actualAttributeSet = actual.attributeSet();
     Set<String> actualKeySet =
         actualAttributeSet.stream().map(Map.Entry::getKey).collect(Collectors.toSet());
-    assertEquals(Set.of("marco", "pi", "afile"), actualKeySet);
+    assertEquals(Set.of("marco", "pi", "afile", "booly"), actualKeySet);
 
     assertEquals("polo", actual.getAttributeValue("marco"));
     assertEquals("https://some/path/to/a/file", actual.getAttributeValue("afile"));
-    // TODO AJ-1452: this should remain a number, not become a string
-    assertEquals("3.14159", actual.getAttributeValue("pi"));
+    assertEquals(BigDecimal.valueOf(3.14159), actual.getAttributeValue("pi"));
+    assertEquals(Boolean.TRUE, actual.getAttributeValue("booly"));
 
     // TODO AJ-1452: add more test coverage as the runtime functionality evolves.
+  }
+
+  // if the GenericRecord contains attributes that are not mentioned in the expected schema,
+  // those attributes should be treated as strings.
+  @Test
+  void missingFieldsInWdsSchema() {
+    Schema myObjSchema =
+        Schema.createRecord(
+            "mytype",
+            "doc",
+            "namespace",
+            false,
+            List.of(
+                new Schema.Field("marco", Schema.create(Schema.Type.STRING)),
+                new Schema.Field("pi", Schema.create(Schema.Type.LONG)),
+                new Schema.Field("e", Schema.create(Schema.Type.LONG)),
+                new Schema.Field("booly", Schema.create(Schema.Type.BOOLEAN))));
+
+    GenericData.Record objectAttributes = new GenericData.Record(myObjSchema);
+    objectAttributes.put("marco", "polo");
+    objectAttributes.put("pi", 3.14159);
+    objectAttributes.put("e", 2.718);
+    objectAttributes.put("booly", Boolean.TRUE);
+
+    // create a WDS schema that is missing some entries
+    Map<String, Map<String, DataTypeMapping>> wdsSchema =
+        Map.of("mytype", Map.of("marco", DataTypeMapping.STRING, "pi", DataTypeMapping.NUMBER));
+
+    GenericRecord input = PfbTestUtils.makeRecord("my-id", "mytype", objectAttributes);
+    Record actual = new PfbRecordConverter(wdsSchema).genericRecordToRecord(input);
+
+    Set<Map.Entry<String, Object>> actualAttributeSet = actual.attributeSet();
+    Set<String> actualKeySet =
+        actualAttributeSet.stream().map(Map.Entry::getKey).collect(Collectors.toSet());
+    assertEquals(Set.of("marco", "pi", "e", "booly"), actualKeySet);
+
+    // these have mappings in the WDS schema
+    assertEquals("polo", actual.getAttributeValue("marco"));
+    assertEquals(BigDecimal.valueOf(3.14159), actual.getAttributeValue("pi"));
+
+    // these do not have mappings and thus get .toString()-ed
+    assertEquals("2.718", actual.getAttributeValue("e"));
+    assertEquals("true", actual.getAttributeValue("booly"));
+  }
+
+  // if the GenericRecord contains a record type that is not mentioned in the expected schema,
+  // all attributes of that type should be treated as strings.
+  @Test
+  void missingRecordTypesInWdsSchema() {
+    Schema myObjSchema =
+        Schema.createRecord(
+            "mytype",
+            "doc",
+            "namespace",
+            false,
+            List.of(
+                new Schema.Field("marco", Schema.create(Schema.Type.STRING)),
+                new Schema.Field("pi", Schema.create(Schema.Type.LONG)),
+                new Schema.Field("afile", Schema.create(Schema.Type.STRING)),
+                new Schema.Field("booly", Schema.create(Schema.Type.BOOLEAN))));
+
+    GenericData.Record objectAttributes = new GenericData.Record(myObjSchema);
+    objectAttributes.put("marco", "polo");
+    objectAttributes.put("pi", 3.14159);
+    objectAttributes.put("afile", "https://some/path/to/a/file");
+    objectAttributes.put("booly", Boolean.TRUE);
+
+    // translate the object schema to WDS schema
+    PfbSchemaConverter pfbSchemaConverter = new PfbSchemaConverter();
+    Map<String, Map<String, DataTypeMapping>> wdsSchema =
+        Map.of("THISISTHEWRONGTYPE", pfbSchemaConverter.pfbSchemaToWdsSchema(myObjSchema));
+
+    GenericRecord input = PfbTestUtils.makeRecord("my-id", "mytype", objectAttributes);
+    Record actual = new PfbRecordConverter(wdsSchema).genericRecordToRecord(input);
+
+    Set<Map.Entry<String, Object>> actualAttributeSet = actual.attributeSet();
+    Set<String> actualKeySet =
+        actualAttributeSet.stream().map(Map.Entry::getKey).collect(Collectors.toSet());
+    assertEquals(Set.of("marco", "pi", "afile", "booly"), actualKeySet);
+
+    assertEquals("polo", actual.getAttributeValue("marco"));
+    assertEquals("https://some/path/to/a/file", actual.getAttributeValue("afile"));
+    assertEquals("3.14159", actual.getAttributeValue("pi"));
+    assertEquals("true", actual.getAttributeValue("booly"));
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/PfbSchemaConverterTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/PfbSchemaConverterTest.java
@@ -1,0 +1,243 @@
+package org.databiosphere.workspacedataservice.dataimport;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.avro.Schema;
+import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
+import org.databiosphere.workspacedataservice.service.model.exception.PfbParsingException;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class PfbSchemaConverterTest {
+
+  // ========== start tests for scalar datatypes
+
+  @Test
+  void mapScalarBoolean() {
+    PfbSchemaConverter pfbSchemaConverter = new PfbSchemaConverter();
+
+    assertEquals(
+        DataTypeMapping.BOOLEAN,
+        pfbSchemaConverter.mapTypes(
+            new PfbSchemaConverter.PfbDataType(false, Schema.Type.BOOLEAN)));
+  }
+
+  @ParameterizedTest(name = "when converting {0}")
+  @EnumSource(
+      value = Schema.Type.class,
+      names = {"DOUBLE", "FLOAT", "INT", "LONG"})
+  void mapScalarNumbers(Schema.Type pfbType) {
+    PfbSchemaConverter pfbSchemaConverter = new PfbSchemaConverter();
+
+    assertEquals(
+        DataTypeMapping.NUMBER,
+        pfbSchemaConverter.mapTypes(new PfbSchemaConverter.PfbDataType(false, pfbType)));
+  }
+
+  // WDS treats enums as strings; this may change at some point
+  @Test
+  void mapScalarEnum() {
+    PfbSchemaConverter pfbSchemaConverter = new PfbSchemaConverter();
+
+    assertEquals(
+        DataTypeMapping.STRING,
+        pfbSchemaConverter.mapTypes(new PfbSchemaConverter.PfbDataType(false, Schema.Type.ENUM)));
+  }
+
+  @Test
+  void mapScalarString() {
+    PfbSchemaConverter pfbSchemaConverter = new PfbSchemaConverter();
+
+    assertEquals(
+        DataTypeMapping.STRING,
+        pfbSchemaConverter.mapTypes(new PfbSchemaConverter.PfbDataType(false, Schema.Type.STRING)));
+  }
+
+  // WDS treats fixed and bytes as strings; this may change at some point
+  @ParameterizedTest(name = "when converting {0}")
+  @EnumSource(
+      value = Schema.Type.class,
+      names = {"FIXED", "BYTES"})
+  void mapScalarBinaries(Schema.Type pfbType) {
+    PfbSchemaConverter pfbSchemaConverter = new PfbSchemaConverter();
+
+    assertEquals(
+        DataTypeMapping.STRING,
+        pfbSchemaConverter.mapTypes(new PfbSchemaConverter.PfbDataType(false, pfbType)));
+  }
+
+  @Disabled("JSON types not handled yet in PfbRecordConverter")
+  @ParameterizedTest(name = "when converting {0}")
+  @EnumSource(
+      value = Schema.Type.class,
+      names = {"RECORD", "MAP"})
+  void mapScalarJsons(Schema.Type pfbType) {
+    PfbSchemaConverter pfbSchemaConverter = new PfbSchemaConverter();
+
+    assertEquals(
+        DataTypeMapping.JSON,
+        pfbSchemaConverter.mapTypes(new PfbSchemaConverter.PfbDataType(false, pfbType)));
+  }
+
+  // ========== start tests for array datatypes
+
+  @Test
+  void mapArrayBoolean() {
+    PfbSchemaConverter pfbSchemaConverter = new PfbSchemaConverter();
+
+    assertEquals(
+        DataTypeMapping.ARRAY_OF_BOOLEAN,
+        pfbSchemaConverter.mapTypes(new PfbSchemaConverter.PfbDataType(true, Schema.Type.BOOLEAN)));
+  }
+
+  @ParameterizedTest(name = "when converting {0}")
+  @EnumSource(
+      value = Schema.Type.class,
+      names = {"DOUBLE", "FLOAT", "INT", "LONG"})
+  void mapArrayNumbers(Schema.Type pfbType) {
+    PfbSchemaConverter pfbSchemaConverter = new PfbSchemaConverter();
+
+    assertEquals(
+        DataTypeMapping.ARRAY_OF_NUMBER,
+        pfbSchemaConverter.mapTypes(new PfbSchemaConverter.PfbDataType(true, pfbType)));
+  }
+
+  // WDS treats enums as strings; this may change at some point
+  @Test
+  void mapArrayEnum() {
+    PfbSchemaConverter pfbSchemaConverter = new PfbSchemaConverter();
+
+    assertEquals(
+        DataTypeMapping.ARRAY_OF_STRING,
+        pfbSchemaConverter.mapTypes(new PfbSchemaConverter.PfbDataType(true, Schema.Type.ENUM)));
+  }
+
+  @Test
+  void mapArrayString() {
+    PfbSchemaConverter pfbSchemaConverter = new PfbSchemaConverter();
+
+    assertEquals(
+        DataTypeMapping.ARRAY_OF_STRING,
+        pfbSchemaConverter.mapTypes(new PfbSchemaConverter.PfbDataType(true, Schema.Type.STRING)));
+  }
+
+  // WDS treats fixed and bytes as strings; this may change at some point
+  @ParameterizedTest(name = "when converting {0}")
+  @EnumSource(
+      value = Schema.Type.class,
+      names = {"FIXED", "BYTES"})
+  void mapArrayBinaries(Schema.Type pfbType) {
+    PfbSchemaConverter pfbSchemaConverter = new PfbSchemaConverter();
+
+    assertEquals(
+        DataTypeMapping.ARRAY_OF_STRING,
+        pfbSchemaConverter.mapTypes(new PfbSchemaConverter.PfbDataType(true, pfbType)));
+  }
+
+  // AJ-1366: array of json not supported; these convert to array of string.
+  @ParameterizedTest(name = "when converting {0}")
+  @EnumSource(
+      value = Schema.Type.class,
+      names = {"RECORD", "MAP"})
+  void mapArrayJsons(Schema.Type pfbType) {
+    PfbSchemaConverter pfbSchemaConverter = new PfbSchemaConverter();
+
+    assertEquals(
+        DataTypeMapping.ARRAY_OF_STRING,
+        pfbSchemaConverter.mapTypes(new PfbSchemaConverter.PfbDataType(true, pfbType)));
+  }
+
+  // ========== start tests for getFieldSchema
+
+  @ParameterizedTest(name = "for schema with array = {0}")
+  @ValueSource(booleans = {true, false})
+  void arrayConversion(Boolean isArray) {
+    PfbSchemaConverter pfbSchemaConverter = new PfbSchemaConverter();
+    Schema schema;
+    if (isArray) {
+      schema = Schema.createArray(Schema.create(Schema.Type.LONG));
+    } else {
+      schema = Schema.create(Schema.Type.LONG);
+    }
+    PfbSchemaConverter.PfbDataType actual = pfbSchemaConverter.getFieldSchema(schema);
+    assertEquals(isArray, actual.isArray());
+  }
+
+  @ParameterizedTest(name = "when converting {0}")
+  @EnumSource(
+      value = Schema.Type.class,
+      names = {"DOUBLE", "STRING", "BOOLEAN"}) // spot-check a few types
+  void unionWithNull(Schema.Type avroType) {
+    PfbSchemaConverter pfbSchemaConverter = new PfbSchemaConverter();
+    Schema schema = Schema.createUnion(Schema.create(Schema.Type.NULL), Schema.create(avroType));
+    PfbSchemaConverter.PfbDataType actual = pfbSchemaConverter.getFieldSchema(schema);
+    assertEquals(avroType, actual.schemaType());
+  }
+
+  @Test
+  void unionEnumWithNull() {
+    PfbSchemaConverter pfbSchemaConverter = new PfbSchemaConverter();
+    Schema enumSchema =
+        Schema.createEnum("name", "doc", "namespace", List.of("enumValue1", "enumValue2"));
+    Schema schema = Schema.createUnion(Schema.create(Schema.Type.NULL), enumSchema);
+    PfbSchemaConverter.PfbDataType actual = pfbSchemaConverter.getFieldSchema(schema);
+    assertEquals(Schema.Type.ENUM, actual.schemaType());
+  }
+
+  @ParameterizedTest(name = "when converting {0}")
+  @EnumSource(
+      value = Schema.Type.class,
+      names = {"DOUBLE", "STRING", "BOOLEAN"}) // spot-check a few types
+  void unionWithAnotherType(Schema.Type avroType) {
+    PfbSchemaConverter pfbSchemaConverter = new PfbSchemaConverter();
+    Schema schema = Schema.createUnion(Schema.create(Schema.Type.LONG), Schema.create(avroType));
+    assertThrows(PfbParsingException.class, () -> pfbSchemaConverter.getFieldSchema(schema));
+  }
+
+  @Test
+  void unionEnumWithAnotherType() {
+    PfbSchemaConverter pfbSchemaConverter = new PfbSchemaConverter();
+    Schema enumSchema =
+        Schema.createEnum("name", "doc", "namespace", List.of("enumValue1", "enumValue2"));
+    Schema schema = Schema.createUnion(Schema.create(Schema.Type.LONG), enumSchema);
+    assertThrows(PfbParsingException.class, () -> pfbSchemaConverter.getFieldSchema(schema));
+  }
+
+  // ========== start tests for pfbSchemaToWdsSchema
+
+  @Test
+  void pfbSchemaToWdsSchema() {
+    List<Schema.Field> fields =
+        List.of(
+            new Schema.Field("string", Schema.create(Schema.Type.STRING)),
+            new Schema.Field("string_array", Schema.createArray(Schema.create(Schema.Type.STRING))),
+            new Schema.Field("number", Schema.create(Schema.Type.LONG)),
+            new Schema.Field("number_array", Schema.createArray(Schema.create(Schema.Type.INT))),
+            new Schema.Field(
+                "union_bool",
+                Schema.createUnion(
+                    Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.BOOLEAN))));
+
+    Schema schema = Schema.createRecord("name", "doc", "namespace", false, fields);
+
+    PfbSchemaConverter pfbSchemaConverter = new PfbSchemaConverter();
+
+    Map<String, DataTypeMapping> expected =
+        Map.of(
+            "string", DataTypeMapping.STRING,
+            "string_array", DataTypeMapping.ARRAY_OF_STRING,
+            "number", DataTypeMapping.NUMBER,
+            "number_array", DataTypeMapping.ARRAY_OF_NUMBER,
+            "union_bool", DataTypeMapping.BOOLEAN);
+
+    Map<String, DataTypeMapping> actual = pfbSchemaConverter.pfbSchemaToWdsSchema(schema);
+
+    assertEquals(expected, actual);
+  }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/BatchWriteServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/BatchWriteServiceTest.java
@@ -144,7 +144,7 @@ class BatchWriteServiceTest {
       //    - 1 call for batch #8 which will be (item, widget)
       //    - 7 more calls for batches #9-15 which will be (widget, widget)
       // * inferTypes once for each of "thing", "item", and "widget"
-      batchWriteService.batchWritePfbStream(pfbStream, INSTANCE, Optional.of(ID_FIELD));
+      batchWriteService.batchWritePfbStream(pfbStream, INSTANCE, Optional.of(ID_FIELD), Map.of());
 
       // verify calls to batchUpsertWithErrorCapture
       verify(recordService, times(3))
@@ -189,7 +189,8 @@ class BatchWriteServiceTest {
     Map<String, Integer> counts = Map.of("thing", 5, "item", 10, "widget", 15);
     try (DataFileStream<GenericRecord> pfbStream = PfbTestUtils.mockPfbStream(counts)) {
       BatchWriteResult result =
-          batchWriteService.batchWritePfbStream(pfbStream, INSTANCE, Optional.of(ID_FIELD));
+          batchWriteService.batchWritePfbStream(
+              pfbStream, INSTANCE, Optional.of(ID_FIELD), Map.of());
       assertEquals(3, result.entrySet().size());
       assertEquals(5, result.getUpdatedCount(RecordType.valueOf("thing")));
       assertEquals(10, result.getUpdatedCount(RecordType.valueOf("item")));
@@ -208,7 +209,8 @@ class BatchWriteServiceTest {
     try (DataFileStream<GenericRecord> dataStream =
         PfbReader.getGenericRecordsStream(url.toString())) {
       BatchWriteResult result =
-          batchWriteService.batchWritePfbStream(dataStream, INSTANCE, Optional.of(ID_FIELD));
+          batchWriteService.batchWritePfbStream(
+              dataStream, INSTANCE, Optional.of(ID_FIELD), Map.of());
 
       assertEquals(2, result.entrySet().size());
       assertEquals(3, result.getUpdatedCount(RecordType.valueOf("data_release")));

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/PfbStreamWriteHandlerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/PfbStreamWriteHandlerTest.java
@@ -10,6 +10,7 @@ import bio.terra.pfb.PfbReader;
 import java.io.IOException;
 import java.net.URL;
 import java.util.List;
+import java.util.Map;
 import org.apache.avro.file.DataFileStream;
 import org.apache.avro.generic.GenericRecord;
 import org.databiosphere.workspacedataservice.dataimport.PfbTestUtils;
@@ -27,7 +28,8 @@ class PfbStreamWriteHandlerTest {
 
     // create a mock PFB stream with 10 rows in it and a PfbStreamWriteHandler for that stream
     DataFileStream<GenericRecord> dataFileStream = PfbTestUtils.mockPfbStream(10, "someType");
-    PfbStreamWriteHandler pfbStreamWriteHandler = new PfbStreamWriteHandler(dataFileStream);
+    PfbStreamWriteHandler pfbStreamWriteHandler =
+        new PfbStreamWriteHandler(dataFileStream, Map.of());
 
     StreamingWriteHandler.WriteStreamInfo batch; // used in assertions below
 
@@ -55,7 +57,8 @@ class PfbStreamWriteHandlerTest {
   @ValueSource(ints = {0, 1, 49, 50, 51, 99, 100, 101})
   void inputStreamOfCount(Integer numRows) {
     DataFileStream<GenericRecord> dataFileStream = PfbTestUtils.mockPfbStream(numRows, "someType");
-    PfbStreamWriteHandler pfbStreamWriteHandler = new PfbStreamWriteHandler(dataFileStream);
+    PfbStreamWriteHandler pfbStreamWriteHandler =
+        new PfbStreamWriteHandler(dataFileStream, Map.of());
 
     int batchSize = 50;
 
@@ -79,7 +82,7 @@ class PfbStreamWriteHandlerTest {
     try (DataFileStream<GenericRecord> dataStream =
         PfbReader.getGenericRecordsStream(url.toString())) {
 
-      PfbStreamWriteHandler pswh = new PfbStreamWriteHandler(dataStream);
+      PfbStreamWriteHandler pswh = new PfbStreamWriteHandler(dataStream, Map.of());
       StreamingWriteHandler.WriteStreamInfo streamInfo = pswh.readRecords(2);
       /*
         Expected records:


### PR DESCRIPTION
I have two PRs for this ticket, which take different approaches to the problem. We will only merge one of them:

## #415 (this PR)
* Before processing any records, read the Avro schema from the PFB.
* Translate the Avro schema into a WDS schema, e.g. map Avro's `Schema.Type.DOUBLE` to WDS's `DataTypeMapping.NUMBER`.
* Pass this WDS schema down through the call stack.
* When converting an Avro record to a WDS record, look up the expected datatype from the schema. Based on the expected schema AND the actual Java object type returned by the Avro API, translate Avro fields into WDS attributes.

## #416
* No inspection of the Avro schema.
* When converting an Avro record to a WDS record, base the translation purely on the actual Java object type returned by the Avro API.

The former PR - #415 (this one) - has more safeguards, at the expense of being notably more complex. The latter PR - #416 - relies on the Avro API being correct and uses that trust to simplify the code.

_my recommendation is to merge #416 but I am looking for feedback!_

Note that both PRs leave outstanding work; I will file follow-on tickets for these:
* decoding enum values; see https://github.com/uc-cdis/pypfb/blob/master/docs/detailed_pfb_doc.md#enum
* #415 only handles scalar strings, enums, booleans, and numbers; other datatypes are TODOs
* #416 handles both scalar and array strings, enums, booleans and numbers, but does not handle Avro datatypes map, record, bytes, or fixed.
