### PR TITLE
Update LZ input

### DIFF
--- a/.github/actions/landing-zone-attach/action.yml
+++ b/.github/actions/landing-zone-attach/action.yml
@@ -13,12 +13,16 @@ inputs:
     description: 'The name of billing project to attach to'
     required: true
     type: string
+  run_name:
+    description: 'Specify the run name to fetch the run ID based on the actual run name'
+    required: false
+    type: string
 
 runs:
   using: 'composite'
   steps:
     - name: dispatch to terra-github-workflows
-      uses: broadinstitute/workflow-dispatch@v3
+      uses: broadinstitute/workflow-dispatch@v4.0.0
       with:
         workflow: attach-billing-project-to-landing-zone.yaml
         repo: broadinstitute/terra-github-workflows
@@ -26,6 +30,7 @@ runs:
         token: '${{ inputs.token }}'
         inputs: >-
           {
+          "run-name": "${{ inputs.run_name }}",
           "bee-name": "${{ inputs.bee_name }}",
           "billing-project": "${{ inputs.project_name }}",
           "service-account": "firecloud-qa@broad-dsde-qa.iam.gserviceaccount.com"

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -7,6 +7,7 @@ name: Run WDS e2e tests with BEE
 env:
   BEE_NAME: 'wds-${{ github.run_id }}-${{ github.run_attempt}}-dev'
   TOKEN: '${{ secrets.BROADBOT_TOKEN }}'
+  ATTACH_BP_TO_LZ_RUN_NAME: 'attach-billing-project-to-landing-zone-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}'
   RUN_NAME_SUFFIX: ${{ github.event.repository.name }}-${{ github.run_id }}-${{github.run_attempt }}
 jobs:
   init-github-context:
@@ -40,7 +41,7 @@ jobs:
     steps:
       - name: Get actions
         uses: actions/checkout@v3
-        
+
       - name: dispatch to terra-github-workflows
         id: FirstAttemptCreateBee
         continue-on-error: true
@@ -53,21 +54,22 @@ jobs:
         if: steps.FirstAttemptCreateBee.outcome == 'failure'
         uses: ./.github/actions/create-bee
         with:
-            bee_name: ${{ env.BEE_NAME }}, 
+            bee_name: ${{ env.BEE_NAME }},
             token: ${{ env.TOKEN }}
-  
+
   attach-landing-zone-to-bee-workflow:
     runs-on: ubuntu-latest
     needs: [ init-github-context, create-bee-workflow, params-gen ]
     steps:
       - name: Get actions
         uses: actions/checkout@v3
-        
+
       - name: dispatch to terra-github-workflows
         id: FirstAttemptLandingZone
         continue-on-error: true
         uses: ./.github/actions/landing-zone-attach
         with:
+            run_name: "${{ env.ATTACH_BP_TO_LZ_RUN_NAME }}"
             bee_name: ${{ env.BEE_NAME }}
             token: '${{ env.TOKEN }}'
             project_name: ${{needs.params-gen.outputs.project-name }}
@@ -76,10 +78,11 @@ jobs:
         if: steps.FirstAttemptLandingZone.outcome == 'failure'
         uses: ./.github/actions/landing-zone-attach
         with:
+            run_name: "${{ env.ATTACH_BP_TO_LZ_RUN_NAME }}-retry"
             bee_name: ${{ env.BEE_NAME }}
             token: '${{ env.TOKEN }}'
             project_name: ${{needs.params-gen.outputs.project-name }}
-            
+
   run-e2e-test-job:
     needs:
       - attach-landing-zone-to-bee-workflow


### PR DESCRIPTION
Reminder:

PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 
