### PR TITLE
AJ-1489 handle array of nulls when saving to db

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -664,7 +664,8 @@ public class RecordDao {
     return records.stream().map(r -> getInsertArgs(r, cols, recordTypeRowIdentifier)).toList();
   }
 
-  private Object getValueForSql(Object attVal, DataTypeMapping typeMapping) {
+  @VisibleForTesting
+  Object getValueForSql(Object attVal, DataTypeMapping typeMapping) {
     if (Objects.isNull(attVal)) {
       return null;
     }
@@ -701,7 +702,9 @@ public class RecordDao {
       return getArrayValues(attVal, typeMapping);
     }
     if (attVal instanceof List<?> list && typeMapping == DataTypeMapping.STRING) {
-      return "{" + list.stream().map(Object::toString).collect(Collectors.joining(",")) + "}";
+      return "{"
+          + list.stream().map(e -> Objects.toString(e, null)).collect(Collectors.joining(","))
+          + "}";
     }
     return attVal;
   }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
@@ -987,6 +987,18 @@ class RecordDaoTest {
   }
 
   @Test
+  void testSqlForNullsList() {
+    List<?> input = new ArrayList<>();
+    input.add(null);
+    input.add(null);
+    input.add(null);
+    String expected = "{null,null,null}";
+    Object actual = recordDao.getValueForSql(input, DataTypeMapping.STRING);
+
+    assertEquals(expected, actual);
+  }
+
+  @Test
   void testSomeNullsInStringList() {
     List<String> input = new ArrayList<>();
     input.add(null);


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1489
Although https://github.com/DataBiosphere/terra-workspace-data-service/pull/422 fixed arrays of nulls when parsing the pfb, it failed to handle them when they are being saved to the database.  This PR implements the same fix and adds a quick unit test.