### PR TITLE
Decode PFB enums

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -77,7 +77,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:4.12.0' // required by Sam client
     implementation "bio.terra:datarepo-client:1.537.0-SNAPSHOT"
     implementation "bio.terra:workspace-manager-client:0.254.717-SNAPSHOT"
-    implementation "bio.terra:java-pfb-library:0.14.0"
+    implementation "bio.terra:java-pfb-library:0.15.0"
     implementation project(path: ':client')
 
     // hk2 is required to use WSM client, but not correctly exposed by the client

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbRecordConverter.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbRecordConverter.java
@@ -1,5 +1,7 @@
 package org.databiosphere.workspacedataservice.dataimport;
 
+import static bio.terra.pfb.PfbReader.convertEnum;
+
 import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.List;
@@ -72,8 +74,7 @@ public class PfbRecordConverter {
 
     // Avro enums
     if (attribute instanceof GenericEnumSymbol<?> enumAttr) {
-      // TODO AJ-1479: decode enums using PfbReader.convertEnum
-      return enumAttr.toString();
+      return convertEnum(enumAttr.toString());
     }
 
     // Avro arrays

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/PfbRecordConverterTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/PfbRecordConverterTest.java
@@ -227,4 +227,20 @@ class PfbRecordConverterTest {
     Object actual = pfbRecordConverter.convertAttributeType(input);
     assertEquals(List.of("bar", "foo", "baz"), actual);
   }
+
+  @Test
+  void decodesEnumsCorrectly() {
+    PfbRecordConverter pfbRecordConverter = new PfbRecordConverter();
+
+    Object input =
+        List.of(
+            new GenericData.EnumSymbol(Schema.create(Schema.Type.STRING), "bpm_20__3E__20_60"),
+            new GenericData.EnumSymbol(Schema.create(Schema.Type.STRING), "bpm_20__3E__20_80"),
+            new GenericData.EnumSymbol(
+                Schema.create(Schema.Type.STRING), "only_20_space_20_conversions"),
+            new GenericData.EnumSymbol(Schema.create(Schema.Type.STRING), "noconversion"));
+
+    Object actual = pfbRecordConverter.convertAttributeType(input);
+    assertEquals(List.of("bpm > 60", "bpm > 80", "only space conversions", "noconversion"), actual);
+  }
 }


### PR DESCRIPTION
Ticket: [AJ-1479](https://broadworkbench.atlassian.net/browse/AJ-1479)

This is a shallow fix to converting enum values that include special characters, per the pypfb docs: https://github.com/uc-cdis/pypfb/blob/master/docs/detailed_pfb_doc.md#enum

Depends on https://github.com/DataBiosphere/java-pfb/pull/16 which exposes the `convertEnum` function.

The deeper fix is tracked by [AJ-1288](https://broadworkbench.atlassian.net/browse/AJ-1288).

[AJ-1479]: https://broadworkbench.atlassian.net/browse/AJ-1479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AJ-1288]: https://broadworkbench.atlassian.net/browse/AJ-1288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ