### PR TITLE
Add `MockSamUsersApi`

### DIFF
--- a/service/src/test/java/org/databiosphere/workspacedataservice/sam/MockSamClientFactory.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/sam/MockSamClientFactory.java
@@ -18,7 +18,7 @@ public class MockSamClientFactory implements SamClientFactory {
 
   @Override
   public UsersApi getUsersApi(String token) {
-    return null;
+    return new MockSamUsersApi();
   }
 
   @Override

--- a/service/src/test/java/org/databiosphere/workspacedataservice/sam/MockSamUsersApi.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/sam/MockSamUsersApi.java
@@ -1,0 +1,11 @@
+package org.databiosphere.workspacedataservice.sam;
+
+import org.broadinstitute.dsde.workbench.client.sam.api.UsersApi;
+import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo;
+
+public class MockSamUsersApi extends UsersApi {
+  @Override
+  public UserStatusInfo getUserStatusInfo() {
+    return new UserStatusInfo().userSubjectId("mock-user-subject-id");
+  }
+}


### PR DESCRIPTION
This is in response to the following stacktrace printing 252 times in the logs during a full suite test run.  It apparently doesn't cause any test failures, but definitely makes them noisy (when test output is enabled) and distracts from actual issues or real stacktraces that might be happening.

To repro, set the following in build.gradle and rerun `./gradlew test`
```
testLogging {
  showStandardStreams = true
}
```

This is a prefactor for tests being added as part of [AJ-1523](https://broadworkbench.atlassian.net/browse/AJ-1523), which was tripping this stacktrace.

```
500 INTERNAL_SERVER_ERROR "Error from Sam.getUserInfo REST target: Cannot invoke "org.broadinstitute.dsde.workbench.client.sam.api.UsersApi.getUserStatusInfo()" because the return value of "org.databiosphere.workspacedataservice.sam.SamClientFactory.getUsersApi(String)" is null"
	at org.databiosphere.workspacedataservice.retry.RestClientRetry.withRetryAndErrorHandling(RestClientRetry.java:81)
	...
	at org.databiosphere.workspacedataservice.retry.RestClientRetry$$SpringCGLIB$$0.withRetryAndErrorHandling(<generated>)
	at org.databiosphere.workspacedataservice.sam.HttpSamDao.getUserInfo(HttpSamDao.java:104)
	at org.databiosphere.workspacedataservice.sam.HttpSamDao.getUserId(HttpSamDao.java:97)
	...
	at org.databiosphere.workspacedataservice.sam.HttpSamDao$$SpringCGLIB$$0.getUserId(<generated>)
	at org.databiosphere.workspacedataservice.activitylog.ActivityEventBuilder.currentUser(ActivityEventBuilder.java:43)
	at org.databiosphere.workspacedataservice.activitylog.ActivityLogger.saveEventForCurrentUser(ActivityLogger.java:46)
	at org.databiosphere.workspacedataservice.dataimport.PfbQuartzJob.lambda$importTables$3(PfbQuartzJob.java:152)
	at java.base/java.util.HashMap$EntrySet.forEach(HashMap.java:1126)
	at org.databiosphere.workspacedataservice.dataimport.PfbQuartzJob.importTables(PfbQuartzJob.java:148)
	at org.databiosphere.workspacedataservice.dataimport.PfbQuartzJob.lambda$executeInternal$0(PfbQuartzJob.java:97)
	at org.databiosphere.workspacedataservice.dataimport.PfbQuartzJob.withPfbStream(PfbQuartzJob.java:124)
	at org.databiosphere.workspacedataservice.dataimport.PfbQuartzJob.executeInternal(PfbQuartzJob.java:97)
	at org.databiosphere.workspacedataservice.jobexec.QuartzJob.execute(QuartzJob.java:50)
	at org.databiosphere.workspacedataservice.dataimport.PfbQuartzJobE2ETest.numberPrecision(PfbQuartzJobE2ETest.java:235)
	...
```

[AJ-1523]: https://broadworkbench.atlassian.net/browse/AJ-1523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ