### PR TITLE
AJ-1351 - Make java version wait for the version bump to ensure all versions align

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -43,6 +43,7 @@ jobs:
     secrets:
       PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
   java-client-job:
+    needs: tag-job
     uses: ./.github/workflows/publish-java-client.yml
     secrets:
       ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}


### PR DESCRIPTION
if you look at the [tag-job](https://github.com/DataBiosphere/terra-workspace-data-service/pull/431/files#diff-84dff8d1094ca39c02ac0e48d951ca22f4da29c76b50ae517f5bd2d50f94c2f6R27) tasks, you will see that this actually pushes a change into main that bumps the version (like [this](https://github.com/DataBiosphere/terra-workspace-data-service/commit/0d6aab5b92431c3dd0eae90d13bf240fea7a3709)) The rest of the tasks in this action all depend on the tag-job and therefore get the updated tag version. The java client tasks spins at the same time as the tag-job tasks without waiting and checks out the [repo](https://github.com/DataBiosphere/terra-workspace-data-service/blob/main/.github/workflows/publish-java-client.yml#L17), so it is not getting the commit with the updated version therefore resulting in the previous version instead. If we make it wait for the commit to be published, we should get the newest version. 

there is no easy way for me to test this without majorly adjusting the github action flow, but I feel pretty confident that this fix should do it :) 

Reminder:

PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 
