### PR TITLE
AJ-1463: update to Spring Boot 2.7.18 and dependency management 1.1.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,6 @@ subprojects {
 
         dependencies {
             dependency 'org.yaml:snakeyaml:2.0'
-            dependency 'io.netty:netty-handler:4.1.94.Final'
             dependency 'org.webjars:webjars-locator-core:0.53'
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
 plugins {
-    id 'org.springframework.boot' version '2.7.12' apply false
-    id 'io.spring.dependency-management' version '1.1.0' apply false
+    id 'org.springframework.boot' version '2.7.18' apply false
+    id 'io.spring.dependency-management' version '1.1.4' apply false
     id 'com.google.cloud.tools.jib' version '3.2.1' apply false
     id "org.sonarqube" version "4.4.1.3373" apply false
     id 'idea'


### PR DESCRIPTION
Version upgrades:
* `org.springframework.boot` 2.7.12 -> 2.7.18
* `io.spring.dependency-management` 1.1.0 -> 1.1.4

The upgrade to the latest Spring Boot version carries with it an upgrade to `io.projectreactor.netty:reactor-netty-http`, which satisfies a Dependabot alert.

```
➜  terra-workspace-data-service git:(da_AJ-1463_updateSpringBoot) gw :service:dependencyInsight --dependency  io.projectreactor.netty:reactor-netty-http

> Configure project :service
The 'sonarqube' task depends on compile tasks. This behavior is now deprecated and will be removed in version 5.x. To avoid implicit compilation, set property 'sonar.gradle.skipCompile' to 'true' and make sure your project is compiled, before analysis has started.
The 'sonar' task depends on compile tasks. This behavior is now deprecated and will be removed in version 5.x. To avoid implicit compilation, set property 'sonar.gradle.skipCompile' to 'true' and make sure your project is compiled, before analysis has started.

> Task :service:dependencyInsight
io.projectreactor.netty:reactor-netty-http:1.0.39 (selected by rule)
  Variant compile:
    | Attribute Name                 | Provided | Requested    |
```

Release notes:
1. https://spring.io/blog/2023/06/22/spring-boot-2-7-13-available-now
2. https://spring.io/blog/2023/07/20/spring-boot-2-7-14-available-now
3. https://spring.io/blog/2023/08/24/spring-boot-2-7-15-available-now
4. https://spring.io/blog/2023/09/21/spring-boot-2-7-16-available-now
5. https://spring.io/blog/2023/10/19/spring-boot-2-7-17-available-now
6. https://spring.io/blog/2023/11/23/spring-boot-2-7-18-available-now

