### PR TITLE
AJ-1533: Spring Boot 3.2.2 / Spring Framework 6.1.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
 plugins {
-    id 'org.springframework.boot' version '3.2.1' apply false
+    id 'org.springframework.boot' version '3.2.2' apply false
     id 'io.spring.dependency-management' version '1.1.4' apply false
     id 'com.google.cloud.tools.jib' version '3.2.1' apply false
     id "org.sonarqube" version "4.4.1.3373" apply false


### PR DESCRIPTION
Upgrade Spring Boot 3.2.1 -> 3.2.2, which includes an upgrade to Spring Framework 6.1.3.

Release notes: https://github.com/spring-projects/spring-boot/releases/tag/v3.2.2

Should resolve a Dependabot issue.