### PR TITLE
[AJ-1279] Add tests for SQL expressions for data type conversions

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -1104,7 +1104,8 @@ public class RecordDao {
     }
   }
 
-  private String getPostgresTypeConversionExpression(
+  @VisibleForTesting
+  String getPostgresTypeConversionExpression(
       String attribute, DataTypeMapping dataType, DataTypeMapping newDataType) {
     // Some data types are not yet supported.
     // Some conversions don't make sense / are invalid.

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
@@ -1,5 +1,6 @@
 package org.databiosphere.workspacedataservice.dao;
 
+import static org.databiosphere.workspacedataservice.service.model.DataTypeMapping.*;
 import static org.databiosphere.workspacedataservice.service.model.DataTypeMapping.ARRAY_OF_NUMBER;
 import static org.databiosphere.workspacedataservice.service.model.DataTypeMapping.ARRAY_OF_STRING;
 import static org.databiosphere.workspacedataservice.service.model.ReservedNames.RECORD_ID;
@@ -179,7 +180,7 @@ class RecordDaoTest {
     Record testRecord = new Record(recordId, funkyPk, RecordAttributes.empty());
     recordDao.createRecordType(
         instanceId,
-        Map.of("attr1", DataTypeMapping.STRING),
+        Map.of("attr1", STRING),
         funkyPk,
         new RelationCollection(Collections.emptySet(), Collections.emptySet()),
         sample_id);
@@ -202,7 +203,7 @@ class RecordDaoTest {
     String sample_id = "Sample ID";
     String recordId = "1199";
     Record testRecord = new Record(recordId, referencedRt, RecordAttributes.empty());
-    Map<String, DataTypeMapping> schema = Map.of("attr1", DataTypeMapping.RELATION);
+    Map<String, DataTypeMapping> schema = Map.of("attr1", RELATION);
     recordDao.createRecordType(
         instanceId,
         schema,
@@ -254,7 +255,7 @@ class RecordDaoTest {
     recordDao.batchUpsert(instanceId, referencedRt, referencedRecords, Collections.emptyMap());
 
     // Create records to do the referencing
-    Map<String, DataTypeMapping> schema = Map.of("attr1", DataTypeMapping.ARRAY_OF_RELATION);
+    Map<String, DataTypeMapping> schema = Map.of("attr1", ARRAY_OF_RELATION);
     RecordType referencer = RecordType.valueOf("referencer");
     Relation arrayRel = new Relation("attr1", referencedRt);
     recordDao.createRecordType(
@@ -303,8 +304,8 @@ class RecordDaoTest {
   void testGetRecordsWithRelations() {
     // Create two records of the same type, one with a value for a relation
     // attribute, the other without
-    recordDao.addColumn(instanceId, recordType, "foo", DataTypeMapping.STRING);
-    recordDao.addColumn(instanceId, recordType, "relationAttr", DataTypeMapping.RELATION);
+    recordDao.addColumn(instanceId, recordType, "foo", STRING);
+    recordDao.addColumn(instanceId, recordType, "relationAttr", RELATION);
     recordDao.addForeignKeyForReference(recordType, recordType, instanceId, "relationAttr");
 
     String refRecordId = "referencedRecord";
@@ -324,8 +325,7 @@ class RecordDaoTest {
         instanceId,
         recordType,
         List.of(referencedRecord, testRecord),
-        new HashMap<>(
-            Map.of("foo", DataTypeMapping.STRING, "relationAttr", DataTypeMapping.RELATION)));
+        new HashMap<>(Map.of("foo", STRING, "relationAttr", RELATION)));
 
     List<Relation> relations = recordDao.getRelationCols(instanceId, recordType);
 
@@ -344,7 +344,7 @@ class RecordDaoTest {
   @Test
   @Transactional
   void testCreateSingleRecord() throws InvalidRelationException {
-    recordDao.addColumn(instanceId, recordType, "foo", DataTypeMapping.STRING);
+    recordDao.addColumn(instanceId, recordType, "foo", STRING);
 
     // create record with no attributes
     String recordId = "testRecord";
@@ -363,7 +363,7 @@ class RecordDaoTest {
         instanceId,
         recordType,
         Collections.singletonList(recordWithAttr),
-        new HashMap<>(Map.of("foo", DataTypeMapping.STRING)));
+        new HashMap<>(Map.of("foo", STRING)));
 
     search = recordDao.getSingleRecord(instanceId, recordType, attrId).get();
     assertEquals(
@@ -375,9 +375,9 @@ class RecordDaoTest {
   void testCreateRecordWithRelations() {
     // make sure columns are in recordType, as this will be taken care of before we
     // get to the dao
-    recordDao.addColumn(instanceId, recordType, "foo", DataTypeMapping.STRING);
+    recordDao.addColumn(instanceId, recordType, "foo", STRING);
 
-    recordDao.addColumn(instanceId, recordType, "testRecordType", DataTypeMapping.RELATION);
+    recordDao.addColumn(instanceId, recordType, "testRecordType", RELATION);
     recordDao.addForeignKeyForReference(recordType, recordType, instanceId, "testRecordType");
 
     String refRecordId = "referencedRecord";
@@ -396,8 +396,7 @@ class RecordDaoTest {
         instanceId,
         recordType,
         Collections.singletonList(testRecord),
-        new HashMap<>(
-            Map.of("foo", DataTypeMapping.STRING, "testRecordType", DataTypeMapping.RELATION)));
+        new HashMap<>(Map.of("foo", STRING, "testRecordType", RELATION)));
 
     Record search = recordDao.getSingleRecord(instanceId, recordType, recordId).get();
     assertEquals(testRecord, search, "Created record with references should match entered record");
@@ -406,7 +405,7 @@ class RecordDaoTest {
   @Test
   @Transactional
   void testGetReferenceCols() {
-    recordDao.addColumn(instanceId, recordType, "referenceCol", DataTypeMapping.STRING);
+    recordDao.addColumn(instanceId, recordType, "referenceCol", STRING);
     recordDao.addForeignKeyForReference(recordType, recordType, instanceId, "referenceCol");
 
     List<Relation> refCols = recordDao.getRelationCols(instanceId, recordType);
@@ -437,14 +436,10 @@ class RecordDaoTest {
   void testDeleteRelatedRecord() {
     // make sure columns are in recordType, as this will be taken care of before we
     // get to the dao
-    recordDao.addColumn(instanceId, recordType, "foo", DataTypeMapping.STRING);
+    recordDao.addColumn(instanceId, recordType, "foo", STRING);
 
     recordDao.addColumn(
-        instanceId,
-        recordType,
-        "testRecordType",
-        DataTypeMapping.RELATION,
-        RecordType.valueOf("testRecordType"));
+        instanceId, recordType, "testRecordType", RELATION, RecordType.valueOf("testRecordType"));
 
     String refRecordId = "referencedRecord";
     Record referencedRecord =
@@ -462,8 +457,7 @@ class RecordDaoTest {
         instanceId,
         recordType,
         Collections.singletonList(testRecord),
-        new HashMap<>(
-            Map.of("foo", DataTypeMapping.STRING, "testRecordType", DataTypeMapping.RELATION)));
+        new HashMap<>(Map.of("foo", STRING, "testRecordType", RELATION)));
 
     // Should throw an error
     assertThrows(
@@ -489,7 +483,7 @@ class RecordDaoTest {
     // Create record type
     RecordType relationArrayType = RecordType.valueOf("relationArrayType");
     Relation arrayRelation = new Relation("relArrAttr", recordType);
-    Map<String, DataTypeMapping> schema = Map.of("relArrAttr", DataTypeMapping.ARRAY_OF_RELATION);
+    Map<String, DataTypeMapping> schema = Map.of("relArrAttr", ARRAY_OF_RELATION);
     recordDao.createRecordType(
         instanceId,
         schema,
@@ -542,7 +536,7 @@ class RecordDaoTest {
     // Create record type
     RecordType relationArrayType = RecordType.valueOf("relationArrayType");
     Relation arrayRelation = new Relation("relArrAttr", recordType);
-    Map<String, DataTypeMapping> schema = Map.of("relArrAttr", DataTypeMapping.ARRAY_OF_RELATION);
+    Map<String, DataTypeMapping> schema = Map.of("relArrAttr", ARRAY_OF_RELATION);
     recordDao.createRecordType(
         instanceId,
         schema,
@@ -614,7 +608,7 @@ class RecordDaoTest {
     Relation arrayRelation = new Relation("relArrAttr", recordType);
     recordDao.createRecordType(
         instanceId,
-        Map.of("relArrAttr", DataTypeMapping.ARRAY_OF_RELATION),
+        Map.of("relArrAttr", ARRAY_OF_RELATION),
         relationArrayType,
         new RelationCollection(Collections.emptySet(), Set.of(arrayRelation)),
         RECORD_ID);
@@ -675,8 +669,7 @@ class RecordDaoTest {
         new RelationCollection(Collections.emptySet(), Collections.emptySet()),
         RECORD_ID);
 
-    recordDao.addColumn(
-        instanceId, recordTypeName, "relation", DataTypeMapping.RELATION, referencedType);
+    recordDao.addColumn(instanceId, recordTypeName, "relation", RELATION, referencedType);
 
     String refRecordId = "referencedRecord";
     Record referencedRecord = new Record(refRecordId, referencedType, RecordAttributes.empty());
@@ -691,7 +684,7 @@ class RecordDaoTest {
         instanceId,
         recordTypeName,
         Collections.singletonList(testRecord),
-        new HashMap<>(Map.of("relation", DataTypeMapping.RELATION)));
+        new HashMap<>(Map.of("relation", RELATION)));
 
     // Should throw an error
     assertThrows(
@@ -715,7 +708,7 @@ class RecordDaoTest {
     // Create referencing record type
     RecordType relationArrayType = RecordType.valueOf("relationArrayType");
     Relation arrayRelation = new Relation("relArrAttr", recordType);
-    Map<String, DataTypeMapping> schema = Map.of("relArrAttr", DataTypeMapping.ARRAY_OF_RELATION);
+    Map<String, DataTypeMapping> schema = Map.of("relArrAttr", ARRAY_OF_RELATION);
     recordDao.createRecordType(
         instanceId,
         schema,
@@ -761,7 +754,7 @@ class RecordDaoTest {
     RecordType recordTypeWithAttributes = RecordType.valueOf("withAttributes");
     recordDao.createRecordType(
         instanceId,
-        Map.of("foo", DataTypeMapping.STRING, "bar", DataTypeMapping.STRING),
+        Map.of("foo", STRING, "bar", STRING),
         recordTypeWithAttributes,
         new RelationCollection(Collections.emptySet(), Collections.emptySet()),
         PRIMARY_KEY);
@@ -801,261 +794,179 @@ class RecordDaoTest {
   static Stream<Arguments> stringConversionExpressions() {
     return Stream.of(
         // Number
-        Arguments.of(DataTypeMapping.STRING, DataTypeMapping.NUMBER, "\"attr\"::numeric"),
+        args(STRING, NUMBER, "\"attr\"::numeric"),
         // Boolean
-        Arguments.of(DataTypeMapping.STRING, DataTypeMapping.BOOLEAN, "\"attr\"::boolean"),
+        args(STRING, BOOLEAN, "\"attr\"::boolean"),
         // Date
-        Arguments.of(DataTypeMapping.STRING, DataTypeMapping.DATE, "\"attr\"::date"),
+        args(STRING, DATE, "\"attr\"::date"),
         // Datetime
-        Arguments.of(
-            DataTypeMapping.STRING,
-            DataTypeMapping.DATE_TIME,
-            "\"attr\"::timestamp with time zone"),
+        args(STRING, DATE_TIME, "\"attr\"::timestamp with time zone"),
         // String array
-        Arguments.of(
-            DataTypeMapping.STRING,
-            DataTypeMapping.ARRAY_OF_STRING,
-            "array_append('{}', \"attr\")::text[]"),
+        args(STRING, ARRAY_OF_STRING, "array_append('{}', \"attr\")::text[]"),
         // Number array
-        Arguments.of(
-            DataTypeMapping.STRING,
-            DataTypeMapping.ARRAY_OF_NUMBER,
-            "array_append('{}', \"attr\")::numeric[]"),
+        args(STRING, ARRAY_OF_NUMBER, "array_append('{}', \"attr\")::numeric[]"),
         // Boolean array
-        Arguments.of(
-            DataTypeMapping.STRING,
-            DataTypeMapping.ARRAY_OF_BOOLEAN,
-            "array_append('{}', \"attr\")::boolean[]"),
+        args(STRING, ARRAY_OF_BOOLEAN, "array_append('{}', \"attr\")::boolean[]"),
         // Date array
-        Arguments.of(
-            DataTypeMapping.STRING,
-            DataTypeMapping.ARRAY_OF_DATE,
-            "array_append('{}', \"attr\")::date[]"),
+        args(STRING, ARRAY_OF_DATE, "array_append('{}', \"attr\")::date[]"),
         // Datetime array
-        Arguments.of(
-            DataTypeMapping.STRING,
-            DataTypeMapping.ARRAY_OF_DATE_TIME,
+        args(
+            STRING,
+            ARRAY_OF_DATE_TIME,
             "array_append('{}', \"attr\")::timestamp with time zone[]"));
   }
 
   static Stream<Arguments> stringArrayConversionExpressions() {
     return Stream.of(
         // Number array
-        Arguments.of(
-            DataTypeMapping.ARRAY_OF_STRING,
-            DataTypeMapping.ARRAY_OF_NUMBER,
-            "\"attr\"::numeric[]"),
+        args(ARRAY_OF_STRING, ARRAY_OF_NUMBER, "\"attr\"::numeric[]"),
         // Boolean array
-        Arguments.of(
-            DataTypeMapping.ARRAY_OF_STRING,
-            DataTypeMapping.ARRAY_OF_BOOLEAN,
-            "\"attr\"::boolean[]"),
+        args(ARRAY_OF_STRING, ARRAY_OF_BOOLEAN, "\"attr\"::boolean[]"),
         // Date array
-        Arguments.of(
-            DataTypeMapping.ARRAY_OF_STRING, DataTypeMapping.ARRAY_OF_DATE, "\"attr\"::date[]"),
+        args(ARRAY_OF_STRING, ARRAY_OF_DATE, "\"attr\"::date[]"),
         // Datetime array
-        Arguments.of(
-            DataTypeMapping.ARRAY_OF_STRING,
-            DataTypeMapping.ARRAY_OF_DATE_TIME,
-            "\"attr\"::timestamp with time zone[]"));
+        args(ARRAY_OF_STRING, ARRAY_OF_DATE_TIME, "\"attr\"::timestamp with time zone[]"));
   }
 
   static Stream<Arguments> numberConversionExpressions() {
     return Stream.of(
         // String
-        Arguments.of(DataTypeMapping.NUMBER, DataTypeMapping.STRING, "\"attr\"::text"),
+        args(NUMBER, STRING, "\"attr\"::text"),
         // Boolean
-        Arguments.of(DataTypeMapping.NUMBER, DataTypeMapping.BOOLEAN, "\"attr\"::int::boolean"),
+        args(NUMBER, BOOLEAN, "\"attr\"::int::boolean"),
         // Date
-        Arguments.of(DataTypeMapping.NUMBER, DataTypeMapping.DATE, "to_timestamp(\"attr\")::date"),
+        args(NUMBER, DATE, "to_timestamp(\"attr\")::date"),
         // Datetime
-        Arguments.of(
-            DataTypeMapping.NUMBER,
-            DataTypeMapping.DATE_TIME,
-            "to_timestamp(\"attr\")::timestamp with time zone"),
+        args(NUMBER, DATE_TIME, "to_timestamp(\"attr\")::timestamp with time zone"),
         // String array
-        Arguments.of(
-            DataTypeMapping.NUMBER,
-            DataTypeMapping.ARRAY_OF_STRING,
-            "array_append('{}', \"attr\")::text[]"),
+        args(NUMBER, ARRAY_OF_STRING, "array_append('{}', \"attr\")::text[]"),
         // Number array
-        Arguments.of(
-            DataTypeMapping.NUMBER,
-            DataTypeMapping.ARRAY_OF_NUMBER,
-            "array_append('{}', \"attr\")::numeric[]"),
+        args(NUMBER, ARRAY_OF_NUMBER, "array_append('{}', \"attr\")::numeric[]"),
         // Boolean array
-        Arguments.of(
-            DataTypeMapping.NUMBER,
-            DataTypeMapping.ARRAY_OF_BOOLEAN,
-            "array_append('{}', \"attr\")::int[]::boolean[]"),
+        args(NUMBER, ARRAY_OF_BOOLEAN, "array_append('{}', \"attr\")::int[]::boolean[]"),
         // Date array
-        Arguments.of(
-            DataTypeMapping.NUMBER,
-            DataTypeMapping.ARRAY_OF_DATE,
-            "array_append('{}', to_timestamp(\"attr\"))::date[]"),
+        args(NUMBER, ARRAY_OF_DATE, "array_append('{}', to_timestamp(\"attr\"))::date[]"),
         // Datetime array
-        Arguments.of(
-            DataTypeMapping.NUMBER,
-            DataTypeMapping.ARRAY_OF_DATE_TIME,
+        args(
+            NUMBER,
+            ARRAY_OF_DATE_TIME,
             "array_append('{}', to_timestamp(\"attr\"))::timestamp with time zone[]"));
   }
 
   static Stream<Arguments> numberArrayConversionExpressions() {
     return Stream.of(
         // String array
-        Arguments.of(
-            DataTypeMapping.ARRAY_OF_NUMBER, DataTypeMapping.ARRAY_OF_STRING, "\"attr\"::text[]"),
+        args(ARRAY_OF_NUMBER, ARRAY_OF_STRING, "\"attr\"::text[]"),
         // Boolean array
-        Arguments.of(
-            DataTypeMapping.ARRAY_OF_NUMBER,
-            DataTypeMapping.ARRAY_OF_BOOLEAN,
-            "\"attr\"::int[]::boolean[]"),
+        args(ARRAY_OF_NUMBER, ARRAY_OF_BOOLEAN, "\"attr\"::int[]::boolean[]"),
         // Date array
-        Arguments.of(
-            DataTypeMapping.ARRAY_OF_NUMBER,
-            DataTypeMapping.ARRAY_OF_DATE,
+        args(
+            ARRAY_OF_NUMBER,
+            ARRAY_OF_DATE,
             "(sys_wds.convert_array_of_numbers_to_timestamps(\"attr\"))::date[]"),
         // Datetime array
-        Arguments.of(
-            DataTypeMapping.ARRAY_OF_NUMBER,
-            DataTypeMapping.ARRAY_OF_DATE_TIME,
+        args(
+            ARRAY_OF_NUMBER,
+            ARRAY_OF_DATE_TIME,
             "(sys_wds.convert_array_of_numbers_to_timestamps(\"attr\"))::timestamp with time zone[]"));
   }
 
   static Stream<Arguments> booleanConversionExpressions() {
     return Stream.of(
         // String
-        Arguments.of(DataTypeMapping.BOOLEAN, DataTypeMapping.STRING, "\"attr\"::text"),
+        args(BOOLEAN, STRING, "\"attr\"::text"),
         // Number
-        Arguments.of(DataTypeMapping.BOOLEAN, DataTypeMapping.NUMBER, "\"attr\"::int::numeric"),
+        args(BOOLEAN, NUMBER, "\"attr\"::int::numeric"),
         // String array
-        Arguments.of(
-            DataTypeMapping.BOOLEAN,
-            DataTypeMapping.ARRAY_OF_STRING,
-            "array_append('{}', \"attr\")::text[]"),
+        args(BOOLEAN, ARRAY_OF_STRING, "array_append('{}', \"attr\")::text[]"),
         // Number array
-        Arguments.of(
-            DataTypeMapping.BOOLEAN,
-            DataTypeMapping.ARRAY_OF_NUMBER,
-            "array_append('{}', \"attr\")::int[]::numeric[]"),
+        args(BOOLEAN, ARRAY_OF_NUMBER, "array_append('{}', \"attr\")::int[]::numeric[]"),
         // Boolean array
-        Arguments.of(
-            DataTypeMapping.BOOLEAN,
-            DataTypeMapping.ARRAY_OF_BOOLEAN,
-            "array_append('{}', \"attr\")::boolean[]"));
+        args(BOOLEAN, ARRAY_OF_BOOLEAN, "array_append('{}', \"attr\")::boolean[]"));
   }
 
   static Stream<Arguments> booleanArrayConversionExpressions() {
     return Stream.of(
         // String array
-        Arguments.of(
-            DataTypeMapping.ARRAY_OF_BOOLEAN, DataTypeMapping.ARRAY_OF_STRING, "\"attr\"::text[]"),
+        args(ARRAY_OF_BOOLEAN, ARRAY_OF_STRING, "\"attr\"::text[]"),
         // Number array
-        Arguments.of(
-            DataTypeMapping.ARRAY_OF_BOOLEAN,
-            DataTypeMapping.ARRAY_OF_NUMBER,
-            "\"attr\"::int[]::numeric[]"));
+        args(ARRAY_OF_BOOLEAN, ARRAY_OF_NUMBER, "\"attr\"::int[]::numeric[]"));
   }
 
   static Stream<Arguments> dateConversionExpressions() {
     return Stream.of(
         // String
-        Arguments.of(DataTypeMapping.DATE, DataTypeMapping.STRING, "\"attr\"::text"),
+        args(DATE, STRING, "\"attr\"::text"),
         // Number
-        Arguments.of(
-            DataTypeMapping.DATE,
-            DataTypeMapping.NUMBER,
-            "extract(epoch from \"attr\")::bigint::numeric"),
+        args(DATE, NUMBER, "extract(epoch from \"attr\")::bigint::numeric"),
         // Datetime
-        Arguments.of(
-            DataTypeMapping.DATE, DataTypeMapping.DATE_TIME, "\"attr\"::timestamp with time zone"),
+        args(DATE, DATE_TIME, "\"attr\"::timestamp with time zone"),
         // String array
-        Arguments.of(
-            DataTypeMapping.DATE,
-            DataTypeMapping.ARRAY_OF_STRING,
-            "array_append('{}', \"attr\")::text[]"),
+        args(DATE, ARRAY_OF_STRING, "array_append('{}', \"attr\")::text[]"),
         // Number array
-        Arguments.of(
-            DataTypeMapping.DATE,
-            DataTypeMapping.ARRAY_OF_NUMBER,
+        args(
+            DATE,
+            ARRAY_OF_NUMBER,
             "array_append('{}', extract(epoch from \"attr\")::bigint)::numeric[]"),
         // Date array
-        Arguments.of(
-            DataTypeMapping.DATE,
-            DataTypeMapping.ARRAY_OF_DATE,
-            "array_append('{}', \"attr\")::date[]"),
+        args(DATE, ARRAY_OF_DATE, "array_append('{}', \"attr\")::date[]"),
         // Datetime array
-        Arguments.of(
-            DataTypeMapping.DATE,
-            DataTypeMapping.ARRAY_OF_DATE_TIME,
-            "array_append('{}', \"attr\")::timestamp with time zone[]"));
+        args(DATE, ARRAY_OF_DATE_TIME, "array_append('{}', \"attr\")::timestamp with time zone[]"));
   }
 
   static Stream<Arguments> dateArrayConversionExpressions() {
     return Stream.of(
         // String array
-        Arguments.of(
-            DataTypeMapping.ARRAY_OF_DATE, DataTypeMapping.ARRAY_OF_STRING, "\"attr\"::text[]"),
+        args(ARRAY_OF_DATE, ARRAY_OF_STRING, "\"attr\"::text[]"),
         // Number array
-        Arguments.of(
-            DataTypeMapping.ARRAY_OF_DATE,
-            DataTypeMapping.ARRAY_OF_NUMBER,
+        args(
+            ARRAY_OF_DATE,
+            ARRAY_OF_NUMBER,
             "(sys_wds.convert_array_of_timestamps_to_numbers(\"attr\")::bigint[])::numeric[]"),
         // Datetime array
-        Arguments.of(
-            DataTypeMapping.ARRAY_OF_DATE,
-            DataTypeMapping.ARRAY_OF_DATE_TIME,
-            "\"attr\"::timestamp with time zone[]"));
+        args(ARRAY_OF_DATE, ARRAY_OF_DATE_TIME, "\"attr\"::timestamp with time zone[]"));
   }
 
   static Stream<Arguments> datetimeConversionExpressions() {
     return Stream.of(
         // String
-        Arguments.of(DataTypeMapping.DATE_TIME, DataTypeMapping.STRING, "\"attr\"::text"),
+        args(DATE_TIME, STRING, "\"attr\"::text"),
         // Number
-        Arguments.of(
-            DataTypeMapping.DATE_TIME,
-            DataTypeMapping.NUMBER,
-            "extract(epoch from \"attr\")::numeric"),
+        args(DATE_TIME, NUMBER, "extract(epoch from \"attr\")::numeric"),
         // Date
-        Arguments.of(DataTypeMapping.DATE_TIME, DataTypeMapping.DATE, "\"attr\"::date"),
+        args(DATE_TIME, DATE, "\"attr\"::date"),
         // String array
-        Arguments.of(
-            DataTypeMapping.DATE_TIME,
-            DataTypeMapping.ARRAY_OF_STRING,
-            "array_append('{}', \"attr\")::text[]"),
+        args(DATE_TIME, ARRAY_OF_STRING, "array_append('{}', \"attr\")::text[]"),
         // Number array
-        Arguments.of(
-            DataTypeMapping.DATE_TIME,
-            DataTypeMapping.ARRAY_OF_NUMBER,
+        args(
+            DATE_TIME,
+            ARRAY_OF_NUMBER,
             "array_append('{}', extract(epoch from \"attr\"))::numeric[]"),
         // Date array
-        Arguments.of(
-            DataTypeMapping.DATE_TIME,
-            DataTypeMapping.ARRAY_OF_DATE,
-            "array_append('{}', \"attr\")::date[]"),
+        args(DATE_TIME, ARRAY_OF_DATE, "array_append('{}', \"attr\")::date[]"),
         // Datetime array
-        Arguments.of(
-            DataTypeMapping.DATE_TIME,
-            DataTypeMapping.ARRAY_OF_DATE_TIME,
+        args(
+            DATE_TIME,
+            ARRAY_OF_DATE_TIME,
             "array_append('{}', \"attr\")::timestamp with time zone[]"));
   }
 
   static Stream<Arguments> datetimeArrayConversionExpressions() {
     return Stream.of(
         // String array
-        Arguments.of(
-            DataTypeMapping.ARRAY_OF_DATE_TIME,
-            DataTypeMapping.ARRAY_OF_STRING,
-            "\"attr\"::text[]"),
+        args(ARRAY_OF_DATE_TIME, ARRAY_OF_STRING, "\"attr\"::text[]"),
         // Number array
-        Arguments.of(
-            DataTypeMapping.ARRAY_OF_DATE_TIME,
-            DataTypeMapping.ARRAY_OF_NUMBER,
+        args(
+            ARRAY_OF_DATE_TIME,
+            ARRAY_OF_NUMBER,
             "(sys_wds.convert_array_of_timestamps_to_numbers(\"attr\"))::numeric[]"),
         // Date array
-        Arguments.of(
-            DataTypeMapping.ARRAY_OF_DATE_TIME, DataTypeMapping.ARRAY_OF_DATE, "\"attr\"::date[]"));
+        args(ARRAY_OF_DATE_TIME, ARRAY_OF_DATE, "\"attr\"::date[]"));
+  }
+
+  /** Simple helper to provide an even terser shorthand */
+  private static Arguments args(Object... arguments) {
+    return Arguments.of(arguments);
   }
 
   @Test
@@ -1065,7 +976,7 @@ class RecordDaoTest {
     RecordType recordTypeWithAttributes = RecordType.valueOf("withAttributes");
     recordDao.createRecordType(
         instanceId,
-        Map.of("attr1", DataTypeMapping.STRING, "attr2", DataTypeMapping.STRING),
+        Map.of("attr1", STRING, "attr2", STRING),
         recordTypeWithAttributes,
         new RelationCollection(Collections.emptySet(), Collections.emptySet()),
         PRIMARY_KEY);
@@ -1106,13 +1017,7 @@ class RecordDaoTest {
     Relation arrayRelation = new Relation("relArrAttr", recordType);
     recordDao.createRecordType(
         instanceId,
-        Map.of(
-            "stringAttr",
-            DataTypeMapping.STRING,
-            "refAttr",
-            DataTypeMapping.RELATION,
-            "relArrAttr",
-            DataTypeMapping.ARRAY_OF_RELATION),
+        Map.of("stringAttr", STRING, "refAttr", RELATION, "relArrAttr", ARRAY_OF_RELATION),
         relationarrayType,
         new RelationCollection(Set.of(singleRelation), Set.of(arrayRelation)),
         RECORD_ID);
@@ -1120,9 +1025,9 @@ class RecordDaoTest {
     Map<String, DataTypeMapping> schema =
         recordDao.getExistingTableSchemaLessPrimaryKey(instanceId, relationarrayType);
     assertEquals(3, schema.size());
-    assertEquals(DataTypeMapping.STRING, schema.get("stringAttr"));
-    assertEquals(DataTypeMapping.RELATION, schema.get("refAttr"));
-    assertEquals(DataTypeMapping.ARRAY_OF_RELATION, schema.get("relArrAttr"));
+    assertEquals(STRING, schema.get("stringAttr"));
+    assertEquals(RELATION, schema.get("refAttr"));
+    assertEquals(ARRAY_OF_RELATION, schema.get("relArrAttr"));
     List<Relation> relationCols = recordDao.getRelationCols(instanceId, relationarrayType);
     assertEquals(List.of(singleRelation), relationCols);
     List<Relation> relationArrayCols =
@@ -1148,13 +1053,7 @@ class RecordDaoTest {
     RecordType relationArrayType = RecordType.valueOf("relationArrayType");
     Relation arrayRelation = new Relation("relArrAttr", recordType);
     Map<String, DataTypeMapping> schema =
-        Map.of(
-            "stringAttr",
-            DataTypeMapping.STRING,
-            "refAttr",
-            DataTypeMapping.RELATION,
-            "relArrAttr",
-            DataTypeMapping.ARRAY_OF_RELATION);
+        Map.of("stringAttr", STRING, "refAttr", RELATION, "relArrAttr", ARRAY_OF_RELATION);
     recordDao.createRecordType(
         instanceId,
         schema,
@@ -1210,11 +1109,7 @@ class RecordDaoTest {
     Relation arrayRelation2 = new Relation("relArr2", recordType);
     recordDao.createRecordType(
         instanceId,
-        Map.of(
-            "relArr1",
-            DataTypeMapping.ARRAY_OF_RELATION,
-            "relArr2",
-            DataTypeMapping.ARRAY_OF_RELATION),
+        Map.of("relArr1", ARRAY_OF_RELATION, "relArr2", ARRAY_OF_RELATION),
         relationarrayType,
         new RelationCollection(Collections.emptySet(), Set.of(arrayRelation1, arrayRelation2)),
         RECORD_ID);


### PR DESCRIPTION
Following up on https://github.com/DataBiosphere/terra-workspace-data-service/pull/472#discussion_r1465451372...

This adds tests that show the SQL expression generated for each attribute data type conversion.