### PR TITLE
AJ-1337: add custom dimensions to application insights metrics

### DIFF
--- a/service/src/main/resources/applicationinsights.json
+++ b/service/src/main/resources/applicationinsights.json
@@ -1,0 +1,6 @@
+{
+  "customDimensions": {
+    "workspaceId": "${WORKSPACE_ID}",
+    "service.version": "${RELEASE_NAME}"
+  }
+}


### PR DESCRIPTION
Adds two custom dimensions to application insights, which we can later use for segmenting or analysis. See https://learn.microsoft.com/en-us/azure/azure-monitor/app/java-standalone-config#custom-dimensions for doc on custom dimensions.

![Screenshot 11-30-2023 at 10 43 AM](https://github.com/DataBiosphere/terra-workspace-data-service/assets/6041577/84ee9b15-4948-43ee-91e2-25916d92489c)

The `service.version` and `workspaceId` dimensions in this PR mirror the `release` and `workspaceId` values we use for Sentry: https://github.com/DataBiosphere/terra-workspace-data-service/blob/0d6aab5b92431c3dd0eae90d13bf240fea7a3709/service/src/main/java/org/databiosphere/workspacedataservice/SentryInitializer.java#L54-L55. The name `service.version` is suggested by Azure in the doc link above.

See also https://github.com/broadinstitute/terra-helmfile/pull/4805, which sets the app insights role name.



