### PR TITLE
AJ-1548: Update custom metrics

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/metrics/MetricsConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/metrics/MetricsConfig.java
@@ -56,7 +56,8 @@ public class MetricsConfig {
             .config()
             .commonTags(
                 new ImmutableList.Builder<Tag>()
-                    .add(Tag.of("wds.version", buildProperties.getVersion()))
+                    .add(Tag.of("service", "wds"))
+                    .add(Tag.of("version", buildProperties.getVersion()))
                     .build());
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordService.java
@@ -5,8 +5,8 @@ import static org.databiosphere.workspacedataservice.service.model.ReservedNames
 import bio.terra.common.db.WriteTransaction;
 import com.google.common.collect.MapDifference;
 import com.google.common.collect.Maps;
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -43,7 +43,7 @@ import org.springframework.web.server.ResponseStatusException;
 @Service
 public class RecordService {
   // strings used for metrics
-  public static final String COUNTER_COL_CHANGE = "column.change.datatype";
+  public static final String METRIC_COL_CHANGE = "wds.column.change.datatype";
   public static final String TAG_RECORD_TYPE = "RecordType";
   public static final String TAG_INSTANCE = "Instance";
   public static final String TAG_ATTRIBUTE_NAME = "AttributeName";
@@ -54,12 +54,13 @@ public class RecordService {
 
   private final DataTypeInferer inferer;
 
-  private final MeterRegistry meterRegistry;
+  private final ObservationRegistry observationRegistry;
 
-  public RecordService(RecordDao recordDao, DataTypeInferer inferer, MeterRegistry meterRegistry) {
+  public RecordService(
+      RecordDao recordDao, DataTypeInferer inferer, ObservationRegistry observationRegistry) {
     this.recordDao = recordDao;
     this.inferer = inferer;
-    this.meterRegistry = meterRegistry;
+    this.observationRegistry = observationRegistry;
   }
 
   public void prepareAndUpsert(
@@ -218,20 +219,17 @@ public class RecordService {
       }
       DataTypeMapping updatedColType =
           inferer.selectBestType(valueDifference.leftValue(), valueDifference.rightValue());
-      recordDao.changeColumn(instanceId, recordType, column, updatedColType);
-      schema.put(column, updatedColType);
 
-      // update a metrics counter with this schema change
-      Counter counter =
-          Counter.builder(COUNTER_COL_CHANGE)
-              .tag(TAG_RECORD_TYPE, recordType.getName())
-              .tag(TAG_ATTRIBUTE_NAME, column)
-              .tag(TAG_INSTANCE, instanceId.toString())
-              .tag(TAG_OLD_DATATYPE, valueDifference.leftValue().toString())
-              .tag(TAG_NEW_DATATYPE, updatedColType.toString())
-              .description("Column schema changes")
-              .register(meterRegistry);
-      counter.increment();
+      // time the schema change and record some high cardinality tracing details
+      Observation.createNotStarted(METRIC_COL_CHANGE, observationRegistry)
+          .lowCardinalityKeyValue(TAG_OLD_DATATYPE, valueDifference.leftValue().toString())
+          .lowCardinalityKeyValue(TAG_NEW_DATATYPE, updatedColType.toString())
+          .highCardinalityKeyValue(TAG_RECORD_TYPE, recordType.getName())
+          .highCardinalityKeyValue(TAG_ATTRIBUTE_NAME, column)
+          .highCardinalityKeyValue(TAG_INSTANCE, instanceId.toString())
+          .observe(() -> recordDao.changeColumn(instanceId, recordType, column, updatedColType));
+
+      schema.put(column, updatedColType);
     }
     return schema;
   }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/metrics/MetricsConfigTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/metrics/MetricsConfigTest.java
@@ -34,8 +34,8 @@ class MetricsConfigTest {
     mockMvc
         .perform(get("/prometheus"))
         .andExpect(status().isOk())
-        .andExpect(
-            content().string(containsString("wds_version=\"%s\"".formatted(expectedVersion))));
+        .andExpect(content().string(containsString("version=\"%s\"".formatted(expectedVersion))))
+        .andExpect(content().string(containsString("service=\"wds\"")));
   }
 
   private static Set<String> allowedPrefixes() {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordServiceTest.java
@@ -1,5 +1,7 @@
 package org.databiosphere.workspacedataservice.service;
 
+import static io.micrometer.observation.tck.TestObservationRegistryAssert.assertThat;
+import static org.databiosphere.workspacedataservice.service.RecordService.METRIC_COL_CHANGE;
 import static org.databiosphere.workspacedataservice.service.RecordService.TAG_ATTRIBUTE_NAME;
 import static org.databiosphere.workspacedataservice.service.RecordService.TAG_INSTANCE;
 import static org.databiosphere.workspacedataservice.service.RecordService.TAG_NEW_DATATYPE;
@@ -8,13 +10,14 @@ import static org.databiosphere.workspacedataservice.service.RecordService.TAG_R
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistry;
 import java.math.BigDecimal;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
+import org.databiosphere.workspacedataservice.observability.TestObservationRegistryConfig;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
 import org.databiosphere.workspacedataservice.shared.model.RecordRequest;
@@ -24,15 +27,19 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles(profiles = {"mock-sam"})
+@Import(TestObservationRegistryConfig.class)
 class RecordServiceTest {
 
   @Autowired DataTypeInferer inferer;
   @Autowired InstanceService instanceService;
   @Autowired RecordDao recordDao;
+  // overridden by TestObservationRegistryConfig with a TestObservationRegistry
+  @Autowired private ObservationRegistry observationRegistry;
 
   private UUID instanceId;
 
@@ -49,13 +56,13 @@ class RecordServiceTest {
 
   @Test
   void schemaChangesIncrementMetricsCounter() {
-    // in-memory meter registry for unit-testing
-    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    TestObservationRegistry testObservationRegistry =
+        assertInstanceOf(TestObservationRegistry.class, observationRegistry);
     // create record service that uses the simple meter registry
-    RecordService recordService = new RecordService(recordDao, inferer, meterRegistry);
+    RecordService recordService = new RecordService(recordDao, inferer, testObservationRegistry);
 
-    // assert the meter registry has no counters yet
-    assertEquals(0, meterRegistry.getMeters().size());
+    // assert the observation registry has no observations
+    assertThat(testObservationRegistry).hasNumberOfObservationsEqualTo(0);
 
     // insert a simple record; this will create "myAttr" as numeric
     RecordType recordType = RecordType.valueOf("myType");
@@ -71,9 +78,9 @@ class RecordServiceTest {
         Map.of("pk", DataTypeMapping.STRING, "myAttr", DataTypeMapping.NUMBER),
         recordDao.getExistingTableSchema(instanceId, recordType));
 
-    // assert the meter registry still has no counters; we only create the counter when altering
-    // a column, and we just created a table but didn't issue any alters
-    assertEquals(0, meterRegistry.getMeters().size());
+    // assert the observation registry still has no counters; we only create an observation when
+    // altering a column, and we just created a table but didn't issue any alters
+    assertThat(testObservationRegistry).hasNumberOfObservationsEqualTo(0);
 
     // insert another record, which will update the "myAttr" to be a string
     recordService.upsertSingleRecord(
@@ -88,17 +95,18 @@ class RecordServiceTest {
         Map.of("pk", DataTypeMapping.STRING, "myAttr", DataTypeMapping.STRING),
         recordDao.getExistingTableSchema(instanceId, recordType));
 
-    // we should have created a counter
-    assertEquals(1, meterRegistry.getMeters().size());
-    // get that counter
-    Counter counter = assertInstanceOf(Counter.class, meterRegistry.getMeters().get(0));
-    // assert the counter has been incremented once
-    assertEquals(1, counter.count());
-    // validate the tags for that counter
-    assertEquals(recordType.getName(), counter.getId().getTag(TAG_RECORD_TYPE));
-    assertEquals("myAttr", counter.getId().getTag(TAG_ATTRIBUTE_NAME));
-    assertEquals(instanceId.toString(), counter.getId().getTag(TAG_INSTANCE));
-    assertEquals(DataTypeMapping.NUMBER.toString(), counter.getId().getTag(TAG_OLD_DATATYPE));
-    assertEquals(DataTypeMapping.STRING.toString(), counter.getId().getTag(TAG_NEW_DATATYPE));
+    // we should have created an observation
+    assertThat(testObservationRegistry)
+        .doesNotHaveAnyRemainingCurrentObservation()
+        .hasNumberOfObservationsWithNameEqualTo(METRIC_COL_CHANGE, 1)
+        .hasObservationWithNameEqualTo(METRIC_COL_CHANGE)
+        .that()
+        .hasLowCardinalityKeyValue(TAG_OLD_DATATYPE, DataTypeMapping.NUMBER.toString())
+        .hasLowCardinalityKeyValue(TAG_NEW_DATATYPE, DataTypeMapping.STRING.toString())
+        .hasHighCardinalityKeyValue(TAG_RECORD_TYPE, recordType.getName())
+        .hasHighCardinalityKeyValue(TAG_ATTRIBUTE_NAME, "myAttr")
+        .hasHighCardinalityKeyValue(TAG_INSTANCE, instanceId.toString())
+        .hasBeenStarted()
+        .hasBeenStopped();
   }
 }


### PR DESCRIPTION
Ticket [AJ-1548](https://broadworkbench.atlassian.net/browse/AJ-1548): Standardize tags for metrics.

* Tags describing generic non-wds specific concepts don't need a `wds` prefix, so we drop the `wds_` prefix from `wds_version`.
* All services should provide a `service` tag.  This allows aggregation and breakdown by service dimensions.
* Custom metrics should be prefixed with `wds`.
* High cardinality labels should be annotated as such to prevent combinatorial explosion.

[AJ-1548]: https://broadworkbench.atlassian.net/browse/AJ-1548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ