### PR TITLE
[AJ-1279] Add prepareThreshold=0 to defautl JDBC configuration

### DIFF
--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -9,7 +9,7 @@ env:
       user: ${WDS_DB_USER:wds}
       # When running on Azure in k8s with workload identity set ADDITIONAL_JDBC_URL_PARAMS to
       # sslmode=require&authenticationPluginClassName=com.azure.identity.extensions.jdbc.postgresql.AzurePostgresqlAuthenticationPlugin
-      additionalUrlParams: ${ADDITIONAL_JDBC_URL_PARAMS:}
+      additionalUrlParams: ${ADDITIONAL_JDBC_URL_PARAMS:prepareThreshold=0}
 
 management:
   endpoint:


### PR DESCRIPTION
While testing attribute data type conversions, I started running into an error after a certain number of tests were run.

```
org.springframework.transaction.TransactionSystemException: JDBC rollback failed
        at app//org.springframework.jdbc.datasource.DataSourceTransactionManager.translateException(DataSourceTransactionManager.java:439)
        at app//org.springframework.jdbc.support.JdbcTransactionManager.translateException(JdbcTransactionManager.java:184)
        at app//org.springframework.jdbc.datasource.DataSourceTransactionManager.doRollback(DataSourceTransactionManager.java:355)
        at app//org.springframework.transaction.support.AbstractPlatformTransactionManager.processRollback(AbstractPlatformTransactionManager.java:896)
        at app//org.springframework.transaction.support.AbstractPlatformTransactionManager.rollback(AbstractPlatformTransactionManager.java:865)
        at app//org.springframework.transaction.interceptor.TransactionAspectSupport.completeTransactionAfterThrowing(TransactionAspectSupport.java:687)
        at app//org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:389)
        at app//org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:119)
        at app//org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184)
        at app//org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:765)
        at app//org.springframework.retry.interceptor.RetryOperationsInterceptor$1.doWithRetry(RetryOperationsInterceptor.java:102)
        at app//org.springframework.retry.support.RetryTemplate.doExecute(RetryTemplate.java:335)
        at app//org.springframework.retry.support.RetryTemplate.execute(RetryTemplate.java:211)
        at app//org.springframework.retry.interceptor.RetryOperationsInterceptor.invoke(RetryOperationsInterceptor.java:135)
        at app//org.springframework.retry.annotation.AnnotationAwareRetryOperationsInterceptor.invoke(AnnotationAwareRetryOperationsInterceptor.java:161)
        at app//org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184)
        at app//org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:765)
        at app//org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:717)
        at app//org.databiosphere.workspacedataservice.service.RecordOrchestratorService$$SpringCGLIB$$0.getSingleRecord(<generated>)
        at app//org.databiosphere.workspacedataservice.service.RecordOrchestratorServiceTest.updateAttributeDataType(RecordOrchestratorServiceTest.java:242)

        Caused by:
        java.sql.SQLException: Connection is closed
            at com.zaxxer.hikari.pool.ProxyConnection$ClosedConnection.lambda$getClosedConnection$0(ProxyConnection.java:502)
            at jdk.proxy4/jdk.proxy4.$Proxy154.rollback(Unknown Source)
            at com.zaxxer.hikari.pool.ProxyConnection.rollback(ProxyConnection.java:385)
            at com.zaxxer.hikari.pool.HikariProxyConnection.rollback(HikariProxyConnection.java)
            at org.springframework.jdbc.datasource.DataSourceTransactionManager.doRollback(DataSourceTransactionManager.java:352)
            ... 17 more
```

The log output from WDS revealed more information.
```
2024-01-22T16:37:38.711Z  WARN 44407 --- [    Test worker] com.zaxxer.hikari.pool.ProxyConnection   : HikariPool-1 - Connection org.postgresql.jdbc.PgConnection@24cc4f2a marked as broken because of SQLSTATE(0A000), ErrorCode(0)

org.postgresql.util.PSQLException: ERROR: cached plan must not change result type
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2713)
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2401)
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:368)
	at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:498)
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:415)
	at org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:190)
	at org.postgresql.jdbc.PgPreparedStatement.executeQuery(PgPreparedStatement.java:134)
	at com.zaxxer.hikari.pool.ProxyPreparedStatement.executeQuery(ProxyPreparedStatement.java:52)
	at com.zaxxer.hikari.pool.HikariProxyPreparedStatement.executeQuery(HikariProxyPreparedStatement.java)
	at org.springframework.jdbc.core.JdbcTemplate$1.doInPreparedStatement(JdbcTemplate.java:732)
	at org.springframework.jdbc.core.JdbcTemplate.execute(JdbcTemplate.java:658)
	at org.springframework.jdbc.core.JdbcTemplate.query(JdbcTemplate.java:723)
	at org.springframework.jdbc.core.JdbcTemplate.query(JdbcTemplate.java:748)
	at org.springframework.jdbc.core.JdbcTemplate.query(JdbcTemplate.java:804)
	at org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate.queryForObject(NamedParameterJdbcTemplate.java:252)
	at org.databiosphere.workspacedataservice.dao.RecordDao.getSingleRecord(RecordDao.java:965)
```

My understanding of the issue is that after a query is run a certain number of times, the Postgres JDBC driver will attempt to optimize performance by switching over to server-prepared statements for that query. However, this breaks down when we alter column data types while the app is running, resulting in this error about "cached plan must not change result type".

There are a few JDBC settings that can be changed to resolve this issue. Tests passed with any one of `autosave=conservative`, `preparedStatementCacheQueries=0`, or `prepareThreshold=0`. Since there are multiple options, it makes sense to allow deployments to choose whichever. Because at least one is needed, it also makes sense to configure one by default.

We already use `prepareThresholds=0` in production for compatibility with PgBouncer, which makes it a good candidate for a default. This also means that our tests run with a similar configuration to production.