### PR TITLE
AJ-1351 - Set specific branch for checkout event

### DIFF
--- a/.github/workflows/publish-java-client.yml
+++ b/.github/workflows/publish-java-client.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          repository: main
+          ref: main
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/publish-java-client.yml
+++ b/.github/workflows/publish-java-client.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          repository: main
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
So the checkout step, if not specified, defaults to the latest [commit ](https://github.com/actions/checkout#checkout-v4)in the default branch (in our case main) at the time of action creation. This means that even though we wait for the version bump to complete, the checkout is done on main prior to the version bump commit. Specifying the branch should make it so it grabs the default commit from main vs the last commit when action is kicked off. 

after more reading, checking this in. ref should do the right thing and no other configuration like fetch-depth should  needed. 

Reminder:

PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 
