### PR TITLE
QA-2191: Shift contract tests versioning to semver

### DIFF
--- a/.github/workflows/publish-pacts.yml
+++ b/.github/workflows/publish-pacts.yml
@@ -16,6 +16,37 @@ env:
   WDS_PACTS_OUTPUT_DIR: service/build/pacts/
 
 jobs:
+  # The primary objective of this section is to carefully control the dispatching of tags,
+  # ensuring it only occurs during the 'Tag, publish, deploy' workflow.
+  # However, a challenge arises with contract tests, as they require knowledge of the upcoming tag
+  # before the actual deployment. To address this, we leverage the dry run feature provided by bumper.
+  # This allows us to obtain the next tag for publishing contracts and verifying consumer pacts without
+  # triggering the tag dispatch. This approach sidesteps the need for orchestrating multiple workflows,
+  # simplifying our implementation.
+  #
+  # We regulate the tag job to meet the following requirements according to the trigger event type:
+  # 1. pull_request event (due to opening or updating of PR branch):
+  #      dry-run flag is set to false
+  #         this allows the new semver tag #major.#minor.#patch-#commit to be used to identity pacticipant version for development purpose
+  #         PR has no effect on the value of the latest tag in settings.gradle on disk
+  # 2. PR merge to main, this triggers a push event on the main branch:
+  #      dry-run flag is set to true
+  #         this allows the new semver tag #major.#minor.#patch to be used to identity pacticipant version, and
+  #         this action will not update the value of the latest tag in settings.gradle on disk
+  #
+  # Note: All workflows from the same PR merge should have the same copy of settings.gradle on disk,
+  # which should be the one from the HEAD of the main branch before the workflow starts running
+  regulated-tag-job:
+    uses: ./.github/workflows/tag-0.3.0.yml
+    with:
+      # The 'ref' parameter ensures that the consumer version is postfixed with the HEAD commit of the PR branch,
+      # facilitating cross-referencing of a pact between Pact Broker and GitHub.
+      ref: ${{ github.head_ref || '' }}
+      # The 'dry-run' parameter prevents the new tag from being dispatched.
+      dry-run: true
+      release-branches: main
+    secrets: inherit
+
   init-github-context:
     runs-on: ubuntu-latest
     outputs:
@@ -96,7 +127,7 @@ jobs:
 
   publish-pacts-job:
     runs-on: ubuntu-latest
-    needs: [ init-github-context, run-consumer-contract-tests ]
+    needs: [ regulated-tag-job, init-github-context, run-consumer-contract-tests ]
     strategy:
       matrix:
         pact_path: ${{ fromJson(needs.run-consumer-contract-tests.outputs.pact-paths) }}
@@ -128,5 +159,6 @@ jobs:
             "pact-b64": "${{ steps.encode-pact.outputs.pact-b64 }}",
             "repo-owner": "${{ github.repository_owner }}",
             "repo-name": "${{ github.event.repository.name }}",
-            "repo-branch": "${{ needs.init-github-context.outputs.repo-branch }}"
+            "repo-branch": "${{ needs.init-github-context.outputs.repo-branch }}",
+            "release-tag": "${{ needs.regulated-tag-job.outputs.new-tag }}"
           }'

--- a/.github/workflows/tag-0.3.0.yml
+++ b/.github/workflows/tag-0.3.0.yml
@@ -1,0 +1,72 @@
+name: Tag 0.3.0
+on:
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      ref:
+        description: "The branch, tag or SHA to checkout"
+        default: ''
+        required: false
+        type: string
+      dry-run:
+        description: "Determine the next version without tagging the branch. The workflow can use the outputs new_tag and tag in subsequent steps. Possible values are true and false (default)"
+        default: false
+        required: false
+        type: string
+      print-tag:
+        description: "Echo tag to console"
+        default: true
+        required: false
+        type: string
+      release-branches:
+        description: "Default branch (main, develop, etc)"
+        default: 'main'
+        required: false
+        type: string
+    outputs:
+      tag:
+        description: "The value of the latest tag after running this action"
+        value: ${{ jobs.tag-job.outputs.tag }}
+      new-tag:
+        description: "The value of the newly created tag"
+        value: ${{ jobs.tag-job.outputs.new-tag }}
+    secrets:
+      BROADBOT_TOKEN:
+        required: true
+
+jobs:
+  # On tag vs. new-tag.
+  # The new-tag is always the tag resulting from a bump to the original tag.
+  # However, the tag is by definition the value of the latest tag after running the action,
+  # which might not change if dry run is used, and remains same as the original tag.
+  tag-job:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+      new-tag: ${{ steps.tag.outputs.new_tag }}
+    steps:
+      - name: Checkout current code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          token: ${{ secrets.BROADBOT_TOKEN }} # this allows the push to succeed later
+      - name: Bump the tag to a new version
+        # https://github.com/DataBiosphere/github-actions/tree/master/actions/bumper
+        uses: databiosphere/github-actions/actions/bumper@bumper-0.3.0
+        id: tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
+          HOTFIX_BRANCHES: hotfix.*
+          DEFAULT_BUMP: patch
+          DRY_RUN: ${{ inputs.dry-run }}
+          RELEASE_BRANCHES: ${{ inputs.release-branches }}
+          VERSION_FILE_PATH: build.gradle
+          VERSION_LINE_MATCH: "^\\s*version\\s*=\\s*'.*'"
+          VERSION_SUFFIX: SNAPSHOT
+      - name: Echo tag to console
+        if: ${{ inputs.print-tag == 'true' }}
+        run: |
+          echo "Newly created version tag: '${{ steps.tag.outputs.new_tag }}'"
+          echo "build.gradle"
+          echo "==============="
+          cat build.gradle

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Bump the tag to a new version
         # https://github.com/DataBiosphere/github-actions/tree/master/actions/bumper
-        uses: databiosphere/github-actions/actions/bumper@bumper-0.2.0
+        uses: databiosphere/github-actions/actions/bumper@bumper-0.3.0
         id: tag
         env:
           GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}


### PR DESCRIPTION
Jira ticket: [QA-2191](https://broadworkbench.atlassian.net/browse/QA-2191)

More details on why we're doing this shifting:

- Create a ledger to trace published contracts through PR and merge commits. 
- To be consistent with Sherlock app versioning

Here's the expected behavior of the `semver` versioning in the context of contract tests
**Multiple Developers and Commits in a PR**

- Multiple developers can collaborate on the same pull request (PR).
- The PR can have multiple commits.

**Continuous Publishing of Contracts**

- WDS contracts from PRs are published to Pact Broker.
- The tagging mechanism is introduced to create a ledger of published contracts in Pact Broker. For PRs, the tag is appended with the commit hash. The contracts will be published using the new tag without hash.
- This ledger allows developers to trace issues on both the consumer or provider side.

Reminder:

PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 


[QA-2191]: https://broadworkbench.atlassian.net/browse/QA-2191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ