### PR TITLE
AJ-1013: TDR snapshot import

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -85,7 +85,7 @@ dependencies {
     // Parquet, used for TDR snapshot import
     implementation "org.apache.parquet:parquet-common:$parquet_mr_version"
     implementation "org.apache.parquet:parquet-avro:$parquet_mr_version"
-    implementation("org.apache.parquet:parquet-hadoop:$parquet_mr_version")
+    implementation "org.apache.parquet:parquet-hadoop:$parquet_mr_version"
 
     // we need Hadoop libraries to read Parquet files for TDR import. However, Hadoop brings
     // a boatload of transitive dependencies we don't need, some of which (e.g. com.sun.xml.bind)

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -87,12 +87,10 @@ dependencies {
     implementation "org.apache.parquet:parquet-avro:$parquet_mr_version"
     implementation("org.apache.parquet:parquet-hadoop:$parquet_mr_version")
 
-    // Hadoop libraries, used for TDR snapshot import
     // we need Hadoop libraries to read Parquet files for TDR import. However, Hadoop brings
     // a boatload of transitive dependencies we don't need, some of which (e.g. com.sun.xml.bind)
     // cause conflicts. Exclude a lot of the transitive deps. Inspired by https://stackoverflow.com/a/60067027
-    // TODO AJ-1013 can the excludes be factored out into a common method?
-    implementation("org.apache.hadoop:hadoop-common:$hadoop_version") {
+    def withoutHadoopExcludes = {
         exclude(group: 'log4j')
         exclude(group: 'org.slf4j')
         exclude(group: 'org.mortbay.jetty')
@@ -104,18 +102,8 @@ dependencies {
         exclude(group: 'org.apache.kerby')
         exclude(group: 'com.google.protobuf')
     }
-    implementation("org.apache.hadoop:hadoop-mapreduce-client-core:$hadoop_version") {
-        exclude(group: 'log4j')
-        exclude(group: 'org.slf4j')
-        exclude(group: 'org.mortbay.jetty')
-        exclude(group: 'javax.servlet.jsp')
-        exclude(group: 'com.sun.jersey')
-        exclude(group: 'com.sun.xml.bind')
-        exclude(group: 'org.apache.curator')
-        exclude(group: 'org.apache.zookeeper')
-        exclude(group: 'org.apache.kerby')
-        exclude(group: 'com.google.protobuf')
-    }
+    implementation "org.apache.hadoop:hadoop-common:$hadoop_version", withoutHadoopExcludes
+    implementation "org.apache.hadoop:hadoop-mapreduce-client-core:$hadoop_version", withoutHadoopExcludes
 
     // hk2 is required to use WSM client, but not correctly exposed by the client
     implementation "org.glassfish.jersey.inject:jersey-hk2:$jersey_version"

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -37,6 +37,8 @@ jib {
 
 ext {
     jersey_version = "2.36"
+    parquet_mr_version = "1.13.1"
+    hadoop_version = "3.3.6"
 }
 
 dependencies {
@@ -79,6 +81,41 @@ dependencies {
     implementation "bio.terra:workspace-manager-client:0.254.717-SNAPSHOT"
     implementation "bio.terra:java-pfb-library:0.15.0"
     implementation project(path: ':client')
+
+    // Parquet, used for TDR snapshot import
+    implementation "org.apache.parquet:parquet-common:$parquet_mr_version"
+    implementation "org.apache.parquet:parquet-avro:$parquet_mr_version"
+    implementation("org.apache.parquet:parquet-hadoop:$parquet_mr_version")
+
+    // Hadoop libraries, used for TDR snapshot import
+    // we need Hadoop libraries to read Parquet files for TDR import. However, Hadoop brings
+    // a boatload of transitive dependencies we don't need, some of which (e.g. com.sun.xml.bind)
+    // cause conflicts. Exclude a lot of the transitive deps. Inspired by https://stackoverflow.com/a/60067027
+    // TODO AJ-1013 can the excludes be factored out into a common method?
+    implementation("org.apache.hadoop:hadoop-common:$hadoop_version") {
+        exclude(group: 'log4j')
+        exclude(group: 'org.slf4j')
+        exclude(group: 'org.mortbay.jetty')
+        exclude(group: 'javax.servlet.jsp')
+        exclude(group: 'com.sun.jersey')
+        exclude(group: 'com.sun.xml.bind')
+        exclude(group: 'org.apache.curator')
+        exclude(group: 'org.apache.zookeeper')
+        exclude(group: 'org.apache.kerby')
+        exclude(group: 'com.google.protobuf')
+    }
+    implementation("org.apache.hadoop:hadoop-mapreduce-client-core:$hadoop_version") {
+        exclude(group: 'log4j')
+        exclude(group: 'org.slf4j')
+        exclude(group: 'org.mortbay.jetty')
+        exclude(group: 'javax.servlet.jsp')
+        exclude(group: 'com.sun.jersey')
+        exclude(group: 'com.sun.xml.bind')
+        exclude(group: 'org.apache.curator')
+        exclude(group: 'org.apache.zookeeper')
+        exclude(group: 'org.apache.kerby')
+        exclude(group: 'com.google.protobuf')
+    }
 
     // hk2 is required to use WSM client, but not correctly exposed by the client
     implementation "org.glassfish.jersey.inject:jersey-hk2:$jersey_version"

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/AvroRecordConverter.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/AvroRecordConverter.java
@@ -22,10 +22,7 @@ import org.databiosphere.workspacedataservice.shared.model.RecordType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * Logic to convert Avro GenericRecord to WDS's Record Avro GenericRecord is used by PFB import and
- * TDR import.
- */
+/** Logic to convert Avro GenericRecord to WDS's Record. Used by PFB import and TDR import. */
 public abstract class AvroRecordConverter {
   private static final Logger LOGGER = LoggerFactory.getLogger(AvroRecordConverter.class);
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/AvroRecordConverter.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/AvroRecordConverter.java
@@ -1,0 +1,165 @@
+package org.databiosphere.workspacedataservice.dataimport;
+
+import static bio.terra.pfb.PfbReader.convertEnum;
+import static org.databiosphere.workspacedataservice.service.PfbStreamWriteHandler.PfbImportMode.RELATIONS;
+
+import com.google.mu.util.stream.BiStream;
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericEnumSymbol;
+import org.apache.avro.generic.GenericFixed;
+import org.apache.avro.generic.GenericRecord;
+import org.databiosphere.workspacedataservice.service.PfbStreamWriteHandler;
+import org.databiosphere.workspacedataservice.shared.model.Record;
+import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Logic to convert Avro GenericRecord to WDS's Record Avro GenericRecord is used by PFB import and
+ * TDR import.
+ */
+public abstract class AvroRecordConverter {
+  private static final Logger LOGGER = LoggerFactory.getLogger(AvroRecordConverter.class);
+
+  public AvroRecordConverter() {}
+
+  /**
+   * Create the "shell" Record, with a valid RecordId and a valid RecordType, but no attributes.
+   * Subclasses must implement this method, which is called for every GenericRecord in the inbound
+   * import data.
+   *
+   * @param genRec the Avro GenericRecord to be converted
+   * @return the WDS Record shell
+   */
+  abstract Record createRecordShell(GenericRecord genRec);
+
+  abstract Record addAttributes(GenericRecord objectAttributes, Record converted);
+
+  abstract Record addRelations(GenericRecord genRec, Record converted);
+
+  public Record genericRecordToRecord(
+      GenericRecord genRec, PfbStreamWriteHandler.PfbImportMode pfbImportMode) {
+    // create the WDS record shell (id, record type, empty attributes)
+    Record converted = createRecordShell(genRec);
+    if (pfbImportMode == RELATIONS) {
+      return addRelations(genRec, converted);
+    } else {
+      return addAttributes(genRec, converted);
+    }
+  }
+
+  protected Record addAttributes(
+      GenericRecord objectAttributes, Record converted, Set<String> ignoreAttributes) {
+    // loop over all Avro fields and add to the record's attributes
+    Schema schema = objectAttributes.getSchema();
+    List<Schema.Field> fields = schema.getFields();
+    RecordAttributes attributes = RecordAttributes.empty();
+    for (Schema.Field field : fields) {
+      String fieldName = field.name();
+      // if this attribute is marked as ignorable, skip it
+      if (ignoreAttributes.contains(fieldName)) {
+        continue;
+      }
+      Object value =
+          objectAttributes.get(fieldName) == null
+              ? null
+              : convertAttributeType(objectAttributes.get(fieldName));
+      attributes.putAttribute(fieldName, value);
+    }
+    converted.setAttributes(attributes);
+    return converted;
+  }
+
+  protected Object convertAttributeType(Object attribute) {
+
+    if (attribute == null) {
+      return null;
+    }
+
+    // For list of Avro types - see
+    // https://avro.apache.org/docs/current/api/java/org/apache/avro/generic/package-summary.html#package_description
+
+    // Avro records
+    if (attribute instanceof GenericRecord recordAttr) {
+      return recordAttr.toString(); // TODO AJ-1478: Make these into WDS json?
+    }
+
+    // Avro enums
+    if (attribute instanceof GenericEnumSymbol<?> enumAttr) {
+      return convertEnum(enumAttr.toString());
+    }
+
+    // Avro arrays
+    if (attribute instanceof Collection<?> collAttr) {
+      // recurse
+      return collAttr.stream().map(this::convertAttributeType).toList();
+    }
+
+    // Avro maps
+    if (attribute instanceof Map<?, ?> mapAttr) {
+      // recurse
+      return BiStream.from(mapAttr)
+          .mapKeys(Object::toString)
+          .mapValues(this::convertAttributeType)
+          .toMap();
+    }
+
+    // Avro fixed
+    if (attribute instanceof GenericFixed fixedAttr) {
+      return new String(fixedAttr.bytes());
+    }
+
+    // Avro strings
+    if (attribute instanceof String stringAttr) {
+      return stringAttr;
+    }
+
+    // Avro bytes
+    if (attribute instanceof ByteBuffer byteBufferAttr) {
+      return new String(byteBufferAttr.array());
+    }
+
+    // Avro ints
+    if (attribute instanceof Integer intAttr) {
+      return BigDecimal.valueOf(intAttr);
+    }
+
+    // Avro longs
+    if (attribute instanceof Long longAttr) {
+      return BigDecimal.valueOf(longAttr);
+    }
+
+    // Avro floats
+    if (attribute instanceof Float floatAttr) {
+      return BigDecimal.valueOf(floatAttr);
+    }
+
+    // Avro doubles
+    if (attribute instanceof Double doubleAttr) {
+      return BigDecimal.valueOf(doubleAttr);
+    }
+
+    // Avro booleans
+    if (attribute instanceof Boolean boolAttr) {
+      return boolAttr;
+    }
+
+    // We don't see this type in PFB files, is this specific to parquet-mr?
+    if (attribute instanceof org.apache.avro.util.Utf8 utf8data) {
+      return new String(utf8data.getBytes(), StandardCharsets.UTF_8);
+    }
+
+    LOGGER.warn(
+        "convertAttributeType received value \"{}\" with unexpected type {}",
+        attribute,
+        attribute.getClass());
+    return attribute.toString();
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/AvroRecordConverter.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/AvroRecordConverter.java
@@ -15,7 +15,7 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericEnumSymbol;
 import org.apache.avro.generic.GenericFixed;
 import org.apache.avro.generic.GenericRecord;
-import org.databiosphere.workspacedataservice.service.PfbStreamWriteHandler;
+import org.databiosphere.workspacedataservice.service.TwoPassStreamingWriteHandler;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
@@ -54,7 +54,7 @@ public abstract class AvroRecordConverter {
   abstract RecordType extractRecordType(GenericRecord genericRecord);
 
   /**
-   * When operating in {@see PfbStreamWriteHandler.PfbImportMode.BASE_ATTRIBUTES} mode, what
+   * When operating in {@see TwoPassStreamingWriteHandler.ImportMode.BASE_ATTRIBUTES} mode, what
    * attributes should be upserted for this GenericRecord?
    *
    * @param genericRecord the inbound Avro GenericRecord to be converted
@@ -63,8 +63,8 @@ public abstract class AvroRecordConverter {
   abstract RecordAttributes extractBaseAttributes(GenericRecord genericRecord);
 
   /**
-   * When operating in {@see PfbStreamWriteHandler.PfbImportMode.RELATIONS} mode, what attributes
-   * should be upserted for this GenericRecord?
+   * When operating in {@see TwoPassStreamingWriteHandler.ImportMode.RELATIONS} mode, what
+   * attributes should be upserted for this GenericRecord?
    *
    * @param genericRecord the inbound Avro GenericRecord to be converted
    * @return the WDS relation attributes
@@ -72,14 +72,14 @@ public abstract class AvroRecordConverter {
   abstract RecordAttributes extractRelations(GenericRecord genericRecord);
 
   public Record genericRecordToRecord(
-      GenericRecord genRec, PfbStreamWriteHandler.PfbImportMode pfbImportMode) {
+      GenericRecord genRec, TwoPassStreamingWriteHandler.ImportMode importMode) {
     // determine id and type for this record
     String id = extractRecordId(genRec);
     RecordType recordType = extractRecordType(genRec);
 
     // determine attributes for this record
     RecordAttributes recordAttributes =
-        switch (pfbImportMode) {
+        switch (importMode) {
           case RELATIONS -> extractRelations(genRec);
           case BASE_ATTRIBUTES -> extractBaseAttributes(genRec);
         };

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ParquetRecordConverter.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ParquetRecordConverter.java
@@ -13,7 +13,7 @@ import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 
 /** Logic to convert a TDR Parquet's GenericRecord to WDS's Record */
-// TODO AJ-1013 should ParquetRecordConverter be a bean, like PfbRecordConverter? Right now,
+// TODO AJ-1522 should ParquetRecordConverter be a bean, like PfbRecordConverter? Right now,
 //     we construct separate ParquetRecordConverter instances for each table being imported.
 public class ParquetRecordConverter extends AvroRecordConverter {
   private final RecordType recordType;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ParquetRecordConverter.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ParquetRecordConverter.java
@@ -1,176 +1,39 @@
 package org.databiosphere.workspacedataservice.dataimport;
 
-import static bio.terra.pfb.PfbReader.convertEnum;
-import static org.databiosphere.workspacedataservice.service.PfbStreamWriteHandler.PfbImportMode.RELATIONS;
-
-import com.google.mu.util.stream.BiStream;
-import java.math.BigDecimal;
-import java.nio.ByteBuffer;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericEnumSymbol;
-import org.apache.avro.generic.GenericFixed;
+import java.util.Set;
 import org.apache.avro.generic.GenericRecord;
-import org.databiosphere.workspacedataservice.service.PfbStreamWriteHandler;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-// TODO AJ-1013 consolidate code with PfbRecordConverter
 /** Logic to convert a TDR Parquet's GenericRecord to WDS's Record */
-public class ParquetRecordConverter {
+public class ParquetRecordConverter extends AvroRecordConverter {
   private static final Logger LOGGER = LoggerFactory.getLogger(ParquetRecordConverter.class);
-
-  //  public static final String RELATIONS_FIELD = "relations";
-  //  public static final String RELATIONS_ID = "dst_id";
-  //  public static final String RELATIONS_NAME = "dst_name";
 
   private final RecordType recordType;
   private final String idField;
 
   public ParquetRecordConverter(RecordType recordType, String idField) {
+    super();
     this.recordType = recordType;
     this.idField = idField;
   }
 
-  public Record genericRecordToRecord(
-      GenericRecord genRec, PfbStreamWriteHandler.PfbImportMode pfbImportMode) {
-    // create the WDS record shell (id, record type, empty attributes)
-    Record converted =
-        new Record(genRec.get(idField).toString(), recordType, RecordAttributes.empty());
-    if (pfbImportMode == RELATIONS) {
-      return addRelations(genRec, converted);
-    } else {
-      return addAttributes(genRec, converted);
-    }
+  @Override
+  Record createRecordShell(GenericRecord genRec) {
+    return new Record(genRec.get(idField).toString(), recordType, RecordAttributes.empty());
   }
 
-  private Record addAttributes(GenericRecord objectAttributes, Record converted) {
-    // loop over all Avro fields and add to the record's attributes
-    // TODO AJ-1013 skip the primary key field??
-    // if (genRec.get(OBJECT_FIELD) instanceof GenericRecord objectAttributes) {
-    Schema schema = objectAttributes.getSchema();
-    List<Schema.Field> fields = schema.getFields();
-    RecordAttributes attributes = RecordAttributes.empty();
-    for (Schema.Field field : fields) {
-      String fieldName = field.name();
-      Object value =
-          objectAttributes.get(fieldName) == null
-              ? null
-              : convertAttributeType(objectAttributes.get(fieldName));
-      attributes.putAttribute(fieldName, value);
-    }
-    converted.setAttributes(attributes);
-    // }
+  @Override
+  protected final Record addAttributes(GenericRecord objectAttributes, Record converted) {
+    return super.addAttributes(objectAttributes, converted, Set.of(idField));
+  }
+
+  @Override
+  protected final Record addRelations(GenericRecord genRec, Record converted) {
+    // TODO AJ-1013 implement relations for TDR import
     return converted;
-  }
-
-  private Record addRelations(GenericRecord genRec, Record converted) {
-    // get the relations array from the record
-    //    if (genRec.get(RELATIONS_FIELD) instanceof Collection<?> relationArray
-    //        && !relationArray.isEmpty()) {
-    //      RecordAttributes attributes = RecordAttributes.empty();
-    //      for (Object relationObject : relationArray) {
-    //        // Here we assume that the relations object is a GenericRecord with keys "dst_name"
-    // and
-    //        // "dst_id"
-    //        if (relationObject instanceof GenericRecord relation) {
-    //          String relationType = relation.get(RELATIONS_NAME).toString();
-    //          String relationId = relation.get(RELATIONS_ID).toString();
-    //          // Give the relation column the name of the record type it's linked to
-    //          attributes.putAttribute(
-    //              relationType,
-    //              RelationUtils.createRelationString(RecordType.valueOf(relationType),
-    // relationId));
-    //        }
-    //      }
-    //      converted.setAttributes(attributes);
-    //    }
-    return converted;
-  }
-
-  Object convertAttributeType(Object attribute) {
-
-    if (attribute == null) {
-      return null;
-    }
-
-    // For list of Avro types - see
-    // https://avro.apache.org/docs/current/api/java/org/apache/avro/generic/package-summary.html#package_description
-
-    // Avro records
-    if (attribute instanceof GenericRecord recordAttr) {
-      return recordAttr.toString(); // TODO AJ-1478: Make these into WDS json?
-    }
-
-    // Avro enums
-    if (attribute instanceof GenericEnumSymbol<?> enumAttr) {
-      return convertEnum(enumAttr.toString());
-    }
-
-    // Avro arrays
-    if (attribute instanceof Collection<?> collAttr) {
-      // recurse
-      return collAttr.stream().map(this::convertAttributeType).toList();
-    }
-
-    // Avro maps
-    if (attribute instanceof Map<?, ?> mapAttr) {
-      // recurse
-      return BiStream.from(mapAttr)
-          .mapKeys(Object::toString)
-          .mapValues(this::convertAttributeType)
-          .toMap();
-    }
-
-    // Avro fixed
-    if (attribute instanceof GenericFixed fixedAttr) {
-      return new String(fixedAttr.bytes());
-    }
-
-    // Avro strings
-    if (attribute instanceof String stringAttr) {
-      return stringAttr;
-    }
-
-    // Avro bytes
-    if (attribute instanceof ByteBuffer byteBufferAttr) {
-      return new String(byteBufferAttr.array());
-    }
-
-    // Avro ints
-    if (attribute instanceof Integer intAttr) {
-      return BigDecimal.valueOf(intAttr);
-    }
-
-    // Avro longs
-    if (attribute instanceof Long longAttr) {
-      return BigDecimal.valueOf(longAttr);
-    }
-
-    // Avro floats
-    if (attribute instanceof Float floatAttr) {
-      return BigDecimal.valueOf(floatAttr);
-    }
-
-    // Avro doubles
-    if (attribute instanceof Double doubleAttr) {
-      return BigDecimal.valueOf(doubleAttr);
-    }
-
-    // Avro booleans
-    if (attribute instanceof Boolean boolAttr) {
-      return boolAttr;
-    }
-
-    LOGGER.warn(
-        "convertAttributeType received value \"{}\" with unexpected type {}",
-        attribute,
-        attribute.getClass());
-    return attribute.toString();
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ParquetRecordConverter.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ParquetRecordConverter.java
@@ -1,0 +1,176 @@
+package org.databiosphere.workspacedataservice.dataimport;
+
+import static bio.terra.pfb.PfbReader.convertEnum;
+import static org.databiosphere.workspacedataservice.service.PfbStreamWriteHandler.PfbImportMode.RELATIONS;
+
+import com.google.mu.util.stream.BiStream;
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericEnumSymbol;
+import org.apache.avro.generic.GenericFixed;
+import org.apache.avro.generic.GenericRecord;
+import org.databiosphere.workspacedataservice.service.PfbStreamWriteHandler;
+import org.databiosphere.workspacedataservice.shared.model.Record;
+import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
+import org.databiosphere.workspacedataservice.shared.model.RecordType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+// TODO AJ-1013 consolidate code with PfbRecordConverter
+/** Logic to convert a TDR Parquet's GenericRecord to WDS's Record */
+public class ParquetRecordConverter {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ParquetRecordConverter.class);
+
+  //  public static final String RELATIONS_FIELD = "relations";
+  //  public static final String RELATIONS_ID = "dst_id";
+  //  public static final String RELATIONS_NAME = "dst_name";
+
+  private final RecordType recordType;
+  private final String idField;
+
+  public ParquetRecordConverter(RecordType recordType, String idField) {
+    this.recordType = recordType;
+    this.idField = idField;
+  }
+
+  public Record genericRecordToRecord(
+      GenericRecord genRec, PfbStreamWriteHandler.PfbImportMode pfbImportMode) {
+    // create the WDS record shell (id, record type, empty attributes)
+    Record converted =
+        new Record(genRec.get(idField).toString(), recordType, RecordAttributes.empty());
+    if (pfbImportMode == RELATIONS) {
+      return addRelations(genRec, converted);
+    } else {
+      return addAttributes(genRec, converted);
+    }
+  }
+
+  private Record addAttributes(GenericRecord objectAttributes, Record converted) {
+    // loop over all Avro fields and add to the record's attributes
+    // TODO AJ-1013 skip the primary key field??
+    // if (genRec.get(OBJECT_FIELD) instanceof GenericRecord objectAttributes) {
+    Schema schema = objectAttributes.getSchema();
+    List<Schema.Field> fields = schema.getFields();
+    RecordAttributes attributes = RecordAttributes.empty();
+    for (Schema.Field field : fields) {
+      String fieldName = field.name();
+      Object value =
+          objectAttributes.get(fieldName) == null
+              ? null
+              : convertAttributeType(objectAttributes.get(fieldName));
+      attributes.putAttribute(fieldName, value);
+    }
+    converted.setAttributes(attributes);
+    // }
+    return converted;
+  }
+
+  private Record addRelations(GenericRecord genRec, Record converted) {
+    // get the relations array from the record
+    //    if (genRec.get(RELATIONS_FIELD) instanceof Collection<?> relationArray
+    //        && !relationArray.isEmpty()) {
+    //      RecordAttributes attributes = RecordAttributes.empty();
+    //      for (Object relationObject : relationArray) {
+    //        // Here we assume that the relations object is a GenericRecord with keys "dst_name"
+    // and
+    //        // "dst_id"
+    //        if (relationObject instanceof GenericRecord relation) {
+    //          String relationType = relation.get(RELATIONS_NAME).toString();
+    //          String relationId = relation.get(RELATIONS_ID).toString();
+    //          // Give the relation column the name of the record type it's linked to
+    //          attributes.putAttribute(
+    //              relationType,
+    //              RelationUtils.createRelationString(RecordType.valueOf(relationType),
+    // relationId));
+    //        }
+    //      }
+    //      converted.setAttributes(attributes);
+    //    }
+    return converted;
+  }
+
+  Object convertAttributeType(Object attribute) {
+
+    if (attribute == null) {
+      return null;
+    }
+
+    // For list of Avro types - see
+    // https://avro.apache.org/docs/current/api/java/org/apache/avro/generic/package-summary.html#package_description
+
+    // Avro records
+    if (attribute instanceof GenericRecord recordAttr) {
+      return recordAttr.toString(); // TODO AJ-1478: Make these into WDS json?
+    }
+
+    // Avro enums
+    if (attribute instanceof GenericEnumSymbol<?> enumAttr) {
+      return convertEnum(enumAttr.toString());
+    }
+
+    // Avro arrays
+    if (attribute instanceof Collection<?> collAttr) {
+      // recurse
+      return collAttr.stream().map(this::convertAttributeType).toList();
+    }
+
+    // Avro maps
+    if (attribute instanceof Map<?, ?> mapAttr) {
+      // recurse
+      return BiStream.from(mapAttr)
+          .mapKeys(Object::toString)
+          .mapValues(this::convertAttributeType)
+          .toMap();
+    }
+
+    // Avro fixed
+    if (attribute instanceof GenericFixed fixedAttr) {
+      return new String(fixedAttr.bytes());
+    }
+
+    // Avro strings
+    if (attribute instanceof String stringAttr) {
+      return stringAttr;
+    }
+
+    // Avro bytes
+    if (attribute instanceof ByteBuffer byteBufferAttr) {
+      return new String(byteBufferAttr.array());
+    }
+
+    // Avro ints
+    if (attribute instanceof Integer intAttr) {
+      return BigDecimal.valueOf(intAttr);
+    }
+
+    // Avro longs
+    if (attribute instanceof Long longAttr) {
+      return BigDecimal.valueOf(longAttr);
+    }
+
+    // Avro floats
+    if (attribute instanceof Float floatAttr) {
+      return BigDecimal.valueOf(floatAttr);
+    }
+
+    // Avro doubles
+    if (attribute instanceof Double doubleAttr) {
+      return BigDecimal.valueOf(doubleAttr);
+    }
+
+    // Avro booleans
+    if (attribute instanceof Boolean boolAttr) {
+      return boolAttr;
+    }
+
+    LOGGER.warn(
+        "convertAttributeType received value \"{}\" with unexpected type {}",
+        attribute,
+        attribute.getClass());
+    return attribute.toString();
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ParquetRecordConverter.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ParquetRecordConverter.java
@@ -1,6 +1,7 @@
 package org.databiosphere.workspacedataservice.dataimport;
 
 import bio.terra.datarepo.model.RelationshipModel;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -18,8 +19,8 @@ public class ParquetRecordConverter extends AvroRecordConverter {
   private final String idField;
   private final List<RelationshipModel> relationshipModels;
 
-  public ParquetRecordConverter(TdrManifestImportTable table) {
-    super();
+  public ParquetRecordConverter(TdrManifestImportTable table, ObjectMapper objectMapper) {
+    super(objectMapper);
     this.recordType = table.recordType();
     this.idField = table.primaryKey();
     this.relationshipModels = table.relations();

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ParquetStreamWriteHandler.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ParquetStreamWriteHandler.java
@@ -12,7 +12,7 @@ import org.databiosphere.workspacedataservice.service.model.TdrManifestImportTab
 import org.databiosphere.workspacedataservice.shared.model.OperationType;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 
-// TODO AJ-1013 reorganize StreamingWriteHandler out of the service package, and add some
+// TODO AJ-1519 reorganize StreamingWriteHandler out of the service package, and add some
 //     hierarchy to the dataimport package,
 public class ParquetStreamWriteHandler implements TwoPassStreamingWriteHandler {
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ParquetStreamWriteHandler.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ParquetStreamWriteHandler.java
@@ -11,6 +11,7 @@ import org.databiosphere.workspacedataservice.service.PfbStreamWriteHandler;
 import org.databiosphere.workspacedataservice.service.StreamingWriteHandler;
 import org.databiosphere.workspacedataservice.shared.model.OperationType;
 import org.databiosphere.workspacedataservice.shared.model.Record;
+import org.databiosphere.workspacedataservice.shared.model.RecordType;
 
 // TODO AJ-1013: how much can be consolidated with PfbStreamWriteHandler?
 public class ParquetStreamWriteHandler implements StreamingWriteHandler {
@@ -18,11 +19,18 @@ public class ParquetStreamWriteHandler implements StreamingWriteHandler {
   private final ParquetReader<GenericRecord> parquetReader;
   private final PfbStreamWriteHandler.PfbImportMode pfbImportMode;
 
+  private final RecordType recordType;
+  private final String primaryKey;
+
   public ParquetStreamWriteHandler(
       ParquetReader<GenericRecord> parquetReader,
-      PfbStreamWriteHandler.PfbImportMode pfbImportMode) {
+      PfbStreamWriteHandler.PfbImportMode pfbImportMode,
+      RecordType recordType,
+      String primaryKey) {
     this.parquetReader = parquetReader;
     this.pfbImportMode = pfbImportMode;
+    this.recordType = recordType;
+    this.primaryKey = primaryKey;
   }
 
   @Override
@@ -39,7 +47,7 @@ public class ParquetStreamWriteHandler implements StreamingWriteHandler {
     }
 
     // convert avro generic records to WDS records
-    PfbRecordConverter converter = new PfbRecordConverter();
+    ParquetRecordConverter converter = new ParquetRecordConverter(recordType, primaryKey);
     List<Record> records =
         genericRecords.stream()
             .map(gr -> converter.genericRecordToRecord(gr, BASE_ATTRIBUTES))

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ParquetStreamWriteHandler.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ParquetStreamWriteHandler.java
@@ -1,6 +1,5 @@
 package org.databiosphere.workspacedataservice.dataimport;
 
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ParquetStreamWriteHandler.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ParquetStreamWriteHandler.java
@@ -12,6 +12,8 @@ import org.databiosphere.workspacedataservice.service.model.TdrManifestImportTab
 import org.databiosphere.workspacedataservice.shared.model.OperationType;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 
+// TODO AJ-1013 reorganize StreamingWriteHandler out of the service package, and add some
+//     hierarchy to the dataimport package,
 public class ParquetStreamWriteHandler implements TwoPassStreamingWriteHandler {
 
   private final ParquetReader<GenericRecord> parquetReader;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ParquetStreamWriteHandler.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ParquetStreamWriteHandler.java
@@ -7,12 +7,12 @@ import java.util.List;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.parquet.hadoop.ParquetReader;
 import org.databiosphere.workspacedataservice.service.PfbStreamWriteHandler;
-import org.databiosphere.workspacedataservice.service.StreamingWriteHandler;
+import org.databiosphere.workspacedataservice.service.TwoPassStreamingWriteHandler;
 import org.databiosphere.workspacedataservice.service.model.TdrManifestImportTable;
 import org.databiosphere.workspacedataservice.shared.model.OperationType;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 
-public class ParquetStreamWriteHandler implements StreamingWriteHandler {
+public class ParquetStreamWriteHandler implements TwoPassStreamingWriteHandler {
 
   private final ParquetReader<GenericRecord> parquetReader;
   private final PfbStreamWriteHandler.PfbImportMode pfbImportMode;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ParquetStreamWriteHandler.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ParquetStreamWriteHandler.java
@@ -1,0 +1,55 @@
+package org.databiosphere.workspacedataservice.dataimport;
+
+import static org.databiosphere.workspacedataservice.service.PfbStreamWriteHandler.PfbImportMode.BASE_ATTRIBUTES;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.parquet.hadoop.ParquetReader;
+import org.databiosphere.workspacedataservice.service.PfbStreamWriteHandler;
+import org.databiosphere.workspacedataservice.service.StreamingWriteHandler;
+import org.databiosphere.workspacedataservice.shared.model.OperationType;
+import org.databiosphere.workspacedataservice.shared.model.Record;
+
+// TODO AJ-1013: how much can be consolidated with PfbStreamWriteHandler?
+public class ParquetStreamWriteHandler implements StreamingWriteHandler {
+
+  private final ParquetReader<GenericRecord> parquetReader;
+  private final PfbStreamWriteHandler.PfbImportMode pfbImportMode;
+
+  public ParquetStreamWriteHandler(
+      ParquetReader<GenericRecord> parquetReader,
+      PfbStreamWriteHandler.PfbImportMode pfbImportMode) {
+    this.parquetReader = parquetReader;
+    this.pfbImportMode = pfbImportMode;
+  }
+
+  @Override
+  public WriteStreamInfo readRecords(int numRecords) throws IOException {
+    List<GenericRecord> genericRecords = new ArrayList<>();
+
+    while (genericRecords.size() < numRecords) {
+      GenericRecord genericRecord = parquetReader.read();
+      if (genericRecord == null) {
+        // end of the parquet input
+        break;
+      }
+      genericRecords.add(genericRecord);
+    }
+
+    // convert avro generic records to WDS records
+    PfbRecordConverter converter = new PfbRecordConverter();
+    List<Record> records =
+        genericRecords.stream()
+            .map(gr -> converter.genericRecordToRecord(gr, BASE_ATTRIBUTES))
+            .toList();
+
+    return new WriteStreamInfo(records, OperationType.UPSERT);
+  }
+
+  @Override
+  public void close() throws IOException {
+    parquetReader.close();
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ParquetStreamWriteHandler.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ParquetStreamWriteHandler.java
@@ -48,7 +48,7 @@ public class ParquetStreamWriteHandler implements TwoPassStreamingWriteHandler {
     // convert avro generic records to WDS records
     ParquetRecordConverter converter = new ParquetRecordConverter(table, objectMapper);
     List<Record> records =
-        genericRecords.stream().map(gr -> converter.genericRecordToRecord(gr, importMode)).toList();
+        genericRecords.stream().map(gr -> converter.convert(gr, importMode)).toList();
 
     return new WriteStreamInfo(records, OperationType.UPSERT);
   }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ParquetStreamWriteHandler.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ParquetStreamWriteHandler.java
@@ -7,27 +7,24 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.parquet.hadoop.ParquetReader;
 import org.databiosphere.workspacedataservice.service.PfbStreamWriteHandler;
 import org.databiosphere.workspacedataservice.service.StreamingWriteHandler;
+import org.databiosphere.workspacedataservice.service.model.TdrManifestImportTable;
 import org.databiosphere.workspacedataservice.shared.model.OperationType;
 import org.databiosphere.workspacedataservice.shared.model.Record;
-import org.databiosphere.workspacedataservice.shared.model.RecordType;
 
 public class ParquetStreamWriteHandler implements StreamingWriteHandler {
 
   private final ParquetReader<GenericRecord> parquetReader;
   private final PfbStreamWriteHandler.PfbImportMode pfbImportMode;
 
-  private final RecordType recordType;
-  private final String primaryKey;
+  private final TdrManifestImportTable table;
 
   public ParquetStreamWriteHandler(
       ParquetReader<GenericRecord> parquetReader,
       PfbStreamWriteHandler.PfbImportMode pfbImportMode,
-      RecordType recordType,
-      String primaryKey) {
+      TdrManifestImportTable table) {
     this.parquetReader = parquetReader;
     this.pfbImportMode = pfbImportMode;
-    this.recordType = recordType;
-    this.primaryKey = primaryKey;
+    this.table = table;
   }
 
   @Override
@@ -44,7 +41,7 @@ public class ParquetStreamWriteHandler implements StreamingWriteHandler {
     }
 
     // convert avro generic records to WDS records
-    ParquetRecordConverter converter = new ParquetRecordConverter(recordType, primaryKey);
+    ParquetRecordConverter converter = new ParquetRecordConverter(table);
     List<Record> records =
         genericRecords.stream()
             .map(gr -> converter.genericRecordToRecord(gr, pfbImportMode))

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ParquetStreamWriteHandler.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ParquetStreamWriteHandler.java
@@ -1,6 +1,5 @@
 package org.databiosphere.workspacedataservice.dataimport;
 
-import static org.databiosphere.workspacedataservice.service.PfbStreamWriteHandler.PfbImportMode.BASE_ATTRIBUTES;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -13,7 +12,6 @@ import org.databiosphere.workspacedataservice.shared.model.OperationType;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 
-// TODO AJ-1013: how much can be consolidated with PfbStreamWriteHandler?
 public class ParquetStreamWriteHandler implements StreamingWriteHandler {
 
   private final ParquetReader<GenericRecord> parquetReader;
@@ -50,7 +48,7 @@ public class ParquetStreamWriteHandler implements StreamingWriteHandler {
     ParquetRecordConverter converter = new ParquetRecordConverter(recordType, primaryKey);
     List<Record> records =
         genericRecords.stream()
-            .map(gr -> converter.genericRecordToRecord(gr, BASE_ATTRIBUTES))
+            .map(gr -> converter.genericRecordToRecord(gr, pfbImportMode))
             .toList();
 
     return new WriteStreamInfo(records, OperationType.UPSERT);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ParquetStreamWriteHandler.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ParquetStreamWriteHandler.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.parquet.hadoop.ParquetReader;
-import org.databiosphere.workspacedataservice.service.PfbStreamWriteHandler;
 import org.databiosphere.workspacedataservice.service.TwoPassStreamingWriteHandler;
 import org.databiosphere.workspacedataservice.service.model.TdrManifestImportTable;
 import org.databiosphere.workspacedataservice.shared.model.OperationType;
@@ -17,18 +16,18 @@ import org.databiosphere.workspacedataservice.shared.model.Record;
 public class ParquetStreamWriteHandler implements TwoPassStreamingWriteHandler {
 
   private final ParquetReader<GenericRecord> parquetReader;
-  private final PfbStreamWriteHandler.PfbImportMode pfbImportMode;
+  private final ImportMode importMode;
 
   private final TdrManifestImportTable table;
   private final ObjectMapper objectMapper;
 
   public ParquetStreamWriteHandler(
       ParquetReader<GenericRecord> parquetReader,
-      PfbStreamWriteHandler.PfbImportMode pfbImportMode,
+      ImportMode importMode,
       TdrManifestImportTable table,
       ObjectMapper objectMapper) {
     this.parquetReader = parquetReader;
-    this.pfbImportMode = pfbImportMode;
+    this.importMode = importMode;
     this.table = table;
     this.objectMapper = objectMapper;
   }
@@ -49,9 +48,7 @@ public class ParquetStreamWriteHandler implements TwoPassStreamingWriteHandler {
     // convert avro generic records to WDS records
     ParquetRecordConverter converter = new ParquetRecordConverter(table, objectMapper);
     List<Record> records =
-        genericRecords.stream()
-            .map(gr -> converter.genericRecordToRecord(gr, pfbImportMode))
-            .toList();
+        genericRecords.stream().map(gr -> converter.genericRecordToRecord(gr, importMode)).toList();
 
     return new WriteStreamInfo(records, OperationType.UPSERT);
   }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ParquetStreamWriteHandler.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ParquetStreamWriteHandler.java
@@ -1,5 +1,6 @@
 package org.databiosphere.workspacedataservice.dataimport;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -17,14 +18,17 @@ public class ParquetStreamWriteHandler implements StreamingWriteHandler {
   private final PfbStreamWriteHandler.PfbImportMode pfbImportMode;
 
   private final TdrManifestImportTable table;
+  private final ObjectMapper objectMapper;
 
   public ParquetStreamWriteHandler(
       ParquetReader<GenericRecord> parquetReader,
       PfbStreamWriteHandler.PfbImportMode pfbImportMode,
-      TdrManifestImportTable table) {
+      TdrManifestImportTable table,
+      ObjectMapper objectMapper) {
     this.parquetReader = parquetReader;
     this.pfbImportMode = pfbImportMode;
     this.table = table;
+    this.objectMapper = objectMapper;
   }
 
   @Override
@@ -41,7 +45,7 @@ public class ParquetStreamWriteHandler implements StreamingWriteHandler {
     }
 
     // convert avro generic records to WDS records
-    ParquetRecordConverter converter = new ParquetRecordConverter(table);
+    ParquetRecordConverter converter = new ParquetRecordConverter(table, objectMapper);
     List<Record> records =
         genericRecords.stream()
             .map(gr -> converter.genericRecordToRecord(gr, pfbImportMode))

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbQuartzJob.java
@@ -1,8 +1,8 @@
 package org.databiosphere.workspacedataservice.dataimport;
 
 import static org.databiosphere.workspacedataservice.dataimport.PfbRecordConverter.ID_FIELD;
-import static org.databiosphere.workspacedataservice.service.PfbStreamWriteHandler.PfbImportMode.BASE_ATTRIBUTES;
-import static org.databiosphere.workspacedataservice.service.PfbStreamWriteHandler.PfbImportMode.RELATIONS;
+import static org.databiosphere.workspacedataservice.service.TwoPassStreamingWriteHandler.ImportMode.BASE_ATTRIBUTES;
+import static org.databiosphere.workspacedataservice.service.TwoPassStreamingWriteHandler.ImportMode.RELATIONS;
 import static org.databiosphere.workspacedataservice.shared.model.Schedulable.ARG_INSTANCE;
 import static org.databiosphere.workspacedataservice.shared.model.Schedulable.ARG_URL;
 
@@ -24,7 +24,7 @@ import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.jobexec.QuartzJob;
 import org.databiosphere.workspacedataservice.retry.RestClientRetry;
 import org.databiosphere.workspacedataservice.service.BatchWriteService;
-import org.databiosphere.workspacedataservice.service.PfbStreamWriteHandler;
+import org.databiosphere.workspacedataservice.service.TwoPassStreamingWriteHandler;
 import org.databiosphere.workspacedataservice.service.model.BatchWriteResult;
 import org.databiosphere.workspacedataservice.service.model.exception.PfbParsingException;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
@@ -132,15 +132,15 @@ public class PfbQuartzJob extends QuartzJob {
    *
    * @param dataStream stream representing the PFB.
    * @param targetInstance the UUID of the WDS instance being imported to
-   * @param pfbImportMode indicating whether to import all data in the tables or only the relations
+   * @param importMode indicating whether to import all data in the tables or only the relations
    */
   BatchWriteResult importTables(
       DataFileStream<GenericRecord> dataStream,
       UUID targetInstance,
-      PfbStreamWriteHandler.PfbImportMode pfbImportMode) {
+      TwoPassStreamingWriteHandler.ImportMode importMode) {
     BatchWriteResult result =
         batchWriteService.batchWritePfbStream(
-            dataStream, targetInstance, Optional.of(ID_FIELD), pfbImportMode);
+            dataStream, targetInstance, Optional.of(ID_FIELD), importMode);
 
     if (result != null) {
       result

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbRecordConverter.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbRecordConverter.java
@@ -1,19 +1,8 @@
 package org.databiosphere.workspacedataservice.dataimport;
 
-import static bio.terra.pfb.PfbReader.convertEnum;
-import static org.databiosphere.workspacedataservice.service.PfbStreamWriteHandler.PfbImportMode.RELATIONS;
-
-import com.google.mu.util.stream.BiStream;
-import java.math.BigDecimal;
-import java.nio.ByteBuffer;
 import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericEnumSymbol;
-import org.apache.avro.generic.GenericFixed;
+import java.util.Set;
 import org.apache.avro.generic.GenericRecord;
-import org.databiosphere.workspacedataservice.service.PfbStreamWriteHandler;
 import org.databiosphere.workspacedataservice.service.RelationUtils;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
@@ -22,7 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Logic to convert a PFB's GenericRecord to WDS's Record */
-public class PfbRecordConverter {
+public class PfbRecordConverter extends AvroRecordConverter {
   private static final Logger LOGGER = LoggerFactory.getLogger(PfbRecordConverter.class);
 
   public static final String ID_FIELD = "id";
@@ -32,41 +21,29 @@ public class PfbRecordConverter {
   public static final String RELATIONS_ID = "dst_id";
   public static final String RELATIONS_NAME = "dst_name";
 
-  public Record genericRecordToRecord(
-      GenericRecord genRec, PfbStreamWriteHandler.PfbImportMode pfbImportMode) {
-    // create the WDS record shell (id, record type, empty attributes)
-    Record converted =
-        new Record(
-            genRec.get(ID_FIELD).toString(),
-            RecordType.valueOf(genRec.get(TYPE_FIELD).toString()),
-            RecordAttributes.empty());
-    if (pfbImportMode == RELATIONS) {
-      return addRelations(genRec, converted);
-    } else {
-      return addAttributes(genRec, converted);
-    }
+  public PfbRecordConverter() {
+    super();
   }
 
-  private Record addAttributes(GenericRecord genRec, Record converted) {
-    // loop over all Avro fields and add to the record's attributes
+  @Override
+  Record createRecordShell(GenericRecord genRec) {
+    return new Record(
+        genRec.get(ID_FIELD).toString(),
+        RecordType.valueOf(genRec.get(TYPE_FIELD).toString()),
+        RecordAttributes.empty());
+  }
+
+  @Override
+  protected final Record addAttributes(GenericRecord genRec, Record converted) {
+    // extract the OBJECT_FIELD sub-record, then find all its attributes
     if (genRec.get(OBJECT_FIELD) instanceof GenericRecord objectAttributes) {
-      Schema schema = objectAttributes.getSchema();
-      List<Schema.Field> fields = schema.getFields();
-      RecordAttributes attributes = RecordAttributes.empty();
-      for (Schema.Field field : fields) {
-        String fieldName = field.name();
-        Object value =
-            objectAttributes.get(fieldName) == null
-                ? null
-                : convertAttributeType(objectAttributes.get(fieldName));
-        attributes.putAttribute(fieldName, value);
-      }
-      converted.setAttributes(attributes);
+      return super.addAttributes(objectAttributes, converted, Set.of());
     }
     return converted;
   }
 
-  private Record addRelations(GenericRecord genRec, Record converted) {
+  @Override
+  protected final Record addRelations(GenericRecord genRec, Record converted) {
     // get the relations array from the record
     if (genRec.get(RELATIONS_FIELD) instanceof Collection<?> relationArray
         && !relationArray.isEmpty()) {
@@ -86,86 +63,5 @@ public class PfbRecordConverter {
       converted.setAttributes(attributes);
     }
     return converted;
-  }
-
-  Object convertAttributeType(Object attribute) {
-
-    if (attribute == null) {
-      return null;
-    }
-
-    // For list of Avro types - see
-    // https://avro.apache.org/docs/current/api/java/org/apache/avro/generic/package-summary.html#package_description
-
-    // Avro records
-    if (attribute instanceof GenericRecord recordAttr) {
-      return recordAttr.toString(); // TODO AJ-1478: Make these into WDS json?
-    }
-
-    // Avro enums
-    if (attribute instanceof GenericEnumSymbol<?> enumAttr) {
-      return convertEnum(enumAttr.toString());
-    }
-
-    // Avro arrays
-    if (attribute instanceof Collection<?> collAttr) {
-      // recurse
-      return collAttr.stream().map(this::convertAttributeType).toList();
-    }
-
-    // Avro maps
-    if (attribute instanceof Map<?, ?> mapAttr) {
-      // recurse
-      return BiStream.from(mapAttr)
-          .mapKeys(Object::toString)
-          .mapValues(this::convertAttributeType)
-          .toMap();
-    }
-
-    // Avro fixed
-    if (attribute instanceof GenericFixed fixedAttr) {
-      return new String(fixedAttr.bytes());
-    }
-
-    // Avro strings
-    if (attribute instanceof String stringAttr) {
-      return stringAttr;
-    }
-
-    // Avro bytes
-    if (attribute instanceof ByteBuffer byteBufferAttr) {
-      return new String(byteBufferAttr.array());
-    }
-
-    // Avro ints
-    if (attribute instanceof Integer intAttr) {
-      return BigDecimal.valueOf(intAttr);
-    }
-
-    // Avro longs
-    if (attribute instanceof Long longAttr) {
-      return BigDecimal.valueOf(longAttr);
-    }
-
-    // Avro floats
-    if (attribute instanceof Float floatAttr) {
-      return BigDecimal.valueOf(floatAttr);
-    }
-
-    // Avro doubles
-    if (attribute instanceof Double doubleAttr) {
-      return BigDecimal.valueOf(doubleAttr);
-    }
-
-    // Avro booleans
-    if (attribute instanceof Boolean boolAttr) {
-      return boolAttr;
-    }
-
-    LOGGER.warn(
-        "convertAttributeType received value \"{}\" with unexpected type {}",
-        attribute,
-        attribute.getClass());
-    return attribute.toString();
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbRecordConverter.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/PfbRecordConverter.java
@@ -1,23 +1,8 @@
 package org.databiosphere.workspacedataservice.dataimport;
 
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Collection;
 import java.util.Set;
-
-import static bio.terra.pfb.PfbReader.convertEnum;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.math.BigDecimal;
-import java.nio.ByteBuffer;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericData;
-import org.apache.avro.generic.GenericEnumSymbol;
-import org.apache.avro.generic.GenericFixed;
-
 import org.apache.avro.generic.GenericRecord;
 import org.databiosphere.workspacedataservice.service.RelationUtils;
 import org.databiosphere.workspacedataservice.shared.model.Record;
@@ -37,11 +22,8 @@ public class PfbRecordConverter extends AvroRecordConverter {
   public static final String RELATIONS_ID = "dst_id";
   public static final String RELATIONS_NAME = "dst_name";
 
-  private final ObjectMapper objectMapper;
-
   public PfbRecordConverter(ObjectMapper objectMapper) {
-    super();
-    this.objectMapper = objectMapper;
+    super(objectMapper);
   }
 
   @Override
@@ -82,100 +64,5 @@ public class PfbRecordConverter extends AvroRecordConverter {
       converted.setAttributes(attributes);
     }
     return converted;
-  }
-
-  Object convertAttributeType(Object attribute) {
-
-    if (attribute == null) {
-      return null;
-    }
-
-    // For list of Avro types - see
-    // https://avro.apache.org/docs/current/api/java/org/apache/avro/generic/package-summary.html#package_description
-
-    // Avro records
-    if (attribute instanceof GenericRecord recordAttr) {
-      // According to its Javadoc, GenericData#toString() renders the given datum as JSON
-      // However, it may contribute to numeric precision loss (see:
-      // https://broadworkbench.atlassian.net/browse/AJ-1292)
-      // If that's the case, then it may be necessary to traverse the record recursively and do a
-      // less lossy conversion process.
-      return GenericData.get().toString(recordAttr);
-    }
-
-    // Avro enums
-    if (attribute instanceof GenericEnumSymbol<?> enumAttr) {
-      return convertEnum(enumAttr.toString());
-    }
-
-    // Avro arrays
-    if (attribute instanceof Collection<?> collAttr) {
-      // recurse
-      return collAttr.stream().map(this::convertAttributeType).toList();
-    }
-
-    // Avro maps
-    if (attribute instanceof Map<?, ?> mapAttr) {
-      return convertToString(mapAttr);
-    }
-
-    // Avro fixed
-    if (attribute instanceof GenericFixed fixedAttr) {
-      return new String(fixedAttr.bytes());
-    }
-
-    // Avro strings
-    if (attribute instanceof CharSequence charSequenceAttr) {
-      return charSequenceAttr.toString();
-    }
-
-    // Avro bytes
-    if (attribute instanceof ByteBuffer byteBufferAttr) {
-      return new String(byteBufferAttr.array());
-    }
-
-    // Avro ints
-    if (attribute instanceof Integer intAttr) {
-      return BigDecimal.valueOf(intAttr);
-    }
-
-    // Avro longs
-    if (attribute instanceof Long longAttr) {
-      return BigDecimal.valueOf(longAttr);
-    }
-
-    // Avro floats
-    if (attribute instanceof Float floatAttr) {
-      return BigDecimal.valueOf(floatAttr);
-    }
-
-    // Avro doubles
-    if (attribute instanceof Double doubleAttr) {
-      return BigDecimal.valueOf(doubleAttr);
-    }
-
-    // Avro booleans
-    if (attribute instanceof Boolean boolAttr) {
-      return boolAttr;
-    }
-
-    LOGGER.warn(
-        "convertAttributeType received value \"{}\" with unexpected type {}",
-        attribute,
-        attribute.getClass());
-    return attribute.toString();
-  }
-
-  private String convertToString(Object attribute) {
-    try {
-      return objectMapper.writeValueAsString(attribute);
-    } catch (JsonProcessingException e) {
-      LOGGER.warn(
-          String.format(
-              "Unable to convert attribute \"%s\" to JSON string, falling back to toString()",
-              attribute),
-          e);
-      return attribute.toString();
-    }
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/TdrManifestQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/TdrManifestQuartzJob.java
@@ -128,6 +128,12 @@ public class TdrManifestQuartzJob extends QuartzJob {
       TdrManifestImportTable table,
       UUID targetInstance,
       TwoPassStreamingWriteHandler.ImportMode importMode) {
+    // In the TDR manifest, for Azure snapshots only,
+    // the first file in the list will always be a directory. Attempting to import that directory
+    // will fail; it has no content. To ensure we are resilient to those failures, wrap everything
+    // in try/catch.
+    // TODO AJ-1518 more specific handling for 0-length directories; other errors should
+    //     be true failures
     try {
       // download the file from the URL to a temp file on the local filesystem
       // Azure urls, with SAS tokens, don't need any particular auth.
@@ -200,9 +206,7 @@ public class TdrManifestQuartzJob extends QuartzJob {
       List<TdrManifestImportTable> importTables,
       UUID targetInstance,
       TwoPassStreamingWriteHandler.ImportMode importMode) {
-    // loop through the tables that have data files. In the TDR manifest, for Azure snapshots only,
-    // the first file in the list will always be a directory. Attempting to import that directory
-    // will fail; it has no content. Ensure we are resilient to those failures.
+    // loop through the tables that have data files.
     importTables.forEach(
         importTable -> {
           logger.info("Processing table '{}' ...", importTable.recordType().getName());

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/TdrManifestQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/TdrManifestQuartzJob.java
@@ -3,32 +3,70 @@ package org.databiosphere.workspacedataservice.dataimport;
 import static org.databiosphere.workspacedataservice.shared.model.Schedulable.ARG_INSTANCE;
 import static org.databiosphere.workspacedataservice.shared.model.Schedulable.ARG_URL;
 
+import bio.terra.datarepo.model.RelationshipModel;
 import bio.terra.datarepo.model.SnapshotExportResponseModel;
+import bio.terra.datarepo.model.SnapshotExportResponseModelFormatParquetLocationTables;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Multimap;
 import java.io.IOException;
 import java.net.URL;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.avro.AvroParquetReader;
+import org.apache.parquet.hadoop.ParquetReader;
+import org.apache.parquet.hadoop.util.HadoopInputFile;
+import org.apache.parquet.io.InputFile;
+import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.jobexec.JobExecutionException;
 import org.databiosphere.workspacedataservice.jobexec.QuartzJob;
+import org.databiosphere.workspacedataservice.retry.RestClientRetry;
+import org.databiosphere.workspacedataservice.service.BatchWriteService;
 import org.databiosphere.workspacedataservice.service.DataRepoService;
+import org.databiosphere.workspacedataservice.service.PfbStreamWriteHandler;
+import org.databiosphere.workspacedataservice.shared.model.RecordType;
+import org.databiosphere.workspacedataservice.workspacemanager.WorkspaceManagerDao;
 import org.quartz.JobDataMap;
 import org.quartz.JobExecutionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
 public class TdrManifestQuartzJob extends QuartzJob {
 
   private final JobDao jobDao;
+  private final WorkspaceManagerDao wsmDao;
+  private final RestClientRetry restClientRetry;
+  private final UUID workspaceId;
+  private final BatchWriteService batchWriteService;
+  private final ActivityLogger activityLogger;
   private final ObjectMapper mapper;
-  private final DataRepoService dataRepoService;
+  private final DataRepoService dataRepoService; // TODO AJ-1013 do we need this dao?
 
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
-  public TdrManifestQuartzJob(JobDao jobDao, ObjectMapper mapper, DataRepoService dataRepoService) {
+  public TdrManifestQuartzJob(
+      JobDao jobDao,
+      WorkspaceManagerDao wsmDao,
+      RestClientRetry restClientRetry,
+      BatchWriteService batchWriteService,
+      ActivityLogger activityLogger,
+      @Value("${twds.instance.workspace-id}") UUID workspaceId,
+      ObjectMapper mapper,
+      DataRepoService dataRepoService) {
     this.jobDao = jobDao;
+    this.wsmDao = wsmDao;
+    this.restClientRetry = restClientRetry;
+    this.workspaceId = workspaceId;
+    this.batchWriteService = batchWriteService;
+    this.activityLogger = activityLogger;
     this.mapper = mapper;
     this.dataRepoService = dataRepoService;
   }
@@ -38,6 +76,7 @@ public class TdrManifestQuartzJob extends QuartzJob {
     return this.jobDao;
   }
 
+  // TODO AJ-1013 unit tests
   @Override
   protected void executeInternal(UUID jobId, JobExecutionContext context) {
     // retrieve the Quartz JobDataMap, which contains arguments for this execution
@@ -48,6 +87,16 @@ public class TdrManifestQuartzJob extends QuartzJob {
 
     // get the TDR manifest url from job data
     URL url = getJobDataUrl(jobDataMap, ARG_URL);
+    /*
+      + 1. read manifest, find snapshot id
+      2. create reference from workspace to snapshot
+      3. find all tables and primary keys for each table. Potentially read the whole schema here.
+      4. Identify all the parquet files for each table.
+      5. Read each parquet file into Avro java objects
+      6. Insert base attributes for each parquet file, using recordType=tableName and id=primary key from schema
+      7. Second pass to insert relations
+
+    */
 
     // read manifest
     SnapshotExportResponseModel snapshotExportResponseModel;
@@ -61,8 +110,75 @@ public class TdrManifestQuartzJob extends QuartzJob {
     // get the snapshot id from the manifest
     UUID snapshotId = snapshotExportResponseModel.getSnapshot().getId();
     logger.info("Starting import of snapshot {} to instance {}", snapshotId, instanceId);
-    // perform the import via DataRepoService
-    // TODO: AJ-1011 pass token to dataRepoService, or possibly stash it on the thread
-    dataRepoService.importSnapshot(instanceId, snapshotId);
+
+    TdrSnapshotSupport tdrSnapshotSupport =
+        new TdrSnapshotSupport(workspaceId, wsmDao, restClientRetry);
+
+    // TODO AJ-1013 create snapshot reference - use linkSnapshots from PfbQuartzJob
+
+    // find all the exported tables in the manifest.
+    // This is the format.parquet.location.tables section in the manifest
+    List<SnapshotExportResponseModelFormatParquetLocationTables> tables =
+        snapshotExportResponseModel.getFormat().getParquet().getLocation().getTables();
+
+    // find the primary keys for each table.
+    // This is the snapshot.tables section in the manifest
+    Map<RecordType, String> primaryKeys =
+        tdrSnapshotSupport.identifyPrimaryKeys(
+            snapshotExportResponseModel.getSnapshot().getTables());
+
+    // find the relations for each table.
+    // This is the snapshot.relationships section in the manifest
+    Multimap<RecordType, RelationshipModel> relations =
+        tdrSnapshotSupport.identifyRelations(
+            snapshotExportResponseModel.getSnapshot().getRelationships());
+
+    // loop through the exported tables and process the parquet files for each one
+    tables.forEach(
+        table -> {
+          // record type and primary key for this table
+          RecordType recordType = RecordType.valueOf(table.getName());
+          String pk =
+              primaryKeys.getOrDefault(recordType, tdrSnapshotSupport.getDefaultPrimaryKey());
+
+          logger.info("Processing table '{}' ...", table.getName());
+          List<String> paths = table.getPaths();
+          paths.forEach(
+              path -> {
+                logger.info("opening reader for file ...");
+                InputFile inputFile;
+                // open the parquet file for reading
+                try {
+                  // TODO AJ-1013: auth? If this is only signed urls, there's no problem.
+                  inputFile = HadoopInputFile.fromPath(new Path(path), new Configuration());
+                } catch (IOException e) {
+                  throw new RuntimeException(e);
+                }
+                // upsert this parquet file's contents
+                try (ParquetReader<GenericRecord> avroParquetReader =
+                    AvroParquetReader.genericRecordReader(inputFile)) {
+
+                  logger.info("batch-writing records for file ...");
+
+                  // TODO AJ-1013 pass in which columns are relations
+                  batchWriteService.batchWriteParquetStream(
+                      avroParquetReader,
+                      instanceId,
+                      recordType,
+                      Optional.of(pk),
+                      PfbStreamWriteHandler.PfbImportMode.BASE_ATTRIBUTES);
+
+                  // TODO AJ-1013: activity logging
+
+                } catch (IOException e) {
+                  throw new RuntimeException(e);
+                }
+              });
+        });
+
+    // TODO AJ-1013 upsert relation columns
+
+    logger.info(tables.toString());
+    // TODO AJ-1013 re-evaluate dataRepoService.importSnapshot, should it be removed?
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/TdrManifestQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/TdrManifestQuartzJob.java
@@ -79,7 +79,7 @@ public class TdrManifestQuartzJob extends QuartzJob {
     return this.jobDao;
   }
 
-  // TODO AJ-1013 unit tests
+  // TODO AJ-1523 unit tests
   @Override
   protected void executeInternal(UUID jobId, JobExecutionContext context) {
     // Grab the manifest url from the job's data map
@@ -111,7 +111,7 @@ public class TdrManifestQuartzJob extends QuartzJob {
     importTables(
         tdrManifestImportTables, targetInstance, PfbStreamWriteHandler.PfbImportMode.RELATIONS);
 
-    // TODO AJ-1013 re-evaluate dataRepoService.importSnapshot, should it be removed?
+    // TODO AJ-1521 re-evaluate dataRepoService.importSnapshot, should it be removed?
   }
 
   /**
@@ -131,7 +131,7 @@ public class TdrManifestQuartzJob extends QuartzJob {
     try {
       // download the file from the URL to a temp file on the local filesystem
       // Azure urls, with SAS tokens, don't need any particular auth.
-      // TODO AJ-1013 can we access the URL directly, no temp file?
+      // TODO AJ-1517 can we access the URL directly, no temp file?
       File tempFile = File.createTempFile("tdr-", "download");
       logger.info("downloading to temp file {} ...", tempFile.getPath());
       FileUtils.copyURLToFile(path, tempFile);
@@ -157,6 +157,8 @@ public class TdrManifestQuartzJob extends QuartzJob {
                 avroParquetReader, targetInstance, table, pfbImportMode);
 
         // activity logging
+        // TODO AJ-1520 this activity logging can be a "false positive" - we will log here,
+        //     but if the overall transaction fails and is rolled back these logs will be false
         if (result != null) {
           result
               .entrySet()
@@ -175,14 +177,14 @@ public class TdrManifestQuartzJob extends QuartzJob {
         logger.error("Hit an error on file: {}", e.getMessage(), e);
         return new BatchWriteResult(Map.of());
         // throw new TdrManifestImportException(e.getMessage());
-        // TODO AJ-1013 more specific handling for 0-length directories; other errors should
+        // TODO AJ-1518 more specific handling for 0-length directories; other errors should
         //     be true failures
       }
     } catch (Throwable t) {
       logger.error("Hit an error on file: {}. Continuing.", t.getMessage());
       return new BatchWriteResult(Map.of());
       // throw new TdrManifestImportException(t.getMessage());
-      // TODO AJ-1013 more specific handling for 0-length directories; other errors should
+      // TODO AJ-1518 more specific handling for 0-length directories; other errors should
       //     be true failures
     }
   }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/TdrManifestQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/TdrManifestQuartzJob.java
@@ -232,7 +232,7 @@ public class TdrManifestQuartzJob extends QuartzJob {
    * @param manifestUrl url to the manifest
    * @return parsed object
    */
-  private SnapshotExportResponseModel parseManifest(URL manifestUrl) {
+  SnapshotExportResponseModel parseManifest(URL manifestUrl) {
     // read manifest
     try {
       return mapper.readValue(manifestUrl, SnapshotExportResponseModel.class);
@@ -248,8 +248,7 @@ public class TdrManifestQuartzJob extends QuartzJob {
    * @param snapshotExportResponseModel the inbound manifest
    * @return information necessary for the import
    */
-  // TODO AJ-1013 unit tests
-  private List<TdrManifestImportTable> extractTableInfo(
+  List<TdrManifestImportTable> extractTableInfo(
       SnapshotExportResponseModel snapshotExportResponseModel) {
 
     TdrSnapshotSupport tdrSnapshotSupport =

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/TdrManifestQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/TdrManifestQuartzJob.java
@@ -307,11 +307,11 @@ public class TdrManifestQuartzJob extends QuartzJob {
               List<URL> dataFiles =
                   table.getPaths().stream()
                       .map(
-                          x -> {
+                          path -> {
                             try {
-                              return new URL(x);
+                              return new URL(path);
                             } catch (MalformedURLException e) {
-                              throw new TdrManifestImportException(e.getMessage());
+                              throw new TdrManifestImportException(e.getMessage(), e);
                             }
                           })
                       .toList();

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/TdrSnapshotSupport.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/TdrSnapshotSupport.java
@@ -167,6 +167,7 @@ public class TdrSnapshotSupport {
       } catch (RestException re) {
         throw new DataImportException("Error processing data import: " + re.getMessage(), re);
       }
+      // TODO AJ-1013 activity logging for linking the snapshot
     }
   }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/TdrSnapshotSupport.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/TdrSnapshotSupport.java
@@ -171,7 +171,6 @@ public class TdrSnapshotSupport {
     }
   }
 
-  // TODO AJ-1013 unit tests
   Map<RecordType, String> identifyPrimaryKeys(List<TableModel> tables) {
     return tables.stream()
         .collect(
@@ -180,7 +179,6 @@ public class TdrSnapshotSupport {
                 tableModel -> identifyPrimaryKey(tableModel.getPrimaryKey())));
   }
 
-  // TODO AJ-1013 unit tests
   String identifyPrimaryKey(List<String> snapshotKeys) {
     if (snapshotKeys.size() == 1) {
       return snapshotKeys.get(0);
@@ -193,7 +191,6 @@ public class TdrSnapshotSupport {
   }
 
   // TODO AJ-1013 unit tests
-
   /**
    * Returns a Multimap of RecordType -> RelationshipModel, indicating all the outbound relations
    * for any given RecordType in this snapshot model.

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/TdrSnapshotSupport.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/TdrSnapshotSupport.java
@@ -10,6 +10,7 @@ import bio.terra.workspace.model.ResourceList;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
+import com.google.common.collect.Sets;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -146,10 +147,9 @@ public class TdrSnapshotSupport {
    */
   protected void linkSnapshots(Set<UUID> snapshotIds) {
     // list existing snapshots linked to this workspace
-    List<UUID> existingSnapshotIds = existingPolicySnapshotIds(/* pageSize= */ 50);
+    Set<UUID> existingSnapshotIds = Set.copyOf(existingPolicySnapshotIds(/* pageSize= */ 50));
     // find the snapshots that are not already linked to this workspace
-    List<UUID> newSnapshotIds =
-        snapshotIds.stream().filter(id -> !existingSnapshotIds.contains(id)).toList();
+    Set<UUID> newSnapshotIds = Sets.difference(snapshotIds, existingSnapshotIds);
 
     logger.info(
         "Import data contains {} snapshot ids. {} of these are already linked to the workspace; {} new links will be created.",

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/TdrSnapshotSupport.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/TdrSnapshotSupport.java
@@ -180,7 +180,7 @@ public class TdrSnapshotSupport {
   }
 
   String identifyPrimaryKey(List<String> snapshotKeys) {
-    if (snapshotKeys.size() == 1) {
+    if (snapshotKeys != null && snapshotKeys.size() == 1) {
       return snapshotKeys.get(0);
     }
     return DEFAULT_PRIMARY_KEY;
@@ -190,7 +190,6 @@ public class TdrSnapshotSupport {
     return DEFAULT_PRIMARY_KEY;
   }
 
-  // TODO AJ-1013 unit tests
   /**
    * Returns a Multimap of RecordType -> RelationshipModel, indicating all the outbound relations
    * for any given RecordType in this snapshot model.

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/TdrSnapshotSupport.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/TdrSnapshotSupport.java
@@ -167,7 +167,7 @@ public class TdrSnapshotSupport {
       } catch (RestException re) {
         throw new DataImportException("Error processing data import: " + re.getMessage(), re);
       }
-      // TODO AJ-1013 activity logging for linking the snapshot
+      // TODO AJ-1520 activity logging for linking the snapshot
     }
   }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/BatchWriteService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/BatchWriteService.java
@@ -95,10 +95,11 @@ public class BatchWriteService {
     BatchWriteResult result = BatchWriteResult.empty();
     try {
       // Verify relationsOnly is only for pfbstreamingwriteHandler
-      if (pfbImportMode == RELATIONS && !(streamingWriteHandler instanceof PfbStreamWriteHandler)) {
+      if (pfbImportMode == RELATIONS
+          && !(streamingWriteHandler instanceof TwoPassStreamingWriteHandler)) {
         throw new BadStreamingWriteRequestException(
-            "BatchWriteService attempted to re-read PFB "
-                + "on a non-PFB import. Cannot continue.");
+            "BatchWriteService attempted to re-read input data, but this input is not configured "
+                + "as re-readable. Cannot continue.");
       }
 
       // tracker to stash the schemas for the record types seen while processing this stream

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/BatchWriteService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/BatchWriteService.java
@@ -24,6 +24,7 @@ import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.databiosphere.workspacedataservice.dataimport.ParquetStreamWriteHandler;
 import org.databiosphere.workspacedataservice.service.model.BatchWriteResult;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
+import org.databiosphere.workspacedataservice.service.model.TdrManifestImportTable;
 import org.databiosphere.workspacedataservice.service.model.exception.BadStreamingWriteRequestException;
 import org.databiosphere.workspacedataservice.service.model.exception.BatchWriteException;
 import org.databiosphere.workspacedataservice.shared.model.OperationType;
@@ -231,13 +232,17 @@ public class BatchWriteService {
   public BatchWriteResult batchWriteParquetStream(
       ParquetReader<GenericRecord> avroParquetReader,
       UUID instanceId,
-      RecordType recordType,
-      String primaryKey,
+      TdrManifestImportTable table,
       PfbStreamWriteHandler.PfbImportMode pfbImportMode) {
+    // record type and primary key for this
     try (ParquetStreamWriteHandler streamingWriteHandler =
-        new ParquetStreamWriteHandler(avroParquetReader, pfbImportMode, recordType, primaryKey)) {
+        new ParquetStreamWriteHandler(avroParquetReader, pfbImportMode, table)) {
       return consumeWriteStreamWithRelations(
-          streamingWriteHandler, instanceId, recordType, Optional.of(primaryKey), pfbImportMode);
+          streamingWriteHandler,
+          instanceId,
+          table.recordType(),
+          Optional.of(table.primaryKey()),
+          pfbImportMode);
     } catch (IOException e) {
       throw new BadStreamingWriteRequestException(e);
     }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/BatchWriteService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/BatchWriteService.java
@@ -221,6 +221,9 @@ public class BatchWriteService {
           streamingWriteHandler, instanceId, null, primaryKey, pfbImportMode);
     } catch (IOException e) {
       throw new BadStreamingWriteRequestException(e);
+    } catch (Exception e) {
+      System.err.println("ERROR IN batchWritePfbStream: " + e.getMessage());
+      return new BatchWriteResult(Map.of());
     }
   }
 
@@ -229,12 +232,12 @@ public class BatchWriteService {
       ParquetReader<GenericRecord> avroParquetReader,
       UUID instanceId,
       RecordType recordType,
-      Optional<String> primaryKey,
+      String primaryKey,
       PfbStreamWriteHandler.PfbImportMode pfbImportMode) {
     try (ParquetStreamWriteHandler streamingWriteHandler =
-        new ParquetStreamWriteHandler(avroParquetReader, pfbImportMode)) {
+        new ParquetStreamWriteHandler(avroParquetReader, pfbImportMode, recordType, primaryKey)) {
       return consumeWriteStreamWithRelations(
-          streamingWriteHandler, instanceId, recordType, primaryKey, pfbImportMode);
+          streamingWriteHandler, instanceId, recordType, Optional.of(primaryKey), pfbImportMode);
     } catch (IOException e) {
       throw new BadStreamingWriteRequestException(e);
     }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/BatchWriteService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/BatchWriteService.java
@@ -19,7 +19,9 @@ import java.util.Set;
 import java.util.UUID;
 import org.apache.avro.file.DataFileStream;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.parquet.hadoop.ParquetReader;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
+import org.databiosphere.workspacedataservice.dataimport.ParquetStreamWriteHandler;
 import org.databiosphere.workspacedataservice.service.model.BatchWriteResult;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
 import org.databiosphere.workspacedataservice.service.model.exception.BadStreamingWriteRequestException;
@@ -217,6 +219,22 @@ public class BatchWriteService {
         new PfbStreamWriteHandler(is, pfbImportMode)) {
       return consumeWriteStreamWithRelations(
           streamingWriteHandler, instanceId, null, primaryKey, pfbImportMode);
+    } catch (IOException e) {
+      throw new BadStreamingWriteRequestException(e);
+    }
+  }
+
+  @WriteTransaction
+  public BatchWriteResult batchWriteParquetStream(
+      ParquetReader<GenericRecord> avroParquetReader,
+      UUID instanceId,
+      RecordType recordType,
+      Optional<String> primaryKey,
+      PfbStreamWriteHandler.PfbImportMode pfbImportMode) {
+    try (ParquetStreamWriteHandler streamingWriteHandler =
+        new ParquetStreamWriteHandler(avroParquetReader, pfbImportMode)) {
+      return consumeWriteStreamWithRelations(
+          streamingWriteHandler, instanceId, recordType, primaryKey, pfbImportMode);
     } catch (IOException e) {
       throw new BadStreamingWriteRequestException(e);
     }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/BatchWriteService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/BatchWriteService.java
@@ -1,7 +1,7 @@
 package org.databiosphere.workspacedataservice.service;
 
-import static org.databiosphere.workspacedataservice.service.PfbStreamWriteHandler.PfbImportMode.BASE_ATTRIBUTES;
-import static org.databiosphere.workspacedataservice.service.PfbStreamWriteHandler.PfbImportMode.RELATIONS;
+import static org.databiosphere.workspacedataservice.service.TwoPassStreamingWriteHandler.ImportMode.BASE_ATTRIBUTES;
+import static org.databiosphere.workspacedataservice.service.TwoPassStreamingWriteHandler.ImportMode.RELATIONS;
 import static org.databiosphere.workspacedataservice.service.model.ReservedNames.RECORD_ID;
 
 import bio.terra.common.db.WriteTransaction;
@@ -91,11 +91,11 @@ public class BatchWriteService {
       UUID instanceId,
       RecordType recordType,
       Optional<String> primaryKey,
-      PfbStreamWriteHandler.PfbImportMode pfbImportMode) {
+      TwoPassStreamingWriteHandler.ImportMode importMode) {
     BatchWriteResult result = BatchWriteResult.empty();
     try {
       // Verify relationsOnly is only for pfbstreamingwriteHandler
-      if (pfbImportMode == RELATIONS
+      if (importMode == RELATIONS
           && !(streamingWriteHandler instanceof TwoPassStreamingWriteHandler)) {
         throw new BadStreamingWriteRequestException(
             "BatchWriteService attempted to re-read input data, but this input is not configured "
@@ -145,8 +145,8 @@ public class BatchWriteService {
             typesSeen.put(recType, finalSchema);
           }
           // when updating relations only, do not update if there are no relations
-          if (pfbImportMode == BASE_ATTRIBUTES || !typesSeen.get(recType).isEmpty()) {
-            if (pfbImportMode == RELATIONS) {
+          if (importMode == BASE_ATTRIBUTES || !typesSeen.get(recType).isEmpty()) {
+            if (importMode == RELATIONS) {
               // For relations only, remove records that have no relations
               rList = rList.stream().filter(rec -> !rec.attributeSet().isEmpty()).toList();
             }
@@ -220,11 +220,11 @@ public class BatchWriteService {
       DataFileStream<GenericRecord> is,
       UUID instanceId,
       Optional<String> primaryKey,
-      PfbStreamWriteHandler.PfbImportMode pfbImportMode) {
+      TwoPassStreamingWriteHandler.ImportMode importMode) {
     try (PfbStreamWriteHandler streamingWriteHandler =
-        new PfbStreamWriteHandler(is, pfbImportMode, pfbRecordConverter)) {
+        new PfbStreamWriteHandler(is, importMode, pfbRecordConverter)) {
       return consumeWriteStreamWithRelations(
-          streamingWriteHandler, instanceId, null, primaryKey, pfbImportMode);
+          streamingWriteHandler, instanceId, null, primaryKey, importMode);
     } catch (IOException e) {
       throw new BadStreamingWriteRequestException(e);
     } catch (Exception e) {
@@ -238,16 +238,16 @@ public class BatchWriteService {
       ParquetReader<GenericRecord> avroParquetReader,
       UUID instanceId,
       TdrManifestImportTable table,
-      PfbStreamWriteHandler.PfbImportMode pfbImportMode) {
+      TwoPassStreamingWriteHandler.ImportMode importMode) {
     // record type and primary key for this
     try (ParquetStreamWriteHandler streamingWriteHandler =
-        new ParquetStreamWriteHandler(avroParquetReader, pfbImportMode, table, objectMapper)) {
+        new ParquetStreamWriteHandler(avroParquetReader, importMode, table, objectMapper)) {
       return consumeWriteStreamWithRelations(
           streamingWriteHandler,
           instanceId,
           table.recordType(),
           Optional.of(table.primaryKey()),
-          pfbImportMode);
+          importMode);
     } catch (IOException e) {
       throw new BadStreamingWriteRequestException(e);
     }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/BatchWriteService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/BatchWriteService.java
@@ -240,7 +240,7 @@ public class BatchWriteService {
       PfbStreamWriteHandler.PfbImportMode pfbImportMode) {
     // record type and primary key for this
     try (ParquetStreamWriteHandler streamingWriteHandler =
-        new ParquetStreamWriteHandler(avroParquetReader, pfbImportMode, table)) {
+        new ParquetStreamWriteHandler(avroParquetReader, pfbImportMode, table, objectMapper)) {
       return consumeWriteStreamWithRelations(
           streamingWriteHandler,
           instanceId,

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/PfbStreamWriteHandler.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/PfbStreamWriteHandler.java
@@ -13,28 +13,24 @@ import org.databiosphere.workspacedataservice.shared.model.OperationType;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 
 public class PfbStreamWriteHandler implements TwoPassStreamingWriteHandler {
-  public enum PfbImportMode {
-    RELATIONS,
-    BASE_ATTRIBUTES
-  }
 
   private final DataFileStream<GenericRecord> inputStream;
-  private final PfbImportMode pfbImportMode;
+  private final ImportMode importMode;
   private final PfbRecordConverter pfbRecordConverter;
 
   /**
    * Create a new PfbStreamWriteHandler and specify the expected schemas for the PFB.
    *
    * @param inputStream the PFB stream
-   * @param pfbImportMode the mode to use when importing the PFB
+   * @param importMode the mode to use when importing the PFB
    * @param pfbRecordConverter the converter to use when converting PFB records to WDS records
    */
   public PfbStreamWriteHandler(
       DataFileStream<GenericRecord> inputStream,
-      PfbImportMode pfbImportMode,
+      ImportMode importMode,
       PfbRecordConverter pfbRecordConverter) {
     this.inputStream = inputStream;
-    this.pfbImportMode = pfbImportMode;
+    this.importMode = importMode;
     this.pfbRecordConverter = pfbRecordConverter;
   }
 
@@ -47,7 +43,7 @@ public class PfbStreamWriteHandler implements TwoPassStreamingWriteHandler {
 
     // convert the PFB GenericRecord objects into WDS Record objects
     List<Record> records =
-        pfbBatch.map(rec -> pfbRecordConverter.genericRecordToRecord(rec, pfbImportMode)).toList();
+        pfbBatch.map(rec -> pfbRecordConverter.genericRecordToRecord(rec, importMode)).toList();
 
     return new WriteStreamInfo(records, OperationType.UPSERT);
   }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/PfbStreamWriteHandler.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/PfbStreamWriteHandler.java
@@ -12,7 +12,7 @@ import org.databiosphere.workspacedataservice.dataimport.PfbRecordConverter;
 import org.databiosphere.workspacedataservice.shared.model.OperationType;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 
-public class PfbStreamWriteHandler implements StreamingWriteHandler {
+public class PfbStreamWriteHandler implements TwoPassStreamingWriteHandler {
   public enum PfbImportMode {
     RELATIONS,
     BASE_ATTRIBUTES

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/PfbStreamWriteHandler.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/PfbStreamWriteHandler.java
@@ -43,7 +43,7 @@ public class PfbStreamWriteHandler implements TwoPassStreamingWriteHandler {
 
     // convert the PFB GenericRecord objects into WDS Record objects
     List<Record> records =
-        pfbBatch.map(rec -> pfbRecordConverter.genericRecordToRecord(rec, importMode)).toList();
+        pfbBatch.map(rec -> pfbRecordConverter.convert(rec, importMode)).toList();
 
     return new WriteStreamInfo(records, OperationType.UPSERT);
   }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/TwoPassStreamingWriteHandler.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/TwoPassStreamingWriteHandler.java
@@ -1,3 +1,8 @@
 package org.databiosphere.workspacedataservice.service;
 
+/**
+ * Marker interface that denotes a StreamingWriteHandler which runs in two passes. The first pass
+ * will upsert base attributes, and the second pass will upsert relation attributes. This allows for
+ * data streams where earlier records contain relations to later records.
+ */
 public interface TwoPassStreamingWriteHandler extends StreamingWriteHandler {}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/TwoPassStreamingWriteHandler.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/TwoPassStreamingWriteHandler.java
@@ -5,4 +5,10 @@ package org.databiosphere.workspacedataservice.service;
  * will upsert base attributes, and the second pass will upsert relation attributes. This allows for
  * data streams where earlier records contain relations to later records.
  */
-public interface TwoPassStreamingWriteHandler extends StreamingWriteHandler {}
+public interface TwoPassStreamingWriteHandler extends StreamingWriteHandler {
+
+  enum ImportMode {
+    RELATIONS,
+    BASE_ATTRIBUTES
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/TwoPassStreamingWriteHandler.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/TwoPassStreamingWriteHandler.java
@@ -1,0 +1,3 @@
+package org.databiosphere.workspacedataservice.service;
+
+public interface TwoPassStreamingWriteHandler extends StreamingWriteHandler {}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/TdrManifestImportTable.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/TdrManifestImportTable.java
@@ -1,0 +1,12 @@
+package org.databiosphere.workspacedataservice.service.model;
+
+import bio.terra.datarepo.model.RelationshipModel;
+import java.net.URL;
+import java.util.List;
+import org.databiosphere.workspacedataservice.shared.model.RecordType;
+
+public record TdrManifestImportTable(
+    RecordType recordType,
+    String primaryKey,
+    List<URL> dataFiles,
+    List<RelationshipModel> relations) {}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/DataImportException.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/DataImportException.java
@@ -4,13 +4,13 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 @ResponseStatus(code = HttpStatus.INTERNAL_SERVER_ERROR)
-public class PfbImportException extends DataImportException {
+public class DataImportException extends RuntimeException {
 
-  public PfbImportException(String message) {
+  public DataImportException(String message) {
     super(message);
   }
 
-  public PfbImportException(String message, Exception e) {
+  public DataImportException(String message, Exception e) {
     super(message, e);
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/TdrManifestImportException.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/TdrManifestImportException.java
@@ -1,0 +1,16 @@
+package org.databiosphere.workspacedataservice.service.model.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(code = HttpStatus.INTERNAL_SERVER_ERROR)
+public class TdrManifestImportException extends DataImportException {
+
+  public TdrManifestImportException(String message) {
+    super(message);
+  }
+
+  public TdrManifestImportException(String message, Exception e) {
+    super(message, e);
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/Record.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/Record.java
@@ -26,16 +26,12 @@ public class Record {
 
   public Record() {}
 
-  public Record(String id) {
-    Preconditions.checkArgument(StringUtils.isNotBlank(id), "Record id can't be null or empty");
-    this.id = id;
+  public Record(String id, RecordType type) {
+    this(id, type, RecordAttributes.empty());
   }
 
   public Record(String id, RecordType type, RecordRequest request) {
-    Preconditions.checkArgument(StringUtils.isNotBlank(id), "Record id can't be null or empty");
-    this.id = id;
-    this.recordType = type;
-    this.attributes = request.recordAttributes();
+    this(id, type, request.recordAttributes());
   }
 
   public String getId() {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/PfbQuartzJobTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/PfbQuartzJobTest.java
@@ -2,7 +2,7 @@ package org.databiosphere.workspacedataservice.dataimport;
 
 import static org.databiosphere.workspacedataservice.dataimport.PfbTestUtils.buildQuartzJob;
 import static org.databiosphere.workspacedataservice.dataimport.PfbTestUtils.stubJobContext;
-import static org.databiosphere.workspacedataservice.service.PfbStreamWriteHandler.PfbImportMode.BASE_ATTRIBUTES;
+import static org.databiosphere.workspacedataservice.service.TwoPassStreamingWriteHandler.ImportMode.BASE_ATTRIBUTES;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/PfbRecordConverterTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/PfbRecordConverterTest.java
@@ -137,8 +137,7 @@ class PfbRecordConverterTest {
             .set("embeddedObject", embeddedObjectRecord)
             .build();
     GenericRecord input = PfbTestUtils.makeRecord("my-id", "mytype", objectAttributes);
-    Record actual =
-        converter.convert(input, TwoPassStreamingWriteHandler.ImportMode.BASE_ATTRIBUTES);
+    Record actual = converter.convert(input, ImportMode.BASE_ATTRIBUTES);
 
     Set<Map.Entry<String, Object>> actualAttributeSet = actual.attributeSet();
     Set<String> actualKeySet =
@@ -196,7 +195,7 @@ class PfbRecordConverterTest {
     GenericRecord input =
         PfbTestUtils.makeRecord(
             "my-id", "mytype", new GenericData.Record(OBJECT_SCHEMA), relations);
-    Record actual = converter.convert(input, TwoPassStreamingWriteHandler.ImportMode.RELATIONS);
+    Record actual = converter.convert(input, ImportMode.RELATIONS);
 
     assertEquals(
         RelationUtils.createRelationString(RecordType.valueOf("relation_table"), "relation_id"),

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/PfbRecordConverterTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/PfbRecordConverterTest.java
@@ -25,8 +25,8 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.databiosphere.workspacedataservice.service.JsonConfig;
-import org.databiosphere.workspacedataservice.service.PfbStreamWriteHandler.PfbImportMode;
 import org.databiosphere.workspacedataservice.service.RelationUtils;
+import org.databiosphere.workspacedataservice.service.TwoPassStreamingWriteHandler;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 import org.junit.jupiter.api.Test;
@@ -48,7 +48,9 @@ class PfbRecordConverterTest {
     String inputName = RandomStringUtils.randomAlphanumeric(16);
     GenericRecord input = PfbTestUtils.makeRecord(inputId, inputName);
 
-    Record actual = converter.genericRecordToRecord(input, PfbImportMode.BASE_ATTRIBUTES);
+    Record actual =
+        converter.genericRecordToRecord(
+            input, TwoPassStreamingWriteHandler.ImportMode.BASE_ATTRIBUTES);
 
     assertEquals(inputId, actual.getId());
     assertEquals(inputName, actual.getRecordTypeName());
@@ -58,7 +60,9 @@ class PfbRecordConverterTest {
   @Test
   void emptyObjectAttributes() {
     GenericRecord input = PfbTestUtils.makeRecord("my-id", "my-name");
-    Record actual = converter.genericRecordToRecord(input, PfbImportMode.BASE_ATTRIBUTES);
+    Record actual =
+        converter.genericRecordToRecord(
+            input, TwoPassStreamingWriteHandler.ImportMode.BASE_ATTRIBUTES);
 
     assertThat(actual.attributeSet()).isEmpty();
   }
@@ -137,7 +141,9 @@ class PfbRecordConverterTest {
             .set("embeddedObject", embeddedObjectRecord)
             .build();
     GenericRecord input = PfbTestUtils.makeRecord("my-id", "mytype", objectAttributes);
-    Record actual = converter.genericRecordToRecord(input, PfbImportMode.BASE_ATTRIBUTES);
+    Record actual =
+        converter.genericRecordToRecord(
+            input, TwoPassStreamingWriteHandler.ImportMode.BASE_ATTRIBUTES);
 
     Set<Map.Entry<String, Object>> actualAttributeSet = actual.attributeSet();
     Set<String> actualKeySet =
@@ -195,7 +201,8 @@ class PfbRecordConverterTest {
     GenericRecord input =
         PfbTestUtils.makeRecord(
             "my-id", "mytype", new GenericData.Record(OBJECT_SCHEMA), relations);
-    Record actual = converter.genericRecordToRecord(input, PfbImportMode.RELATIONS);
+    Record actual =
+        converter.genericRecordToRecord(input, TwoPassStreamingWriteHandler.ImportMode.RELATIONS);
 
     assertEquals(
         RelationUtils.createRelationString(RecordType.valueOf("relation_table"), "relation_id"),

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/PfbRecordConverterTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/PfbRecordConverterTest.java
@@ -49,8 +49,7 @@ class PfbRecordConverterTest {
     GenericRecord input = PfbTestUtils.makeRecord(inputId, inputName);
 
     Record actual =
-        converter.genericRecordToRecord(
-            input, TwoPassStreamingWriteHandler.ImportMode.BASE_ATTRIBUTES);
+        converter.convert(input, TwoPassStreamingWriteHandler.ImportMode.BASE_ATTRIBUTES);
 
     assertEquals(inputId, actual.getId());
     assertEquals(inputName, actual.getRecordTypeName());
@@ -61,8 +60,7 @@ class PfbRecordConverterTest {
   void emptyObjectAttributes() {
     GenericRecord input = PfbTestUtils.makeRecord("my-id", "my-name");
     Record actual =
-        converter.genericRecordToRecord(
-            input, TwoPassStreamingWriteHandler.ImportMode.BASE_ATTRIBUTES);
+        converter.convert(input, TwoPassStreamingWriteHandler.ImportMode.BASE_ATTRIBUTES);
 
     assertThat(actual.attributeSet()).isEmpty();
   }
@@ -142,8 +140,7 @@ class PfbRecordConverterTest {
             .build();
     GenericRecord input = PfbTestUtils.makeRecord("my-id", "mytype", objectAttributes);
     Record actual =
-        converter.genericRecordToRecord(
-            input, TwoPassStreamingWriteHandler.ImportMode.BASE_ATTRIBUTES);
+        converter.convert(input, TwoPassStreamingWriteHandler.ImportMode.BASE_ATTRIBUTES);
 
     Set<Map.Entry<String, Object>> actualAttributeSet = actual.attributeSet();
     Set<String> actualKeySet =
@@ -201,8 +198,7 @@ class PfbRecordConverterTest {
     GenericRecord input =
         PfbTestUtils.makeRecord(
             "my-id", "mytype", new GenericData.Record(OBJECT_SCHEMA), relations);
-    Record actual =
-        converter.genericRecordToRecord(input, TwoPassStreamingWriteHandler.ImportMode.RELATIONS);
+    Record actual = converter.convert(input, TwoPassStreamingWriteHandler.ImportMode.RELATIONS);
 
     assertEquals(
         RelationUtils.createRelationString(RecordType.valueOf("relation_table"), "relation_id"),

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/PfbRecordConverterTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/PfbRecordConverterTest.java
@@ -26,7 +26,7 @@ import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.databiosphere.workspacedataservice.service.JsonConfig;
 import org.databiosphere.workspacedataservice.service.RelationUtils;
-import org.databiosphere.workspacedataservice.service.TwoPassStreamingWriteHandler;
+import org.databiosphere.workspacedataservice.service.TwoPassStreamingWriteHandler.ImportMode;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 import org.junit.jupiter.api.Test;
@@ -48,8 +48,7 @@ class PfbRecordConverterTest {
     String inputName = RandomStringUtils.randomAlphanumeric(16);
     GenericRecord input = PfbTestUtils.makeRecord(inputId, inputName);
 
-    Record actual =
-        converter.convert(input, TwoPassStreamingWriteHandler.ImportMode.BASE_ATTRIBUTES);
+    Record actual = converter.convert(input, ImportMode.BASE_ATTRIBUTES);
 
     assertEquals(inputId, actual.getId());
     assertEquals(inputName, actual.getRecordTypeName());
@@ -59,8 +58,7 @@ class PfbRecordConverterTest {
   @Test
   void emptyObjectAttributes() {
     GenericRecord input = PfbTestUtils.makeRecord("my-id", "my-name");
-    Record actual =
-        converter.convert(input, TwoPassStreamingWriteHandler.ImportMode.BASE_ATTRIBUTES);
+    Record actual = converter.convert(input, ImportMode.BASE_ATTRIBUTES);
 
     assertThat(actual.attributeSet()).isEmpty();
   }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/TdrManifestExemplarData.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/TdrManifestExemplarData.java
@@ -1,0 +1,42 @@
+package org.databiosphere.workspacedataservice.dataimport;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+
+/**
+ * (partial) Java representations of the test manifests located in
+ * service/src/test/resources/tdrmanifest
+ */
+public class TdrManifestExemplarData {
+
+  /** the "azure_small.json" file */
+  static class AzureSmall {
+
+    static List<URL> projectParquetUrls;
+    static List<URL> edgesParquetUrls;
+    static List<URL> testResultParquetUrls;
+
+    static {
+      try {
+        projectParquetUrls =
+            List.of(
+                new URL(
+                    "https://mysnapshotsa.blob.core.windows.net/metadata/parquet/9516afec-583f-11ec-bf63-0242ac130002/project.parquet/F0EE365B-314D-4E19-A177-E8F63D883716_9274_0-1.parquet?sp=r&st=2022-08-04T15:31:55Z&se=2022-08-06T23:31:55Z&spr=https&sv=2021-06-08&sr=b&sig=bogus"));
+        edgesParquetUrls =
+            List.of(
+                new URL(
+                    "https://mysnapshotsa.blob.core.windows.net/metadata/parquet/9516afec-583f-11ec-bf63-0242ac130002/edges.parquet/F0EE365B-314D-4E19-A177-E8F63D883716_9274_0-1.parquet?sp=r&st=2022-08-04T15:31:55Z&se=2022-08-06T23:31:55Z&spr=https&sv=2021-06-08&sr=b&sig=bogus"),
+                new URL(
+                    "https://mysnapshotsa.blob.core.windows.net/metadata/parquet/9516afec-583f-11ec-bf63-0242ac130002/edges.parquet/F0EE365B-314D-4E19-A177-E8F63D883716_9274_0-2.parquet?sp=r&st=2022-08-04T15:31:55Z&se=2022-08-06T23:31:55Z&spr=https&sv=2021-06-08&sr=b&sig=bogus"));
+        testResultParquetUrls =
+            List.of(
+                new URL(
+                    "https://mysnapshotsa.blob.core.windows.net/metadata/parquet/9516afec-583f-11ec-bf63-0242ac130002/test_result.parquet/F0EE365B-314D-4E19-A177-E8F63D883716_9274_0-1.parquet?sp=r&st=2022-08-04T15:31:55Z&se=2022-08-06T23:31:55Z&spr=https&sv=2021-06-08&sr=b&sig=bogus"));
+
+      } catch (MalformedURLException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/TdrManifestQuartzJobTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/TdrManifestQuartzJobTest.java
@@ -7,11 +7,11 @@ import bio.terra.datarepo.model.RelationshipTermModel;
 import bio.terra.datarepo.model.SnapshotExportResponseModel;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
-import java.net.URL;
 import java.util.List;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
 import org.databiosphere.workspacedataservice.dao.JobDao;
+import org.databiosphere.workspacedataservice.dataimport.TdrManifestExemplarData.AzureSmall;
 import org.databiosphere.workspacedataservice.retry.RestClientRetry;
 import org.databiosphere.workspacedataservice.service.BatchWriteService;
 import org.databiosphere.workspacedataservice.service.model.TdrManifestImportTable;
@@ -59,34 +59,21 @@ public class TdrManifestQuartzJobTest {
     SnapshotExportResponseModel snapshotExportResponseModel =
         tdrManifestQuartzJob.parseManifest(manifestAzure.getURL());
 
-    // URLs for use in the manifest below
-    List<URL> projectParquetUrls =
-        List.of(
-            new URL(
-                "https://mysnapshotsa.blob.core.windows.net/metadata/parquet/9516afec-583f-11ec-bf63-0242ac130002/project.parquet/F0EE365B-314D-4E19-A177-E8F63D883716_9274_0-1.parquet?sp=r&st=2022-08-04T15:31:55Z&se=2022-08-06T23:31:55Z&spr=https&sv=2021-06-08&sr=b&sig=bogus"));
-    List<URL> edgesParquetUrls =
-        List.of(
-            new URL(
-                "https://mysnapshotsa.blob.core.windows.net/metadata/parquet/9516afec-583f-11ec-bf63-0242ac130002/edges.parquet/F0EE365B-314D-4E19-A177-E8F63D883716_9274_0-1.parquet?sp=r&st=2022-08-04T15:31:55Z&se=2022-08-06T23:31:55Z&spr=https&sv=2021-06-08&sr=b&sig=bogus"),
-            new URL(
-                "https://mysnapshotsa.blob.core.windows.net/metadata/parquet/9516afec-583f-11ec-bf63-0242ac130002/edges.parquet/F0EE365B-314D-4E19-A177-E8F63D883716_9274_0-2.parquet?sp=r&st=2022-08-04T15:31:55Z&se=2022-08-06T23:31:55Z&spr=https&sv=2021-06-08&sr=b&sig=bogus"));
-    List<URL> testResultParquetUrls =
-        List.of(
-            new URL(
-                "https://mysnapshotsa.blob.core.windows.net/metadata/parquet/9516afec-583f-11ec-bf63-0242ac130002/test_result.parquet/F0EE365B-314D-4E19-A177-E8F63D883716_9274_0-1.parquet?sp=r&st=2022-08-04T15:31:55Z&se=2022-08-06T23:31:55Z&spr=https&sv=2021-06-08&sr=b&sig=bogus"));
-
     // this manifest describes tables for project, edges, test_result, genome in the snapshot,
     // but only contains export data files for project, edges, and test_result.
     List<TdrManifestImportTable> expected =
         List.of(
             // single primary key
             new TdrManifestImportTable(
-                RecordType.valueOf("project"), "project_id", projectParquetUrls, List.of()),
+                RecordType.valueOf("project"),
+                "project_id",
+                AzureSmall.projectParquetUrls,
+                List.of()),
             // null primary key
             new TdrManifestImportTable(
                 RecordType.valueOf("edges"),
                 "datarepo_row_id",
-                edgesParquetUrls,
+                AzureSmall.edgesParquetUrls,
                 List.of(
                     new RelationshipModel()
                         .name("from_edges.project_id_to_project.project_id")
@@ -97,7 +84,7 @@ public class TdrManifestQuartzJobTest {
             new TdrManifestImportTable(
                 RecordType.valueOf("test_result"),
                 "datarepo_row_id",
-                testResultParquetUrls,
+                AzureSmall.testResultParquetUrls,
                 List.of()));
 
     List<TdrManifestImportTable> actual =

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/TdrManifestQuartzJobTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/TdrManifestQuartzJobTest.java
@@ -1,0 +1,103 @@
+package org.databiosphere.workspacedataservice.dataimport;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import bio.terra.datarepo.model.RelationshipModel;
+import bio.terra.datarepo.model.RelationshipTermModel;
+import bio.terra.datarepo.model.SnapshotExportResponseModel;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.net.URL;
+import java.util.List;
+import java.util.UUID;
+import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
+import org.databiosphere.workspacedataservice.dao.JobDao;
+import org.databiosphere.workspacedataservice.retry.RestClientRetry;
+import org.databiosphere.workspacedataservice.service.BatchWriteService;
+import org.databiosphere.workspacedataservice.service.model.TdrManifestImportTable;
+import org.databiosphere.workspacedataservice.shared.model.RecordType;
+import org.databiosphere.workspacedataservice.workspacemanager.WorkspaceManagerDao;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.core.io.Resource;
+import org.springframework.test.annotation.DirtiesContext;
+
+@DirtiesContext
+@SpringBootTest
+public class TdrManifestQuartzJobTest {
+
+  @MockBean JobDao jobDao;
+  @MockBean WorkspaceManagerDao wsmDao;
+  @MockBean BatchWriteService batchWriteService;
+  @MockBean ActivityLogger activityLogger;
+  @Autowired RestClientRetry restClientRetry;
+  @Autowired ObjectMapper objectMapper;
+
+  // test resources used below
+  @Value("classpath:tdrmanifest/azure_small.json")
+  Resource manifestAzure;
+
+  @Value("classpath:tdrmanifest/tdr_response_with_cycle.json")
+  Resource manifestWithCycle;
+
+  @Test
+  void extractSnapshotInfo() throws IOException {
+    UUID workspaceId = UUID.randomUUID();
+    TdrManifestQuartzJob tdrManifestQuartzJob =
+        new TdrManifestQuartzJob(
+            jobDao,
+            wsmDao,
+            restClientRetry,
+            batchWriteService,
+            activityLogger,
+            workspaceId,
+            objectMapper);
+
+    SnapshotExportResponseModel snapshotExportResponseModel =
+        tdrManifestQuartzJob.parseManifest(manifestAzure.getURL());
+
+    // this manifest describes tables for project, edges, test_result, genome in the snapshot
+    // schema,
+    // but only contains export data files for project, edges, and test_result.
+    List<TdrManifestImportTable> expected =
+        List.of(
+            // null primary key
+            new TdrManifestImportTable(
+                RecordType.valueOf("project"),
+                "datarepo_row_id",
+                List.of(
+                    new URL(
+                        "https://mysnapshotsa.blob.core.windows.net/metadata/parquet/9516afec-583f-11ec-bf63-0242ac130002/project.parquet/F0EE365B-314D-4E19-A177-E8F63D883716_9274_0-1.parquet?sp=r&st=2022-08-04T15:31:55Z&se=2022-08-06T23:31:55Z&spr=https&sv=2021-06-08&sr=b&sig=bogus")),
+                List.of()),
+            // single primary key
+            new TdrManifestImportTable(
+                RecordType.valueOf("edges"),
+                "edges_id",
+                List.of(
+                    new URL(
+                        "https://mysnapshotsa.blob.core.windows.net/metadata/parquet/9516afec-583f-11ec-bf63-0242ac130002/edges.parquet/F0EE365B-314D-4E19-A177-E8F63D883716_9274_0-1.parquet?sp=r&st=2022-08-04T15:31:55Z&se=2022-08-06T23:31:55Z&spr=https&sv=2021-06-08&sr=b&sig=bogus"),
+                    new URL(
+                        "https://mysnapshotsa.blob.core.windows.net/metadata/parquet/9516afec-583f-11ec-bf63-0242ac130002/edges.parquet/F0EE365B-314D-4E19-A177-E8F63D883716_9274_0-2.parquet?sp=r&st=2022-08-04T15:31:55Z&se=2022-08-06T23:31:55Z&spr=https&sv=2021-06-08&sr=b&sig=bogus")),
+                List.of(
+                    new RelationshipModel()
+                        .name("from_edges.project_id_to_project.project_id")
+                        .from(new RelationshipTermModel().table("edges").column("project_id"))
+                        .to(new RelationshipTermModel().table("project").column("project_id")))),
+            // compound primary key
+            new TdrManifestImportTable(
+                RecordType.valueOf("test_result"),
+                "datarepo_row_id",
+                List.of(
+                    new URL(
+                        "https://mysnapshotsa.blob.core.windows.net/metadata/parquet/9516afec-583f-11ec-bf63-0242ac130002/test_result.parquet/F0EE365B-314D-4E19-A177-E8F63D883716_9274_0-1.parquet?sp=r&st=2022-08-04T15:31:55Z&se=2022-08-06T23:31:55Z&spr=https&sv=2021-06-08&sr=b&sig=bogus")),
+                List.of()));
+
+    List<TdrManifestImportTable> actual =
+        tdrManifestQuartzJob.extractTableInfo(snapshotExportResponseModel);
+
+    assertEquals(expected, actual);
+  }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/TdrManifestQuartzJobTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/TdrManifestQuartzJobTest.java
@@ -59,28 +59,34 @@ public class TdrManifestQuartzJobTest {
     SnapshotExportResponseModel snapshotExportResponseModel =
         tdrManifestQuartzJob.parseManifest(manifestAzure.getURL());
 
-    // this manifest describes tables for project, edges, test_result, genome in the snapshot
-    // schema,
+    // URLs for use in the manifest below
+    List<URL> projectParquetUrls =
+        List.of(
+            new URL(
+                "https://mysnapshotsa.blob.core.windows.net/metadata/parquet/9516afec-583f-11ec-bf63-0242ac130002/project.parquet/F0EE365B-314D-4E19-A177-E8F63D883716_9274_0-1.parquet?sp=r&st=2022-08-04T15:31:55Z&se=2022-08-06T23:31:55Z&spr=https&sv=2021-06-08&sr=b&sig=bogus"));
+    List<URL> edgesParquetUrls =
+        List.of(
+            new URL(
+                "https://mysnapshotsa.blob.core.windows.net/metadata/parquet/9516afec-583f-11ec-bf63-0242ac130002/edges.parquet/F0EE365B-314D-4E19-A177-E8F63D883716_9274_0-1.parquet?sp=r&st=2022-08-04T15:31:55Z&se=2022-08-06T23:31:55Z&spr=https&sv=2021-06-08&sr=b&sig=bogus"),
+            new URL(
+                "https://mysnapshotsa.blob.core.windows.net/metadata/parquet/9516afec-583f-11ec-bf63-0242ac130002/edges.parquet/F0EE365B-314D-4E19-A177-E8F63D883716_9274_0-2.parquet?sp=r&st=2022-08-04T15:31:55Z&se=2022-08-06T23:31:55Z&spr=https&sv=2021-06-08&sr=b&sig=bogus"));
+    List<URL> testResultParquetUrls =
+        List.of(
+            new URL(
+                "https://mysnapshotsa.blob.core.windows.net/metadata/parquet/9516afec-583f-11ec-bf63-0242ac130002/test_result.parquet/F0EE365B-314D-4E19-A177-E8F63D883716_9274_0-1.parquet?sp=r&st=2022-08-04T15:31:55Z&se=2022-08-06T23:31:55Z&spr=https&sv=2021-06-08&sr=b&sig=bogus"));
+
+    // this manifest describes tables for project, edges, test_result, genome in the snapshot,
     // but only contains export data files for project, edges, and test_result.
     List<TdrManifestImportTable> expected =
         List.of(
             // single primary key
             new TdrManifestImportTable(
-                RecordType.valueOf("project"),
-                "project_id",
-                List.of(
-                    new URL(
-                        "https://mysnapshotsa.blob.core.windows.net/metadata/parquet/9516afec-583f-11ec-bf63-0242ac130002/project.parquet/F0EE365B-314D-4E19-A177-E8F63D883716_9274_0-1.parquet?sp=r&st=2022-08-04T15:31:55Z&se=2022-08-06T23:31:55Z&spr=https&sv=2021-06-08&sr=b&sig=bogus")),
-                List.of()),
+                RecordType.valueOf("project"), "project_id", projectParquetUrls, List.of()),
             // null primary key
             new TdrManifestImportTable(
                 RecordType.valueOf("edges"),
                 "datarepo_row_id",
-                List.of(
-                    new URL(
-                        "https://mysnapshotsa.blob.core.windows.net/metadata/parquet/9516afec-583f-11ec-bf63-0242ac130002/edges.parquet/F0EE365B-314D-4E19-A177-E8F63D883716_9274_0-1.parquet?sp=r&st=2022-08-04T15:31:55Z&se=2022-08-06T23:31:55Z&spr=https&sv=2021-06-08&sr=b&sig=bogus"),
-                    new URL(
-                        "https://mysnapshotsa.blob.core.windows.net/metadata/parquet/9516afec-583f-11ec-bf63-0242ac130002/edges.parquet/F0EE365B-314D-4E19-A177-E8F63D883716_9274_0-2.parquet?sp=r&st=2022-08-04T15:31:55Z&se=2022-08-06T23:31:55Z&spr=https&sv=2021-06-08&sr=b&sig=bogus")),
+                edgesParquetUrls,
                 List.of(
                     new RelationshipModel()
                         .name("from_edges.project_id_to_project.project_id")
@@ -91,9 +97,7 @@ public class TdrManifestQuartzJobTest {
             new TdrManifestImportTable(
                 RecordType.valueOf("test_result"),
                 "datarepo_row_id",
-                List.of(
-                    new URL(
-                        "https://mysnapshotsa.blob.core.windows.net/metadata/parquet/9516afec-583f-11ec-bf63-0242ac130002/test_result.parquet/F0EE365B-314D-4E19-A177-E8F63D883716_9274_0-1.parquet?sp=r&st=2022-08-04T15:31:55Z&se=2022-08-06T23:31:55Z&spr=https&sv=2021-06-08&sr=b&sig=bogus")),
+                testResultParquetUrls,
                 List.of()));
 
     List<TdrManifestImportTable> actual =

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/TdrManifestQuartzJobTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/TdrManifestQuartzJobTest.java
@@ -64,18 +64,18 @@ public class TdrManifestQuartzJobTest {
     // but only contains export data files for project, edges, and test_result.
     List<TdrManifestImportTable> expected =
         List.of(
-            // null primary key
+            // single primary key
             new TdrManifestImportTable(
                 RecordType.valueOf("project"),
-                "datarepo_row_id",
+                "project_id",
                 List.of(
                     new URL(
                         "https://mysnapshotsa.blob.core.windows.net/metadata/parquet/9516afec-583f-11ec-bf63-0242ac130002/project.parquet/F0EE365B-314D-4E19-A177-E8F63D883716_9274_0-1.parquet?sp=r&st=2022-08-04T15:31:55Z&se=2022-08-06T23:31:55Z&spr=https&sv=2021-06-08&sr=b&sig=bogus")),
                 List.of()),
-            // single primary key
+            // null primary key
             new TdrManifestImportTable(
                 RecordType.valueOf("edges"),
-                "edges_id",
+                "datarepo_row_id",
                 List.of(
                     new URL(
                         "https://mysnapshotsa.blob.core.windows.net/metadata/parquet/9516afec-583f-11ec-bf63-0242ac130002/edges.parquet/F0EE365B-314D-4E19-A177-E8F63D883716_9274_0-1.parquet?sp=r&st=2022-08-04T15:31:55Z&se=2022-08-06T23:31:55Z&spr=https&sv=2021-06-08&sr=b&sig=bogus"),
@@ -86,7 +86,8 @@ public class TdrManifestQuartzJobTest {
                         .name("from_edges.project_id_to_project.project_id")
                         .from(new RelationshipTermModel().table("edges").column("project_id"))
                         .to(new RelationshipTermModel().table("project").column("project_id")))),
-            // compound primary key
+            // compound primary key. Also has a relation listed in the manifest, but with an invalid
+            // target
             new TdrManifestImportTable(
                 RecordType.valueOf("test_result"),
                 "datarepo_row_id",

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/TdrSnapshotSupportTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/TdrSnapshotSupportTest.java
@@ -181,6 +181,13 @@ class TdrSnapshotSupportTest {
   }
 
   @Test
+  void nullPrimaryKey() {
+    TdrSnapshotSupport support = defaultSupport();
+    String actual = support.identifyPrimaryKey(null);
+    assertEquals(support.getDefaultPrimaryKey(), actual);
+  }
+
+  @Test
   void missingPrimaryKey() {
     TdrSnapshotSupport support = defaultSupport();
     String actual = support.identifyPrimaryKey(List.of());

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/BatchWriteServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/BatchWriteServiceTest.java
@@ -1,8 +1,8 @@
 package org.databiosphere.workspacedataservice.service;
 
 import static org.databiosphere.workspacedataservice.dataimport.PfbRecordConverter.ID_FIELD;
-import static org.databiosphere.workspacedataservice.service.PfbStreamWriteHandler.PfbImportMode.BASE_ATTRIBUTES;
-import static org.databiosphere.workspacedataservice.service.PfbStreamWriteHandler.PfbImportMode.RELATIONS;
+import static org.databiosphere.workspacedataservice.service.TwoPassStreamingWriteHandler.ImportMode.BASE_ATTRIBUTES;
+import static org.databiosphere.workspacedataservice.service.TwoPassStreamingWriteHandler.ImportMode.RELATIONS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/PfbStreamWriteHandlerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/PfbStreamWriteHandlerTest.java
@@ -15,7 +15,7 @@ import java.util.List;
 import org.apache.avro.file.DataFileStream;
 import org.apache.avro.generic.GenericRecord;
 import org.databiosphere.workspacedataservice.dataimport.PfbRecordConverter;
-import org.databiosphere.workspacedataservice.service.PfbStreamWriteHandler.PfbImportMode;
+import org.databiosphere.workspacedataservice.service.TwoPassStreamingWriteHandler.ImportMode;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 import org.junit.jupiter.api.Test;
@@ -33,7 +33,8 @@ class PfbStreamWriteHandlerTest {
   void testBatching() {
     // create a mock PFB stream with 10 rows in it and a PfbStreamWriteHandler for that stream
     PfbStreamWriteHandler pfbStreamWriteHandler =
-        buildHandler(mockPfbStream(10, "someType"), PfbImportMode.BASE_ATTRIBUTES);
+        buildHandler(
+            mockPfbStream(10, "someType"), TwoPassStreamingWriteHandler.ImportMode.BASE_ATTRIBUTES);
 
     StreamingWriteHandler.WriteStreamInfo batch; // used in assertions below
 
@@ -61,7 +62,9 @@ class PfbStreamWriteHandlerTest {
   @ValueSource(ints = {0, 1, 49, 50, 51, 99, 100, 101})
   void inputStreamOfCount(Integer numRows) {
     PfbStreamWriteHandler pfbStreamWriteHandler =
-        buildHandler(mockPfbStream(numRows, "someType"), PfbImportMode.BASE_ATTRIBUTES);
+        buildHandler(
+            mockPfbStream(numRows, "someType"),
+            TwoPassStreamingWriteHandler.ImportMode.BASE_ATTRIBUTES);
 
     int batchSize = 50;
 
@@ -81,7 +84,7 @@ class PfbStreamWriteHandlerTest {
   // PFB?
   void pfbTablesAreParsedCorrectly() {
     try (DataFileStream<GenericRecord> dataFileStream = streamRecordsFromFile("/two_tables.avro")) {
-      PfbStreamWriteHandler pswh = buildHandler(dataFileStream, PfbImportMode.BASE_ATTRIBUTES);
+      PfbStreamWriteHandler pswh = buildHandler(dataFileStream, ImportMode.BASE_ATTRIBUTES);
       StreamingWriteHandler.WriteStreamInfo streamInfo = pswh.readRecords(2);
       /*
         Expected records:
@@ -156,7 +159,7 @@ class PfbStreamWriteHandlerTest {
     try (DataFileStream<GenericRecord> dataFileStream = streamRecordsFromFile("/test.avro")) {
 
       StreamingWriteHandler.WriteStreamInfo streamInfo =
-          buildHandler(dataFileStream, PfbImportMode.RELATIONS).readRecords(5);
+          buildHandler(dataFileStream, ImportMode.RELATIONS).readRecords(5);
 
       List<Record> result = streamInfo.getRecords();
       assertEquals(5, result.size());
@@ -202,7 +205,7 @@ class PfbStreamWriteHandlerTest {
   }
 
   private PfbStreamWriteHandler buildHandler(
-      DataFileStream<GenericRecord> dataFileStream, PfbImportMode importMode) {
+      DataFileStream<GenericRecord> dataFileStream, ImportMode importMode) {
     return new PfbStreamWriteHandler(dataFileStream, importMode, pfbRecordConverter);
   }
 }

--- a/service/src/test/resources/tdrmanifest/azure_small.json
+++ b/service/src/test/resources/tdrmanifest/azure_small.json
@@ -1,0 +1,204 @@
+{
+  "snapshot": {
+    "id": "9516afec-583f-11ec-bf63-0242ac130002",
+    "name": "unit_test_snapshot",
+    "description": "Exemplar snapshot for unit testing data",
+    "createdDate": "2021-04-05T07:07:08.654321Z",
+    "source": [
+      {
+        "dataset": {
+          "id": "d70f8266-583f-11ec-bf63-0242ac130002",
+          "name": "unit_test_dataset",
+          "description": "Exemplar dataset for unit testing data",
+          "defaultProfileId": "e55435f6-583f-11ec-bf63-0242ac130002",
+          "createdDate": "2021-01-02T03:04:05.654321Z",
+          "storage": [
+            {
+              "region": "westus2",
+              "cloudResource": "application_deployment",
+              "cloudPlatform": "azure"
+            },
+            {
+              "region": "westus2",
+              "cloudResource": "storage_account",
+              "cloudPlatform": "azure"
+            },
+            {
+              "region": "westus2",
+              "cloudResource": "synapse_workspace",
+              "cloudPlatform": "azure"
+            }
+          ]
+        },
+        "asset": null
+      }
+    ],
+    "tables": [
+      {
+        "name": "project",
+        "columns": [
+          {
+            "name": "project_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 1
+      },
+      {
+        "name": "edges",
+        "columns": [
+          {
+            "name": "edges_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "project_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": [
+          "edges_id"
+        ],
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 221
+      },
+      {
+        "name": "test_result",
+        "columns": [
+          {
+            "name": "test_result_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": [
+          "version",
+          "content"
+        ],
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "genome",
+        "columns": [
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "file_id",
+            "datatype": "fileref",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "genome_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "descriptor",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 2097
+      }
+    ],
+    "relationships": [
+      {
+        "name": "from_edges.project_id_to_project.project_id",
+        "from": {
+          "table": "edges",
+          "column": "project_id"
+        },
+        "to": {
+          "table": "project",
+          "column": "project_id"
+        }
+      }
+    ],
+    "profileId": "bff61446-583f-11ec-bf63-0242ac130002",
+    "dataProject": null,
+    "accessInformation": null
+  },
+  "format": {
+    "parquet": {
+      "location": {
+        "tables": [
+          {
+            "name": "project",
+            "paths": [
+              "https://mysnapshotsa.blob.core.windows.net/metadata/parquet/9516afec-583f-11ec-bf63-0242ac130002/project.parquet/F0EE365B-314D-4E19-A177-E8F63D883716_9274_0-1.parquet?sp=r&st=2022-08-04T15:31:55Z&se=2022-08-06T23:31:55Z&spr=https&sv=2021-06-08&sr=b&sig=bogus"
+            ]
+          },
+          {
+            "name": "edges",
+            "paths": [
+              "https://mysnapshotsa.blob.core.windows.net/metadata/parquet/9516afec-583f-11ec-bf63-0242ac130002/edges.parquet/F0EE365B-314D-4E19-A177-E8F63D883716_9274_0-1.parquet?sp=r&st=2022-08-04T15:31:55Z&se=2022-08-06T23:31:55Z&spr=https&sv=2021-06-08&sr=b&sig=bogus",
+              "https://mysnapshotsa.blob.core.windows.net/metadata/parquet/9516afec-583f-11ec-bf63-0242ac130002/edges.parquet/F0EE365B-314D-4E19-A177-E8F63D883716_9274_0-2.parquet?sp=r&st=2022-08-04T15:31:55Z&se=2022-08-06T23:31:55Z&spr=https&sv=2021-06-08&sr=b&sig=bogus"
+            ]
+          },
+          {
+            "name": "test_result",
+            "paths": [
+              "https://mysnapshotsa.blob.core.windows.net/metadata/parquet/9516afec-583f-11ec-bf63-0242ac130002/test_result.parquet/F0EE365B-314D-4E19-A177-E8F63D883716_9274_0-1.parquet?sp=r&st=2022-08-04T15:31:55Z&se=2022-08-06T23:31:55Z&spr=https&sv=2021-06-08&sr=b&sig=bogus"
+            ]
+          }
+        ]
+      },
+      "manifest": "https://mysnapshotsa.blob.core.windows.net/metadata/manifests/rand.json"
+    },
+    "workspace": null
+  }
+}

--- a/service/src/test/resources/tdrmanifest/azure_small.json
+++ b/service/src/test/resources/tdrmanifest/azure_small.json
@@ -53,7 +53,9 @@
             "array_of": false
           }
         ],
-        "primaryKey": null,
+        "primaryKey": [
+          "project_id"
+        ],
         "partitionMode": "none",
         "datePartitionOptions": null,
         "intPartitionOptions": null,
@@ -83,9 +85,7 @@
             "array_of": false
           }
         ],
-        "primaryKey": [
-          "edges_id"
-        ],
+        "primaryKey": null,
         "partitionMode": "none",
         "datePartitionOptions": null,
         "intPartitionOptions": null,
@@ -165,6 +165,17 @@
         "to": {
           "table": "project",
           "column": "project_id"
+        }
+      },
+      {
+        "name": "from_test_result.project_id_to_project.project_id",
+        "from": {
+          "table": "test_result",
+          "column": "version"
+        },
+        "to": {
+          "table": "edges",
+          "column": "edges_id"
         }
       }
     ],

--- a/service/src/test/resources/tdrmanifest/azure_small.json
+++ b/service/src/test/resources/tdrmanifest/azure_small.json
@@ -190,14 +190,12 @@
           {
             "name": "project",
             "paths": [
-              "https://i.am.a.directory/skip/me",
               "https://mysnapshotsa.blob.core.windows.net/metadata/parquet/9516afec-583f-11ec-bf63-0242ac130002/project.parquet/F0EE365B-314D-4E19-A177-E8F63D883716_9274_0-1.parquet?sp=r&st=2022-08-04T15:31:55Z&se=2022-08-06T23:31:55Z&spr=https&sv=2021-06-08&sr=b&sig=bogus"
             ]
           },
           {
             "name": "edges",
             "paths": [
-              "https://i.am.a.directory/skip/me",
               "https://mysnapshotsa.blob.core.windows.net/metadata/parquet/9516afec-583f-11ec-bf63-0242ac130002/edges.parquet/F0EE365B-314D-4E19-A177-E8F63D883716_9274_0-1.parquet?sp=r&st=2022-08-04T15:31:55Z&se=2022-08-06T23:31:55Z&spr=https&sv=2021-06-08&sr=b&sig=bogus",
               "https://mysnapshotsa.blob.core.windows.net/metadata/parquet/9516afec-583f-11ec-bf63-0242ac130002/edges.parquet/F0EE365B-314D-4E19-A177-E8F63D883716_9274_0-2.parquet?sp=r&st=2022-08-04T15:31:55Z&se=2022-08-06T23:31:55Z&spr=https&sv=2021-06-08&sr=b&sig=bogus"
             ]
@@ -205,7 +203,6 @@
           {
             "name": "test_result",
             "paths": [
-              "https://i.am.a.directory/skip/me",
               "https://mysnapshotsa.blob.core.windows.net/metadata/parquet/9516afec-583f-11ec-bf63-0242ac130002/test_result.parquet/F0EE365B-314D-4E19-A177-E8F63D883716_9274_0-1.parquet?sp=r&st=2022-08-04T15:31:55Z&se=2022-08-06T23:31:55Z&spr=https&sv=2021-06-08&sr=b&sig=bogus"
             ]
           }

--- a/service/src/test/resources/tdrmanifest/azure_small.json
+++ b/service/src/test/resources/tdrmanifest/azure_small.json
@@ -190,12 +190,14 @@
           {
             "name": "project",
             "paths": [
+              "https://i.am.a.directory/skip/me",
               "https://mysnapshotsa.blob.core.windows.net/metadata/parquet/9516afec-583f-11ec-bf63-0242ac130002/project.parquet/F0EE365B-314D-4E19-A177-E8F63D883716_9274_0-1.parquet?sp=r&st=2022-08-04T15:31:55Z&se=2022-08-06T23:31:55Z&spr=https&sv=2021-06-08&sr=b&sig=bogus"
             ]
           },
           {
             "name": "edges",
             "paths": [
+              "https://i.am.a.directory/skip/me",
               "https://mysnapshotsa.blob.core.windows.net/metadata/parquet/9516afec-583f-11ec-bf63-0242ac130002/edges.parquet/F0EE365B-314D-4E19-A177-E8F63D883716_9274_0-1.parquet?sp=r&st=2022-08-04T15:31:55Z&se=2022-08-06T23:31:55Z&spr=https&sv=2021-06-08&sr=b&sig=bogus",
               "https://mysnapshotsa.blob.core.windows.net/metadata/parquet/9516afec-583f-11ec-bf63-0242ac130002/edges.parquet/F0EE365B-314D-4E19-A177-E8F63D883716_9274_0-2.parquet?sp=r&st=2022-08-04T15:31:55Z&se=2022-08-06T23:31:55Z&spr=https&sv=2021-06-08&sr=b&sig=bogus"
             ]
@@ -203,6 +205,7 @@
           {
             "name": "test_result",
             "paths": [
+              "https://i.am.a.directory/skip/me",
               "https://mysnapshotsa.blob.core.windows.net/metadata/parquet/9516afec-583f-11ec-bf63-0242ac130002/test_result.parquet/F0EE365B-314D-4E19-A177-E8F63D883716_9274_0-1.parquet?sp=r&st=2022-08-04T15:31:55Z&se=2022-08-06T23:31:55Z&spr=https&sv=2021-06-08&sr=b&sig=bogus"
             ]
           }

--- a/service/src/test/resources/tdrmanifest/tdr_response_with_cycle.json
+++ b/service/src/test/resources/tdrmanifest/tdr_response_with_cycle.json
@@ -1,0 +1,1002 @@
+{
+  "snapshot": {
+    "id": "9516afec-583f-11ec-bf63-0242ac130002",
+    "name": "unit_test_snapshot",
+    "description": "Exemplar snapshot for unit testing data",
+    "createdDate": "2021-04-05T07:07:08.654321Z",
+    "source": [
+      {
+        "dataset": {
+          "id": "d70f8266-583f-11ec-bf63-0242ac130002",
+          "name": "unit_test_dataset",
+          "description": "Exemplar dataset for unit testing data",
+          "defaultProfileId": "e55435f6-583f-11ec-bf63-0242ac130002",
+          "createdDate": "2021-01-02T03:04:05.654321Z",
+          "storage": [
+            {
+              "region": "us-central1",
+              "cloudResource": "bigquery",
+              "cloudPlatform": "gcp"
+            },
+            {
+              "region": "us-east4",
+              "cloudResource": "firestore",
+              "cloudPlatform": "gcp"
+            },
+            {
+              "region": "us-central1",
+              "cloudResource": "bucket",
+              "cloudPlatform": "gcp"
+            }
+          ]
+        },
+        "asset": null
+      }
+    ],
+    "tables": [
+      {
+        "name": "messages",
+        "columns": [
+          {
+            "name": "messages_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "location",
+        "columns": [
+          {
+            "name": "location_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "cost",
+        "columns": [
+          {
+            "name": "cost_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 82
+      },
+      {
+        "name": "product",
+        "columns": [
+          {
+            "name": "product_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "footnote",
+        "columns": [
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "file_id",
+            "datatype": "fileref",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "footnote_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "descriptor",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 23
+      },
+      {
+        "name": "diagram",
+        "columns": [
+          {
+            "name": "diagram_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "graphic",
+        "columns": [
+          {
+            "name": "graphic_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "sequence",
+        "columns": [
+          {
+            "name": "sequence_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 21
+      },
+      {
+        "name": "project",
+        "columns": [
+          {
+            "name": "project_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 1
+      },
+      {
+        "name": "person",
+        "columns": [
+          {
+            "name": "person_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 1643
+      },
+      {
+        "name": "signature",
+        "columns": [
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "file_id",
+            "datatype": "fileref",
+            "array_of": false
+          },
+          {
+            "name": "signature_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "descriptor",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "photo",
+        "columns": [
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "file_id",
+            "datatype": "fileref",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "photo_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "descriptor",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "regulation",
+        "columns": [
+          {
+            "name": "regulation_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "annotation",
+        "columns": [
+          {
+            "name": "annotation_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "lab",
+        "columns": [
+          {
+            "name": "lab_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "edges",
+        "columns": [
+          {
+            "name": "edges_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "project_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 221
+      },
+      {
+        "name": "xray",
+        "columns": [
+          {
+            "name": "xray_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "file_id",
+            "datatype": "fileref",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "descriptor",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "test",
+        "columns": [
+          {
+            "name": "test_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 1
+      },
+      {
+        "name": "vial",
+        "columns": [
+          {
+            "name": "vial_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 1
+      },
+      {
+        "name": "process",
+        "columns": [
+          {
+            "name": "process_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 9876
+      },
+      {
+        "name": "test_result",
+        "columns": [
+          {
+            "name": "test_result_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "room",
+        "columns": [
+          {
+            "name": "room_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "chemical",
+        "columns": [
+          {
+            "name": "chemical_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 2345
+      },
+      {
+        "name": "letter",
+        "columns": [
+          {
+            "name": "letter_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "species",
+        "columns": [
+          {
+            "name": "species_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 808
+      },
+      {
+        "name": "reading",
+        "columns": [
+          {
+            "name": "reading_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 1
+      },
+      {
+        "name": "genome",
+        "columns": [
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "file_id",
+            "datatype": "fileref",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "genome_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "descriptor",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 2097
+      }
+    ],
+    "relationships": [
+      {
+        "name": "from_edges.project_id_to_project.project_id",
+        "from": {
+          "table": "edges",
+          "column": "project_id"
+        },
+        "to": {
+          "table": "project",
+          "column": "project_id"
+        }
+      },
+      {
+        "name": "test1",
+        "from": {
+          "table": "product",
+          "column": "test_column"
+        },
+        "to": {
+          "table": "footnote",
+          "column": "datarepo_row_id"
+        }
+      },
+      {
+        "name": "test2",
+        "from": {
+          "table": "footnote",
+          "column": "test_column"
+        },
+        "to": {
+          "table": "diagram",
+          "column": "datarepo_row_id"
+        }
+      },
+      {
+        "name": "test3",
+        "from": {
+          "table": "diagram",
+          "column": "test_column"
+        },
+        "to": {
+          "table": "messages",
+          "column": "datarepo_row_id"
+        }
+      },
+      {
+        "name": "test4",
+        "from": {
+          "table": "messages",
+          "column": "test_column"
+        },
+        "to": {
+          "table": "product",
+          "column": "datarepo_row_id"
+        }
+      }
+    ],
+    "profileId": "bff61446-583f-11ec-bf63-0242ac130002",
+    "dataProject": "my-project",
+    "accessInformation": null
+  },
+  "format": {
+    "parquet": {
+      "location": {
+        "tables": [
+          {
+            "name": "messages",
+            "paths": [
+              "gs://my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/messages/messages-000000000000.parquet"
+            ]
+          },
+          {
+            "name": "location",
+            "paths": [
+              "gs://my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/location/location-000000000000.parquet"
+            ]
+          },
+          {
+            "name": "cost",
+            "paths": [
+              "gs://my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/cost/cost-000000000000.parquet"
+            ]
+          },
+          {
+            "name": "product",
+            "paths": [
+              "gs://my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/product/product-000000000000.parquet"
+            ]
+          },
+          {
+            "name": "footnote",
+            "paths": [
+              "gs://my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/footnote/footnote-000000000000.parquet"
+            ]
+          },
+          {
+            "name": "diagram",
+            "paths": [
+              "gs://my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/diagram/diagram-000000000000.parquet"
+            ]
+          },
+          {
+            "name": "graphic",
+            "paths": [
+              "gs://my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/graphic/graphic-000000000000.parquet"
+            ]
+          },
+          {
+            "name": "sequence",
+            "paths": [
+              "gs://my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/sequence/sequence-000000000000.parquet"
+            ]
+          },
+          {
+            "name": "project",
+            "paths": [
+              "gs://my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/project/project-000000000000.parquet"
+            ]
+          },
+          {
+            "name": "person",
+            "paths": [
+              "gs://my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/person/person-000000000000.parquet"
+            ]
+          },
+          {
+            "name": "signature",
+            "paths": [
+              "gs://my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/signature/signature-000000000000.parquet"
+            ]
+          },
+          {
+            "name": "photo",
+            "paths": [
+              "gs://my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/photo/photo-000000000000.parquet"
+            ]
+          },
+          {
+            "name": "regulation",
+            "paths": [
+              "gs://my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/regulation/regulation-000000000000.parquet"
+            ]
+          },
+          {
+            "name": "annotation",
+            "paths": [
+              "gs://my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/annotation/annotation-000000000000.parquet"
+            ]
+          },
+          {
+            "name": "lab",
+            "paths": [
+              "gs://my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/lab/lab-000000000000.parquet"
+            ]
+          },
+          {
+            "name": "edges",
+            "paths": [
+              "gs://my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/edges/edges-000000000000.parquet",
+              "gs://my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/edges/edges-000000000001.parquet"
+            ]
+          },
+          {
+            "name": "xray",
+            "paths": [
+              "gs://my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/xray/xray-000000000000.parquet"
+            ]
+          },
+          {
+            "name": "test",
+            "paths": [
+              "gs://my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/test/test-000000000000.parquet"
+            ]
+          },
+          {
+            "name": "vial",
+            "paths": [
+              "gs://my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/vial/vial-000000000000.parquet"
+            ]
+          },
+          {
+            "name": "process",
+            "paths": [
+              "gs://my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/process/process-000000000000.parquet"
+            ]
+          },
+          {
+            "name": "test_result",
+            "paths": [
+              "gs://my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/test_result/test_result-000000000000.parquet"
+            ]
+          },
+          {
+            "name": "room",
+            "paths": [
+              "gs://my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/room/room-000000000000.parquet"
+            ]
+          },
+          {
+            "name": "chemical",
+            "paths": [
+              "gs://my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/chemical/chemical-000000000000.parquet"
+            ]
+          },
+          {
+            "name": "letter",
+            "paths": [
+              "gs://my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/letter/letter-000000000000.parquet"
+            ]
+          },
+          {
+            "name": "species",
+            "paths": [
+              "gs://my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/species/species-000000000000.parquet"
+            ]
+          },
+          {
+            "name": "reading",
+            "paths": [
+              "gs://my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/reading/reading-000000000000.parquet"
+            ]
+          },
+          {
+            "name": "genome",
+            "paths": [
+              "gs://my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/genome/genome-000000000000.parquet"
+            ]
+          }
+        ]
+      },
+      "manifest": "gs://my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/manifest.json"
+    },
+    "workspace": null
+  }
+}


### PR DESCRIPTION
Highlights:
* bring in the `parquet-avro` library and supporting libraries, which allows reading Parquet files into Avro Java classes
* create new `ParquetRecordConverter`
* factor out a bunch of shared logic from `PfbRecordConverter` and `ParquetRecordConverter` into a new abstract base class `AvroRecordConverter`
* create new `ParquetStreamWriteHandler`, which mirrors `PfbStreamWriteHandler`
* create new `TdrManifestQuartzJob`
* factor out shared logic from `PfbQuartzJob` and `TdrManifestQuartzJob` into `TdrSnapshotSupport`