### PR TITLE
AJ-1500: Enable Prometheus metrics

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -55,6 +55,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-batch'
     implementation 'org.springframework.boot:spring-boot-starter-quartz'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'org.springframework.integration:spring-integration-jdbc'
     implementation 'org.aspectj:aspectjweaver:1.8.9' // required by spring-retry, not used directly
     implementation 'com.google.guava:guava:32.1.3-jre'

--- a/service/src/main/java/org/databiosphere/workspacedataservice/metrics/MetricsConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/metrics/MetricsConfig.java
@@ -1,0 +1,63 @@
+package org.databiosphere.workspacedataservice.metrics;
+
+import static io.micrometer.core.instrument.config.MeterFilter.acceptNameStartsWith;
+import static io.micrometer.core.instrument.config.MeterFilter.deny;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import java.util.Set;
+import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MetricsConfig {
+  private final BuildProperties buildProperties;
+
+  public MetricsConfig(BuildProperties buildProperties) {
+    this.buildProperties = buildProperties;
+  }
+
+  @VisibleForTesting
+  static final Set<String> ALLOWED_PREFIXES =
+      // please keep this list alphabetized
+      ImmutableSet.of(
+          "application",
+          "cache",
+          "disk",
+          "executor",
+          "hikaricp",
+          "http",
+          "jdbc",
+          "jvm",
+          "logback",
+          "process",
+          "spring",
+          "system",
+          "tomcat",
+          "wds");
+
+  @Bean
+  MeterRegistryCustomizer<MeterRegistry> allowlistMetrics() {
+    return registry -> {
+      ALLOWED_PREFIXES.forEach(
+          prefix -> registry.config().meterFilter(acceptNameStartsWith(prefix)));
+      registry.config().meterFilter(deny()); // deny everything else
+    };
+  }
+
+  @Bean
+  MeterRegistryCustomizer<MeterRegistry> addWdsVersionTag() {
+    return registry ->
+        registry
+            .config()
+            .commonTags(
+                new ImmutableList.Builder<Tag>()
+                    .add(Tag.of("wds.version", buildProperties.getVersion()))
+                    .build());
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/metrics/MetricsConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/metrics/MetricsConfig.java
@@ -5,7 +5,6 @@ import static io.micrometer.core.instrument.config.MeterFilter.deny;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import java.util.Set;
@@ -25,7 +24,7 @@ public class MetricsConfig {
   @VisibleForTesting
   static final Set<String> ALLOWED_PREFIXES =
       // please keep this list alphabetized
-      ImmutableSet.of(
+      Set.of(
           "application",
           "cache",
           "disk",

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -23,14 +23,18 @@ management:
       group:
         liveness:
           include: livenessState,db
+    prometheus:
+      enabled: true
   endpoints:
     enabled-by-default: false
     web:
-      exposure.include: info,health
+      exposure:
+        include: "info,health,prometheus"
       base-path: /
       path-mapping:
         info: version
         health: status
+        prometheus: prometheus
   # additional keys to expose in the actuator info endpoint:
   info:
     env:

--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -507,6 +507,15 @@ paths:
       responses:
         200:
           $ref: '#/components/responses/VersionResponseBody'
+  /prometheus:
+    get:
+      summary: App health metrics for Prometheus -- generated via Spring Boot Actuator (see https://docs.spring.io/spring-boot/docs/current/actuator-api/htmlsingle/#prometheus for details)
+      operationId: prometheusGet
+      tags:
+        - General WDS Information
+      responses:
+        200:
+          $ref: '#/components/responses/PrometheusResponseBody'
 
   ##############################
   # Capabilities APIs
@@ -635,6 +644,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/VersionResponse'
+    PrometheusResponseBody:
+      description: Metrics in a format that can be scraped by Prometheus
+      content:
+        text/plain:
+          schema:
+            type: string
 
   requestBodies:
     BackupRestoreRequestBody:

--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -507,15 +507,6 @@ paths:
       responses:
         200:
           $ref: '#/components/responses/VersionResponseBody'
-  /prometheus:
-    get:
-      summary: App health metrics for Prometheus -- generated via Spring Boot Actuator (see https://docs.spring.io/spring-boot/docs/current/actuator-api/htmlsingle/#prometheus for details)
-      operationId: prometheusGet
-      tags:
-        - General WDS Information
-      responses:
-        200:
-          $ref: '#/components/responses/PrometheusResponseBody'
 
   ##############################
   # Capabilities APIs
@@ -644,13 +635,6 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/VersionResponse'
-    PrometheusResponseBody:
-      description: Metrics in a format that can be scraped by Prometheus
-      content:
-        text/plain:
-          schema:
-            type: string
-
   requestBodies:
     BackupRestoreRequestBody:
       description: A backup request

--- a/service/src/test/java/org/databiosphere/workspacedataservice/metrics/MetricsConfigTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/metrics/MetricsConfigTest.java
@@ -1,0 +1,84 @@
+package org.databiosphere.workspacedataservice.metrics;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.Set;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+
+@DirtiesContext
+@SpringBootTest(properties = "management.metrics.export.prometheus.enabled=true")
+@AutoConfigureMockMvc
+public class MetricsConfigTest {
+  @Autowired private BuildProperties buildProperties;
+  @Autowired private MockMvc mockMvc;
+  @Autowired private MeterRegistry metrics;
+
+  @Test
+  void metricsAreTaggedWithVersion() throws Exception {
+    String expectedVersion = buildProperties.getVersion();
+    mockMvc
+        .perform(get("/prometheus"))
+        .andExpect(status().isOk())
+        .andExpect(
+            content().string(containsString("wds_version=\"%s\"".formatted(expectedVersion))));
+  }
+
+  private static Set<String> allowedPrefixes() {
+    return MetricsConfig.ALLOWED_PREFIXES;
+  }
+
+  @ParameterizedTest(name = "metrics with a \"{0}\" prefix are included in prometheus output")
+  @MethodSource("allowedPrefixes")
+  void allowlistedMetricsAreVisible(String prefix) throws Exception {
+    String randomMetricName = RandomStringUtils.randomAlphanumeric(10);
+    String expectedPrometheusString = "%s_%s".formatted(prefix, randomMetricName);
+
+    mockMvc
+        .perform(get("/prometheus"))
+        .andExpect(status().isOk())
+        .andExpect(content().string(not(containsString(expectedPrometheusString))));
+
+    metrics.counter("%s.%s".formatted(prefix, randomMetricName)).increment();
+
+    mockMvc
+        .perform(get("/prometheus"))
+        .andExpect(status().isOk())
+        .andExpect(content().string(containsString(expectedPrometheusString)));
+  }
+
+  @ParameterizedTest(name = "\"{0}\" is excluded from prometheus output")
+  @ValueSource(
+      strings = {
+        "some.random.metric",
+        "foo",
+        "bar",
+        "foobar",
+        // wds is an allowed prefix, but doesn't count if it's embedded deeper in the name
+        "metric.containing.but.not.starting.with.wds"
+      })
+  void excludeMetricsThatAreNotOnAllowlist(String disallowedMetricName) throws Exception {
+    String unexpectedPrometheusString = disallowedMetricName.replace('.', '_');
+
+    metrics.counter(disallowedMetricName).increment();
+
+    mockMvc
+        .perform(get("/prometheus"))
+        .andExpect(status().isOk())
+        .andExpect(content().string(not(containsString(unexpectedPrometheusString))));
+  }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/metrics/MetricsConfigTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/metrics/MetricsConfigTest.java
@@ -23,7 +23,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @DirtiesContext
 @SpringBootTest(properties = "management.metrics.export.prometheus.enabled=true")
 @AutoConfigureMockMvc
-public class MetricsConfigTest {
+class MetricsConfigTest {
   @Autowired private BuildProperties buildProperties;
   @Autowired private MockMvc mockMvc;
   @Autowired private MeterRegistry metrics;


### PR DESCRIPTION
[AJ-1500](https://broadworkbench.atlassian.net/browse/AJ-1500)

For prometheus output format and usage, see:
https://docs.spring.io/spring-boot/docs/current/actuator-api/htmlsingle/#prometheus

Also:
* Allow any metrics starting with `MetricsConfig.ALLOWED_PREFIXES`;
this list currently includes everything enabled out of the box, plus a
`wds` prefix for our custom metrics.
* Deny everything not explicitly allowlisted.  This is to help manage egress cost.
* Add a tag to every gathered metric which includes WDS version.

Note: we're not actually tagging metrics with a workspace ID, as this
would be a high cardinality metric if aggregated globally.

Sample requests while running locally:

```
curl http://localhost:8080/prometheus

curl http://localhost:8080/prometheus?includedNames=jvm_memory_used_bytes%2Cjvm_memory_committed_bytes
```



[AJ-1500]: https://broadworkbench.atlassian.net/browse/AJ-1500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ