### PR TITLE
Update VS Code formatting setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,7 @@
     "spotlessGradle.format.enable": true,
     "editor.defaultFormatter": "richardwillis.vscode-spotless-gradle",
     "editor.codeActionsOnSave": {
-      "source.fixAll.spotlessGradle": true
+      "source.fixAll.spotlessGradle": "explicit"
     }
   },
 }


### PR DESCRIPTION
As part of enforcing consistent formatting, we have VS Code configured to have the [Spotless Gradle extension](https://marketplace.visualstudio.com/items?itemName=richardwillis.vscode-spotless-gradle) fix issues on save.

The November 2023 update to VS Code changed the format of this setting.
https://code.visualstudio.com/updates/v1_85#_code-actions-on-save-and-auto

This updates the setting to the new format so that it doesn't become noise in another PR.