### PR TITLE
[AJ-1282] Refactor edit attribute validation

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
@@ -255,15 +255,13 @@ public class RecordOrchestratorService { // TODO give me a better name
       UUID instanceId, RecordType recordType, String attribute, String newAttributeName) {
     RecordTypeSchema schema = getSchemaDescription(instanceId, recordType);
 
-    if (attribute.equals(schema.primaryKey())) {
+    if (schema.isPrimaryKey(attribute)) {
       throw new ValidationException("Unable to rename primary key attribute");
     }
-    if (schema.attributes().stream()
-        .noneMatch(attributeSchema -> attributeSchema.name().equals(attribute))) {
+    if (!schema.containsAttribute(attribute)) {
       throw new MissingObjectException("Attribute");
     }
-    if (schema.attributes().stream()
-        .anyMatch(attributeSchema -> attributeSchema.name().equals(newAttributeName))) {
+    if (schema.containsAttribute(newAttributeName)) {
       throw new ConflictException("Attribute already exists");
     }
   }
@@ -281,11 +279,10 @@ public class RecordOrchestratorService { // TODO give me a better name
   private void validateDeleteAttribute(UUID instanceId, RecordType recordType, String attribute) {
     RecordTypeSchema schema = getSchemaDescription(instanceId, recordType);
 
-    if (attribute.equals(schema.primaryKey())) {
+    if (schema.isPrimaryKey(attribute)) {
       throw new ValidationException("Unable to delete primary key attribute");
     }
-    if (schema.attributes().stream()
-        .noneMatch(attributeSchema -> attributeSchema.name().equals(attribute))) {
+    if (!schema.containsAttribute(attribute)) {
       throw new MissingObjectException("Attribute");
     }
   }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/RecordTypeSchema.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/RecordTypeSchema.java
@@ -4,4 +4,14 @@ import java.util.List;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 
 public record RecordTypeSchema(
-    RecordType name, List<AttributeSchema> attributes, int count, String primaryKey) {}
+    RecordType name, List<AttributeSchema> attributes, int count, String primaryKey) {
+
+  public boolean isPrimaryKey(String attribute) {
+    return attribute.equals(primaryKey);
+  }
+
+  public boolean containsAttribute(String attribute) {
+    return attributes.stream()
+        .anyMatch(attributeSchema -> attributeSchema.name().equals(attribute));
+  }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/model/RecordTypeSchemaTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/model/RecordTypeSchemaTest.java
@@ -1,0 +1,40 @@
+package org.databiosphere.workspacedataservice.service.model;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import org.databiosphere.workspacedataservice.shared.model.RecordType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RecordTypeSchemaTest {
+  private static final RecordType RECORD_TYPE = RecordType.valueOf("record");
+
+  private static final String PRIMARY_KEY = "id";
+
+  private RecordTypeSchema schema;
+
+  @BeforeEach
+  void setUp() {
+    List<AttributeSchema> attributes =
+        Arrays.asList(
+            new AttributeSchema("id", "STRING", null),
+            new AttributeSchema("attr1", "STRING", null));
+
+    schema = new RecordTypeSchema(RECORD_TYPE, attributes, 0, PRIMARY_KEY);
+  }
+
+  @Test
+  void testIsPrimaryKey() {
+    assertTrue(schema.isPrimaryKey(PRIMARY_KEY));
+    assertFalse(schema.isPrimaryKey("attr1"));
+  }
+
+  @Test
+  void testContainsAttribute() {
+    assertTrue(schema.containsAttribute("attr1"));
+    assertFalse(schema.containsAttribute("doesNotExist"));
+  }
+}


### PR DESCRIPTION
Addressing @davidangb's [comment](https://github.com/DataBiosphere/terra-workspace-data-service/pull/455#discussion_r1450553757) on #455.

> Thinking out loud: since there's a decent amount of duplication between validateRenameAttribute and validateDeleteAttribute, I'd love to see these encapsulated as methods of RecordTypeSchema. ...