### PR TITLE
[AJ-1279] Add alternate constructors for AttributeSchema

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/AttributeSchema.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/AttributeSchema.java
@@ -4,4 +4,21 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record AttributeSchema(String name, String datatype, RecordType relatesTo) {}
+public record AttributeSchema(String name, String datatype, RecordType relatesTo) {
+
+  public AttributeSchema(String name, DataTypeMapping datatype, RecordType relatesTo) {
+    this(name, datatype.name(), relatesTo);
+  }
+
+  public AttributeSchema(String name, String datatype) {
+    this(name, datatype, null);
+  }
+
+  public AttributeSchema(String name, DataTypeMapping datatype) {
+    this(name, datatype, null);
+  }
+
+  public AttributeSchema(String name) {
+    this(name, (String) null, null);
+  }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -2012,8 +2012,7 @@ class RecordControllerMockMvcTest {
                     recordType,
                     attributeToRename)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(
-                    mapper.writeValueAsString(new AttributeSchema(newAttributeName, null, null))))
+                .content(mapper.writeValueAsString(new AttributeSchema(newAttributeName))))
         .andExpect(status().isOk());
 
     MvcResult mvcResult =
@@ -2050,7 +2049,7 @@ class RecordControllerMockMvcTest {
                     recordType,
                     "doesNotExist")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(mapper.writeValueAsString(new AttributeSchema("newAttr", null, null))))
+                .content(mapper.writeValueAsString(new AttributeSchema("newAttr"))))
         .andExpect(status().isNotFound());
   }
 
@@ -2071,7 +2070,7 @@ class RecordControllerMockMvcTest {
                     recordType,
                     attributeToRename)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(mapper.writeValueAsString(new AttributeSchema("newAttr", null, null))))
+                .content(mapper.writeValueAsString(new AttributeSchema("newAttr"))))
         .andExpect(status().isBadRequest());
   }
 
@@ -2093,8 +2092,7 @@ class RecordControllerMockMvcTest {
                     recordType,
                     attributeToRename)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(
-                    mapper.writeValueAsString(new AttributeSchema(newAttributeName, null, null))))
+                .content(mapper.writeValueAsString(new AttributeSchema(newAttributeName))))
         .andExpect(status().isConflict());
   }
 
@@ -2188,24 +2186,25 @@ class RecordControllerMockMvcTest {
 
     List<AttributeSchema> expectedAttributes =
         Arrays.asList(
-            new AttributeSchema("array-of-date", "ARRAY_OF_DATE", null),
-            new AttributeSchema("array-of-datetime", "ARRAY_OF_DATE_TIME", null),
-            new AttributeSchema("array-of-relation", "ARRAY_OF_RELATION", referencedType),
-            new AttributeSchema("array-of-string", "ARRAY_OF_STRING", null),
-            new AttributeSchema("attr-boolean", "BOOLEAN", null),
-            new AttributeSchema("attr-dt", "DATE_TIME", null),
-            new AttributeSchema("attr-json", "JSON", null),
-            new AttributeSchema("attr-ref", "RELATION", referencedType),
-            new AttributeSchema("attr1", "STRING", null),
-            new AttributeSchema("attr2", "NUMBER", null),
-            new AttributeSchema("attr3", "DATE", null),
-            new AttributeSchema("attr4", "STRING", null),
-            new AttributeSchema("attr5", "NUMBER", null),
-            new AttributeSchema("sys_name", "STRING", null),
-            new AttributeSchema("z-array-of-boolean", "ARRAY_OF_BOOLEAN", null),
-            new AttributeSchema("z-array-of-number-double", "ARRAY_OF_NUMBER", null),
-            new AttributeSchema("z-array-of-number-long", "ARRAY_OF_NUMBER", null),
-            new AttributeSchema("z-array-of-string", "ARRAY_OF_STRING", null));
+            new AttributeSchema("array-of-date", DataTypeMapping.ARRAY_OF_DATE),
+            new AttributeSchema("array-of-datetime", DataTypeMapping.ARRAY_OF_DATE_TIME),
+            new AttributeSchema(
+                "array-of-relation", DataTypeMapping.ARRAY_OF_RELATION, referencedType),
+            new AttributeSchema("array-of-string", DataTypeMapping.ARRAY_OF_STRING),
+            new AttributeSchema("attr-boolean", DataTypeMapping.BOOLEAN),
+            new AttributeSchema("attr-dt", DataTypeMapping.DATE_TIME),
+            new AttributeSchema("attr-json", DataTypeMapping.JSON),
+            new AttributeSchema("attr-ref", DataTypeMapping.RELATION, referencedType),
+            new AttributeSchema("attr1", DataTypeMapping.STRING),
+            new AttributeSchema("attr2", DataTypeMapping.NUMBER),
+            new AttributeSchema("attr3", DataTypeMapping.DATE),
+            new AttributeSchema("attr4", DataTypeMapping.STRING),
+            new AttributeSchema("attr5", DataTypeMapping.NUMBER),
+            new AttributeSchema("sys_name", DataTypeMapping.STRING),
+            new AttributeSchema("z-array-of-boolean", DataTypeMapping.ARRAY_OF_BOOLEAN),
+            new AttributeSchema("z-array-of-number-double", DataTypeMapping.ARRAY_OF_NUMBER),
+            new AttributeSchema("z-array-of-number-long", DataTypeMapping.ARRAY_OF_NUMBER),
+            new AttributeSchema("z-array-of-string", DataTypeMapping.ARRAY_OF_STRING));
 
     RecordTypeSchema expected = new RecordTypeSchema(type, expectedAttributes, 1, RECORD_ID);
 
@@ -2273,22 +2272,22 @@ class RecordControllerMockMvcTest {
 
     List<AttributeSchema> expectedAttributes =
         Arrays.asList(
-            new AttributeSchema("array-of-date", "ARRAY_OF_DATE", null),
-            new AttributeSchema("array-of-datetime", "ARRAY_OF_DATE_TIME", null),
-            new AttributeSchema("array-of-string", "ARRAY_OF_STRING", null),
-            new AttributeSchema("attr-boolean", "BOOLEAN", null),
-            new AttributeSchema("attr-dt", "DATE_TIME", null),
-            new AttributeSchema("attr-json", "JSON", null),
-            new AttributeSchema("attr1", "STRING", null),
-            new AttributeSchema("attr2", "NUMBER", null),
-            new AttributeSchema("attr3", "DATE", null),
-            new AttributeSchema("attr4", "STRING", null),
-            new AttributeSchema("attr5", "NUMBER", null),
-            new AttributeSchema("sys_name", "STRING", null),
-            new AttributeSchema("z-array-of-boolean", "ARRAY_OF_BOOLEAN", null),
-            new AttributeSchema("z-array-of-number-double", "ARRAY_OF_NUMBER", null),
-            new AttributeSchema("z-array-of-number-long", "ARRAY_OF_NUMBER", null),
-            new AttributeSchema("z-array-of-string", "ARRAY_OF_STRING", null));
+            new AttributeSchema("array-of-date", DataTypeMapping.ARRAY_OF_DATE),
+            new AttributeSchema("array-of-datetime", DataTypeMapping.ARRAY_OF_DATE_TIME),
+            new AttributeSchema("array-of-string", DataTypeMapping.ARRAY_OF_STRING),
+            new AttributeSchema("attr-boolean", DataTypeMapping.BOOLEAN),
+            new AttributeSchema("attr-dt", DataTypeMapping.DATE_TIME),
+            new AttributeSchema("attr-json", DataTypeMapping.JSON),
+            new AttributeSchema("attr1", DataTypeMapping.STRING),
+            new AttributeSchema("attr2", DataTypeMapping.NUMBER),
+            new AttributeSchema("attr3", DataTypeMapping.DATE),
+            new AttributeSchema("attr4", DataTypeMapping.STRING),
+            new AttributeSchema("attr5", DataTypeMapping.NUMBER),
+            new AttributeSchema("sys_name", DataTypeMapping.STRING),
+            new AttributeSchema("z-array-of-boolean", DataTypeMapping.ARRAY_OF_BOOLEAN),
+            new AttributeSchema("z-array-of-number-double", DataTypeMapping.ARRAY_OF_NUMBER),
+            new AttributeSchema("z-array-of-number-long", DataTypeMapping.ARRAY_OF_NUMBER),
+            new AttributeSchema("z-array-of-string", DataTypeMapping.ARRAY_OF_STRING));
 
     List<RecordTypeSchema> expectedSchemas =
         Arrays.asList(

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/model/AttributeSchemaTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/model/AttributeSchemaTest.java
@@ -13,6 +13,9 @@ class AttributeSchemaTest {
         new AttributeSchema("attr", DataTypeMapping.STRING, RecordType.valueOf("otherAttr")));
 
     assertEquals(
+        new AttributeSchema("attr", "STRING", null), new AttributeSchema("attr", "STRING"));
+
+    assertEquals(
         new AttributeSchema("attr", "STRING", null),
         new AttributeSchema("attr", DataTypeMapping.STRING));
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/model/AttributeSchemaTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/model/AttributeSchemaTest.java
@@ -5,9 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 import org.junit.jupiter.api.Test;
 
-public class AttributeSchemaTest {
+class AttributeSchemaTest {
   @Test
-  public void testAlternateConstructors() {
+  void testAlternateConstructors() {
     assertEquals(
         new AttributeSchema("attr", "STRING", RecordType.valueOf("otherAttr")),
         new AttributeSchema("attr", DataTypeMapping.STRING, RecordType.valueOf("otherAttr")));

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/model/AttributeSchemaTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/model/AttributeSchemaTest.java
@@ -1,0 +1,21 @@
+package org.databiosphere.workspacedataservice.service.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.databiosphere.workspacedataservice.shared.model.RecordType;
+import org.junit.jupiter.api.Test;
+
+public class AttributeSchemaTest {
+  @Test
+  public void testAlternateConstructors() {
+    assertEquals(
+        new AttributeSchema("attr", "STRING", RecordType.valueOf("otherAttr")),
+        new AttributeSchema("attr", DataTypeMapping.STRING, RecordType.valueOf("otherAttr")));
+
+    assertEquals(
+        new AttributeSchema("attr", "STRING", null),
+        new AttributeSchema("attr", DataTypeMapping.STRING));
+
+    assertEquals(new AttributeSchema("attr", (String) null, null), new AttributeSchema("attr"));
+  }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/model/RecordTypeSchemaTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/model/RecordTypeSchemaTest.java
@@ -23,8 +23,8 @@ class RecordTypeSchemaTest {
   void setUp() {
     List<AttributeSchema> attributes =
         Arrays.asList(
-            new AttributeSchema(/* name */ "id", /* datatype */ "STRING", /* relatesTo */ null),
-            new AttributeSchema(/* name */ "attr1", /* datatype */ "STRING", /* relatesTo */ null));
+            new AttributeSchema("id", DataTypeMapping.STRING),
+            new AttributeSchema("attr1", DataTypeMapping.STRING));
 
     schema = new RecordTypeSchema(RECORD_TYPE, attributes, 0, PRIMARY_KEY);
   }
@@ -44,8 +44,7 @@ class RecordTypeSchemaTest {
   @Test
   void testGetAttributeSchema() {
     assertEquals(
-        schema.getAttributeSchema("attr1"),
-        new AttributeSchema(/* name */ "attr1", /* datatype */ "STRING", /* relatesTo */ null));
+        schema.getAttributeSchema("attr1"), new AttributeSchema("attr1", DataTypeMapping.STRING));
   }
 
   @Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/model/RecordTypeSchemaTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/model/RecordTypeSchemaTest.java
@@ -44,7 +44,7 @@ class RecordTypeSchemaTest {
   @Test
   void testGetAttributeSchema() {
     assertEquals(
-        schema.getAttributeSchema("attr1"), new AttributeSchema("attr1", DataTypeMapping.STRING));
+        new AttributeSchema("attr1", DataTypeMapping.STRING), schema.getAttributeSchema("attr1"));
   }
 
   @Test


### PR DESCRIPTION
Addressing @jladieu's comment here: https://github.com/DataBiosphere/terra-workspace-data-service/pull/463#discussion_r1459406188.

In tests, AttributeSchema is frequently instantiated with a null value for `relatesTo` and occasionally with a null value for `datatype`. This adds alternate constructors that allow omitting null values and also allow passing a DataTypeMapping instead of a string for the `datatype` argument. This clarifies the meaning of the second argument and reduces the chance of a typo causing a test failure due to an invalid data type.