### PR TITLE
AJ-1529: json parsing should be resilient to unknown properties

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/JsonConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/JsonConfig.java
@@ -25,6 +25,7 @@ public class JsonConfig {
             .configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION, true)
             .configure(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS, true)
             .configure(DeserializationFeature.USE_BIG_INTEGER_FOR_INTS, true)
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
             .findAndAddModules()
             .build();
     mapper

--- a/service/src/test/resources/tdrmanifest/extra_properties.json
+++ b/service/src/test/resources/tdrmanifest/extra_properties.json
@@ -1,0 +1,218 @@
+{
+  "snapshot": {
+    "extra": "this is an unknown property so unit tests can validate we have resilient parsing",
+    "extra-extra": "another unknown",
+    "extra-extra-extra": "triple extra.",
+    "id": "00000000-1111-2222-3333-444455556666",
+    "name": "unit_test_snapshot",
+    "description": "Exemplar snapshot for unit testing data",
+    "createdDate": "2021-04-05T07:07:08.654321Z",
+    "source": [
+      {
+        "dataset": {
+          "id": "d70f8266-583f-11ec-bf63-0242ac130002",
+          "name": "unit_test_dataset",
+          "description": "Exemplar dataset for unit testing data",
+          "defaultProfileId": "e55435f6-583f-11ec-bf63-0242ac130002",
+          "createdDate": "2021-01-02T03:04:05.654321Z",
+          "storage": [
+            {
+              "region": "westus2",
+              "cloudResource": "application_deployment",
+              "cloudPlatform": "azure"
+            },
+            {
+              "region": "westus2",
+              "cloudResource": "storage_account",
+              "cloudPlatform": "azure"
+            },
+            {
+              "region": "westus2",
+              "cloudResource": "synapse_workspace",
+              "cloudPlatform": "azure"
+            }
+          ]
+        },
+        "asset": null
+      }
+    ],
+    "tables": [
+      {
+        "name": "project",
+        "columns": [
+          {
+            "name": "project_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": [
+          "project_id"
+        ],
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 1
+      },
+      {
+        "name": "edges",
+        "columns": [
+          {
+            "name": "edges_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "project_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 221
+      },
+      {
+        "name": "test_result",
+        "columns": [
+          {
+            "name": "test_result_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": [
+          "version",
+          "content"
+        ],
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "genome",
+        "columns": [
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "file_id",
+            "datatype": "fileref",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "genome_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "descriptor",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 2097
+      }
+    ],
+    "relationships": [
+      {
+        "name": "from_edges.project_id_to_project.project_id",
+        "from": {
+          "table": "edges",
+          "column": "project_id"
+        },
+        "to": {
+          "table": "project",
+          "column": "project_id"
+        }
+      },
+      {
+        "name": "from_test_result.project_id_to_project.project_id",
+        "from": {
+          "table": "test_result",
+          "column": "version"
+        },
+        "to": {
+          "table": "edges",
+          "column": "edges_id"
+        }
+      }
+    ],
+    "profileId": "bff61446-583f-11ec-bf63-0242ac130002",
+    "dataProject": null,
+    "accessInformation": null
+  },
+  "format": {
+    "parquet": {
+      "location": {
+        "tables": [
+          {
+            "name": "project",
+            "paths": [
+              "https://mysnapshotsa.blob.core.windows.net/metadata/parquet/9516afec-583f-11ec-bf63-0242ac130002/project.parquet/F0EE365B-314D-4E19-A177-E8F63D883716_9274_0-1.parquet?sp=r&st=2022-08-04T15:31:55Z&se=2022-08-06T23:31:55Z&spr=https&sv=2021-06-08&sr=b&sig=bogus"
+            ]
+          },
+          {
+            "name": "edges",
+            "paths": [
+              "https://mysnapshotsa.blob.core.windows.net/metadata/parquet/9516afec-583f-11ec-bf63-0242ac130002/edges.parquet/F0EE365B-314D-4E19-A177-E8F63D883716_9274_0-1.parquet?sp=r&st=2022-08-04T15:31:55Z&se=2022-08-06T23:31:55Z&spr=https&sv=2021-06-08&sr=b&sig=bogus",
+              "https://mysnapshotsa.blob.core.windows.net/metadata/parquet/9516afec-583f-11ec-bf63-0242ac130002/edges.parquet/F0EE365B-314D-4E19-A177-E8F63D883716_9274_0-2.parquet?sp=r&st=2022-08-04T15:31:55Z&se=2022-08-06T23:31:55Z&spr=https&sv=2021-06-08&sr=b&sig=bogus"
+            ]
+          },
+          {
+            "name": "test_result",
+            "paths": [
+              "https://mysnapshotsa.blob.core.windows.net/metadata/parquet/9516afec-583f-11ec-bf63-0242ac130002/test_result.parquet/F0EE365B-314D-4E19-A177-E8F63D883716_9274_0-1.parquet?sp=r&st=2022-08-04T15:31:55Z&se=2022-08-06T23:31:55Z&spr=https&sv=2021-06-08&sr=b&sig=bogus"
+            ]
+          }
+        ]
+      },
+      "manifest": "https://mysnapshotsa.blob.core.windows.net/metadata/manifests/rand.json"
+    },
+    "workspace": null
+  }
+}


### PR DESCRIPTION
turns out that AJ-1529 was not a problem with the TDR client; it was a problem with our own JSON parsing. Our `ObjectMapper` was not configured to ignore unknown properties, so when TDR added new properties to the manifest and we tried to parse them into an older version of the model which didn't have those properties, we hit an error.

This PR fixes that by setting `DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES` to false, and adding a unit test.

The unit test is in `TdrManifestQuartzJobTest` because that's our driving use case, but the setting applies to all JSON parsing.