### PR TITLE
[AJ-1279] Add RecordTypeSchema.getAttributeSchema

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -182,11 +182,7 @@ public class RecordController {
 
     RecordTypeSchema recordTypeSchema =
         recordOrchestratorService.describeRecordType(instanceId, version, recordType);
-    AttributeSchema attributeSchema =
-        recordTypeSchema.attributes().stream()
-            .filter(attr -> attr.name().equals(newAttributeName))
-            .findFirst()
-            .orElseThrow();
+    AttributeSchema attributeSchema = recordTypeSchema.getAttributeSchema(newAttributeName);
     return new ResponseEntity<>(attributeSchema, HttpStatus.OK);
   }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/RecordTypeSchema.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/RecordTypeSchema.java
@@ -14,4 +14,11 @@ public record RecordTypeSchema(
     return attributes.stream()
         .anyMatch(attributeSchema -> attributeSchema.name().equals(attribute));
   }
+
+  public AttributeSchema getAttributeSchema(String attribute) {
+    return attributes.stream()
+        .filter(attr -> attr.name().equals(attribute))
+        .findFirst()
+        .orElseThrow();
+  }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/model/RecordTypeSchemaTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/model/RecordTypeSchemaTest.java
@@ -43,7 +43,9 @@ class RecordTypeSchemaTest {
 
   @Test
   void testGetAttributeSchema() {
-    assertEquals(schema.getAttributeSchema("attr1"), new AttributeSchema(/* name */ "attr1", /* datatype */ "STRING", /* relatesTo */ null));
+    assertEquals(
+        schema.getAttributeSchema("attr1"),
+        new AttributeSchema(/* name */ "attr1", /* datatype */ "STRING", /* relatesTo */ null));
   }
 
   @Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/model/RecordTypeSchemaTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/model/RecordTypeSchemaTest.java
@@ -1,10 +1,13 @@
 package org.databiosphere.workspacedataservice.service.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.NoSuchElementException;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,5 +39,18 @@ class RecordTypeSchemaTest {
   void testContainsAttribute() {
     assertTrue(schema.containsAttribute("attr1"));
     assertFalse(schema.containsAttribute("doesNotExist"));
+  }
+
+  @Test
+  void testGetAttributeSchema() {
+    assertEquals(schema.getAttributeSchema("attr1"), new AttributeSchema("attr1", "STRING", null));
+  }
+
+  @Test
+  void testGetNonExistentAttributeSchema() {
+    assertThrows(
+        NoSuchElementException.class,
+        () -> schema.getAttributeSchema("doesNotExist"),
+        "getAttributeSchema should have thrown an error");
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/model/RecordTypeSchemaTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/model/RecordTypeSchemaTest.java
@@ -23,8 +23,8 @@ class RecordTypeSchemaTest {
   void setUp() {
     List<AttributeSchema> attributes =
         Arrays.asList(
-            new AttributeSchema("id", "STRING", null),
-            new AttributeSchema("attr1", "STRING", null));
+            new AttributeSchema(/* name */ "id", /* datatype */ "STRING", /* relatesTo */ null),
+            new AttributeSchema(/* name */ "attr1", /* datatype */ "STRING", /* relatesTo */ null));
 
     schema = new RecordTypeSchema(RECORD_TYPE, attributes, 0, PRIMARY_KEY);
   }
@@ -43,7 +43,7 @@ class RecordTypeSchemaTest {
 
   @Test
   void testGetAttributeSchema() {
-    assertEquals(schema.getAttributeSchema("attr1"), new AttributeSchema("attr1", "STRING", null));
+    assertEquals(schema.getAttributeSchema("attr1"), new AttributeSchema(/* name */ "attr1", /* datatype */ "STRING", /* relatesTo */ null));
   }
 
   @Test


### PR DESCRIPTION
Small refactor to add a more convenient API for getting a specific attribute's schema.