### PR TITLE
Clean up `RecordDaoTest`

### DIFF
--- a/.github/actions/landing-zone-attach/action.yml
+++ b/.github/actions/landing-zone-attach/action.yml
@@ -13,12 +13,16 @@ inputs:
     description: 'The name of billing project to attach to'
     required: true
     type: string
+  run_name:
+    description: 'Specify the run name to fetch the run ID based on the actual run name'
+    required: false
+    type: string
 
 runs:
   using: 'composite'
   steps:
     - name: dispatch to terra-github-workflows
-      uses: broadinstitute/workflow-dispatch@v3
+      uses: broadinstitute/workflow-dispatch@v4.0.0
       with:
         workflow: attach-billing-project-to-landing-zone.yaml
         repo: broadinstitute/terra-github-workflows
@@ -26,6 +30,7 @@ runs:
         token: '${{ inputs.token }}'
         inputs: >-
           {
+          "run-name": "${{ inputs.run_name }}",
           "bee-name": "${{ inputs.bee_name }}",
           "billing-project": "${{ inputs.project_name }}",
           "service-account": "firecloud-qa@broad-dsde-qa.iam.gserviceaccount.com"

--- a/.github/workflows/release-python-client.yml
+++ b/.github/workflows/release-python-client.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Mock Sam via command-line docker run
         run: |
-          docker run -v ${{ github.workspace }}/service/src/test/resources/nginx.conf:/etc/nginx/nginx.conf:ro -p 9889:80 -d nginx:1.23.3
+          docker run -v ${{ github.workspace }}/service/src/test/resources/nginx.conf:/etc/nginx/nginx.conf:ro -v ${{ github.workspace }}/service/src/test/resources:/usr/share/nginx/html -p 9889:80 -d nginx:1.23.3
 
       - name: Set up JDK
         uses: actions/setup-java@v3

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -7,6 +7,7 @@ name: Run WDS e2e tests with BEE
 env:
   BEE_NAME: 'wds-${{ github.run_id }}-${{ github.run_attempt}}-dev'
   TOKEN: '${{ secrets.BROADBOT_TOKEN }}'
+  ATTACH_BP_TO_LZ_RUN_NAME: 'attach-billing-project-to-landing-zone-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}'
   RUN_NAME_SUFFIX: ${{ github.event.repository.name }}-${{ github.run_id }}-${{github.run_attempt }}
 jobs:
   init-github-context:
@@ -40,7 +41,7 @@ jobs:
     steps:
       - name: Get actions
         uses: actions/checkout@v3
-        
+
       - name: dispatch to terra-github-workflows
         id: FirstAttemptCreateBee
         continue-on-error: true
@@ -53,21 +54,22 @@ jobs:
         if: steps.FirstAttemptCreateBee.outcome == 'failure'
         uses: ./.github/actions/create-bee
         with:
-            bee_name: ${{ env.BEE_NAME }}, 
+            bee_name: ${{ env.BEE_NAME }},
             token: ${{ env.TOKEN }}
-  
+
   attach-landing-zone-to-bee-workflow:
     runs-on: ubuntu-latest
     needs: [ init-github-context, create-bee-workflow, params-gen ]
     steps:
       - name: Get actions
         uses: actions/checkout@v3
-        
+
       - name: dispatch to terra-github-workflows
         id: FirstAttemptLandingZone
         continue-on-error: true
         uses: ./.github/actions/landing-zone-attach
         with:
+            run_name: "${{ env.ATTACH_BP_TO_LZ_RUN_NAME }}"
             bee_name: ${{ env.BEE_NAME }}
             token: '${{ env.TOKEN }}'
             project_name: ${{needs.params-gen.outputs.project-name }}
@@ -76,10 +78,11 @@ jobs:
         if: steps.FirstAttemptLandingZone.outcome == 'failure'
         uses: ./.github/actions/landing-zone-attach
         with:
+            run_name: "${{ env.ATTACH_BP_TO_LZ_RUN_NAME }}-retry"
             bee_name: ${{ env.BEE_NAME }}
             token: '${{ env.TOKEN }}'
             project_name: ${{needs.params-gen.outputs.project-name }}
-            
+
   run-e2e-test-job:
     needs:
       - attach-landing-zone-to-bee-workflow

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,7 @@
     "spotlessGradle.format.enable": true,
     "editor.defaultFormatter": "richardwillis.vscode-spotless-gradle",
     "editor.codeActionsOnSave": {
-      "source.fixAll.spotlessGradle": true
+      "source.fixAll.spotlessGradle": "explicit"
     }
   },
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
 plugins {
-    id 'org.springframework.boot' version '3.2.1' apply false
+    id 'org.springframework.boot' version '3.2.2' apply false
     id 'io.spring.dependency-management' version '1.1.4' apply false
     id 'com.google.cloud.tools.jib' version '3.2.1' apply false
     id "org.sonarqube" version "4.4.1.3373" apply false

--- a/docs/WDS Running Python tests locally.md
+++ b/docs/WDS Running Python tests locally.md
@@ -36,6 +36,13 @@ To run tests, WDS uses pytest. Ensure that is installed by running:
 pip install pytest
 ```
 
+Some tests also require a server from which to fetch test files.  For these to work, you'll have to set up the nginx docker container to serve them:
+```bash
+# start the server as a docker container in detached mode
+docker run -v `pwd`/service/src/test/resources/nginx.conf:/etc/nginx/nginx.conf -v `pwd`/service/src/test/resources:/usr/share/nginx/html -p 9889:80 -d nginx:1.23.3
+```
+
+
 ## Build wds_client locally
 
 Once you confirm that you have python and openapitools, you will need to build and create a local version of the wds_client package (make sure you are in the right branch that has the changes you want to test). Note that you will need to re-generate the client for each code change you make. To do that, run the following command (from the root of your repo or adjust path accordingly). If this command is generating errors, it is likely because the openapi is set to the wrong version. Note that package version is hard coded since it is not important to track locally - adjust as you se fit if you want to the version to change when you install the package locally. 
@@ -64,5 +71,9 @@ Once you have the wds_client package importing locally with no issues, you are r
 ```
 pytest service/src/test/python/test.py
 ```
+
+Note: Make sure your local WDS database does not have data in it before running these tests, as its presence may cause the tests to fail.
+
+To debug tests, you may want to try out python's [pdb debugger](https://realpython.com/python-debugging-pdb/).
 
 In case you get frustrated with python, go [here](https://xkcd.com/1987/) for a quick laugh. 

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -229,6 +229,7 @@ jacocoTestReport {
 test {
     systemProperties['pact.rootDir'] = "$buildDir/pacts"
     systemProperties['pact.provider.version'] = "$project.version"
+    systemProperties['user.timezone'] = "UTC";
 }
 
 tasks.register("pactTests", Test) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -182,11 +182,7 @@ public class RecordController {
 
     RecordTypeSchema recordTypeSchema =
         recordOrchestratorService.describeRecordType(instanceId, version, recordType);
-    AttributeSchema attributeSchema =
-        recordTypeSchema.attributes().stream()
-            .filter(attr -> attr.name().equals(newAttributeName))
-            .findFirst()
-            .orElseThrow();
+    AttributeSchema attributeSchema = recordTypeSchema.getAttributeSchema(newAttributeName);
     return new ResponseEntity<>(attributeSchema, HttpStatus.OK);
   }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -1104,7 +1104,8 @@ public class RecordDao {
     }
   }
 
-  private String getPostgresTypeConversionExpression(
+  @VisibleForTesting
+  String getPostgresTypeConversionExpression(
       String attribute, DataTypeMapping dataType, DataTypeMapping newDataType) {
     // Some data types are not yet supported.
     // Some conversions don't make sense / are invalid.

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/AvroRecordConverter.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/AvroRecordConverter.java
@@ -139,7 +139,6 @@ public abstract class AvroRecordConverter {
 
     // Avro fixed
     if (attribute instanceof GenericData.Fixed fixedAttr) {
-      // TODO(AJ-1537): better handle null bytes vs. string bytes
       return fixedAttr.toString();
     }
 
@@ -150,7 +149,6 @@ public abstract class AvroRecordConverter {
 
     // Avro bytes
     if (attribute instanceof ByteBuffer byteBufferAttr) {
-      // TODO(AJ-1537): better handle null bytes vs. string bytes
       // copy the behavior of GenericData.Fixed.toString()
       // to protect against null bytes that may be present in the buffer
       return Arrays.toString(byteBufferAttr.array());

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/FileDownloadHelper.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/FileDownloadHelper.java
@@ -1,0 +1,67 @@
+package org.databiosphere.workspacedataservice.dataimport;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Set;
+import org.apache.commons.io.FileUtils;
+import org.databiosphere.workspacedataservice.service.model.exception.TdrManifestImportException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FileDownloadHelper {
+
+  private final Logger logger = LoggerFactory.getLogger(this.getClass());
+  private final Path tempFileDir;
+  private final Multimap<String, File> fileMap;
+  private final FileAttribute<Set<PosixFilePermission>> permissions =
+      PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwx------"));
+
+  public FileDownloadHelper(String dirName) throws IOException {
+    this.tempFileDir = Files.createTempDirectory(dirName, permissions);
+    this.fileMap = HashMultimap.create();
+  }
+
+  public void downloadFileFromURL(String tableName, URL pathToRemoteFile) {
+    try {
+      Path tempFilePath =
+          Files.createTempFile(
+              tempFileDir, /* prefix= */ "tdr-", /* suffix= */ "download", permissions);
+      logger.info("downloading to temp file {} ...", tempFilePath);
+      FileUtils.copyURLToFile(pathToRemoteFile, tempFilePath.toFile());
+      // In the TDR manifest, for Azure snapshots only,
+      // the first file in the list will always be a directory.
+      // Attempting to import that directory
+      // will fail; it has no content. To avoid those failures,
+      // check files for length and ignore any that are empty
+      if (tempFilePath.toFile().length() == 0) {
+        logger.info("Empty file in parquet, skipping");
+        Files.delete(tempFilePath);
+      } else {
+        // Once the remote file has been copied to the temp file, make it read-only
+        fileMap.put(tableName, tempFilePath.toFile());
+      }
+    } catch (IOException e) {
+      throw new TdrManifestImportException(e.getMessage(), e);
+    }
+  }
+
+  public void deleteFileDirectory() {
+    try {
+      Files.delete(tempFileDir);
+    } catch (IOException e) {
+      logger.error("Error deleting temporary files: {}", e.getMessage());
+    }
+  }
+
+  public Multimap<String, File> getFileMap() {
+    return fileMap;
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordService.java
@@ -415,6 +415,12 @@ public class RecordService {
   }
 
   @WriteTransaction
+  public void updateAttributeDataType(
+      UUID instanceId, RecordType recordType, String attribute, DataTypeMapping newDataType) {
+    recordDao.updateAttributeDataType(instanceId, recordType, attribute, newDataType);
+  }
+
+  @WriteTransaction
   public void deleteAttribute(UUID instanceId, RecordType recordType, String attribute) {
     recordDao.deleteAttribute(instanceId, recordType, attribute);
   }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/AttributeSchema.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/AttributeSchema.java
@@ -4,4 +4,21 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record AttributeSchema(String name, String datatype, RecordType relatesTo) {}
+public record AttributeSchema(String name, String datatype, RecordType relatesTo) {
+
+  public AttributeSchema(String name, DataTypeMapping datatype, RecordType relatesTo) {
+    this(name, datatype.name(), relatesTo);
+  }
+
+  public AttributeSchema(String name, String datatype) {
+    this(name, datatype, null);
+  }
+
+  public AttributeSchema(String name, DataTypeMapping datatype) {
+    this(name, datatype, null);
+  }
+
+  public AttributeSchema(String name) {
+    this(name, (String) null, null);
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/DataTypeMapping.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/DataTypeMapping.java
@@ -1,9 +1,11 @@
 package org.databiosphere.workspacedataservice.service.model;
 
+import com.google.common.collect.ImmutableList;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.NoSuchElementException;
 
 public enum DataTypeMapping {
   NULL(null, "text", false, "?"),
@@ -34,6 +36,19 @@ public enum DataTypeMapping {
   private final String writePlaceholder;
 
   private static final Map<String, DataTypeMapping> MAPPING_BY_PG_TYPE = new HashMap<>();
+
+  private static record BaseTypeAndArrayTypePair(
+      DataTypeMapping baseType, DataTypeMapping arrayType) {}
+
+  private static final ImmutableList<BaseTypeAndArrayTypePair> BASE_TYPE_AND_ARRAY_TYPE_PAIRS =
+      ImmutableList.of(
+          new BaseTypeAndArrayTypePair(STRING, ARRAY_OF_STRING),
+          new BaseTypeAndArrayTypePair(NUMBER, ARRAY_OF_NUMBER),
+          new BaseTypeAndArrayTypePair(BOOLEAN, ARRAY_OF_BOOLEAN),
+          new BaseTypeAndArrayTypePair(DATE, ARRAY_OF_DATE),
+          new BaseTypeAndArrayTypePair(DATE_TIME, ARRAY_OF_DATE_TIME),
+          new BaseTypeAndArrayTypePair(FILE, ARRAY_OF_FILE),
+          new BaseTypeAndArrayTypePair(RELATION, ARRAY_OF_RELATION));
 
   static {
     Arrays.stream(DataTypeMapping.values())
@@ -69,21 +84,38 @@ public enum DataTypeMapping {
     if (baseType == null) {
       return EMPTY_ARRAY;
     }
-    return switch (baseType) {
-      case STRING -> ARRAY_OF_STRING;
-      case FILE -> ARRAY_OF_FILE;
-      case RELATION -> ARRAY_OF_RELATION;
-      case BOOLEAN -> ARRAY_OF_BOOLEAN;
-      case NUMBER -> ARRAY_OF_NUMBER;
-      case DATE -> ARRAY_OF_DATE;
-      case DATE_TIME -> ARRAY_OF_DATE_TIME;
-      case NULL ->
-      // if we only detect nulls in the array, we can't detect the intended type.
-      // treat it as a string in this case.
-      ARRAY_OF_STRING;
 
-      default -> throw new IllegalArgumentException("No supported array type for " + baseType);
-    };
+    // if we only detect nulls in the array, we can't detect the intended type.
+    // treat it as a string in this case.
+    if (baseType == NULL) {
+      return ARRAY_OF_STRING;
+    }
+
+    try {
+      return BASE_TYPE_AND_ARRAY_TYPE_PAIRS.stream()
+          .filter(types -> types.baseType().equals(baseType))
+          .findFirst()
+          .orElseThrow()
+          .arrayType();
+    } catch (NoSuchElementException e) {
+      throw new IllegalArgumentException("No supported array type for " + baseType);
+    }
+  }
+
+  public DataTypeMapping getBaseType() {
+    if (!isArrayType()) {
+      return this;
+    }
+
+    if (this == EMPTY_ARRAY) {
+      return NULL;
+    }
+
+    return BASE_TYPE_AND_ARRAY_TYPE_PAIRS.stream()
+        .filter(types -> types.arrayType().equals(this))
+        .findFirst()
+        .orElseThrow()
+        .baseType();
   }
 
   public String getWritePlaceholder() {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/RecordTypeSchema.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/RecordTypeSchema.java
@@ -14,4 +14,11 @@ public record RecordTypeSchema(
     return attributes.stream()
         .anyMatch(attributeSchema -> attributeSchema.name().equals(attribute));
   }
+
+  public AttributeSchema getAttributeSchema(String attribute) {
+    return attributes.stream()
+        .filter(attr -> attr.name().equals(attribute))
+        .findFirst()
+        .orElseThrow();
+  }
 }

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -9,7 +9,7 @@ env:
       user: ${WDS_DB_USER:wds}
       # When running on Azure in k8s with workload identity set ADDITIONAL_JDBC_URL_PARAMS to
       # sslmode=require&authenticationPluginClassName=com.azure.identity.extensions.jdbc.postgresql.AzurePostgresqlAuthenticationPlugin
-      additionalUrlParams: ${ADDITIONAL_JDBC_URL_PARAMS:}
+      additionalUrlParams: ${ADDITIONAL_JDBC_URL_PARAMS:prepareThreshold=0}
 
 management:
   endpoint:

--- a/service/src/main/resources/liquibase/changelog.yaml
+++ b/service/src/main/resources/liquibase/changelog.yaml
@@ -23,3 +23,6 @@ databaseChangeLog:
   - include:
       file: changesets/20231011_job_table.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/20240118_number_timestamp_array_conversions.yaml
+      relativeToChangelogFile: true

--- a/service/src/main/resources/liquibase/changesets/20240118_number_timestamp_array_conversions.yaml
+++ b/service/src/main/resources/liquibase/changesets/20240118_number_timestamp_array_conversions.yaml
@@ -1,0 +1,37 @@
+databaseChangeLog:
+  - changeSet:
+      id:  20240118_number_timestamp_array_conversions
+      author:  nwatts
+      changes:
+        -  sql:
+             dbms:  postgresql
+             splitStatements: false
+             sql:  |
+               create or replace function sys_wds.convert_array_of_numbers_to_timestamps(numeric[])
+                returns timestamp with time zone[] as $$
+                  declare
+                    numbers alias for $1;
+                    timestamps timestamp with time zone[];
+                  begin
+                    for i in array_lower(numbers, 1)..array_upper(numbers, 1) loop
+                      timestamps[i] := to_timestamp(numbers[i]);
+                    end loop;
+                    return timestamps;
+                  end;
+                $$ language plpgsql immutable;
+        - sql:
+            dbms: postgresql
+            splitStatements: false
+            sql: |
+              create or replace function sys_wds.convert_array_of_timestamps_to_numbers(timestamp with time zone[])
+               returns numeric[] as $$
+                 declare
+                    timestamps alias for $1;
+                    numbers numeric[];
+                  begin
+                    for i in array_lower(timestamps, 1)..array_upper(timestamps, 1) loop
+                      numbers[i] := extract(epoch from timestamps[i]);
+                    end loop;
+                    return numbers;
+                  end;
+               $$ language plpgsql immutable;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -2012,8 +2012,7 @@ class RecordControllerMockMvcTest {
                     recordType,
                     attributeToRename)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(
-                    mapper.writeValueAsString(new AttributeSchema(newAttributeName, null, null))))
+                .content(mapper.writeValueAsString(new AttributeSchema(newAttributeName))))
         .andExpect(status().isOk());
 
     MvcResult mvcResult =
@@ -2050,7 +2049,7 @@ class RecordControllerMockMvcTest {
                     recordType,
                     "doesNotExist")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(mapper.writeValueAsString(new AttributeSchema("newAttr", null, null))))
+                .content(mapper.writeValueAsString(new AttributeSchema("newAttr"))))
         .andExpect(status().isNotFound());
   }
 
@@ -2071,7 +2070,7 @@ class RecordControllerMockMvcTest {
                     recordType,
                     attributeToRename)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(mapper.writeValueAsString(new AttributeSchema("newAttr", null, null))))
+                .content(mapper.writeValueAsString(new AttributeSchema("newAttr"))))
         .andExpect(status().isBadRequest());
   }
 
@@ -2093,8 +2092,7 @@ class RecordControllerMockMvcTest {
                     recordType,
                     attributeToRename)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(
-                    mapper.writeValueAsString(new AttributeSchema(newAttributeName, null, null))))
+                .content(mapper.writeValueAsString(new AttributeSchema(newAttributeName))))
         .andExpect(status().isConflict());
   }
 
@@ -2188,24 +2186,25 @@ class RecordControllerMockMvcTest {
 
     List<AttributeSchema> expectedAttributes =
         Arrays.asList(
-            new AttributeSchema("array-of-date", "ARRAY_OF_DATE", null),
-            new AttributeSchema("array-of-datetime", "ARRAY_OF_DATE_TIME", null),
-            new AttributeSchema("array-of-relation", "ARRAY_OF_RELATION", referencedType),
-            new AttributeSchema("array-of-string", "ARRAY_OF_STRING", null),
-            new AttributeSchema("attr-boolean", "BOOLEAN", null),
-            new AttributeSchema("attr-dt", "DATE_TIME", null),
-            new AttributeSchema("attr-json", "JSON", null),
-            new AttributeSchema("attr-ref", "RELATION", referencedType),
-            new AttributeSchema("attr1", "STRING", null),
-            new AttributeSchema("attr2", "NUMBER", null),
-            new AttributeSchema("attr3", "DATE", null),
-            new AttributeSchema("attr4", "STRING", null),
-            new AttributeSchema("attr5", "NUMBER", null),
-            new AttributeSchema("sys_name", "STRING", null),
-            new AttributeSchema("z-array-of-boolean", "ARRAY_OF_BOOLEAN", null),
-            new AttributeSchema("z-array-of-number-double", "ARRAY_OF_NUMBER", null),
-            new AttributeSchema("z-array-of-number-long", "ARRAY_OF_NUMBER", null),
-            new AttributeSchema("z-array-of-string", "ARRAY_OF_STRING", null));
+            new AttributeSchema("array-of-date", DataTypeMapping.ARRAY_OF_DATE),
+            new AttributeSchema("array-of-datetime", DataTypeMapping.ARRAY_OF_DATE_TIME),
+            new AttributeSchema(
+                "array-of-relation", DataTypeMapping.ARRAY_OF_RELATION, referencedType),
+            new AttributeSchema("array-of-string", DataTypeMapping.ARRAY_OF_STRING),
+            new AttributeSchema("attr-boolean", DataTypeMapping.BOOLEAN),
+            new AttributeSchema("attr-dt", DataTypeMapping.DATE_TIME),
+            new AttributeSchema("attr-json", DataTypeMapping.JSON),
+            new AttributeSchema("attr-ref", DataTypeMapping.RELATION, referencedType),
+            new AttributeSchema("attr1", DataTypeMapping.STRING),
+            new AttributeSchema("attr2", DataTypeMapping.NUMBER),
+            new AttributeSchema("attr3", DataTypeMapping.DATE),
+            new AttributeSchema("attr4", DataTypeMapping.STRING),
+            new AttributeSchema("attr5", DataTypeMapping.NUMBER),
+            new AttributeSchema("sys_name", DataTypeMapping.STRING),
+            new AttributeSchema("z-array-of-boolean", DataTypeMapping.ARRAY_OF_BOOLEAN),
+            new AttributeSchema("z-array-of-number-double", DataTypeMapping.ARRAY_OF_NUMBER),
+            new AttributeSchema("z-array-of-number-long", DataTypeMapping.ARRAY_OF_NUMBER),
+            new AttributeSchema("z-array-of-string", DataTypeMapping.ARRAY_OF_STRING));
 
     RecordTypeSchema expected = new RecordTypeSchema(type, expectedAttributes, 1, RECORD_ID);
 
@@ -2273,22 +2272,22 @@ class RecordControllerMockMvcTest {
 
     List<AttributeSchema> expectedAttributes =
         Arrays.asList(
-            new AttributeSchema("array-of-date", "ARRAY_OF_DATE", null),
-            new AttributeSchema("array-of-datetime", "ARRAY_OF_DATE_TIME", null),
-            new AttributeSchema("array-of-string", "ARRAY_OF_STRING", null),
-            new AttributeSchema("attr-boolean", "BOOLEAN", null),
-            new AttributeSchema("attr-dt", "DATE_TIME", null),
-            new AttributeSchema("attr-json", "JSON", null),
-            new AttributeSchema("attr1", "STRING", null),
-            new AttributeSchema("attr2", "NUMBER", null),
-            new AttributeSchema("attr3", "DATE", null),
-            new AttributeSchema("attr4", "STRING", null),
-            new AttributeSchema("attr5", "NUMBER", null),
-            new AttributeSchema("sys_name", "STRING", null),
-            new AttributeSchema("z-array-of-boolean", "ARRAY_OF_BOOLEAN", null),
-            new AttributeSchema("z-array-of-number-double", "ARRAY_OF_NUMBER", null),
-            new AttributeSchema("z-array-of-number-long", "ARRAY_OF_NUMBER", null),
-            new AttributeSchema("z-array-of-string", "ARRAY_OF_STRING", null));
+            new AttributeSchema("array-of-date", DataTypeMapping.ARRAY_OF_DATE),
+            new AttributeSchema("array-of-datetime", DataTypeMapping.ARRAY_OF_DATE_TIME),
+            new AttributeSchema("array-of-string", DataTypeMapping.ARRAY_OF_STRING),
+            new AttributeSchema("attr-boolean", DataTypeMapping.BOOLEAN),
+            new AttributeSchema("attr-dt", DataTypeMapping.DATE_TIME),
+            new AttributeSchema("attr-json", DataTypeMapping.JSON),
+            new AttributeSchema("attr1", DataTypeMapping.STRING),
+            new AttributeSchema("attr2", DataTypeMapping.NUMBER),
+            new AttributeSchema("attr3", DataTypeMapping.DATE),
+            new AttributeSchema("attr4", DataTypeMapping.STRING),
+            new AttributeSchema("attr5", DataTypeMapping.NUMBER),
+            new AttributeSchema("sys_name", DataTypeMapping.STRING),
+            new AttributeSchema("z-array-of-boolean", DataTypeMapping.ARRAY_OF_BOOLEAN),
+            new AttributeSchema("z-array-of-number-double", DataTypeMapping.ARRAY_OF_NUMBER),
+            new AttributeSchema("z-array-of-number-long", DataTypeMapping.ARRAY_OF_NUMBER),
+            new AttributeSchema("z-array-of-string", DataTypeMapping.ARRAY_OF_STRING));
 
     List<RecordTypeSchema> expectedSchemas =
         Arrays.asList(

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/FileDownloadHelperTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/FileDownloadHelperTest.java
@@ -1,0 +1,23 @@
+package org.databiosphere.workspacedataservice.dataimport;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.io.Resource;
+
+@SpringBootTest
+class FileDownloadHelperTest {
+
+  @Value("classpath:parquet/empty.parquet")
+  Resource emptyParquet;
+
+  @Test
+  void downloadEmptyFile() throws IOException {
+    FileDownloadHelper helper = new FileDownloadHelper("test");
+    assertDoesNotThrow(() -> helper.downloadFileFromURL("empty_table", emptyParquet.getURL()));
+    assert helper.getFileMap().isEmpty();
+  }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobE2ETest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobE2ETest.java
@@ -2,7 +2,6 @@ package org.databiosphere.workspacedataservice.dataimport.pfb;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.databiosphere.workspacedataservice.TestTags.SLOW;
-import static org.databiosphere.workspacedataservice.dataimport.pfb.PfbTestUtils.buildPfbQuartzJob;
 import static org.databiosphere.workspacedataservice.dataimport.pfb.PfbTestUtils.stubJobContext;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -19,13 +18,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
-import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.dao.SchedulerDao;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
 import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
-import org.databiosphere.workspacedataservice.retry.RestClientRetry;
-import org.databiosphere.workspacedataservice.service.BatchWriteService;
 import org.databiosphere.workspacedataservice.service.ImportService;
 import org.databiosphere.workspacedataservice.service.InstanceService;
 import org.databiosphere.workspacedataservice.service.RecordOrchestratorService;
@@ -63,14 +58,10 @@ import org.springframework.test.context.ActiveProfiles;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class PfbQuartzJobE2ETest {
 
-  @Autowired JobDao jobDao;
-  @Autowired RestClientRetry restClientRetry;
-  @Autowired BatchWriteService batchWriteService;
-  @Autowired ActivityLogger activityLogger;
   @Autowired RecordOrchestratorService recordOrchestratorService;
   @Autowired ImportService importService;
   @Autowired InstanceService instanceService;
-
+  @Autowired private PfbTestSupport testSupport;
   @MockBean SchedulerDao schedulerDao;
   @MockBean WorkspaceManagerDao wsmDao;
 
@@ -127,8 +118,7 @@ class PfbQuartzJobE2ETest {
     when(wsmDao.enumerateDataRepoSnapshotReferences(any(), anyInt(), anyInt()))
         .thenReturn(new ResourceList());
 
-    buildPfbQuartzJob(jobDao, wsmDao, restClientRetry, batchWriteService, activityLogger)
-        .execute(mockContext);
+    testSupport.buildPfbQuartzJob().execute(mockContext);
 
     /* the testAvroResource should insert:
        - 3202 record(s) of type activities
@@ -184,8 +174,7 @@ class PfbQuartzJobE2ETest {
     when(wsmDao.enumerateDataRepoSnapshotReferences(any(), anyInt(), anyInt()))
         .thenReturn(new ResourceList());
 
-    buildPfbQuartzJob(jobDao, wsmDao, restClientRetry, batchWriteService, activityLogger)
-        .execute(mockContext);
+    testSupport.buildPfbQuartzJob().execute(mockContext);
 
     /* the fourRowsAvroResource should insert:
        - 3 record(s) of type data_release
@@ -231,8 +220,7 @@ class PfbQuartzJobE2ETest {
     when(wsmDao.enumerateDataRepoSnapshotReferences(any(), anyInt(), anyInt()))
         .thenReturn(new ResourceList());
 
-    buildPfbQuartzJob(jobDao, wsmDao, restClientRetry, batchWriteService, activityLogger)
-        .execute(mockContext);
+    testSupport.buildPfbQuartzJob().execute(mockContext);
 
     // this record, within the precision.avro file, is known to have numbers with high decimal
     // precision. Retrieve some of them and check for the expected high-precision values.
@@ -271,8 +259,7 @@ class PfbQuartzJobE2ETest {
     when(wsmDao.enumerateDataRepoSnapshotReferences(any(), anyInt(), anyInt()))
         .thenReturn(new ResourceList());
 
-    buildPfbQuartzJob(jobDao, wsmDao, restClientRetry, batchWriteService, activityLogger)
-        .execute(mockContext);
+    testSupport.buildPfbQuartzJob().execute(mockContext);
 
     /* the forwardRelationsAvroResource should insert:
        - 1 record of type submitted_aligned_reads
@@ -321,8 +308,7 @@ class PfbQuartzJobE2ETest {
     when(wsmDao.enumerateDataRepoSnapshotReferences(any(), anyInt(), anyInt()))
         .thenReturn(new ResourceList());
 
-    buildPfbQuartzJob(jobDao, wsmDao, restClientRetry, batchWriteService, activityLogger)
-        .execute(mockContext);
+    testSupport.buildPfbQuartzJob().execute(mockContext);
 
     RecordTypeSchema dataReleaseSchema =
         recordOrchestratorService.describeRecordType(

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbTestSupport.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbTestSupport.java
@@ -1,0 +1,30 @@
+package org.databiosphere.workspacedataservice.dataimport.pfb;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.UUID;
+import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
+import org.databiosphere.workspacedataservice.dao.JobDao;
+import org.databiosphere.workspacedataservice.retry.RestClientRetry;
+import org.databiosphere.workspacedataservice.service.BatchWriteService;
+import org.databiosphere.workspacedataservice.workspacemanager.WorkspaceManagerDao;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+class PfbTestSupport {
+  @Autowired private JobDao jobDao;
+  @Autowired private WorkspaceManagerDao wsmDao;
+  @Autowired private RestClientRetry restClientRetry;
+  @Autowired private BatchWriteService batchWriteService;
+  @Autowired private ActivityLogger activityLogger;
+  @Autowired private ObjectMapper objectMapper;
+
+  PfbQuartzJob buildPfbQuartzJob(UUID workspaceId) {
+    return new PfbQuartzJob(
+        jobDao, wsmDao, restClientRetry, batchWriteService, activityLogger, workspaceId);
+  }
+
+  PfbQuartzJob buildPfbQuartzJob() {
+    return buildPfbQuartzJob(UUID.randomUUID());
+  }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbTestUtils.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbTestUtils.java
@@ -20,11 +20,6 @@ import org.apache.avro.file.DataFileStream;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.GenericRecordBuilder;
-import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
-import org.databiosphere.workspacedataservice.dao.JobDao;
-import org.databiosphere.workspacedataservice.retry.RestClientRetry;
-import org.databiosphere.workspacedataservice.service.BatchWriteService;
-import org.databiosphere.workspacedataservice.workspacemanager.WorkspaceManagerDao;
 import org.mockito.Mockito;
 import org.quartz.JobDataMap;
 import org.quartz.JobExecutionContext;
@@ -172,15 +167,5 @@ public class PfbTestUtils {
     when(mockContext.getJobDetail()).thenReturn(jobDetail);
 
     return mockContext;
-  }
-
-  public static PfbQuartzJob buildPfbQuartzJob(
-      JobDao jobDao,
-      WorkspaceManagerDao wsmDao,
-      RestClientRetry restClientRetry,
-      BatchWriteService batchWriteService,
-      ActivityLogger activityLogger) {
-    return new PfbQuartzJob(
-        jobDao, wsmDao, restClientRetry, batchWriteService, activityLogger, UUID.randomUUID());
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
@@ -7,6 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -211,7 +213,11 @@ class RecordOrchestratorServiceTest {
     "updateAttributeDataTypeNumberConversions",
     "updateAttributeDataTypeNumberArrayConversions",
     "updateAttributeDataTypeBooleanConversions",
-    "updateAttributeDataTypeBooleanArrayConversions"
+    "updateAttributeDataTypeBooleanArrayConversions",
+    "updateAttributeDataTypeDateConversions",
+    "updateAttributeDataTypeDateArrayConversions",
+    "updateAttributeDataTypeDatetimeConversions",
+    "updateAttributeDataTypeDatetimeArrayConversions"
   })
   void updateAttributeDataType(
       Object attributeValue,
@@ -257,6 +263,15 @@ class RecordOrchestratorServiceTest {
         // Boolean
         Arguments.of("yes", DataTypeMapping.STRING, DataTypeMapping.BOOLEAN, Boolean.TRUE),
         Arguments.of("no", DataTypeMapping.STRING, DataTypeMapping.BOOLEAN, Boolean.FALSE),
+        // Date
+        Arguments.of(
+            "2024/01/24", DataTypeMapping.STRING, DataTypeMapping.DATE, LocalDate.of(2024, 1, 24)),
+        // Datetime
+        Arguments.of(
+            "2024/01/24 02:30:00",
+            DataTypeMapping.STRING,
+            DataTypeMapping.DATE_TIME,
+            LocalDateTime.of(2024, 1, 24, 2, 30, 0)),
         // String array
         Arguments.of(
             "foo", DataTypeMapping.STRING, DataTypeMapping.ARRAY_OF_STRING, new String[] {"foo"}),
@@ -271,7 +286,19 @@ class RecordOrchestratorServiceTest {
             "yes",
             DataTypeMapping.STRING,
             DataTypeMapping.ARRAY_OF_BOOLEAN,
-            new Boolean[] {Boolean.TRUE}));
+            new Boolean[] {Boolean.TRUE}),
+        // Date array
+        Arguments.of(
+            "2024/01/24",
+            DataTypeMapping.STRING,
+            DataTypeMapping.ARRAY_OF_DATE,
+            new LocalDate[] {LocalDate.of(2024, 1, 24)}),
+        // Datetime array
+        Arguments.of(
+            "2024/01/24 02:30:00",
+            DataTypeMapping.STRING,
+            DataTypeMapping.ARRAY_OF_DATE_TIME,
+            new LocalDateTime[] {LocalDateTime.of(2024, 1, 24, 2, 30, 0)}));
   }
 
   static Stream<Arguments> updateAttributeDataTypeStringArrayConversions() {
@@ -287,7 +314,19 @@ class RecordOrchestratorServiceTest {
             List.of("yes", "no"),
             DataTypeMapping.ARRAY_OF_STRING,
             DataTypeMapping.ARRAY_OF_BOOLEAN,
-            new Boolean[] {Boolean.TRUE, Boolean.FALSE}));
+            new Boolean[] {Boolean.TRUE, Boolean.FALSE}),
+        // Date array
+        Arguments.of(
+            List.of("2024/01/24"),
+            DataTypeMapping.ARRAY_OF_STRING,
+            DataTypeMapping.ARRAY_OF_DATE,
+            new LocalDate[] {LocalDate.of(2024, 1, 24)}),
+        // Datetime array
+        Arguments.of(
+            List.of("2024/01/24 02:30:00"),
+            DataTypeMapping.ARRAY_OF_STRING,
+            DataTypeMapping.ARRAY_OF_DATE_TIME,
+            new LocalDateTime[] {LocalDateTime.of(2024, 1, 24, 2, 30, 0)}));
   }
 
   static Stream<Arguments> updateAttributeDataTypeNumberConversions() {
@@ -300,6 +339,18 @@ class RecordOrchestratorServiceTest {
             BigDecimal.valueOf(1), DataTypeMapping.NUMBER, DataTypeMapping.BOOLEAN, Boolean.TRUE),
         Arguments.of(
             BigDecimal.valueOf(0), DataTypeMapping.NUMBER, DataTypeMapping.BOOLEAN, Boolean.FALSE),
+        // Date
+        Arguments.of(
+            BigDecimal.valueOf(1706063400L),
+            DataTypeMapping.NUMBER,
+            DataTypeMapping.DATE,
+            LocalDate.of(2024, 1, 24)),
+        // Datetime
+        Arguments.of(
+            BigDecimal.valueOf(1706063400L),
+            DataTypeMapping.NUMBER,
+            DataTypeMapping.DATE_TIME,
+            LocalDateTime.of(2024, 1, 24, 2, 30, 0)),
         // String array
         Arguments.of(
             BigDecimal.valueOf(123),
@@ -317,7 +368,19 @@ class RecordOrchestratorServiceTest {
             BigDecimal.valueOf(1),
             DataTypeMapping.NUMBER,
             DataTypeMapping.ARRAY_OF_BOOLEAN,
-            new Boolean[] {Boolean.TRUE}));
+            new Boolean[] {Boolean.TRUE}),
+        // Date array
+        Arguments.of(
+            BigDecimal.valueOf(1706063400L),
+            DataTypeMapping.NUMBER,
+            DataTypeMapping.ARRAY_OF_DATE,
+            new LocalDate[] {LocalDate.of(2024, 1, 24)}),
+        // Datetime array
+        Arguments.of(
+            BigDecimal.valueOf(1706063400L),
+            DataTypeMapping.NUMBER,
+            DataTypeMapping.ARRAY_OF_DATE_TIME,
+            new LocalDateTime[] {LocalDateTime.of(2024, 1, 24, 2, 30, 0)}));
   }
 
   static Stream<Arguments> updateAttributeDataTypeNumberArrayConversions() {
@@ -333,7 +396,19 @@ class RecordOrchestratorServiceTest {
             List.of(BigDecimal.valueOf(1), BigDecimal.valueOf(0)),
             DataTypeMapping.ARRAY_OF_NUMBER,
             DataTypeMapping.ARRAY_OF_BOOLEAN,
-            new Boolean[] {Boolean.TRUE, Boolean.FALSE}));
+            new Boolean[] {Boolean.TRUE, Boolean.FALSE}),
+        // Date array
+        Arguments.of(
+            List.of(BigDecimal.valueOf(1706063400L)),
+            DataTypeMapping.ARRAY_OF_NUMBER,
+            DataTypeMapping.ARRAY_OF_DATE,
+            new LocalDate[] {LocalDate.of(2024, 1, 24)}),
+        // Datetime array
+        Arguments.of(
+            List.of(BigDecimal.valueOf(1706063400L)),
+            DataTypeMapping.ARRAY_OF_NUMBER,
+            DataTypeMapping.ARRAY_OF_DATE_TIME,
+            new LocalDateTime[] {LocalDateTime.of(2024, 1, 24, 2, 30, 0)}));
   }
 
   static Stream<Arguments> updateAttributeDataTypeBooleanConversions() {
@@ -397,6 +472,139 @@ class RecordOrchestratorServiceTest {
             new BigDecimal[] {BigDecimal.valueOf(1), BigDecimal.valueOf(0)}));
   }
 
+  static Stream<Arguments> updateAttributeDataTypeDateConversions() {
+    return Stream.of(
+        // String
+        Arguments.of(
+            LocalDate.of(2024, 1, 24), DataTypeMapping.DATE, DataTypeMapping.STRING, "2024-01-24"),
+        // Number
+        Arguments.of(
+            LocalDate.of(2024, 1, 24),
+            DataTypeMapping.DATE,
+            DataTypeMapping.NUMBER,
+            BigDecimal.valueOf(1706054400L)),
+        // Datetime
+        Arguments.of(
+            LocalDate.of(2024, 1, 24),
+            DataTypeMapping.DATE,
+            DataTypeMapping.DATE_TIME,
+            LocalDateTime.of(2024, 1, 24, 0, 0, 0)),
+        // String array
+        Arguments.of(
+            LocalDate.of(2024, 1, 24),
+            DataTypeMapping.DATE,
+            DataTypeMapping.ARRAY_OF_STRING,
+            new String[] {"2024-01-24"}),
+        // Number array
+        Arguments.of(
+            LocalDate.of(2024, 1, 24),
+            DataTypeMapping.DATE,
+            DataTypeMapping.ARRAY_OF_NUMBER,
+            new BigDecimal[] {BigDecimal.valueOf(1706054400L)}),
+        // Date array
+        Arguments.of(
+            LocalDate.of(2024, 1, 24),
+            DataTypeMapping.DATE,
+            DataTypeMapping.ARRAY_OF_DATE,
+            new LocalDate[] {LocalDate.of(2024, 1, 24)}),
+        // Datetime array
+        Arguments.of(
+            LocalDate.of(2024, 1, 24),
+            DataTypeMapping.DATE,
+            DataTypeMapping.ARRAY_OF_DATE_TIME,
+            new LocalDateTime[] {LocalDateTime.of(2024, 1, 24, 0, 0, 0)}));
+  }
+
+  static Stream<Arguments> updateAttributeDataTypeDateArrayConversions() {
+    return Stream.of(
+        // String array
+        Arguments.of(
+            List.of(LocalDate.of(2024, 1, 24)),
+            DataTypeMapping.ARRAY_OF_DATE,
+            DataTypeMapping.ARRAY_OF_STRING,
+            new String[] {"2024-01-24"}),
+        // Number array
+        Arguments.of(
+            List.of(LocalDate.of(2024, 1, 24)),
+            DataTypeMapping.ARRAY_OF_DATE,
+            DataTypeMapping.ARRAY_OF_NUMBER,
+            new BigDecimal[] {BigDecimal.valueOf(1706054400L)}),
+        // Datetime array
+        Arguments.of(
+            List.of(LocalDate.of(2024, 1, 24)),
+            DataTypeMapping.ARRAY_OF_DATE,
+            DataTypeMapping.ARRAY_OF_DATE_TIME,
+            new LocalDateTime[] {LocalDateTime.of(2024, 1, 24, 0, 0, 0)}));
+  }
+
+  static Stream<Arguments> updateAttributeDataTypeDatetimeConversions() {
+    return Stream.of(
+        // String
+        Arguments.of(
+            LocalDateTime.of(2024, 1, 24, 2, 30, 0),
+            DataTypeMapping.DATE_TIME,
+            DataTypeMapping.STRING,
+            "2024-01-24 02:30:00+00"),
+        // Number
+        Arguments.of(
+            LocalDateTime.of(2024, 1, 24, 2, 30, 0),
+            DataTypeMapping.DATE_TIME,
+            DataTypeMapping.NUMBER,
+            new BigDecimal("1706063400.000000")),
+        // Datetime
+        Arguments.of(
+            LocalDateTime.of(2024, 1, 24, 2, 30, 0),
+            DataTypeMapping.DATE_TIME,
+            DataTypeMapping.DATE,
+            LocalDate.of(2024, 1, 24)),
+        // String array
+        Arguments.of(
+            LocalDateTime.of(2024, 1, 24, 2, 30, 0),
+            DataTypeMapping.DATE_TIME,
+            DataTypeMapping.ARRAY_OF_STRING,
+            new String[] {"2024-01-24 02:30:00+00"}),
+        // Number array
+        Arguments.of(
+            LocalDateTime.of(2024, 1, 24, 2, 30, 0),
+            DataTypeMapping.DATE_TIME,
+            DataTypeMapping.ARRAY_OF_NUMBER,
+            new BigDecimal[] {new BigDecimal("1706063400.000000")}),
+        // Date array
+        Arguments.of(
+            LocalDateTime.of(2024, 1, 24, 2, 30, 0),
+            DataTypeMapping.DATE_TIME,
+            DataTypeMapping.ARRAY_OF_DATE,
+            new LocalDate[] {LocalDate.of(2024, 1, 24)}),
+        // Datetime array
+        Arguments.of(
+            LocalDateTime.of(2024, 1, 24, 2, 30, 0),
+            DataTypeMapping.DATE_TIME,
+            DataTypeMapping.ARRAY_OF_DATE_TIME,
+            new LocalDateTime[] {LocalDateTime.of(2024, 1, 24, 2, 30, 0)}));
+  }
+
+  static Stream<Arguments> updateAttributeDataTypeDatetimeArrayConversions() {
+    return Stream.of(
+        // String array
+        Arguments.of(
+            List.of(LocalDateTime.of(2024, 1, 24, 2, 30, 0)),
+            DataTypeMapping.ARRAY_OF_DATE_TIME,
+            DataTypeMapping.ARRAY_OF_STRING,
+            new String[] {"2024-01-24 02:30:00+00"}),
+        // Number array
+        Arguments.of(
+            List.of(LocalDateTime.of(2024, 1, 24, 2, 30, 0)),
+            DataTypeMapping.ARRAY_OF_DATE_TIME,
+            DataTypeMapping.ARRAY_OF_NUMBER,
+            new BigDecimal[] {new BigDecimal("1706063400.000000")}),
+        // Date array
+        Arguments.of(
+            List.of(LocalDateTime.of(2024, 1, 24, 2, 30, 0)),
+            DataTypeMapping.ARRAY_OF_DATE_TIME,
+            DataTypeMapping.ARRAY_OF_DATE,
+            new LocalDate[] {LocalDate.of(2024, 1, 24)}));
+  }
+
   @Test
   void updateAttributeDataTypePrimaryKey() {
     // Arrange
@@ -456,7 +664,7 @@ class RecordOrchestratorServiceTest {
   }
 
   @Test
-  void updateAttributeDataTypeUnableToConvertValues() {
+  void updateAttributeDataTypeFailureToConvertValueChangesNoData() {
     // Arrange
     String attributeName = "testAttribute";
 
@@ -494,6 +702,81 @@ class RecordOrchestratorServiceTest {
         "row_1", attributeName, "123", "expected attribute values to be unchanged");
     assertAttributeValue(
         "row_2", attributeName, "foo", "expected attribute values to be unchanged");
+  }
+
+  @ParameterizedTest(name = "gracefully fails to convert {0} to {1}")
+  @MethodSource("unableToConvertValuesTestCases")
+  void updateAttributeDataTypeUnableToConvertValues(
+      Object attributeValue, DataTypeMapping newDataType) {
+    // Arrange
+    String attributeName = "testAttribute";
+
+    RecordAttributes recordAttributes =
+        RecordAttributes.empty().putAttribute(attributeName, attributeValue);
+    RecordRequest recordRequest = new RecordRequest(recordAttributes);
+    recordOrchestratorService.upsertSingleRecord(
+        INSTANCE, VERSION, TEST_TYPE, RECORD_ID, Optional.of(PRIMARY_KEY), recordRequest);
+
+    // Act/Assert
+    ConflictException e =
+        assertThrows(
+            ConflictException.class,
+            () ->
+                recordOrchestratorService.updateAttributeDataType(
+                    INSTANCE, VERSION, TEST_TYPE, attributeName, newDataType.name()),
+            "updateAttributeDataType should have thrown an error");
+
+    assertEquals(
+        "Unable to convert values for attribute %s to %s".formatted(attributeName, newDataType),
+        e.getMessage());
+  }
+
+  static Stream<Arguments> unableToConvertValuesTestCases() {
+    return Stream.of(
+        Arguments.of("foo", DataTypeMapping.NUMBER),
+        Arguments.of(1000000000000000L, DataTypeMapping.DATE_TIME));
+  }
+
+  @ParameterizedTest(name = "rejects requests to convert from {1} to {2}")
+  @MethodSource("invalidConversionTestCases")
+  void updateAttributeDataTypeInvalidConversion(
+      Object attributeValue, DataTypeMapping expectedInitialDataType, DataTypeMapping newDataType) {
+    // Arrange
+    String attributeName = "testAttribute";
+
+    RecordAttributes recordAttributes =
+        RecordAttributes.empty().putAttribute(attributeName, attributeValue);
+    RecordRequest recordRequest = new RecordRequest(recordAttributes);
+    recordOrchestratorService.upsertSingleRecord(
+        INSTANCE, VERSION, TEST_TYPE, RECORD_ID, Optional.of(PRIMARY_KEY), recordRequest);
+    assertAttributeDataType(
+        attributeName,
+        expectedInitialDataType,
+        "expected initial attribute data type to be %s".formatted(expectedInitialDataType));
+
+    // Act/Assert
+    ValidationException e =
+        assertThrows(
+            ValidationException.class,
+            () ->
+                recordOrchestratorService.updateAttributeDataType(
+                    INSTANCE, VERSION, TEST_TYPE, attributeName, newDataType.name()),
+            "updateAttributeDataType should have thrown an error");
+
+    assertEquals(
+        "Unable to convert attribute from %s to %s".formatted(expectedInitialDataType, newDataType),
+        e.getMessage());
+  }
+
+  static Stream<Arguments> invalidConversionTestCases() {
+    return Stream.of(
+        Arguments.of(Boolean.TRUE, DataTypeMapping.BOOLEAN, DataTypeMapping.DATE),
+        Arguments.of(Boolean.TRUE, DataTypeMapping.BOOLEAN, DataTypeMapping.DATE_TIME),
+        Arguments.of(LocalDate.of(2024, 1, 24), DataTypeMapping.DATE, DataTypeMapping.BOOLEAN),
+        Arguments.of(
+            LocalDateTime.of(2024, 1, 24, 2, 30, 0),
+            DataTypeMapping.DATE_TIME,
+            DataTypeMapping.BOOLEAN));
   }
 
   @Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/model/AttributeSchemaTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/model/AttributeSchemaTest.java
@@ -1,0 +1,24 @@
+package org.databiosphere.workspacedataservice.service.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.databiosphere.workspacedataservice.shared.model.RecordType;
+import org.junit.jupiter.api.Test;
+
+class AttributeSchemaTest {
+  @Test
+  void testAlternateConstructors() {
+    assertEquals(
+        new AttributeSchema("attr", "STRING", RecordType.valueOf("otherAttr")),
+        new AttributeSchema("attr", DataTypeMapping.STRING, RecordType.valueOf("otherAttr")));
+
+    assertEquals(
+        new AttributeSchema("attr", "STRING", null), new AttributeSchema("attr", "STRING"));
+
+    assertEquals(
+        new AttributeSchema("attr", "STRING", null),
+        new AttributeSchema("attr", DataTypeMapping.STRING));
+
+    assertEquals(new AttributeSchema("attr", (String) null, null), new AttributeSchema("attr"));
+  }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/model/DataTypeMappingTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/model/DataTypeMappingTest.java
@@ -1,0 +1,70 @@
+package org.databiosphere.workspacedataservice.service.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class DataTypeMappingTest {
+  @ParameterizedTest(name = "getArrayTypeForBase maps {0} to {1}")
+  @MethodSource("getBaseTypesAndArrayTypes")
+  void testGetArrayTypeForBase(DataTypeMapping baseType, DataTypeMapping expectedArrayType) {
+    DataTypeMapping arrayType = DataTypeMapping.getArrayTypeForBase(baseType);
+    assertEquals(expectedArrayType, arrayType);
+  }
+
+  private static Stream<Arguments> getBaseTypesAndArrayTypes() {
+    return Stream.of(
+        Arguments.of(null, DataTypeMapping.EMPTY_ARRAY),
+        Arguments.of(DataTypeMapping.STRING, DataTypeMapping.ARRAY_OF_STRING),
+        Arguments.of(DataTypeMapping.FILE, DataTypeMapping.ARRAY_OF_FILE),
+        Arguments.of(DataTypeMapping.RELATION, DataTypeMapping.ARRAY_OF_RELATION),
+        Arguments.of(DataTypeMapping.BOOLEAN, DataTypeMapping.ARRAY_OF_BOOLEAN),
+        Arguments.of(DataTypeMapping.NUMBER, DataTypeMapping.ARRAY_OF_NUMBER),
+        Arguments.of(DataTypeMapping.DATE, DataTypeMapping.ARRAY_OF_DATE),
+        Arguments.of(DataTypeMapping.DATE_TIME, DataTypeMapping.ARRAY_OF_DATE_TIME),
+        Arguments.of(DataTypeMapping.NULL, DataTypeMapping.ARRAY_OF_STRING));
+  }
+
+  @Test
+  void testGetArrayTypeForBaseNoArrayType() {
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> DataTypeMapping.getArrayTypeForBase(DataTypeMapping.EMPTY_ARRAY),
+            "getArrayTypeForBase should have thrown an error");
+    assertEquals("No supported array type for EMPTY_ARRAY", e.getMessage());
+  }
+
+  @ParameterizedTest(name = "getBaseType maps {0} to {1}")
+  @MethodSource("getTypesAndBaseTypes")
+  void testGetBaseType(DataTypeMapping type, DataTypeMapping expectedBaseType) {
+    DataTypeMapping baseType = type.getBaseType();
+    assertEquals(expectedBaseType, baseType);
+  }
+
+  private static Stream<Arguments> getTypesAndBaseTypes() {
+    return Stream.of(
+        Arguments.of(DataTypeMapping.NULL, DataTypeMapping.NULL),
+        Arguments.of(DataTypeMapping.STRING, DataTypeMapping.STRING),
+        Arguments.of(DataTypeMapping.FILE, DataTypeMapping.FILE),
+        Arguments.of(DataTypeMapping.RELATION, DataTypeMapping.RELATION),
+        Arguments.of(DataTypeMapping.BOOLEAN, DataTypeMapping.BOOLEAN),
+        Arguments.of(DataTypeMapping.NUMBER, DataTypeMapping.NUMBER),
+        Arguments.of(DataTypeMapping.DATE, DataTypeMapping.DATE),
+        Arguments.of(DataTypeMapping.DATE_TIME, DataTypeMapping.DATE_TIME),
+        Arguments.of(DataTypeMapping.JSON, DataTypeMapping.JSON),
+        Arguments.of(DataTypeMapping.EMPTY_ARRAY, DataTypeMapping.NULL),
+        Arguments.of(DataTypeMapping.ARRAY_OF_STRING, DataTypeMapping.STRING),
+        Arguments.of(DataTypeMapping.ARRAY_OF_FILE, DataTypeMapping.FILE),
+        Arguments.of(DataTypeMapping.ARRAY_OF_RELATION, DataTypeMapping.RELATION),
+        Arguments.of(DataTypeMapping.ARRAY_OF_BOOLEAN, DataTypeMapping.BOOLEAN),
+        Arguments.of(DataTypeMapping.ARRAY_OF_NUMBER, DataTypeMapping.NUMBER),
+        Arguments.of(DataTypeMapping.ARRAY_OF_DATE, DataTypeMapping.DATE),
+        Arguments.of(DataTypeMapping.ARRAY_OF_DATE_TIME, DataTypeMapping.DATE_TIME));
+  }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/model/RecordTypeSchemaTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/model/RecordTypeSchemaTest.java
@@ -1,10 +1,13 @@
 package org.databiosphere.workspacedataservice.service.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.NoSuchElementException;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,8 +23,8 @@ class RecordTypeSchemaTest {
   void setUp() {
     List<AttributeSchema> attributes =
         Arrays.asList(
-            new AttributeSchema("id", "STRING", null),
-            new AttributeSchema("attr1", "STRING", null));
+            new AttributeSchema(/* name */ "id", /* datatype */ "STRING", /* relatesTo */ null),
+            new AttributeSchema(/* name */ "attr1", /* datatype */ "STRING", /* relatesTo */ null));
 
     schema = new RecordTypeSchema(RECORD_TYPE, attributes, 0, PRIMARY_KEY);
   }
@@ -36,5 +39,20 @@ class RecordTypeSchemaTest {
   void testContainsAttribute() {
     assertTrue(schema.containsAttribute("attr1"));
     assertFalse(schema.containsAttribute("doesNotExist"));
+  }
+
+  @Test
+  void testGetAttributeSchema() {
+    assertEquals(
+        schema.getAttributeSchema("attr1"),
+        new AttributeSchema(/* name */ "attr1", /* datatype */ "STRING", /* relatesTo */ null));
+  }
+
+  @Test
+  void testGetNonExistentAttributeSchema() {
+    assertThrows(
+        NoSuchElementException.class,
+        () -> schema.getAttributeSchema("doesNotExist"),
+        "getAttributeSchema should have thrown an error");
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/model/RecordTypeSchemaTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/model/RecordTypeSchemaTest.java
@@ -23,8 +23,8 @@ class RecordTypeSchemaTest {
   void setUp() {
     List<AttributeSchema> attributes =
         Arrays.asList(
-            new AttributeSchema(/* name */ "id", /* datatype */ "STRING", /* relatesTo */ null),
-            new AttributeSchema(/* name */ "attr1", /* datatype */ "STRING", /* relatesTo */ null));
+            new AttributeSchema("id", DataTypeMapping.STRING),
+            new AttributeSchema("attr1", DataTypeMapping.STRING));
 
     schema = new RecordTypeSchema(RECORD_TYPE, attributes, 0, PRIMARY_KEY);
   }
@@ -44,8 +44,7 @@ class RecordTypeSchemaTest {
   @Test
   void testGetAttributeSchema() {
     assertEquals(
-        schema.getAttributeSchema("attr1"),
-        new AttributeSchema(/* name */ "attr1", /* datatype */ "STRING", /* relatesTo */ null));
+        new AttributeSchema("attr1", DataTypeMapping.STRING), schema.getAttributeSchema("attr1"));
   }
 
   @Test

--- a/service/src/test/python/test.py
+++ b/service/src/test/python/test.py
@@ -6,6 +6,7 @@ import  wds_client
 from datetime import date, datetime
 import random
 import csv
+import time
 
 # generate records for testing
 def generate_record():
@@ -96,7 +97,11 @@ class WdsTests(TestCase):
     generalInfo_client = wds_client.GeneralWDSInformationApi(api_client)
     schema_client = wds_client.SchemaApi(api_client)
     instance_client = wds_client.InstancesApi(api_client)
+    import_client = wds_client.ImportApi(api_client)
+    job_client = wds_client.JobApi(api_client)
     current_workspaceId = instance_client.list_wds_instances(version)[0]
+
+    local_server_host = 'http://localhost:9889'
 
     testType1_simple ="s_record_1"
     testType1_complex ="c_record_1"
@@ -236,3 +241,33 @@ class WdsTests(TestCase):
         response = self.schema_client.delete_record_type(self.current_workspaceId, self.version, self.cvsUpload_test);
         workspace_ent_type = self.schema_client.describe_all_record_types(self.current_workspaceId, self.version)
         self.assertTrue(len(workspace_ent_type) == 0)
+
+    # SCENARIO 6
+    # import snapshot from TDR with appropriate permissions
+    def test_import_snapshot(self):
+        import_request = { "type": "TDRMANIFEST", "url": self.local_server_host + "/tdrmanifest/v2f_for_python.json"}
+        job_response = self.import_client.import_v1(self.current_workspaceId, import_request)
+        job_status_response = self.job_client.job_status_v1(job_response.job_id)
+        job_status = job_status_response.status
+        while job_status in ['RUNNING', 'QUEUED']:
+            time.sleep(10) #sleep ten seconds then try again
+            job_status_response = self.job_client.job_status_v1(job_response.job_id)
+            job_status = job_status_response.status
+        assert job_status == 'SUCCEEDED'
+
+
+        # should create tables from manifest, spot-check
+        ent_types = self.schema_client.describe_record_type(self.current_workspaceId, self.version, "all_data_types")
+        assert ent_types.count == 5
+        search_request = { "offset": 0, "limit": 2}
+        records = self.records_client.query_records(self.current_workspaceId, self.version, "all_data_types", search_request)
+        testRecord = records.records[0]
+        assert testRecord.id == "12:101976753:T:C"
+        assert len(testRecord.attributes) == 23
+        assert testRecord.attributes['datarepo_row_id'] == "0E369A2D-25E5-4D65-955B-334F894C2883"
+        # clean up
+        all_record_types = self.schema_client.describe_all_record_types(self.current_workspaceId, self.version)
+        for record_type in all_record_types:
+            self.schema_client.delete_record_type(self.current_workspaceId, self.version, record_type.name)
+        workspace_ent_type = self.schema_client.describe_all_record_types(self.current_workspaceId, self.version)
+        assert len(workspace_ent_type) == 0

--- a/service/src/test/resources/nginx.conf
+++ b/service/src/test/resources/nginx.conf
@@ -37,5 +37,9 @@ http {
         	        types { } default_type "application/json";
         			return 200 "ya29.c.b9Aaedm1EjjI5oy921IM1GnIg2YOadOCjMA7yIyM__15_GdjbhJO_BfN1yCoejd11YmDddE7DEaG1-OCIHK11B_hfIcyjlCEKIOmG77-NM9Mh1IjdoO7OMffBfGMI-nbmyomfIonIBad-eJf4Kf5J7IOGmdhGGImdNlfbmKdm2B29cGGacEj_YofK5JIhllfCNd7nnYE4IBl9_n-BOeMMfIIcDJ-F5Ead7CKIcd17jE4EOEF4Ijh11liMfhCFy5EKMi299J2fhHh7G4fyCOAEOGhnoJfljhGdfndGJDfb9hGIM7-OiGCEIiHI1fnoMGIGhb_-ID1lOG1NdGgE747C_YdJIn9ly4jIo-7Mf-49jefI9cGgjEm15J1Gn_M11hjMGbfMh2hajOy179fh9jmh4nKlcjInjMIBiB4MjB_IlB7IlG_IjIb45K7GlcdjmnfndcG4nBhfnlJnK11BjfmgKdlFF_cYfhBMial7M1mhfdbn4hGMfmyjgj4JIl4Ijj4G49In7alYIIMlddIycJG_beOm_I4aY9-c419lMgjmidBMfj1IhdK7OmnOY9KjfEBIbMhheic-1f9G7KayaI_fnloGgj_hjhoKeiYjGnn_E4IYflBjjIhdd9fOmBKelhfEF7G7_hl2EFMKdOfIBBl7dMObnB5deM9hBf4nnIh1jB4nm5MhKIfleMihn1-4iaOFB1jE9bM4aMnh5GI59ioIdMeOJjehm4OI49jamnfd7GO-h9j4haffMnh9gGMelIMa9dhjfbFh1Iyj7M1n5BdnO1na5I7Em7JcnfGMM_j4JhK7EEnne4-4IGFBIjfIjGnO94jlhGOInhfjMn9-44hbMM4IahK9on-bfIGK9jnhjjBYjjcdKJJF_Y-yGmeO4j_-FiMK5nEj4ndJKnIdifdMInI9Id4EMaMOGK_oMIE_m44eOefhY4JIjlOf4dG1c5JjlhG4n5_oIIIO9y17nnO4nnnO7n7jnEFMhi5goO9M494f-7Mlf1F477I9";
         		}
+
+        location / {
+                root /usr/share/nginx/html; # Root for files
+        }
     }
 }

--- a/service/src/test/resources/tdrmanifest/v2f_for_python.json
+++ b/service/src/test/resources/tdrmanifest/v2f_for_python.json
@@ -1133,10 +1133,10 @@
       "location" : {
         "tables" : [ {
           "name" : "ancestry_specific_meta_analysis",
-          "paths" : [ "classpath:parquet/v2f/ancestry_specific_meta_analysis.parquet" ]
+          "paths" : [ "http://localhost:9889/parquet/v2f/ancestry_specific_meta_analysis.parquet" ]
         }, {
           "name" : "frequency_analysis",
-          "paths" : [ "classpath:parquet/v2f/frequency_analysis.parquet" ]
+          "paths" : [ "http://localhost:9889/parquet/v2f/frequency_analysis.parquet" ]
         }, {
           "name" : "trans_ethnic_meta_analysis",
           "paths" : [ ]
@@ -1145,19 +1145,19 @@
           "paths" : [ ]
         }, {
           "name" : "transcript_consequence",
-          "paths" : [ "classpath:parquet/v2f/transcript_consequence.parquet" ]
+          "paths" : [ "http://localhost:9889/parquet/v2f/transcript_consequence.parquet" ]
         }, {
           "name" : "variant",
-          "paths" : [ "classpath:parquet/v2f/variant.parquet" ]
+          "paths" : [ "http://localhost:9889/parquet/v2f/variant.parquet" ]
         }, {
           "name" : "all_data_types",
-          "paths" : [ "classpath:parquet/v2f/all_data_types.parquet" ]
+          "paths" : [ "http://localhost:9889/parquet/v2f/all_data_types.parquet" ]
         }, {
           "name" : "feature_consequence",
-          "paths" : [ "classpath:parquet/v2f/feature_consequence.parquet" ]
+          "paths" : [ "http://localhost:9889/parquet/v2f/feature_consequence.parquet" ]
         } ]
       },
-      "manifest" : "classpath:tdrmanifest/v2f.json"
+      "manifest" : "http://localhost:9889/tdrmanifest/v2f_for_python.json"
     },
     "workspace" : null
   }


### PR DESCRIPTION
This is maintenance cleanup/refactoring: [AJ-1533](https://broadworkbench.atlassian.net/browse/AJ-1533), followup from 

Clean up `RecordDaoTest`

* Get rid of unnecessary `new HashMap<>(...)` throughout.
* Prefer `RecordAttributes.empty()` to `new RecordAttributes(Map.of())`.
* Prefer `Collections.emptyMap()` to `Map.of()`.

Note: `Collections.emptyMap()` and `Map.of()` are not equivalent, see: https://stackoverflow.com/questions/46404933/map-of-vs-collections-emptymap

While arguably `Map.of()` is preferred where possible, I think `emptyMap()` is more readable and in tests I think readability matters more unless `Map.of()`'s behavior is explicitly relevant to what's being tested.

[AJ-1533]: https://broadworkbench.atlassian.net/browse/AJ-1533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ