### PR TITLE
[AJ-1279] Add DataTypeMapping.getBaseType method

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/DataTypeMapping.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/DataTypeMapping.java
@@ -3,7 +3,9 @@ package org.databiosphere.workspacedataservice.service.model;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import org.apache.commons.lang3.tuple.Pair;
 
 public enum DataTypeMapping {
   NULL(null, "text", false, "?"),
@@ -34,6 +36,16 @@ public enum DataTypeMapping {
   private final String writePlaceholder;
 
   private static final Map<String, DataTypeMapping> MAPPING_BY_PG_TYPE = new HashMap<>();
+
+  private static final List<Pair<DataTypeMapping, DataTypeMapping>> TYPES_WITH_ARRAY_TYPES =
+      List.of(
+          Pair.of(STRING, ARRAY_OF_STRING),
+          Pair.of(NUMBER, ARRAY_OF_NUMBER),
+          Pair.of(BOOLEAN, ARRAY_OF_BOOLEAN),
+          Pair.of(DATE, ARRAY_OF_DATE),
+          Pair.of(DATE_TIME, ARRAY_OF_DATE_TIME),
+          Pair.of(FILE, ARRAY_OF_FILE),
+          Pair.of(RELATION, ARRAY_OF_RELATION));
 
   static {
     Arrays.stream(DataTypeMapping.values())
@@ -84,6 +96,22 @@ public enum DataTypeMapping {
 
       default -> throw new IllegalArgumentException("No supported array type for " + baseType);
     };
+  }
+
+  public DataTypeMapping getBaseType() {
+    if (!isArrayType()) {
+      return this;
+    }
+
+    if (this == EMPTY_ARRAY) {
+      return NULL;
+    }
+
+    return TYPES_WITH_ARRAY_TYPES.stream()
+        .filter(types -> types.getRight().equals(this))
+        .findFirst()
+        .orElseThrow()
+        .getLeft();
   }
 
   public String getWritePlaceholder() {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/model/DataTypeMappingTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/model/DataTypeMappingTest.java
@@ -1,0 +1,38 @@
+package org.databiosphere.workspacedataservice.service.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class DataTypeMappingTest {
+  @ParameterizedTest
+  @MethodSource("getTypesAndBaseTypes")
+  void testGetBaseType(DataTypeMapping type, DataTypeMapping expectedBaseType) {
+    DataTypeMapping baseType = type.getBaseType();
+    assertEquals(expectedBaseType, baseType);
+  }
+
+  private static Stream<Arguments> getTypesAndBaseTypes() {
+    return Stream.of(
+        Arguments.of(DataTypeMapping.NULL, DataTypeMapping.NULL),
+        Arguments.of(DataTypeMapping.STRING, DataTypeMapping.STRING),
+        Arguments.of(DataTypeMapping.FILE, DataTypeMapping.FILE),
+        Arguments.of(DataTypeMapping.RELATION, DataTypeMapping.RELATION),
+        Arguments.of(DataTypeMapping.BOOLEAN, DataTypeMapping.BOOLEAN),
+        Arguments.of(DataTypeMapping.NUMBER, DataTypeMapping.NUMBER),
+        Arguments.of(DataTypeMapping.DATE, DataTypeMapping.DATE),
+        Arguments.of(DataTypeMapping.DATE_TIME, DataTypeMapping.DATE_TIME),
+        Arguments.of(DataTypeMapping.JSON, DataTypeMapping.JSON),
+        Arguments.of(DataTypeMapping.EMPTY_ARRAY, DataTypeMapping.NULL),
+        Arguments.of(DataTypeMapping.ARRAY_OF_STRING, DataTypeMapping.STRING),
+        Arguments.of(DataTypeMapping.ARRAY_OF_FILE, DataTypeMapping.FILE),
+        Arguments.of(DataTypeMapping.ARRAY_OF_RELATION, DataTypeMapping.RELATION),
+        Arguments.of(DataTypeMapping.ARRAY_OF_BOOLEAN, DataTypeMapping.BOOLEAN),
+        Arguments.of(DataTypeMapping.ARRAY_OF_NUMBER, DataTypeMapping.NUMBER),
+        Arguments.of(DataTypeMapping.ARRAY_OF_DATE, DataTypeMapping.DATE),
+        Arguments.of(DataTypeMapping.ARRAY_OF_DATE_TIME, DataTypeMapping.DATE_TIME));
+  }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/model/DataTypeMappingTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/model/DataTypeMappingTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class DataTypeMappingTest {
-  @ParameterizedTest
+  @ParameterizedTest(name = "getArrayTypeForBase maps {0} to {1}")
   @MethodSource("getBaseTypesAndArrayTypes")
   void testGetArrayTypeForBase(DataTypeMapping baseType, DataTypeMapping expectedArrayType) {
     DataTypeMapping arrayType = DataTypeMapping.getArrayTypeForBase(baseType);
@@ -40,7 +40,7 @@ class DataTypeMappingTest {
     assertEquals("No supported array type for EMPTY_ARRAY", e.getMessage());
   }
 
-  @ParameterizedTest
+  @ParameterizedTest(name = "getBaseType maps {0} to {1}")
   @MethodSource("getTypesAndBaseTypes")
   void testGetBaseType(DataTypeMapping type, DataTypeMapping expectedBaseType) {
     DataTypeMapping baseType = type.getBaseType();

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/model/DataTypeMappingTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/model/DataTypeMappingTest.java
@@ -1,13 +1,45 @@
 package org.databiosphere.workspacedataservice.service.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class DataTypeMappingTest {
+  @ParameterizedTest
+  @MethodSource("getBaseTypesAndArrayTypes")
+  void testGetArrayTypeForBase(DataTypeMapping baseType, DataTypeMapping expectedArrayType) {
+    DataTypeMapping arrayType = DataTypeMapping.getArrayTypeForBase(baseType);
+    assertEquals(expectedArrayType, arrayType);
+  }
+
+  private static Stream<Arguments> getBaseTypesAndArrayTypes() {
+    return Stream.of(
+        Arguments.of(null, DataTypeMapping.EMPTY_ARRAY),
+        Arguments.of(DataTypeMapping.STRING, DataTypeMapping.ARRAY_OF_STRING),
+        Arguments.of(DataTypeMapping.FILE, DataTypeMapping.ARRAY_OF_FILE),
+        Arguments.of(DataTypeMapping.RELATION, DataTypeMapping.ARRAY_OF_RELATION),
+        Arguments.of(DataTypeMapping.BOOLEAN, DataTypeMapping.ARRAY_OF_BOOLEAN),
+        Arguments.of(DataTypeMapping.NUMBER, DataTypeMapping.ARRAY_OF_NUMBER),
+        Arguments.of(DataTypeMapping.DATE, DataTypeMapping.ARRAY_OF_DATE),
+        Arguments.of(DataTypeMapping.DATE_TIME, DataTypeMapping.ARRAY_OF_DATE_TIME),
+        Arguments.of(DataTypeMapping.NULL, DataTypeMapping.ARRAY_OF_STRING));
+  }
+
+  @Test
+  void testGetArrayTypeForBaseNoArrayType() {
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> DataTypeMapping.getArrayTypeForBase(DataTypeMapping.EMPTY_ARRAY),
+            "getArrayTypeForBase should have thrown an error");
+    assertEquals("No supported array type for EMPTY_ARRAY", e.getMessage());
+  }
+
   @ParameterizedTest
   @MethodSource("getTypesAndBaseTypes")
   void testGetBaseType(DataTypeMapping type, DataTypeMapping expectedBaseType) {


### PR DESCRIPTION
For data type conversion, it's sometimes useful to check if a DataTypeMapping is `<type>` or `ARRAY_OF_<type>`. For example, `STRING` or `ARRAY_OF_STRING`. To make this more convenient, this adds a `getBaseType` method to DataTypeMapping. For array types, this returns the element type. For non-array types, it returns the type itself.

Since this is similar to the inverse of the existing `DataTypeMapping.getArrayTypeForBase`, I refactored it as well so that both methods use the same type to array type mapping, which makes it easier to keep them in sync if new types are added. 