### PR TITLE
[AJ-1280] Add API for deleting an attribute from a record type

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityEventBuilder.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityEventBuilder.java
@@ -101,6 +101,11 @@ public class ActivityEventBuilder {
     return this;
   }
 
+  public ActivityEventBuilder attribute() {
+    this.thing = ActivityModels.Thing.ATTRIBUTE;
+    return this;
+  }
+
   public ActivityEventBuilder record() {
     this.thing = ActivityModels.Thing.RECORD;
     return this;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityModels.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityModels.java
@@ -25,6 +25,7 @@ public class ActivityModels {
   public enum Thing {
     INSTANCE("instance"),
     TABLE("table"),
+    ATTRIBUTE("attribute"),
     RECORD("record"),
     SNAPSHOT_REFERENCE("snapshot reference"),
     BACKUP("backup");

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -167,6 +167,17 @@ public class RecordController {
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }
 
+  @DeleteMapping("{instanceId}/types/{v}/{type}/{attribute}")
+  @RetryableApi
+  public ResponseEntity<Void> deleteAttribute(
+      @PathVariable("instanceId") UUID instanceId,
+      @PathVariable("v") String version,
+      @PathVariable("type") RecordType recordType,
+      @PathVariable("attribute") String attribute) {
+    recordOrchestratorService.deleteAttribute(instanceId, version, recordType, attribute);
+    return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+  }
+
   @GetMapping("/{instanceId}/types/{v}/{type}")
   @RetryableApi
   public ResponseEntity<RecordTypeSchema> describeRecordType(

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -1024,4 +1024,14 @@ public class RecordDao {
       throw e;
     }
   }
+
+  public void deleteAttribute(UUID instanceId, RecordType recordType, String attribute) {
+    namedTemplate
+        .getJdbcTemplate()
+        .update(
+            "alter table "
+                + getQualifiedTableName(recordType, instanceId)
+                + " drop column "
+                + quote(SqlUtils.validateSqlString(attribute, ATTRIBUTE)));
+  }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
@@ -239,7 +239,7 @@ public class RecordOrchestratorService { // TODO give me a better name
     validateAttributeExistsAndIsEditable(instanceId, recordType, attribute);
     recordService.deleteAttribute(instanceId, recordType, attribute);
     activityLogger.saveEventForCurrentUser(
-        user -> user.updated().table().ofQuantity(1).withRecordType(recordType));
+        user -> user.deleted().attribute().withRecordType(recordType).withId(attribute));
   }
 
   private void validateAttributeExistsAndIsEditable(

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
@@ -238,6 +238,8 @@ public class RecordOrchestratorService { // TODO give me a better name
     checkRecordTypeExists(instanceId, recordType);
     validateAttributeExistsAndIsEditable(instanceId, recordType, attribute);
     recordService.deleteAttribute(instanceId, recordType, attribute);
+    activityLogger.saveEventForCurrentUser(
+        user -> user.updated().table().ofQuantity(1).withRecordType(recordType));
   }
 
   private void validateAttributeExistsAndIsEditable(

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
@@ -20,6 +20,7 @@ import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
 import org.databiosphere.workspacedataservice.service.model.RecordTypeSchema;
 import org.databiosphere.workspacedataservice.service.model.Relation;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthorizationException;
+import org.databiosphere.workspacedataservice.service.model.exception.DeleteAttributeRequestException;
 import org.databiosphere.workspacedataservice.service.model.exception.MissingObjectException;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordQueryResponse;
@@ -229,6 +230,27 @@ public class RecordOrchestratorService { // TODO give me a better name
     recordService.deleteRecordType(instanceId, recordType);
     activityLogger.saveEventForCurrentUser(
         user -> user.deleted().table().ofQuantity(1).withRecordType(recordType));
+  }
+
+  public void deleteAttribute(
+      UUID instanceId, String version, RecordType recordType, String attribute) {
+    validateAndPermissions(instanceId, version);
+    checkRecordTypeExists(instanceId, recordType);
+    validateAttributeExistsAndIsEditable(instanceId, recordType, attribute);
+    recordService.deleteAttribute(instanceId, recordType, attribute);
+  }
+
+  private void validateAttributeExistsAndIsEditable(
+      UUID instanceId, RecordType recordType, String attribute) {
+    RecordTypeSchema schema = getSchemaDescription(instanceId, recordType);
+
+    if (schema.attributes().stream()
+        .noneMatch(attributeSchema -> attributeSchema.name().equals(attribute))) {
+      throw new MissingObjectException("Attribute");
+    }
+    if (attribute.equals(schema.primaryKey())) {
+      throw new DeleteAttributeRequestException("Unable to delete ID attribute");
+    }
   }
 
   @ReadTransaction

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordService.java
@@ -407,4 +407,9 @@ public class RecordService {
   public void deleteRecordType(UUID instanceId, RecordType recordType) {
     recordDao.deleteRecordType(instanceId, recordType);
   }
+
+  @WriteTransaction
+  public void deleteAttribute(UUID instanceId, RecordType recordType, String attribute) {
+    recordDao.deleteAttribute(instanceId, recordType, attribute);
+  }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/DeleteAttributeRequestException.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/DeleteAttributeRequestException.java
@@ -1,0 +1,11 @@
+package org.databiosphere.workspacedataservice.service.model.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(code = HttpStatus.BAD_REQUEST)
+public class DeleteAttributeRequestException extends RuntimeException {
+  public DeleteAttributeRequestException(String message) {
+    super(message);
+  }
+}

--- a/service/src/main/resources/capabilities.json
+++ b/service/src/main/resources/capabilities.json
@@ -1,5 +1,6 @@
 {
   "capabilities": true,
   "dataimport.pfb": true,
-  "dataimport.tdrmanifest": false
+  "dataimport.tdrmanifest": false,
+  "edit.deleteAttribute": true
 }

--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -483,6 +483,35 @@ paths:
           description: Success
         409:
           description: at least one of the records to be deleted is a relation target
+  /{instanceid}/types/{v}/{type}/{attribute}:
+    delete:
+      summary: Delete attribute from record type
+      description: Delete attribute from record type. This attribute will be removed from all records of this type.
+      operationId: deleteAttribute
+      security:
+        - bearerAuth: [ ]
+      tags:
+        - Schema
+      parameters:
+        - $ref: '#/components/parameters/instanceIdPathParam'
+        - $ref: '#/components/parameters/versionPathParam'
+        - $ref: '#/components/parameters/recordTypePathParam'
+        - $ref: '#/components/parameters/attributePathParam'
+      responses:
+        204:
+          description: Success
+        400:
+          description: Attribute is the ID for record type
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        404:
+          description: Attribute does not exist
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   ##############################
   # General WDS Information APIs

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -1976,6 +1976,7 @@ class RecordControllerMockMvcTest {
   void deleteAttribute() throws Exception {
     String recordType = "recordType";
     createSomeRecords(recordType, 3);
+    String attributeToDelete = "attr1";
     mockMvc
         .perform(
             delete(
@@ -1983,8 +1984,13 @@ class RecordControllerMockMvcTest {
                 instanceId,
                 versionId,
                 recordType,
-                "attr1"))
+                attributeToDelete))
         .andExpect(status().isNoContent());
+
+    mockMvc
+        .perform(
+            get("/{instanceId}/types/{version}/{recordType}", instanceId, versionId, recordType))
+        .andExpect(content().string(not(containsString(attributeToDelete))));
   }
 
   @Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -1973,6 +1973,54 @@ class RecordControllerMockMvcTest {
 
   @Test
   @Transactional
+  void deleteAttribute() throws Exception {
+    String recordType = "recordType";
+    createSomeRecords(recordType, 3);
+    mockMvc
+        .perform(
+            delete(
+                "/{instanceId}/types/{v}/{type}/{attribute}",
+                instanceId,
+                versionId,
+                recordType,
+                "attr1"))
+        .andExpect(status().isNoContent());
+  }
+
+  @Test
+  @Transactional
+  void deleteNonExistentAttribute() throws Exception {
+    String recordType = "recordType";
+    createSomeRecords(recordType, 3);
+    mockMvc
+        .perform(
+            delete(
+                "/{instanceId}/types/{v}/{type}/{attribute}",
+                instanceId,
+                versionId,
+                recordType,
+                "doesnotexist"))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @Transactional
+  void deletePrimaryKeyAttribute() throws Exception {
+    String recordType = "recordType";
+    createSomeRecords(recordType, 3);
+    mockMvc
+        .perform(
+            delete(
+                "/{instanceId}/types/{v}/{type}/{attribute}",
+                instanceId,
+                versionId,
+                recordType,
+                "sys_name"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @Transactional
   void describeType() throws Exception {
     RecordType type = RecordType.valueOf("recordType");
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
@@ -753,6 +753,27 @@ class RecordDaoTest {
 
   @Test
   @Transactional
+  void testDeleteAttribute() {
+    // Arrange
+    RecordType recordTypeWithAttributes = RecordType.valueOf("withAttributes");
+    recordDao.createRecordType(
+        instanceId,
+        Map.of("attr1", DataTypeMapping.STRING, "attr2", DataTypeMapping.STRING),
+        recordTypeWithAttributes,
+        new RelationCollection(Collections.emptySet(), Collections.emptySet()),
+        PRIMARY_KEY);
+
+    // Act
+    recordDao.deleteAttribute(instanceId, recordTypeWithAttributes, "attr2");
+
+    // Assert
+    Set<String> attributeNames =
+        Set.copyOf(recordDao.getAllAttributeNames(instanceId, recordTypeWithAttributes));
+    assertEquals(attributeNames, Set.of(PRIMARY_KEY, "attr1"));
+  }
+
+  @Test
+  @Transactional
   void testCreateRelationJoinTable() {
     RecordType secondRecordType = RecordType.valueOf("secondRecordType");
     recordDao.createRecordType(

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
@@ -7,9 +7,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.dao.InstanceDao;
+import org.databiosphere.workspacedataservice.service.model.AttributeSchema;
 import org.databiosphere.workspacedataservice.service.model.RecordTypeSchema;
+import org.databiosphere.workspacedataservice.service.model.exception.DeleteAttributeRequestException;
 import org.databiosphere.workspacedataservice.service.model.exception.MissingObjectException;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
 import org.databiosphere.workspacedataservice.shared.model.RecordQueryResponse;
@@ -125,6 +128,63 @@ class RecordOrchestratorServiceTest {
         MissingObjectException.class,
         () -> recordOrchestratorService.describeRecordType(INSTANCE, VERSION, TEST_TYPE),
         "describeRecordType should have thrown an error");
+  }
+
+  @Test
+  void deleteAttribute() {
+    // Arrange
+    setUpDeleteAttributeTest();
+
+    // Act
+    recordOrchestratorService.deleteAttribute(INSTANCE, VERSION, TEST_TYPE, "attr2");
+
+    // Assert
+    assertAttributes(Set.of("id", "attr1"));
+  }
+
+  @Test
+  void deletePrimaryKeyAttribute() {
+    // Arrange
+    setUpDeleteAttributeTest();
+
+    // Act/Assert
+    assertThrows(
+        DeleteAttributeRequestException.class,
+        () -> recordOrchestratorService.deleteAttribute(INSTANCE, VERSION, TEST_TYPE, "id"),
+        "Unable to delete ID attribute");
+    assertAttributes(Set.of("id", "attr1", "attr2"));
+  }
+
+  @Test
+  void deleteNonexistentAttribute() {
+    // Arrange
+    setUpDeleteAttributeTest();
+
+    // Act/Assert
+    assertThrows(
+        MissingObjectException.class,
+        () ->
+            recordOrchestratorService.deleteAttribute(INSTANCE, VERSION, TEST_TYPE, "doesnotexist"),
+        "Attribute not found");
+    assertAttributes(Set.of("id", "attr1", "attr2"));
+  }
+
+  private void setUpDeleteAttributeTest() {
+    RecordRequest recordRequest =
+        new RecordRequest(
+            RecordAttributes.empty().putAttribute("attr1", "foo").putAttribute("attr2", "bar"));
+
+    ResponseEntity<RecordResponse> response =
+        recordOrchestratorService.upsertSingleRecord(
+            INSTANCE, VERSION, TEST_TYPE, "1", Optional.of("id"), recordRequest);
+  }
+
+  private void assertAttributes(Set<String> expectedAttributeNames) {
+    RecordTypeSchema schema =
+        recordOrchestratorService.describeRecordType(INSTANCE, VERSION, TEST_TYPE);
+    Set<String> actualAttributeNames =
+        Set.copyOf(schema.attributes().stream().map(AttributeSchema::name).toList());
+    assertEquals(actualAttributeNames, expectedAttributeNames);
   }
 
   @Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
@@ -182,6 +182,8 @@ class RecordOrchestratorServiceTest {
     ResponseEntity<RecordResponse> response =
         recordOrchestratorService.upsertSingleRecord(
             INSTANCE, VERSION, TEST_TYPE, "1", Optional.of("id"), recordRequest);
+
+    assertAttributes(Set.of("id", "attr1", "attr2"));
   }
 
   private void assertAttributes(Set<String> expectedAttributeNames) {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
@@ -148,10 +148,12 @@ class RecordOrchestratorServiceTest {
     setUpDeleteAttributeTest();
 
     // Act/Assert
-    assertThrows(
-        DeleteAttributeRequestException.class,
-        () -> recordOrchestratorService.deleteAttribute(INSTANCE, VERSION, TEST_TYPE, "id"),
-        "Unable to delete ID attribute");
+    DeleteAttributeRequestException e =
+        assertThrows(
+            DeleteAttributeRequestException.class,
+            () -> recordOrchestratorService.deleteAttribute(INSTANCE, VERSION, TEST_TYPE, "id"),
+            "deleteAttribute should have thrown an error");
+    assertEquals(e.getMessage(), "Unable to delete ID attribute");
     assertAttributes(Set.of("id", "attr1", "attr2"));
   }
 
@@ -161,11 +163,14 @@ class RecordOrchestratorServiceTest {
     setUpDeleteAttributeTest();
 
     // Act/Assert
-    assertThrows(
-        MissingObjectException.class,
-        () ->
-            recordOrchestratorService.deleteAttribute(INSTANCE, VERSION, TEST_TYPE, "doesnotexist"),
-        "Attribute not found");
+    MissingObjectException e =
+        assertThrows(
+            MissingObjectException.class,
+            () ->
+                recordOrchestratorService.deleteAttribute(
+                    INSTANCE, VERSION, TEST_TYPE, "doesnotexist"),
+            "deleteAttribute should have thrown an error");
+    assertEquals(e.getMessage(), "Attribute does not exist");
     assertAttributes(Set.of("id", "attr1", "attr2"));
   }
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1280

This adds an API that accepts delete requests at `{instanceId}/types/{v}/{type}/{attribute}` and deletes the given attribute from the given record type by dropping the column in the database. It rejects requests to delete the primary key column.