### PR TITLE
AJ-1489: handle arrays of nulls in PFB import

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -712,7 +712,7 @@ public class RecordDao {
     return inferer.getArrayOfType(attVal.toString(), typeMapping.getJavaArrayTypeForDbWrites());
   }
 
-  private Object[] getListAsArray(List<?> attVal, DataTypeMapping typeMapping) {
+  Object[] getListAsArray(List<?> attVal, DataTypeMapping typeMapping) {
     return switch (typeMapping) {
       case ARRAY_OF_STRING,
           ARRAY_OF_FILE,
@@ -720,7 +720,10 @@ public class RecordDao {
           ARRAY_OF_DATE,
           ARRAY_OF_DATE_TIME,
           ARRAY_OF_NUMBER,
-          EMPTY_ARRAY -> attVal.stream().map(Object::toString).toList().toArray(new String[0]);
+          EMPTY_ARRAY -> attVal.stream()
+          .map(e -> Objects.toString(e, null))
+          .toList()
+          .toArray(new String[0]);
       case ARRAY_OF_BOOLEAN ->
       // accept all casings of True and False if they're strings
       attVal.stream()

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -9,6 +9,7 @@ import static org.databiosphere.workspacedataservice.service.model.exception.Inv
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import java.math.BigDecimal;
 import java.sql.Date;
@@ -712,6 +713,7 @@ public class RecordDao {
     return inferer.getArrayOfType(attVal.toString(), typeMapping.getJavaArrayTypeForDbWrites());
   }
 
+  @VisibleForTesting
   Object[] getListAsArray(List<?> attVal, DataTypeMapping typeMapping) {
     return switch (typeMapping) {
       case ARRAY_OF_STRING,
@@ -721,7 +723,7 @@ public class RecordDao {
           ARRAY_OF_DATE_TIME,
           ARRAY_OF_NUMBER,
           EMPTY_ARRAY -> attVal.stream()
-          .map(e -> Objects.toString(e, null))
+          .map(e -> Objects.toString(e, null)) // .toString() non-nulls, else return null
           .toList()
           .toArray(new String[0]);
       case ARRAY_OF_BOOLEAN ->

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbQuartzJob.java
@@ -119,7 +119,7 @@ public class PfbQuartzJob extends QuartzJob {
         PfbReader.getGenericRecordsStream(url.toString())) {
       return consumer.run(dataStream);
     } catch (Exception e) {
-      throw new PfbParsingException("Error processing PFB", e);
+      throw new PfbParsingException("Error processing PFB: " + e.getMessage(), e);
     }
   }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/DataTypeMapping.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/DataTypeMapping.java
@@ -70,13 +70,18 @@ public enum DataTypeMapping {
       return EMPTY_ARRAY;
     }
     return switch (baseType) {
-      case STRING, NULL -> ARRAY_OF_STRING;
+      case STRING -> ARRAY_OF_STRING;
       case FILE -> ARRAY_OF_FILE;
       case RELATION -> ARRAY_OF_RELATION;
       case BOOLEAN -> ARRAY_OF_BOOLEAN;
       case NUMBER -> ARRAY_OF_NUMBER;
       case DATE -> ARRAY_OF_DATE;
       case DATE_TIME -> ARRAY_OF_DATE_TIME;
+      case NULL ->
+      // if we only detect nulls in the array, we can't detect the intended type.
+      // treat it as a string in this case.
+      ARRAY_OF_STRING;
+
       default -> throw new IllegalArgumentException("No supported array type for " + baseType);
     };
   }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/DataTypeMapping.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/DataTypeMapping.java
@@ -70,7 +70,7 @@ public enum DataTypeMapping {
       return EMPTY_ARRAY;
     }
     return switch (baseType) {
-      case STRING -> ARRAY_OF_STRING;
+      case STRING, NULL -> ARRAY_OF_STRING;
       case FILE -> ARRAY_OF_FILE;
       case RELATION -> ARRAY_OF_RELATION;
       case BOOLEAN -> ARRAY_OF_BOOLEAN;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/DataTypeInfererTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/DataTypeInfererTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -173,6 +174,18 @@ class DataTypeInfererTest {
     assertThat(inferer.inferType("[11, 99, -3.14, 09]")).isEqualTo(DataTypeMapping.STRING);
     assertThat(inferer.inferType("[a]")).isEqualTo(DataTypeMapping.STRING);
     assertThat(inferer.inferType("[11, 99, -3.14, 09]")).isEqualTo(DataTypeMapping.STRING);
+  }
+
+  @Test
+  void inferArraysOfOnlyNulls() {
+    assertThat(inferer.inferType(Arrays.asList(null, null, null)))
+        .isEqualTo(DataTypeMapping.ARRAY_OF_STRING);
+  }
+
+  @Test
+  void inferArraysOfSomeNulls() {
+    assertThat(inferer.inferType(Arrays.asList(null, "foo", null, "bar", null)))
+        .isEqualTo(DataTypeMapping.ARRAY_OF_STRING);
   }
 
   // Test for [AJ-1143]: TSV fails to upload if it has nulls in a relation column

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
@@ -1,9 +1,12 @@
 package org.databiosphere.workspacedataservice.dao;
 
+import static org.databiosphere.workspacedataservice.service.model.DataTypeMapping.ARRAY_OF_NUMBER;
+import static org.databiosphere.workspacedataservice.service.model.DataTypeMapping.ARRAY_OF_STRING;
 import static org.databiosphere.workspacedataservice.service.model.ReservedNames.RECORD_ID;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -28,6 +31,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -956,5 +961,56 @@ class RecordDaoTest {
     // But not other values
     joinVals2 = testDao.getRelationArrayValues(instanceId, "referenceArray", fromRecord2, toType);
     assertIterableEquals(List.of(toRecordId, toRecordId2), joinVals2);
+  }
+
+  @ParameterizedTest(name = "for datatype {0}")
+  @EnumSource(
+      value = DataTypeMapping.class,
+      names = {
+        "ARRAY_OF_STRING",
+        "ARRAY_OF_FILE",
+        "ARRAY_OF_RELATION",
+        "ARRAY_OF_DATE",
+        "ARRAY_OF_DATE_TIME",
+        "ARRAY_OF_NUMBER",
+        "EMPTY_ARRAY"
+      })
+  void testOnlyNullsInList(DataTypeMapping typeMapping) {
+    List<?> input = new ArrayList<>();
+    input.add(null);
+    input.add(null);
+    input.add(null);
+    String[] expected = new String[] {null, null, null};
+    Object[] actual = recordDao.getListAsArray(input, typeMapping);
+
+    assertArrayEquals(expected, actual);
+  }
+
+  @Test
+  void testSomeNullsInStringList() {
+    List<String> input = new ArrayList<>();
+    input.add(null);
+    input.add("foo");
+    input.add(null);
+    input.add("bar");
+    input.add(null);
+    String[] expected = new String[] {null, "foo", null, "bar", null};
+    Object[] actual = recordDao.getListAsArray(input, ARRAY_OF_STRING);
+
+    assertArrayEquals(expected, actual);
+  }
+
+  @Test
+  void testSomeNullsInNumberList() {
+    List<Double> input = new ArrayList<>();
+    input.add(null);
+    input.add(3.14);
+    input.add(null);
+    input.add(789d);
+    input.add(null);
+    String[] expected = new String[] {null, "3.14", null, "789.0", null};
+    Object[] actual = recordDao.getListAsArray(input, ARRAY_OF_NUMBER);
+
+    assertArrayEquals(expected, actual);
   }
 }


### PR DESCRIPTION
Allow WDS to handle arrays of nulls. There were a couple places we didn't handle those - see code comments inline for explanations.