### PR TITLE
Add support for Avro `record` type.

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbConfig.java
@@ -1,0 +1,13 @@
+package org.databiosphere.workspacedataservice.dataimport;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class PfbConfig {
+  @Bean
+  public PfbRecordConverter getPfbRecordConverter(ObjectMapper objectMapper) {
+    return new PfbRecordConverter(objectMapper);
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbRecordConverter.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbRecordConverter.java
@@ -1,7 +1,6 @@
 package org.databiosphere.workspacedataservice.dataimport;
 
 import static bio.terra.pfb.PfbReader.convertEnum;
-import static org.databiosphere.workspacedataservice.service.PfbStreamWriteHandler.PfbImportMode.RELATIONS;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbRecordConverter.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbRecordConverter.java
@@ -107,6 +107,10 @@ public class PfbRecordConverter {
     // Avro records
     if (attribute instanceof GenericRecord recordAttr) {
       // According to its Javadoc, GenericData#toString() renders the given datum as JSON
+      // However, it may contribute to numeric precision loss (see:
+      // https://broadworkbench.atlassian.net/browse/AJ-1292)
+      // If that's the case, then it may be necessary to traverse the record recursively and do a
+      // less lossy conversion process.
       return GenericData.get().toString(recordAttr);
     }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbRecordConverter.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbRecordConverter.java
@@ -136,8 +136,8 @@ public class PfbRecordConverter {
     }
 
     // Avro strings
-    if (attribute instanceof String stringAttr) {
-      return stringAttr;
+    if (attribute instanceof CharSequence charSequenceAttr) {
+      return charSequenceAttr.toString();
     }
 
     // Avro bytes

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/BatchWriteService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/BatchWriteService.java
@@ -20,6 +20,7 @@ import java.util.UUID;
 import org.apache.avro.file.DataFileStream;
 import org.apache.avro.generic.GenericRecord;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
+import org.databiosphere.workspacedataservice.dataimport.PfbRecordConverter;
 import org.databiosphere.workspacedataservice.service.model.BatchWriteResult;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
 import org.databiosphere.workspacedataservice.service.model.exception.BadStreamingWriteRequestException;
@@ -44,6 +45,7 @@ public class BatchWriteService {
   private final ObjectReader tsvReader;
 
   private final RecordService recordService;
+  private final PfbRecordConverter pfbRecordConverter;
 
   public BatchWriteService(
       RecordDao recordDao,
@@ -51,13 +53,15 @@ public class BatchWriteService {
       DataTypeInferer inf,
       ObjectMapper objectMapper,
       ObjectReader tsvReader,
-      RecordService recordService) {
+      RecordService recordService,
+      PfbRecordConverter pfbRecordConverter) {
     this.recordDao = recordDao;
     this.batchSize = batchSize;
     this.inferer = inf;
     this.objectMapper = objectMapper;
     this.tsvReader = tsvReader;
     this.recordService = recordService;
+    this.pfbRecordConverter = pfbRecordConverter;
   }
 
   private BatchWriteResult consumeWriteStream(
@@ -214,7 +218,7 @@ public class BatchWriteService {
       Optional<String> primaryKey,
       PfbStreamWriteHandler.PfbImportMode pfbImportMode) {
     try (PfbStreamWriteHandler streamingWriteHandler =
-        new PfbStreamWriteHandler(is, pfbImportMode, objectMapper)) {
+        new PfbStreamWriteHandler(is, pfbImportMode, pfbRecordConverter)) {
       return consumeWriteStreamWithRelations(
           streamingWriteHandler, instanceId, null, primaryKey, pfbImportMode);
     } catch (IOException e) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/BatchWriteService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/BatchWriteService.java
@@ -214,7 +214,7 @@ public class BatchWriteService {
       Optional<String> primaryKey,
       PfbStreamWriteHandler.PfbImportMode pfbImportMode) {
     try (PfbStreamWriteHandler streamingWriteHandler =
-        new PfbStreamWriteHandler(is, pfbImportMode)) {
+        new PfbStreamWriteHandler(is, pfbImportMode, objectMapper)) {
       return consumeWriteStreamWithRelations(
           streamingWriteHandler, instanceId, null, primaryKey, pfbImportMode);
     } catch (IOException e) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/PfbStreamWriteHandler.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/PfbStreamWriteHandler.java
@@ -1,5 +1,6 @@
 package org.databiosphere.workspacedataservice.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.List;
 import java.util.Spliterator;
@@ -13,7 +14,6 @@ import org.databiosphere.workspacedataservice.shared.model.OperationType;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 
 public class PfbStreamWriteHandler implements StreamingWriteHandler {
-
   public enum PfbImportMode {
     RELATIONS,
     BASE_ATTRIBUTES
@@ -21,6 +21,7 @@ public class PfbStreamWriteHandler implements StreamingWriteHandler {
 
   private final DataFileStream<GenericRecord> inputStream;
   private final PfbImportMode pfbImportMode;
+  private final PfbRecordConverter pfbRecordConverter;
 
   /**
    * Create a new PfbStreamWriteHandler and specify the expected schemas for the PFB.
@@ -28,9 +29,12 @@ public class PfbStreamWriteHandler implements StreamingWriteHandler {
    * @param inputStream the PFB stream
    */
   public PfbStreamWriteHandler(
-      DataFileStream<GenericRecord> inputStream, PfbImportMode pfbImportMode) {
+      DataFileStream<GenericRecord> inputStream,
+      PfbImportMode pfbImportMode,
+      ObjectMapper objectMapper) {
     this.inputStream = inputStream;
     this.pfbImportMode = pfbImportMode;
+    this.pfbRecordConverter = new PfbRecordConverter(objectMapper);
   }
 
   public WriteStreamInfo readRecords(int numRecords) {
@@ -41,7 +45,6 @@ public class PfbStreamWriteHandler implements StreamingWriteHandler {
             .limit(numRecords);
 
     // convert the PFB GenericRecord objects into WDS Record objects
-    PfbRecordConverter pfbRecordConverter = new PfbRecordConverter();
     List<Record> records =
         pfbBatch.map(rec -> pfbRecordConverter.genericRecordToRecord(rec, pfbImportMode)).toList();
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/PfbStreamWriteHandler.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/PfbStreamWriteHandler.java
@@ -1,6 +1,5 @@
 package org.databiosphere.workspacedataservice.service;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.List;
 import java.util.Spliterator;
@@ -27,14 +26,16 @@ public class PfbStreamWriteHandler implements StreamingWriteHandler {
    * Create a new PfbStreamWriteHandler and specify the expected schemas for the PFB.
    *
    * @param inputStream the PFB stream
+   * @param pfbImportMode the mode to use when importing the PFB
+   * @param pfbRecordConverter the converter to use when converting PFB records to WDS records
    */
   public PfbStreamWriteHandler(
       DataFileStream<GenericRecord> inputStream,
       PfbImportMode pfbImportMode,
-      ObjectMapper objectMapper) {
+      PfbRecordConverter pfbRecordConverter) {
     this.inputStream = inputStream;
     this.pfbImportMode = pfbImportMode;
-    this.pfbRecordConverter = new PfbRecordConverter(objectMapper);
+    this.pfbRecordConverter = pfbRecordConverter;
   }
 
   public WriteStreamInfo readRecords(int numRecords) {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/SmallBatchWriteTestConfig.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/SmallBatchWriteTestConfig.java
@@ -3,6 +3,7 @@ package org.databiosphere.workspacedataservice.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
+import org.databiosphere.workspacedataservice.dataimport.PfbRecordConverter;
 import org.databiosphere.workspacedataservice.service.BatchWriteService;
 import org.databiosphere.workspacedataservice.service.DataTypeInferer;
 import org.databiosphere.workspacedataservice.service.RecordService;
@@ -22,7 +23,9 @@ public class SmallBatchWriteTestConfig {
       DataTypeInferer inf,
       ObjectMapper objectMapper,
       ObjectReader tsvReader,
-      RecordService recordService) {
-    return new BatchWriteService(recordDao, 1, inf, objectMapper, tsvReader, recordService);
+      RecordService recordService,
+      PfbRecordConverter pfbRecordConverter) {
+    return new BatchWriteService(
+        recordDao, 1, inf, objectMapper, tsvReader, recordService, pfbRecordConverter);
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/PfbRecordConverterTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/PfbRecordConverterTest.java
@@ -33,11 +33,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 
+@SpringBootTest(classes = {JsonConfig.class, PfbConfig.class})
 class PfbRecordConverterTest {
 
-  private final PfbRecordConverter converter =
-      new PfbRecordConverter(new JsonConfig().objectMapper());
+  @Autowired private PfbRecordConverter converter;
 
   // PFB "id" and "name" columns become the WDS Record id and type, respectively
   @Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/PfbTestUtils.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/PfbTestUtils.java
@@ -19,6 +19,7 @@ import org.apache.avro.SchemaBuilder;
 import org.apache.avro.file.DataFileStream;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
 import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.retry.RestClientRetry;
@@ -101,12 +102,12 @@ public class PfbTestUtils {
    */
   public static GenericRecord makeRecord(
       String id, String name, GenericData.Record objectAttributes, GenericData.Array relations) {
-    GenericRecord rec = new GenericData.Record(RECORD_SCHEMA);
-    rec.put("id", id);
-    rec.put("name", name);
-    rec.put("object", objectAttributes);
-    rec.put("relations", relations);
-    return rec;
+    return new GenericRecordBuilder(RECORD_SCHEMA)
+        .set("id", id)
+        .set("name", name)
+        .set("object", objectAttributes)
+        .set("relations", relations)
+        .build();
   }
 
   public static DataFileStream<GenericRecord> mockPfbStream(int numRows, String name) {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/PfbStreamWriteHandlerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/PfbStreamWriteHandlerTest.java
@@ -14,14 +14,20 @@ import java.net.URL;
 import java.util.List;
 import org.apache.avro.file.DataFileStream;
 import org.apache.avro.generic.GenericRecord;
+import org.databiosphere.workspacedataservice.dataimport.PfbRecordConverter;
 import org.databiosphere.workspacedataservice.service.PfbStreamWriteHandler.PfbImportMode;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 
+@SpringBootTest(classes = {JsonConfig.class, PfbRecordConverter.class})
 class PfbStreamWriteHandlerTest {
+  @Autowired private PfbRecordConverter pfbRecordConverter;
+
   // does PfbStreamWriteHandler properly know how to page through a DataFileStream<GenericRecord>?
   @Test
   void testBatching() {
@@ -195,8 +201,8 @@ class PfbStreamWriteHandlerTest {
     return PfbReader.getGenericRecordsStream(url.toString());
   }
 
-  private static PfbStreamWriteHandler buildHandler(
+  private PfbStreamWriteHandler buildHandler(
       DataFileStream<GenericRecord> dataFileStream, PfbImportMode importMode) {
-    return new PfbStreamWriteHandler(dataFileStream, importMode, new JsonConfig().objectMapper());
+    return new PfbStreamWriteHandler(dataFileStream, importMode, pfbRecordConverter);
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/PfbStreamWriteHandlerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/PfbStreamWriteHandlerTest.java
@@ -1,8 +1,7 @@
 package org.databiosphere.workspacedataservice.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.databiosphere.workspacedataservice.service.PfbStreamWriteHandler.PfbImportMode.BASE_ATTRIBUTES;
-import static org.databiosphere.workspacedataservice.service.PfbStreamWriteHandler.PfbImportMode.RELATIONS;
+import static org.databiosphere.workspacedataservice.dataimport.PfbTestUtils.mockPfbStream;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -15,7 +14,7 @@ import java.net.URL;
 import java.util.List;
 import org.apache.avro.file.DataFileStream;
 import org.apache.avro.generic.GenericRecord;
-import org.databiosphere.workspacedataservice.dataimport.PfbTestUtils;
+import org.databiosphere.workspacedataservice.service.PfbStreamWriteHandler.PfbImportMode;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 import org.junit.jupiter.api.Test;
@@ -23,15 +22,12 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class PfbStreamWriteHandlerTest {
-
   // does PfbStreamWriteHandler properly know how to page through a DataFileStream<GenericRecord>?
   @Test
   void testBatching() {
-
     // create a mock PFB stream with 10 rows in it and a PfbStreamWriteHandler for that stream
-    DataFileStream<GenericRecord> dataFileStream = PfbTestUtils.mockPfbStream(10, "someType");
     PfbStreamWriteHandler pfbStreamWriteHandler =
-        new PfbStreamWriteHandler(dataFileStream, BASE_ATTRIBUTES);
+        buildHandler(mockPfbStream(10, "someType"), PfbImportMode.BASE_ATTRIBUTES);
 
     StreamingWriteHandler.WriteStreamInfo batch; // used in assertions below
 
@@ -58,9 +54,8 @@ class PfbStreamWriteHandlerTest {
   @ParameterizedTest(name = "dont error if input has {0} row(s)")
   @ValueSource(ints = {0, 1, 49, 50, 51, 99, 100, 101})
   void inputStreamOfCount(Integer numRows) {
-    DataFileStream<GenericRecord> dataFileStream = PfbTestUtils.mockPfbStream(numRows, "someType");
     PfbStreamWriteHandler pfbStreamWriteHandler =
-        new PfbStreamWriteHandler(dataFileStream, BASE_ATTRIBUTES);
+        buildHandler(mockPfbStream(numRows, "someType"), PfbImportMode.BASE_ATTRIBUTES);
 
     int batchSize = 50;
 
@@ -79,12 +74,8 @@ class PfbStreamWriteHandlerTest {
   // Given a real PFB file, does PfbStreamWriteHandler faithfully return the records inside that
   // PFB?
   void pfbTablesAreParsedCorrectly() {
-    URL url = getClass().getResource("/two_tables.avro");
-    assertNotNull(url);
-    try (DataFileStream<GenericRecord> dataStream =
-        PfbReader.getGenericRecordsStream(url.toString())) {
-
-      PfbStreamWriteHandler pswh = new PfbStreamWriteHandler(dataStream, BASE_ATTRIBUTES);
+    try (DataFileStream<GenericRecord> dataFileStream = streamRecordsFromFile("/two_tables.avro")) {
+      PfbStreamWriteHandler pswh = buildHandler(dataFileStream, PfbImportMode.BASE_ATTRIBUTES);
       StreamingWriteHandler.WriteStreamInfo streamInfo = pswh.readRecords(2);
       /*
         Expected records:
@@ -156,13 +147,10 @@ class PfbStreamWriteHandlerTest {
 
   @Test
   void relationsAreParsedCorrectly() {
-    URL url = getClass().getResource("/test.avro");
-    assertNotNull(url);
-    try (DataFileStream<GenericRecord> dataStream =
-        PfbReader.getGenericRecordsStream(url.toString())) {
+    try (DataFileStream<GenericRecord> dataFileStream = streamRecordsFromFile("/test.avro")) {
 
-      PfbStreamWriteHandler pswh = new PfbStreamWriteHandler(dataStream, RELATIONS);
-      StreamingWriteHandler.WriteStreamInfo streamInfo = pswh.readRecords(5);
+      StreamingWriteHandler.WriteStreamInfo streamInfo =
+          buildHandler(dataFileStream, PfbImportMode.RELATIONS).readRecords(5);
 
       List<Record> result = streamInfo.getRecords();
       assertEquals(5, result.size());
@@ -199,5 +187,16 @@ class PfbStreamWriteHandlerTest {
     } catch (IOException e) {
       fail(e);
     }
+  }
+
+  private DataFileStream<GenericRecord> streamRecordsFromFile(String fileName) throws IOException {
+    URL url = getClass().getResource(fileName);
+    assertNotNull(url);
+    return PfbReader.getGenericRecordsStream(url.toString());
+  }
+
+  private static PfbStreamWriteHandler buildHandler(
+      DataFileStream<GenericRecord> dataFileStream, PfbImportMode importMode) {
+    return new PfbStreamWriteHandler(dataFileStream, importMode, new JsonConfig().objectMapper());
   }
 }


### PR DESCRIPTION
[AJ-1478](https://broadworkbench.atlassian.net/browse/AJ-1478): Respect additional datatypes when parsing PFBs.

Main change:
* Add support for Avro `record` type.

Also:
* Use `objectMapper` to stringify `map` attributes, instead of recursively serializing them.
* Test enums using parameterized test.
* Switch to using `GenericRecordBuilder`.
* Make `PfbRecordConverter` a Spring-managed `@Bean`.

[AJ-1478]: https://broadworkbench.atlassian.net/browse/AJ-1478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ