### PR TITLE
Clean up `RecordDaoTest`

### DIFF
--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
@@ -1,5 +1,6 @@
 package org.databiosphere.workspacedataservice.dao;
 
+import static java.util.Collections.emptyMap;
 import static org.databiosphere.workspacedataservice.service.model.DataTypeMapping.*;
 import static org.databiosphere.workspacedataservice.service.model.DataTypeMapping.ARRAY_OF_NUMBER;
 import static org.databiosphere.workspacedataservice.service.model.DataTypeMapping.ARRAY_OF_STRING;
@@ -10,7 +11,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -79,7 +79,7 @@ class RecordDaoTest {
     instanceDao.createSchema(instanceId);
     recordDao.createRecordType(
         instanceId,
-        Collections.emptyMap(),
+        emptyMap(),
         recordType,
         new RelationCollection(Collections.emptySet(), Collections.emptySet()),
         PRIMARY_KEY);
@@ -161,7 +161,7 @@ class RecordDaoTest {
     String recordId = "testRecord";
     Record testRecord = new Record(recordId, recordType, RecordAttributes.empty());
     recordDao.batchUpsert(
-        instanceId, recordType, Collections.singletonList(testRecord), new HashMap<>());
+        instanceId, recordType, Collections.singletonList(testRecord), emptyMap());
 
     // make sure record is fetched
     Record search = recordDao.getSingleRecord(instanceId, recordType, recordId).get();
@@ -185,11 +185,7 @@ class RecordDaoTest {
         new RelationCollection(Collections.emptySet(), Collections.emptySet()),
         sample_id);
     recordDao.batchUpsert(
-        instanceId,
-        funkyPk,
-        Collections.singletonList(testRecord),
-        Collections.emptyMap(),
-        sample_id);
+        instanceId, funkyPk, Collections.singletonList(testRecord), emptyMap(), sample_id);
     List<Record> queryRes = recordDao.queryForRecords(funkyPk, 10, 0, "ASC", null, instanceId);
     assertEquals(1, queryRes.size());
     assertTrue(recordDao.recordExists(instanceId, funkyPk, recordId));
@@ -211,11 +207,7 @@ class RecordDaoTest {
         new RelationCollection(Collections.emptySet(), Collections.emptySet()),
         sample_id);
     recordDao.batchUpsert(
-        instanceId,
-        referencedRt,
-        Collections.singletonList(testRecord),
-        Collections.emptyMap(),
-        sample_id);
+        instanceId, referencedRt, Collections.singletonList(testRecord), emptyMap(), sample_id);
     RecordType referencer = RecordType.valueOf("referencer");
     recordDao.createRecordType(
         instanceId,
@@ -248,11 +240,11 @@ class RecordDaoTest {
             .collect(Collectors.toList());
     recordDao.createRecordType(
         instanceId,
-        Collections.emptyMap(),
+        emptyMap(),
         referencedRt,
         new RelationCollection(Collections.emptySet(), Collections.emptySet()),
         RECORD_ID);
-    recordDao.batchUpsert(instanceId, referencedRt, referencedRecords, Collections.emptyMap());
+    recordDao.batchUpsert(instanceId, referencedRt, referencedRecords, emptyMap());
 
     // Create records to do the referencing
     Map<String, DataTypeMapping> schema = Map.of("attr1", ARRAY_OF_RELATION);
@@ -320,12 +312,12 @@ class RecordDaoTest {
         new Record(recordId, recordType, new RecordAttributes(Map.of("relationAttr", reference)));
 
     recordDao.batchUpsert(
-        instanceId, recordType, Collections.singletonList(referencedRecord), new HashMap<>());
+        instanceId, recordType, Collections.singletonList(referencedRecord), emptyMap());
     recordDao.batchUpsert(
         instanceId,
         recordType,
         List.of(referencedRecord, testRecord),
-        new HashMap<>(Map.of("foo", STRING, "relationAttr", RELATION)));
+        Map.of("foo", STRING, "relationAttr", RELATION));
 
     List<Relation> relations = recordDao.getRelationCols(instanceId, recordType);
 
@@ -350,7 +342,7 @@ class RecordDaoTest {
     String recordId = "testRecord";
     Record testRecord = new Record(recordId, recordType, RecordAttributes.empty());
     recordDao.batchUpsert(
-        instanceId, recordType, Collections.singletonList(testRecord), new HashMap<>());
+        instanceId, recordType, Collections.singletonList(testRecord), emptyMap());
 
     Record search = recordDao.getSingleRecord(instanceId, recordType, recordId).get();
     assertEquals(testRecord, search, "Created record should match entered record");
@@ -360,10 +352,7 @@ class RecordDaoTest {
     Record recordWithAttr =
         new Record(attrId, recordType, new RecordAttributes(Map.of("foo", "bar")));
     recordDao.batchUpsert(
-        instanceId,
-        recordType,
-        Collections.singletonList(recordWithAttr),
-        new HashMap<>(Map.of("foo", STRING)));
+        instanceId, recordType, Collections.singletonList(recordWithAttr), Map.of("foo", STRING));
 
     search = recordDao.getSingleRecord(instanceId, recordType, attrId).get();
     assertEquals(
@@ -384,7 +373,7 @@ class RecordDaoTest {
     Record referencedRecord =
         new Record(refRecordId, recordType, new RecordAttributes(Map.of("foo", "bar")));
     recordDao.batchUpsert(
-        instanceId, recordType, Collections.singletonList(referencedRecord), new HashMap<>());
+        instanceId, recordType, Collections.singletonList(referencedRecord), emptyMap());
 
     String recordId = "testRecord";
     String reference =
@@ -396,7 +385,7 @@ class RecordDaoTest {
         instanceId,
         recordType,
         Collections.singletonList(testRecord),
-        new HashMap<>(Map.of("foo", STRING, "testRecordType", RELATION)));
+        Map.of("foo", STRING, "testRecordType", RELATION));
 
     Record search = recordDao.getSingleRecord(instanceId, recordType, recordId).get();
     assertEquals(testRecord, search, "Created record with references should match entered record");
@@ -423,7 +412,7 @@ class RecordDaoTest {
     String recordId = "testRecord";
     Record testRecord = new Record(recordId, recordType, RecordAttributes.empty());
     recordDao.batchUpsert(
-        instanceId, recordType, Collections.singletonList(testRecord), new HashMap<>());
+        instanceId, recordType, Collections.singletonList(testRecord), emptyMap());
 
     recordDao.deleteSingleRecord(instanceId, recordType, "testRecord");
 
@@ -445,7 +434,7 @@ class RecordDaoTest {
     Record referencedRecord =
         new Record(refRecordId, recordType, new RecordAttributes(Map.of("foo", "bar")));
     recordDao.batchUpsert(
-        instanceId, recordType, Collections.singletonList(referencedRecord), new HashMap<>());
+        instanceId, recordType, Collections.singletonList(referencedRecord), emptyMap());
 
     String recordId = "testRecord";
     String reference =
@@ -457,7 +446,7 @@ class RecordDaoTest {
         instanceId,
         recordType,
         Collections.singletonList(testRecord),
-        new HashMap<>(Map.of("foo", STRING, "testRecordType", RELATION)));
+        Map.of("foo", STRING, "testRecordType", RELATION));
 
     // Should throw an error
     assertThrows(
@@ -478,7 +467,7 @@ class RecordDaoTest {
     Record referencedRecord2 =
         new Record(refRecordId2, recordType, new RecordAttributes(Map.of("foo", "bar2")));
     recordDao.batchUpsert(
-        instanceId, recordType, List.of(referencedRecord, referencedRecord2), new HashMap<>());
+        instanceId, recordType, List.of(referencedRecord, referencedRecord2), emptyMap());
 
     // Create record type
     RecordType relationArrayType = RecordType.valueOf("relationArrayType");
@@ -531,7 +520,7 @@ class RecordDaoTest {
     Record referencedRecord2 =
         new Record(refRecordId2, recordType, new RecordAttributes(Map.of("foo", "bar2")));
     recordDao.batchUpsert(
-        instanceId, recordType, List.of(referencedRecord, referencedRecord2), new HashMap<>());
+        instanceId, recordType, List.of(referencedRecord, referencedRecord2), emptyMap());
 
     // Create record type
     RecordType relationArrayType = RecordType.valueOf("relationArrayType");
@@ -586,7 +575,7 @@ class RecordDaoTest {
     RecordType newRecordType = RecordType.valueOf("newRecordType");
     recordDao.createRecordType(
         instanceId,
-        Collections.emptyMap(),
+        emptyMap(),
         newRecordType,
         new RelationCollection(Collections.emptySet(), Collections.emptySet()),
         RECORD_ID);
@@ -628,7 +617,7 @@ class RecordDaoTest {
     for (int i = 0; i < 10; i++) {
       Record testRecord = new Record("record" + i, recordType, RecordAttributes.empty());
       recordDao.batchUpsert(
-          instanceId, recordType, Collections.singletonList(testRecord), new HashMap<>());
+          instanceId, recordType, Collections.singletonList(testRecord), emptyMap());
       assertEquals(
           i + 1,
           recordDao.countRecords(instanceId, recordType),
@@ -644,7 +633,7 @@ class RecordDaoTest {
         instanceId,
         recordType,
         Collections.singletonList(new Record("aRecord", recordType, RecordAttributes.empty())),
-        new HashMap<>());
+        emptyMap());
     assertTrue(recordDao.recordExists(instanceId, recordType, "aRecord"));
   }
 
@@ -664,7 +653,7 @@ class RecordDaoTest {
     RecordType referencedType = RecordType.valueOf("referencedType");
     recordDao.createRecordType(
         instanceId,
-        Collections.emptyMap(),
+        emptyMap(),
         referencedType,
         new RelationCollection(Collections.emptySet(), Collections.emptySet()),
         RECORD_ID);
@@ -674,7 +663,7 @@ class RecordDaoTest {
     String refRecordId = "referencedRecord";
     Record referencedRecord = new Record(refRecordId, referencedType, RecordAttributes.empty());
     recordDao.batchUpsert(
-        instanceId, referencedType, Collections.singletonList(referencedRecord), new HashMap<>());
+        instanceId, referencedType, Collections.singletonList(referencedRecord), emptyMap());
 
     String recordId = "testRecord";
     String reference = RelationUtils.createRelationString(referencedType, refRecordId);
@@ -684,7 +673,7 @@ class RecordDaoTest {
         instanceId,
         recordTypeName,
         Collections.singletonList(testRecord),
-        new HashMap<>(Map.of("relation", RELATION)));
+        Map.of("relation", RELATION));
 
     // Should throw an error
     assertThrows(
@@ -703,7 +692,7 @@ class RecordDaoTest {
     Record referencedRecord2 =
         new Record(refRecordId2, recordType, new RecordAttributes(Map.of("foo", "bar2")));
     recordDao.batchUpsert(
-        instanceId, recordType, List.of(referencedRecord, referencedRecord2), new HashMap<>());
+        instanceId, recordType, List.of(referencedRecord, referencedRecord2), emptyMap());
 
     // Create referencing record type
     RecordType relationArrayType = RecordType.valueOf("relationArrayType");
@@ -996,7 +985,7 @@ class RecordDaoTest {
     RecordType secondRecordType = RecordType.valueOf("secondRecordType");
     recordDao.createRecordType(
         instanceId,
-        Collections.emptyMap(),
+        emptyMap(),
         secondRecordType,
         new RelationCollection(Collections.emptySet(), Collections.emptySet()),
         RECORD_ID);
@@ -1047,7 +1036,7 @@ class RecordDaoTest {
     Record referencedRecord2 =
         new Record(refRecordId2, recordType, new RecordAttributes(Map.of("foo", "bar2")));
     recordDao.batchUpsert(
-        instanceId, recordType, List.of(referencedRecord, referencedRecord2), new HashMap<>());
+        instanceId, recordType, List.of(referencedRecord, referencedRecord2), emptyMap());
 
     // Create record type
     RecordType relationArrayType = RecordType.valueOf("relationArrayType");
@@ -1125,28 +1114,26 @@ class RecordDaoTest {
   void testRemoveFromJoin() {
     // create records to reference in join table
     String fromRecordId = "fromRecord1";
-    Record fromRecord = new Record(fromRecordId, recordType, new RecordAttributes(new HashMap<>()));
+    Record fromRecord = new Record(fromRecordId, recordType, RecordAttributes.empty());
     String fromRecordId2 = "fromRecord2";
-    Record fromRecord2 =
-        new Record(fromRecordId2, recordType, new RecordAttributes(new HashMap<>()));
+    Record fromRecord2 = new Record(fromRecordId2, recordType, RecordAttributes.empty());
     String fromRecordId3 = "fromRecord3";
-    Record fromRecord3 =
-        new Record(fromRecordId3, recordType, new RecordAttributes(new HashMap<>()));
+    Record fromRecord3 = new Record(fromRecordId3, recordType, RecordAttributes.empty());
     recordDao.batchUpsert(
-        instanceId, recordType, List.of(fromRecord, fromRecord2, fromRecord3), new HashMap<>());
+        instanceId, recordType, List.of(fromRecord, fromRecord2, fromRecord3), emptyMap());
 
     RecordType toType = RecordType.valueOf("toType");
     recordDao.createRecordType(
         instanceId,
-        new HashMap<>(),
+        emptyMap(),
         toType,
         new RelationCollection(Collections.emptySet(), Collections.emptySet()),
         RECORD_ID);
     String toRecordId = "toRecord1";
-    Record toRecord = new Record(toRecordId, toType, new RecordAttributes(new HashMap<>()));
+    Record toRecord = new Record(toRecordId, toType, RecordAttributes.empty());
     String toRecordId2 = "toRecord2";
-    Record toRecord2 = new Record(toRecordId2, toType, new RecordAttributes(new HashMap<>()));
-    recordDao.batchUpsert(instanceId, toType, List.of(toRecord, toRecord2), new HashMap<>());
+    Record toRecord2 = new Record(toRecordId2, toType, RecordAttributes.empty());
+    recordDao.batchUpsert(instanceId, toType, List.of(toRecord, toRecord2), emptyMap());
 
     // create join table
     recordDao.createRelationJoinTable(instanceId, "referenceArray", recordType, toType);


### PR DESCRIPTION
This is maintenance cleanup/refactoring: [AJ-1533](https://broadworkbench.atlassian.net/browse/AJ-1533), followup from https://github.com/DataBiosphere/terra-workspace-data-service/pull/476#discussion_r1473077717

Clean up `RecordDaoTest`

* Get rid of unnecessary `new HashMap<>(...)` throughout.
* Prefer `RecordAttributes.empty()` to `new RecordAttributes(Map.of())`.
* Prefer `Collections.emptyMap()` to `Map.of()`.

Note: `Collections.emptyMap()` and `Map.of()` are not equivalent, see: https://stackoverflow.com/questions/46404933/map-of-vs-collections-emptymap

While arguably `Map.of()` is preferred where possible, I think `emptyMap()` is more readable and in tests I think readability matters more unless `Map.of()`'s behavior is explicitly relevant to what's being tested.

[AJ-1533]: https://broadworkbench.atlassian.net/browse/AJ-1533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ