### PR TITLE
AJ-1157: Spring Boot 3.2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
 plugins {
-    id 'org.springframework.boot' version '3.0.13' apply false
+    id 'org.springframework.boot' version '3.2.1' apply false
     id 'io.spring.dependency-management' version '1.1.4' apply false
     id 'com.google.cloud.tools.jib' version '3.2.1' apply false
     id "org.sonarqube" version "4.4.1.3373" apply false
@@ -35,6 +35,9 @@ subprojects {
     dependencyManagement {
         imports {
             mavenBom(SpringBootPlugin.BOM_COORDINATES)
+        }
+        dependencies {
+            dependency 'org.liquibase:liquibase-core:4.25.1'
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -36,13 +36,6 @@ subprojects {
         imports {
             mavenBom(SpringBootPlugin.BOM_COORDINATES)
         }
-
-        dependencies {
-//            dependency 'org.yaml:snakeyaml:2.0'
-//            dependency 'org.webjars:webjars-locator-core:0.53'
-//            dependency 'ch.qos.logback:logback-classic:1.2.13+' // CVE-2023-6378
-//            dependency 'ch.qos.logback:logback-core:1.2.13+' // CVE-2023-6378
-        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
 plugins {
-    id 'org.springframework.boot' version '3.2.0' apply false
+    id 'org.springframework.boot' version '3.0.13' apply false
     id 'io.spring.dependency-management' version '1.1.4' apply false
     id 'com.google.cloud.tools.jib' version '3.2.1' apply false
     id "org.sonarqube" version "4.4.1.3373" apply false
@@ -38,10 +38,10 @@ subprojects {
         }
 
         dependencies {
-            dependency 'org.yaml:snakeyaml:2.0'
-            dependency 'org.webjars:webjars-locator-core:0.53'
-            dependency 'ch.qos.logback:logback-classic:1.2.13+' // CVE-2023-6378
-            dependency 'ch.qos.logback:logback-core:1.2.13+' // CVE-2023-6378
+//            dependency 'org.yaml:snakeyaml:2.0'
+//            dependency 'org.webjars:webjars-locator-core:0.53'
+//            dependency 'ch.qos.logback:logback-classic:1.2.13+' // CVE-2023-6378
+//            dependency 'ch.qos.logback:logback-core:1.2.13+' // CVE-2023-6378
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
 plugins {
-    id 'org.springframework.boot' version '2.7.18' apply false
+    id 'org.springframework.boot' version '3.2.0' apply false
     id 'io.spring.dependency-management' version '1.1.4' apply false
     id 'com.google.cloud.tools.jib' version '3.2.1' apply false
     id "org.sonarqube" version "4.4.1.3373" apply false

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -21,10 +21,10 @@ ext {
 
 // default to javax, since WDS is currently on Spring Boot 2. -Pjakarta=true overrides
 // the default and creates a Jakarta-based client.
-if (project.hasProperty("jakarta") && "true".equalsIgnoreCase(project.getProperty("jakarta"))) {
-    apply from: "dependencies-jakarta.gradle"
-} else {
+if (project.hasProperty("jakarta") && "false".equalsIgnoreCase(project.getProperty("jakarta"))) {
     apply from: "dependencies-javax.gradle"
+} else {
+    apply from: "dependencies-jakarta.gradle"
 }
 
 apply from: 'artifactory.gradle'

--- a/client/swagger.gradle
+++ b/client/swagger.gradle
@@ -1,9 +1,9 @@
 dependencies {
     //Need to include libraries for generated code to work
-    api 'com.google.code.gson:gson:2.10.1'
+    api 'com.google.code.gson:gson'
     api 'io.gsonfire:gson-fire:1.9.0'
-    api 'com.squareup.okhttp3:okhttp:4.12.0'
-    api 'com.squareup.okhttp3:logging-interceptor:4.12.0'
+    api 'com.squareup.okhttp3:okhttp'
+    api 'com.squareup.okhttp3:logging-interceptor'
 }
 
 openApiValidate {

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -56,17 +56,17 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'org.springframework.integration:spring-integration-jdbc'
-    implementation 'org.aspectj:aspectjweaver:1.8.9' // required by spring-retry, not used directly
+    implementation 'org.aspectj:aspectjweaver' // required by spring-retry, not used directly
     implementation 'com.google.guava:guava:32.1.3-jre'
     implementation 'org.postgresql:postgresql'
     implementation 'org.webjars:webjars-locator-core' // versioned by spring dependency management
-    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.13.5'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv'
     implementation 'io.sentry:sentry-logback:6.34.0'
-    implementation 'org.liquibase:liquibase-core:4.25.1'
+    implementation 'org.liquibase:liquibase-core'
     implementation 'javax.cache:cache-api'
     implementation 'org.ehcache:ehcache:3.10.8:jakarta'
     implementation 'org.hashids:hashids:1.0.3'
-    implementation 'jakarta.ws.rs:jakarta.ws.rs-api:3.1.0'
+    implementation 'jakarta.ws.rs:jakarta.ws.rs-api'
     implementation 'com.google.mug:mug:6.6'
 
     // required by openapi-generated models and api interfaces
@@ -76,7 +76,7 @@ dependencies {
     // Terra libraries
     implementation group: 'org.broadinstitute.dsde.workbench', name: 'sam-client_2.13', version: '0.1-752b4f3'
     implementation group: 'org.broadinstitute.dsde.workbench', name: 'leonardo-client_2.13', version: '1.3.6-22ee00b'
-    implementation 'com.squareup.okhttp3:okhttp:4.12.0' // required by Sam client
+    implementation 'com.squareup.okhttp3:okhttp' // required by Sam client
     implementation "bio.terra:datarepo-jakarta-client:1.557.0-SNAPSHOT"
     implementation "bio.terra:workspace-manager-client:0.254.983-SNAPSHOT"
     implementation "bio.terra:java-pfb-library:0.15.0"
@@ -113,7 +113,7 @@ dependencies {
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     runtimeOnly 'org.webjars.npm:swagger-ui-dist:5.9.0'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation project(':client')
     testImplementation 'au.com.dius.pact.consumer:junit5:4.6.1'
     testImplementation 'org.junit-pioneer:junit-pioneer:2.1.0'
@@ -241,7 +241,7 @@ testing {
                 implementation project(':client')
                 implementation 'org.springframework.boot:spring-boot-starter-test'
                 implementation 'org.springframework.boot:spring-boot-starter-jdbc'
-                implementation 'org.liquibase:liquibase-core:4.25.1'
+                implementation 'org.liquibase:liquibase-core'
                 implementation "org.glassfish.jersey.core:jersey-client"
                 implementation "org.glassfish.jersey.core:jersey-common"
                 implementation "org.glassfish.jersey.inject:jersey-hk2"

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -62,11 +62,11 @@ dependencies {
     implementation 'org.webjars:webjars-locator-core' // versioned by spring dependency management
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.13.5'
     implementation 'io.sentry:sentry-logback:6.34.0'
-    implementation 'org.liquibase:liquibase-core:4.21.1'
+    implementation 'org.liquibase:liquibase-core:4.25.1'
     implementation 'javax.cache:cache-api'
-    implementation 'org.ehcache:ehcache:3.10.8'
+    implementation 'org.ehcache:ehcache:3.10.8:jakarta'
     implementation 'org.hashids:hashids:1.0.3'
-    implementation 'javax.ws.rs:javax.ws.rs-api:2.1.1'
+    implementation 'jakarta.ws.rs:jakarta.ws.rs-api:3.1.0'
     implementation 'com.google.mug:mug:6.6'
 
     // required by openapi-generated models and api interfaces
@@ -74,11 +74,11 @@ dependencies {
     implementation 'io.swagger.core.v3:swagger-annotations:2.2.16'
 
     // Terra libraries
-    implementation group: 'org.broadinstitute.dsde.workbench', name: 'sam-client_2.13', version: '0.1-08b6588'
+    implementation group: 'org.broadinstitute.dsde.workbench', name: 'sam-client_2.13', version: '0.1-752b4f3'
     implementation group: 'org.broadinstitute.dsde.workbench', name: 'leonardo-client_2.13', version: '1.3.6-22ee00b'
     implementation 'com.squareup.okhttp3:okhttp:4.12.0' // required by Sam client
-    implementation "bio.terra:datarepo-client:1.537.0-SNAPSHOT"
-    implementation "bio.terra:workspace-manager-client:0.254.717-SNAPSHOT"
+    implementation "bio.terra:datarepo-client:1.564.0-SNAPSHOT"
+    implementation "bio.terra:workspace-manager-client:0.254.983-SNAPSHOT"
     implementation "bio.terra:java-pfb-library:0.15.0"
     implementation project(path: ':client')
 
@@ -130,14 +130,14 @@ dependencies {
 
         // this is redundant (and ineffective) without an explicit override in build.gradle
         // dependencyManagement, but left here for documentation purposes
-        implementation('ch.qos.logback:logback-classic:1.2.13+') {
-            because("CVE-2023-6378")
-        }
+//        implementation('ch.qos.logback:logback-classic:1.2.13+') {
+//            because("CVE-2023-6378")
+//        }
         // this is redundant (and ineffective) without an explicit override in build.gradle
         // dependencyManagement, but left here for documentation purposes
-        implementation('ch.qos.logback:logback-core:1.2.13+') {
-            because("CVE-2023-6378")
-        }
+//        implementation('ch.qos.logback:logback-core:1.2.13+') {
+//            because("CVE-2023-6378")
+//        }
     }
 }
 
@@ -253,7 +253,7 @@ testing {
                 implementation project(':client')
                 implementation 'org.springframework.boot:spring-boot-starter-test'
                 implementation 'org.springframework.boot:spring-boot-starter-jdbc'
-                implementation 'org.liquibase:liquibase-core:4.21.1'
+                implementation 'org.liquibase:liquibase-core:4.25.1'
                 implementation "org.glassfish.jersey.core:jersey-client:$jersey_version"
                 implementation "org.glassfish.jersey.core:jersey-common:$jersey_version"
                 implementation "org.glassfish.jersey.inject:jersey-hk2:$jersey_version"

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     implementation 'com.google.mug:mug:6.6'
 
     // required by openapi-generated models and api interfaces
-    implementation 'javax.validation:validation-api'
+    implementation 'jakarta.validation:jakarta.validation-api'
     implementation 'io.swagger.core.v3:swagger-annotations:2.2.16'
 
     // Terra libraries
@@ -158,10 +158,12 @@ tasks.register('generateApiInterfaces', GenerateTask) {
     supportingFilesConstrainedTo.set([]) // empty array means generate none
     skipOperationExample = true // example responses require the ApiUtil.java supporting file
     configOptions.set([
+        useJakartaEe           : "true", // for Spring Boot 3
         interfaceOnly          : "true", // Java interfaces only; no controllers or implementation classes
         useTags                : "true", // use the OpenAPI tag to classify apis, not the first segment of the api path
         hideGenerationTimestamp: "true"  // hidden to prevent unnecessary diff noise on unrelated changes
     ])
+
 }
 
 

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -36,7 +36,6 @@ jib {
 }
 
 ext {
-    jersey_version = "2.36"
     parquet_mr_version = "1.13.1"
     hadoop_version = "3.3.6"
 }
@@ -77,7 +76,7 @@ dependencies {
     implementation group: 'org.broadinstitute.dsde.workbench', name: 'sam-client_2.13', version: '0.1-752b4f3'
     implementation group: 'org.broadinstitute.dsde.workbench', name: 'leonardo-client_2.13', version: '1.3.6-22ee00b'
     implementation 'com.squareup.okhttp3:okhttp:4.12.0' // required by Sam client
-    implementation "bio.terra:datarepo-client:1.564.0-SNAPSHOT"
+    implementation "bio.terra:datarepo-jakarta-client:1.557.0-SNAPSHOT"
     implementation "bio.terra:workspace-manager-client:0.254.983-SNAPSHOT"
     implementation "bio.terra:java-pfb-library:0.15.0"
     implementation project(path: ':client')
@@ -105,10 +104,10 @@ dependencies {
     implementation "org.apache.hadoop:hadoop-common:$hadoop_version", withoutHadoopExcludes
     implementation "org.apache.hadoop:hadoop-mapreduce-client-core:$hadoop_version", withoutHadoopExcludes
 
-    // hk2 is required to use WSM client, but not correctly exposed by the client
-    implementation "org.glassfish.jersey.inject:jersey-hk2:$jersey_version"
-    implementation "org.glassfish.jersey.core:jersey-client:$jersey_version"
-    implementation "org.glassfish.jersey.core:jersey-common:$jersey_version"
+    // Jersey libs, required by WSM client (and maybe other clients?), version managed by Spring
+    implementation "org.glassfish.jersey.inject:jersey-hk2"
+    implementation "org.glassfish.jersey.core:jersey-client"
+    implementation "org.glassfish.jersey.core:jersey-common"
 
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     runtimeOnly 'org.webjars.npm:swagger-ui-dist:5.9.0'
@@ -126,18 +125,6 @@ dependencies {
         implementation('org.apache.commons:commons-compress:1.24.0') {
             because("CVE-2023-42503")
         }
-
-
-        // this is redundant (and ineffective) without an explicit override in build.gradle
-        // dependencyManagement, but left here for documentation purposes
-//        implementation('ch.qos.logback:logback-classic:1.2.13+') {
-//            because("CVE-2023-6378")
-//        }
-        // this is redundant (and ineffective) without an explicit override in build.gradle
-        // dependencyManagement, but left here for documentation purposes
-//        implementation('ch.qos.logback:logback-core:1.2.13+') {
-//            because("CVE-2023-6378")
-//        }
     }
 }
 
@@ -254,9 +241,9 @@ testing {
                 implementation 'org.springframework.boot:spring-boot-starter-test'
                 implementation 'org.springframework.boot:spring-boot-starter-jdbc'
                 implementation 'org.liquibase:liquibase-core:4.25.1'
-                implementation "org.glassfish.jersey.core:jersey-client:$jersey_version"
-                implementation "org.glassfish.jersey.core:jersey-common:$jersey_version"
-                implementation "org.glassfish.jersey.inject:jersey-hk2:$jersey_version"
+                implementation "org.glassfish.jersey.core:jersey-client"
+                implementation "org.glassfish.jersey.core:jersey-common"
+                implementation "org.glassfish.jersey.inject:jersey-hk2"
             }
         }
     }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/InstanceInitializerBean.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/InstanceInitializerBean.java
@@ -247,7 +247,7 @@ public class InstanceInitializerBean {
     } catch (WorkspaceDataServiceException wdsE) {
       if (wdsE.getCause() != null
           && wdsE.getCause() instanceof RestException restException
-          && restException.getStatus() == HttpStatus.NOT_FOUND) {
+          && restException.getStatusCode() == HttpStatus.NOT_FOUND) {
         LOGGER.error(
             "Remote source WDS in workspace {} does not support cloning", sourceWorkspaceId);
         cloneDao.terminateCloneToError(

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/GlobalExceptionHandler.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package org.databiosphere.workspacedataservice.controller;
 
+import com.google.common.annotations.VisibleForTesting;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.ArrayList;
 import java.util.Date;
@@ -74,9 +75,6 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
   public ResponseEntity<Map<String, Object>> handleAllExceptions(
       Exception ex, HttpServletRequest servletRequest) {
     Map<String, Object> errorBody = new LinkedHashMap<>();
-
-    // TODO AJ-1157: what shape should we return here? This will depend on problem details being
-    //    enabled or disabled.
     errorBody.put("timestamp", new Date());
     errorBody.put("status", HttpStatus.BAD_REQUEST.value());
     errorBody.put("error", HttpStatus.BAD_REQUEST.getReasonPhrase());
@@ -94,7 +92,8 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     return ResponseEntity.badRequest().body(errorBody);
   }
 
-  private List<String> gatherNestedErrorMessages(Throwable t, List<String> accumulator) {
+  @VisibleForTesting
+  List<String> gatherNestedErrorMessages(@NotNull Throwable t, @NotNull List<String> accumulator) {
     if (StringUtils.isNotBlank(t.getMessage())) {
       accumulator.add(t.getMessage());
     }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/GlobalExceptionHandler.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/GlobalExceptionHandler.java
@@ -7,15 +7,59 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @ControllerAdvice
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+  /**
+   * Override to explicitly translate Problem Details structures back to {@link
+   * org.databiosphere.workspacedata.model.ErrorResponse} structures. This ensures backwards
+   * compatibility for clients.
+   *
+   * <p>Even though {@code }spring.mvc.problemdetails.enabled} is set to false in config, many
+   * exception classes extend {@link org.springframework.web.server.ResponseStatusException}, and
+   * that exception serializes to a problem detail in the response.
+   *
+   * @param body the body to use for the response
+   * @param headers the headers to use for the response
+   * @param statusCode the status code to use for the response
+   * @param request the current request
+   * @return the {@code ResponseEntity} instance to use
+   */
+  @NotNull
+  @Override
+  protected ResponseEntity<Object> createResponseEntity(
+      Object body,
+      @NotNull HttpHeaders headers,
+      @NotNull HttpStatusCode statusCode,
+      @NotNull WebRequest request) {
+    if (body instanceof ProblemDetail problemDetail) {
+      Map<String, Object> errorBody = new LinkedHashMap<>();
+      errorBody.put("timestamp", new Date());
+      errorBody.put("status", problemDetail.getStatus());
+      errorBody.put("error", problemDetail.getTitle());
+      errorBody.put("message", problemDetail.getDetail());
+
+      if (request instanceof ServletWebRequest servletWebRequest) {
+        errorBody.put("path", servletWebRequest.getRequest().getRequestURI());
+      }
+      return new ResponseEntity<>(errorBody, headers, statusCode);
+    }
+
+    return super.createResponseEntity(body, headers, statusCode, request);
+  }
 
   /**
    * Handler for MethodArgumentTypeMismatchException. This exception contains the real message we
@@ -42,9 +86,9 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     // the real message we want to display. Gather all the nested messages and display the last one.
     List<String> errorMessages = gatherNestedErrorMessages(ex, new ArrayList<>());
     if (!errorMessages.isEmpty()) {
-      errorBody.put("messages", errorMessages.get(errorMessages.size() - 1));
+      errorBody.put("message", errorMessages.get(errorMessages.size() - 1));
     } else {
-      errorBody.put("messages", "Unexpected error: " + ex.getClass().getName());
+      errorBody.put("message", "Unexpected error: " + ex.getClass().getName());
     }
 
     return ResponseEntity.badRequest().body(errorBody);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/GlobalExceptionHandler.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/GlobalExceptionHandler.java
@@ -25,18 +25,18 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 @ControllerAdvice
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
-  private final String ERROR = "error";
-  private final String MESSAGE = "message";
-  private final String PATH = "path";
-  private final String STATUS = "status";
-  private final String TIMESTAMP = "timestamp";
+  private static final String ERROR = "error";
+  private static final String MESSAGE = "message";
+  private static final String PATH = "path";
+  private static final String STATUS = "status";
+  private static final String TIMESTAMP = "timestamp";
 
   /**
    * Override to explicitly translate Problem Details structures back to {@link
    * org.databiosphere.workspacedata.model.ErrorResponse} structures. This ensures backwards
    * compatibility for clients.
    *
-   * <p>Even though {@code }spring.mvc.problemdetails.enabled} is set to false in config, many
+   * <p>Even though {@code spring.mvc.problemdetails.enabled} is set to false in config, many
    * exception classes extend {@link org.springframework.web.server.ResponseStatusException}, and
    * that exception serializes to a problem detail in the response.
    *

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/GlobalExceptionHandler.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/GlobalExceptionHandler.java
@@ -1,0 +1,43 @@
+package org.databiosphere.workspacedataservice.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+  /**
+   * Handler for MethodArgumentTypeMismatchException. This exception contains the real message we
+   * want to display inside the nested cause. This handler ditches the top-level message in favor of
+   * that nested one.
+   *
+   * @param ex the exception in question
+   * @param servletRequest the request
+   * @return the desired response
+   */
+  @ExceptionHandler({MethodArgumentTypeMismatchException.class})
+  public ResponseEntity<Map<String, Object>> handleAllExceptions(
+      Exception ex, HttpServletRequest servletRequest) {
+    Map<String, Object> errorBody = new LinkedHashMap<>();
+
+    errorBody.put("timestamp", new Date());
+    errorBody.put("status", HttpStatus.BAD_REQUEST.value());
+    errorBody.put("error", HttpStatus.BAD_REQUEST.getReasonPhrase());
+    // MethodArgumentTypeMismatchException nested exception contains
+    // the real message we want to display
+    if (ex.getCause() != null && ex.getCause().getCause() != null) {
+      errorBody.put("message", ex.getCause().getCause().getMessage());
+    }
+    errorBody.put("path", servletRequest.getRequestURI());
+
+    return ResponseEntity.badRequest().body(errorBody);
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/GlobalExceptionHandler.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/GlobalExceptionHandler.java
@@ -28,6 +28,8 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
       Exception ex, HttpServletRequest servletRequest) {
     Map<String, Object> errorBody = new LinkedHashMap<>();
 
+    // TODO AJ-1157: what shape should we return here? This will depend on problem details being
+    //    enabled or disabled.
     errorBody.put("timestamp", new Date());
     errorBody.put("status", HttpStatus.BAD_REQUEST.value());
     errorBody.put("error", HttpStatus.BAD_REQUEST.getReasonPhrase());

--- a/service/src/main/java/org/databiosphere/workspacedataservice/datarepo/HttpDataRepoClientFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/datarepo/HttpDataRepoClientFactory.java
@@ -2,7 +2,7 @@ package org.databiosphere.workspacedataservice.datarepo;
 
 import bio.terra.datarepo.api.RepositoryApi;
 import bio.terra.datarepo.client.ApiClient;
-import javax.ws.rs.client.Client;
+import jakarta.ws.rs.client.Client;
 import org.apache.commons.lang3.StringUtils;
 import org.databiosphere.workspacedataservice.sam.TokenContextUtil;
 import org.databiosphere.workspacedataservice.shared.model.BearerToken;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/generated/CapabilitiesApi.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/generated/CapabilitiesApi.java
@@ -25,12 +25,12 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated

--- a/service/src/main/java/org/databiosphere/workspacedataservice/generated/CapabilitiesServerModel.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/generated/CapabilitiesServerModel.java
@@ -9,13 +9,13 @@ import java.util.HashMap;
 import java.util.Map;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * CapabilitiesServerModel

--- a/service/src/main/java/org/databiosphere/workspacedataservice/generated/GenericJobAllOfServerModel.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/generated/GenericJobAllOfServerModel.java
@@ -7,13 +7,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * GenericJobAllOfServerModel

--- a/service/src/main/java/org/databiosphere/workspacedataservice/generated/GenericJobServerModel.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/generated/GenericJobServerModel.java
@@ -11,13 +11,13 @@ import java.util.UUID;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * Generic representation of a job, no opinion on inputs and result for the job. See individual APIs for more guidance on expected input and result payloads. 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/generated/ImportApi.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/generated/ImportApi.java
@@ -27,12 +27,12 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated

--- a/service/src/main/java/org/databiosphere/workspacedataservice/generated/ImportRequestServerModel.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/generated/ImportRequestServerModel.java
@@ -11,13 +11,13 @@ import java.util.HashMap;
 import java.util.Map;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * ImportRequestServerModel

--- a/service/src/main/java/org/databiosphere/workspacedataservice/generated/JobApi.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/generated/JobApi.java
@@ -26,12 +26,12 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated

--- a/service/src/main/java/org/databiosphere/workspacedataservice/generated/JobV1ServerModel.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/generated/JobV1ServerModel.java
@@ -11,13 +11,13 @@ import java.util.UUID;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * JobV1ServerModel

--- a/service/src/main/java/org/databiosphere/workspacedataservice/leonardo/LeonardoServiceException.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/leonardo/LeonardoServiceException.java
@@ -5,6 +5,6 @@ import org.springframework.web.server.ResponseStatusException;
 
 public class LeonardoServiceException extends ResponseStatusException {
   public LeonardoServiceException(RestException cause) {
-    super(cause.getStatus(), cause.getMessage(), cause);
+    super(cause.getStatusCode(), cause.getMessage(), cause);
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/retry/RetryLoggingListener.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/retry/RetryLoggingListener.java
@@ -4,11 +4,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.retry.RetryCallback;
 import org.springframework.retry.RetryContext;
-import org.springframework.retry.listener.RetryListenerSupport;
+import org.springframework.retry.RetryListener;
 import org.springframework.stereotype.Component;
 
 @Component("retryLoggingListener")
-public class RetryLoggingListener extends RetryListenerSupport {
+public class RetryLoggingListener implements RetryListener {
 
   private final Logger logger = LoggerFactory.getLogger(getClass());
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/BearerTokenFilter.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/BearerTokenFilter.java
@@ -2,14 +2,14 @@ package org.databiosphere.workspacedataservice.sam;
 
 import static org.springframework.web.context.request.RequestAttributes.SCOPE_REQUEST;
 
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.util.Objects;
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/TokenContextUtil.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/TokenContextUtil.java
@@ -3,9 +3,9 @@ package org.databiosphere.workspacedataservice.sam;
 import static org.databiosphere.workspacedataservice.sam.BearerTokenFilter.ATTRIBUTE_NAME_TOKEN;
 import static org.springframework.web.context.request.RequestAttributes.SCOPE_REQUEST;
 
+import jakarta.validation.constraints.NotNull;
 import java.util.Map;
 import java.util.function.Supplier;
-import javax.validation.constraints.NotNull;
 import org.databiosphere.workspacedataservice.jobexec.JobContextHolder;
 import org.databiosphere.workspacedataservice.shared.model.BearerToken;
 import org.slf4j.Logger;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/MDCResponseHeaderFilter.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/MDCResponseHeaderFilter.java
@@ -1,12 +1,12 @@
 package org.databiosphere.workspacedataservice.service;
 
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletResponse;
 import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/MDCServletRequestListener.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/MDCServletRequestListener.java
@@ -1,11 +1,11 @@
 package org.databiosphere.workspacedataservice.service;
 
+import jakarta.servlet.ServletRequestEvent;
+import jakarta.servlet.ServletRequestListener;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
-import javax.servlet.ServletRequestEvent;
-import javax.servlet.ServletRequestListener;
-import javax.servlet.http.HttpServletRequest;
 import org.hashids.Hashids;
 import org.slf4j.MDC;
 import org.springframework.stereotype.Component;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sourcewds/WorkspaceDataServiceException.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sourcewds/WorkspaceDataServiceException.java
@@ -16,6 +16,6 @@ public class WorkspaceDataServiceException extends ResponseStatusException {
   }
 
   public WorkspaceDataServiceException(RestException cause) {
-    super(cause.getStatus(), cause.getMessage(), cause);
+    super(cause.getStatusCode(), cause.getMessage(), cause);
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/workspacemanager/HttpWorkspaceManagerClientFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/workspacemanager/HttpWorkspaceManagerClientFactory.java
@@ -4,7 +4,7 @@ import bio.terra.workspace.api.ControlledAzureResourceApi;
 import bio.terra.workspace.api.ReferencedGcpResourceApi;
 import bio.terra.workspace.api.ResourceApi;
 import bio.terra.workspace.client.ApiClient;
-import javax.ws.rs.client.Client;
+import jakarta.ws.rs.client.Client;
 import org.apache.commons.lang3.StringUtils;
 import org.databiosphere.workspacedataservice.sam.TokenContextUtil;
 import org.databiosphere.workspacedataservice.shared.model.BearerToken;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/workspacemanager/WorkspaceManagerException.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/workspacemanager/WorkspaceManagerException.java
@@ -5,6 +5,6 @@ import org.springframework.web.server.ResponseStatusException;
 
 public class WorkspaceManagerException extends ResponseStatusException {
   public WorkspaceManagerException(RestException cause) {
-    super(cause.getStatus(), cause.getMessage(), cause);
+    super(cause.getStatusCode(), cause.getMessage(), cause);
   }
 }

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -53,6 +53,10 @@ spring:
       password: ${env.wds.db.password}
       maximum-pool-size: 7
       minimum-idle: 7
+  mvc:
+    problemdetails:
+      # TODO AJ-1157: can we turn this back on?
+      enabled: false
   servlet:
     multipart.max-request-size: 5GB
     multipart.max-file-size: 5GB

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -39,6 +39,10 @@ management:
   info:
     env:
       enabled: true
+  prometheus:
+    metrics:
+      export:
+        enabled: true
 
 info:
   app:

--- a/service/src/main/resources/logback-spring.xml
+++ b/service/src/main/resources/logback-spring.xml
@@ -1,63 +1,60 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 
-    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+  <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
 
-    <!-- inspired by Spring default ${FILE_LOG_PATTERN} from defaults.xml, modified to include requestId -->
-    <property name="WDS_LOG_PATTERN" value="%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}} ${LOG_LEVEL_PATTERN:-%5p} [%X{requestId}] [%t] %-40.40logger{39} : %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}"/>
+  <!-- inspired by Spring default ${FILE_LOG_PATTERN} from defaults.xml, modified to include requestId -->
+  <property name="WDS_LOG_PATTERN"
+            value="%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}} ${LOG_LEVEL_PATTERN:-%5p} [%X{requestId}] [%t] %-40.40logger{39} : %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}"/>
 
-    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>${WDS_LOG_PATTERN}</pattern>
-            <charset>${CONSOLE_LOG_CHARSET}</charset>
-        </encoder>
-    </appender>
+  <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+  <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
 
-    <appender name="Sentry" class="io.sentry.logback.SentryAppender">
-        <!-- Optionally change minimum Event level. Default for Events is ERROR -->
-        <minimumEventLevel>ERROR</minimumEventLevel>
-        <!-- Optionally change minimum Breadcrumbs level. Default for Breadcrumbs is INFO -->
-        <minimumBreadcrumbLevel>INFO</minimumBreadcrumbLevel>
-    </appender>
+  <appender name="Sentry" class="io.sentry.logback.SentryAppender">
+    <!-- Optionally change minimum Event level. Default for Events is ERROR -->
+    <minimumEventLevel>ERROR</minimumEventLevel>
+    <!-- Optionally change minimum Breadcrumbs level. Default for Breadcrumbs is INFO -->
+    <minimumBreadcrumbLevel>INFO</minimumBreadcrumbLevel>
+  </appender>
 
-    <springProfile name="!local">
-        <!-- log everything at INFO level -->
-        <root level="info">
-            <appender-ref ref="Console" />
-            <appender-ref ref="Sentry" />
-        </root>
+  <springProfile name="!local">
+    <!-- log everything at INFO level -->
+    <root level="info">
+      <appender-ref ref="CONSOLE"/>
+      <appender-ref ref="Sentry"/>
+    </root>
 
-        <!-- log WDS at DEBUG level -->
-        <logger name="org.databiosphere.workspacedataservice" level="debug" additivity="false">
-            <appender-ref ref="Console" />
-            <appender-ref ref="Sentry" />
-        </logger>
+    <!-- log WDS at DEBUG level -->
+    <logger name="org.databiosphere.workspacedataservice" level="debug" additivity="false">
+      <appender-ref ref="CONSOLE"/>
+      <appender-ref ref="Sentry"/>
+    </logger>
 
-        <!-- log WDS Sam integration at DEBUG level -->
-        <logger name="org.databiosphere.workspacedataservice.sam" level="debug" additivity="false">
-            <appender-ref ref="Console" />
-            <appender-ref ref="Sentry" />
-        </logger>
+    <!-- log WDS Sam integration at DEBUG level -->
+    <logger name="org.databiosphere.workspacedataservice.sam" level="debug" additivity="false">
+      <appender-ref ref="CONSOLE"/>
+      <appender-ref ref="Sentry"/>
+    </logger>
 
-        <!-- log org.springframework.web at DEBUG level -->
-        <logger name="org.springframework.web" level="debug" additivity="false">
-            <appender-ref ref="Console" />
-            <appender-ref ref="Sentry" />
-        </logger>
-    </springProfile>
+    <!-- log org.springframework.web at DEBUG level -->
+    <logger name="org.springframework.web" level="debug" additivity="false">
+      <appender-ref ref="CONSOLE"/>
+      <appender-ref ref="Sentry"/>
+    </logger>
+  </springProfile>
 
-    <springProfile name="local">
-        <root level="info">
-            <appender-ref ref="Console" />
-        </root>
+  <springProfile name="local">
+    <root level="info">
+      <appender-ref ref="CONSOLE"/>
+    </root>
 
-        <logger name="org.databiosphere.workspacedataservice" level="debug" additivity="false">
-            <appender-ref ref="Console" />
-        </logger>
+    <logger name="org.databiosphere.workspacedataservice" level="debug" additivity="false">
+      <appender-ref ref="CONSOLE"/>
+    </logger>
 
-        <logger name="org.springframework.web" level="debug" additivity="false">
-            <appender-ref ref="Console" />
-        </logger>
-    </springProfile>
+    <logger name="org.springframework.web" level="debug" additivity="false">
+      <appender-ref ref="CONSOLE"/>
+    </logger>
+  </springProfile>
 
 </configuration>

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/GlobalExceptionHandlerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/GlobalExceptionHandlerTest.java
@@ -43,7 +43,7 @@ class GlobalExceptionHandlerTest {
     List<String> actual =
         globalExceptionHandler.gatherNestedErrorMessages(input, new ArrayList<>());
     assertThat(actual).size().isEqualTo(1);
-    assertEquals(actual.get(0), "one");
+    assertEquals("one", actual.get(0));
   }
 
   @Test
@@ -54,8 +54,8 @@ class GlobalExceptionHandlerTest {
     List<String> actual =
         globalExceptionHandler.gatherNestedErrorMessages(input, new ArrayList<>());
     assertThat(actual).size().isEqualTo(2);
-    assertEquals(actual.get(0), "one");
-    assertEquals(actual.get(1), "two");
+    assertEquals("one", actual.get(0));
+    assertEquals("two", actual.get(1));
   }
 
   @Test
@@ -68,8 +68,8 @@ class GlobalExceptionHandlerTest {
     List<String> actual =
         globalExceptionHandler.gatherNestedErrorMessages(input, new ArrayList<>());
     assertThat(actual).size().isEqualTo(3);
-    assertEquals(actual.get(0), "one");
-    assertEquals(actual.get(1), "two");
-    assertEquals(actual.get(2), "three");
+    assertEquals("one", actual.get(0));
+    assertEquals("two", actual.get(1));
+    assertEquals("three", actual.get(2));
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/GlobalExceptionHandlerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/GlobalExceptionHandlerTest.java
@@ -1,0 +1,75 @@
+package org.databiosphere.workspacedataservice.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class GlobalExceptionHandlerTest {
+  @Autowired private GlobalExceptionHandler globalExceptionHandler;
+
+  @Test
+  void gatherNestedErrorMessagesNullMessage() {
+    Throwable input = new Throwable();
+    List<String> actual =
+        globalExceptionHandler.gatherNestedErrorMessages(input, new ArrayList<>());
+    assertThat(actual).isEmpty();
+  }
+
+  @Test
+  void gatherNestedErrorMessagesEmptyMessage() {
+    Throwable input = new Throwable("");
+    List<String> actual =
+        globalExceptionHandler.gatherNestedErrorMessages(input, new ArrayList<>());
+    assertThat(actual).isEmpty();
+  }
+
+  @Test
+  void gatherNestedErrorMessagesBlankMessage() {
+    Throwable input = new Throwable(" ");
+    List<String> actual =
+        globalExceptionHandler.gatherNestedErrorMessages(input, new ArrayList<>());
+    assertThat(actual).isEmpty();
+  }
+
+  @Test
+  void gatherNestedErrorMessagesOneMessage() {
+    Throwable input = new Throwable("one");
+    List<String> actual =
+        globalExceptionHandler.gatherNestedErrorMessages(input, new ArrayList<>());
+    assertThat(actual).size().isEqualTo(1);
+    assertEquals(actual.get(0), "one");
+  }
+
+  @Test
+  void gatherNestedErrorMessagesTwoMessages() {
+    Throwable input = new Throwable("one");
+    Throwable nested = new Throwable("two");
+    input.initCause(nested);
+    List<String> actual =
+        globalExceptionHandler.gatherNestedErrorMessages(input, new ArrayList<>());
+    assertThat(actual).size().isEqualTo(2);
+    assertEquals(actual.get(0), "one");
+    assertEquals(actual.get(1), "two");
+  }
+
+  @Test
+  void gatherNestedErrorMessagesThreeMessages() {
+    Throwable input = new Throwable("one");
+    Throwable nested = new Throwable("two");
+    Throwable third = new Throwable("three");
+    nested.initCause(third);
+    input.initCause(nested);
+    List<String> actual =
+        globalExceptionHandler.gatherNestedErrorMessages(input, new ArrayList<>());
+    assertThat(actual).size().isEqualTo(3);
+    assertEquals(actual.get(0), "one");
+    assertEquals(actual.get(1), "two");
+    assertEquals(actual.get(2), "three");
+  }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/datarepo/DataRepoDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/datarepo/DataRepoDaoTest.java
@@ -68,7 +68,7 @@ class DataRepoDaoTest {
         .willThrow(new ApiException(statusCode, "Intentional error thrown for unit test"));
     var exception =
         assertThrows(DataRepoException.class, () -> dataRepoDao.getSnapshot(UUID.randomUUID()));
-    assertEquals(statusCode, exception.getRawStatusCode());
+    assertEquals(statusCode, exception.getStatusCode().value());
     Mockito.clearInvocations(mockRepositoryApi);
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/leonardo/LeonardoDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/leonardo/LeonardoDaoTest.java
@@ -57,7 +57,7 @@ class LeonardoDaoTest {
                 statusCode, "Intentional error thrown for unit test"));
     var exception =
         assertThrows(LeonardoServiceException.class, () -> leonardoDao.getWdsEndpointUrl(any()));
-    assertEquals(statusCode, exception.getRawStatusCode());
+    assertEquals(statusCode, exception.getStatusCode().value());
   }
 
   @Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/metrics/MetricsConfigTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/metrics/MetricsConfigTest.java
@@ -21,7 +21,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 
 @DirtiesContext
-@SpringBootTest(properties = "management.metrics.export.prometheus.enabled=true")
+@SpringBootTest(properties = "management.prometheus.metrics.export.enabled=true")
 @AutoConfigureMockMvc
 class MetricsConfigTest {
   @Autowired private BuildProperties buildProperties;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/pact/SamPactTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/pact/SamPactTest.java
@@ -48,7 +48,7 @@ class SamPactTest {
         .method("GET")
         .willRespondWith()
         .status(200)
-        .body("{\"ok\": true}")
+        .body("{\"ok\": true, \"systems\": {}}")
         .toPact();
   }
 
@@ -61,7 +61,7 @@ class SamPactTest {
         .method("GET")
         .willRespondWith()
         .status(500)
-        .body("{\"ok\": false}")
+        .body("{\"ok\": false, \"systems\": {}}")
         .toPact();
   }
 
@@ -131,6 +131,7 @@ class SamPactTest {
         new PactDslJsonBody()
             .stringType("userSubjectId")
             .stringType("userEmail")
+            .booleanType("adminEnabled")
             .booleanType("enabled");
     return builder
         .given("user status info request with access token")

--- a/service/src/test/java/org/databiosphere/workspacedataservice/pact/WsmPactTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/pact/WsmPactTest.java
@@ -480,7 +480,7 @@ public class WsmPactTest {
         assertThrows(
             WorkspaceManagerException.class,
             () -> wsmDao.getBlobStorageUrl(WORKSPACE_UUID.toString(), BEARER_TOKEN));
-    assertEquals(HttpStatus.FORBIDDEN, thrown.getStatus());
+    assertEquals(HttpStatus.FORBIDDEN, thrown.getStatusCode());
   }
 
   @Test
@@ -494,7 +494,7 @@ public class WsmPactTest {
         assertThrows(
             WorkspaceManagerException.class,
             () -> wsmDao.getBlobStorageUrl(WORKSPACE_UUID.toString(), BEARER_TOKEN));
-    assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, thrown.getStatus());
+    assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, thrown.getStatusCode());
   }
 
   @Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/retry/RestClientRetryTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/retry/RestClientRetryTest.java
@@ -304,7 +304,7 @@ class RestClientRetryTest {
 
     assertEquals(
         expectedStatusCode,
-        actual.getRawStatusCode(),
+        actual.getStatusCode().value(),
         "RestCall: Incorrect status code in RestException");
   }
 
@@ -318,7 +318,7 @@ class RestClientRetryTest {
 
     assertEquals(
         expectedStatusCode,
-        actual.getRawStatusCode(),
+        actual.getStatusCode().value(),
         "voidRestCall: Incorrect status code in RestException");
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamExceptionTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamExceptionTest.java
@@ -250,7 +250,7 @@ class InstanceServiceSamExceptionTest {
             "createInstance should throw if caller does not have permission to create wds-instance resource in Sam");
     assertEquals(
         expectedSamExceptionCode,
-        samException.getRawStatusCode(),
+        samException.getStatusCode().value(),
         "RestException from createInstance should have same status code as the thrown ApiException");
     List<UUID> allInstances = instanceService.listInstances(VERSION);
     assertFalse(allInstances.contains(instanceId), "should not have created the instances.");
@@ -270,7 +270,7 @@ class InstanceServiceSamExceptionTest {
             "deleteInstance should throw if caller does not have permission to create wds-instance resource in Sam");
     assertEquals(
         expectedSamExceptionCode,
-        samException.getRawStatusCode(),
+        samException.getStatusCode().value(),
         "RestException from deleteInstance should have same status code as the thrown ApiException");
     allInstances = instanceService.listInstances(VERSION);
     assertTrue(

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
@@ -168,7 +168,7 @@ class RecordOrchestratorServiceTest {
             ResponseStatusException.class,
             () -> validateVersion("invalidVersion"),
             "validateVersion should have thrown an error");
-    assert (e.getStatus().equals(HttpStatus.BAD_REQUEST));
+    assert (e.getStatusCode().equals(HttpStatus.BAD_REQUEST));
   }
 
   private void testCreateRecord(String newRecordId, String testKey, String testVal) {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/workspacemanager/WorkspaceManagerDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/workspacemanager/WorkspaceManagerDaoTest.java
@@ -94,7 +94,7 @@ class WorkspaceManagerDaoTest {
         assertThrows(
             WorkspaceManagerException.class,
             () -> workspaceManagerDao.linkSnapshotForPolicy(testSnapshot));
-    assertEquals(statusCode, exception.getRawStatusCode());
+    assertEquals(statusCode, exception.getStatusCode().value());
   }
 
   @Test

--- a/service/src/test/resources/logback-spring.xml
+++ b/service/src/test/resources/logback-spring.xml
@@ -1,28 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 
-    <appender name="Console"
-              class="ch.qos.logback.core.ConsoleAppender">
-        <layout class="ch.qos.logback.classic.PatternLayout">
-            <Pattern>
-                %green(%d{ISO8601}) %highlight(%-5level) [%blue(%X{requestId})] %yellow(%C{1.}): %msg%n%throwable
-            </Pattern>
-        </layout>
-    </appender>
+  <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+  <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
 
-    <!-- log everything at INFO level -->
-    <root level="info">
-        <appender-ref ref="Console" />
-    </root>
+  <!-- log everything at INFO level -->
+  <root level="info">
+    <appender-ref ref="CONSOLE"/>
+  </root>
 
-    <!-- log WDS at DEBUG level -->
-    <logger name="org.databiosphere.workspacedataservice" level="debug" additivity="false">
-        <appender-ref ref="Console" />
-    </logger>
+  <!-- log WDS at DEBUG level -->
+  <logger name="org.databiosphere.workspacedataservice" level="debug" additivity="false">
+    <appender-ref ref="CONSOLE"/>
+  </logger>
 
-    <!-- log org.springframework.web at DEBUG level -->
-    <logger name="org.springframework.web" level="debug" additivity="false">
-        <appender-ref ref="Console" />
-    </logger>
+  <!-- log org.springframework.web at DEBUG level -->
+  <logger name="org.springframework.web" level="debug" additivity="false">
+    <appender-ref ref="CONSOLE"/>
+  </logger>
 
 </configuration>


### PR DESCRIPTION
Updates WDS to Spring Boot 3.2.1. Supersedes #210.

Highlights of this PR:
* Update Spring Boot dependency to 3.2.1
* Update Data Repo and WSM clients to Jakarta-compatible versions
* Update a bunch of other deps to compatible versions
* Remove dependency overrides and version specifications where possible, since Spring Boot 3 [updates a lot of those for us](https://docs.spring.io/spring-boot/docs/current/reference/html/dependency-versions.html)
* bunch of small syntax compatibility changes due to the javax -> jakarta change and to Spring Boot 3 changes
* Refactor our logging config to include the default Spring Boot defaults; this fixes syntax errors with our previous config

Recommended Reading:
* https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide
* https://github.com/spring-projects/spring-framework/wiki/Upgrading-to-Spring-Framework-6.x
* https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Release-Notes
* https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.1-Release-Notes
* https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.2-Release-Notes

Still TODO:
- [x] a few unit tests are breaking, at least one because some error messages have changed. Address these.
- [x] fix Prometheus metrics

For future PRs:
- [ ] Re-enable [Problem Detail](https://github.com/spring-projects/spring-framework/issues/27052) support, which may have compatibility issues for clients
- [ ] stop publishing a javax client, once CBAS updates to Spring Boot 3 as well