### PR TITLE
AJ-1514: exclude old netty from hadoop; update TDR client

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -77,7 +77,7 @@ dependencies {
     implementation group: 'org.broadinstitute.dsde.workbench', name: 'sam-client_2.13', version: '0.1-752b4f3'
     implementation group: 'org.broadinstitute.dsde.workbench', name: 'leonardo-client_2.13', version: '1.3.6-22ee00b'
     implementation 'com.squareup.okhttp3:okhttp' // required by Sam client
-    implementation "bio.terra:datarepo-jakarta-client:1.557.0-SNAPSHOT"
+    implementation "bio.terra:datarepo-jakarta-client:1.570.0-SNAPSHOT"
     implementation "bio.terra:workspace-manager-client:0.254.983-SNAPSHOT"
     implementation "bio.terra:java-pfb-library:0.15.0"
     implementation project(path: ':client')
@@ -93,6 +93,7 @@ dependencies {
     def withoutHadoopExcludes = {
         exclude(group: 'log4j')
         exclude(group: 'org.slf4j')
+        exclude(group: 'io.netty')
         exclude(group: 'org.mortbay.jetty')
         exclude(group: 'javax.servlet.jsp')
         exclude(group: 'com.sun.jersey')


### PR DESCRIPTION
Two quick changes:
* exclude `io.netty` from the hadoop dependencies. This should resolve some Dependabot warnings.
* update TDR client to latest. This resolves a failure due to a model change in TDR responses.

Note: this does not resolve https://broadworkbench.atlassian.net/browse/AJ-1529. It eliminates the TDR error, but the updated TDR client in this PR is still not resilient to future model changes.


---

Reminder:

PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 
