### PR TITLE
AJ-1561: Associate import jobs with their containing instance

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresBackupDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresBackupDao.java
@@ -96,6 +96,7 @@ public class PostgresBackupDao extends AbstractBackupRestoreDao<BackupResponse> 
       return new Job<>(
           jobId,
           SYNC_BACKUP,
+          /* instanceId= */ null, // backup jobs do not execute within a single instance
           status,
           errorMessage,
           created,

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresCloneDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresCloneDao.java
@@ -176,6 +176,7 @@ public class PostgresCloneDao implements CloneDao {
       return new Job<>(
           jobId,
           SYNC_CLONE,
+          /* instanceId= */ null, // clone jobs do not execute within a single instance
           status,
           errorMessage,
           created,

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresJobDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresJobDao.java
@@ -56,9 +56,11 @@ public class PostgresJobDao implements JobDao {
     namedTemplate
         .getJdbcTemplate()
         .update(
-            "insert into sys_wds.job(id, type, status, input) " + "values (?, ?, ?, ?::jsonb)",
+            "insert into sys_wds.job(id, type, instance_id, status, input) "
+                + "values (?, ?, ?, ?, ?::jsonb)",
             job.getJobId().toString(),
             job.getJobType().name(),
+            job.getInstanceId().id(),
             StatusEnum.CREATED.name(),
             inputJsonb);
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresRestoreDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresRestoreDao.java
@@ -95,6 +95,7 @@ public class PostgresRestoreDao extends AbstractBackupRestoreDao<RestoreResponse
       return new Job<>(
           jobId,
           SYNC_RESTORE,
+          /* instanceId= */ null, // restore jobs do not execute within a single instance
           status,
           errorMessage,
           created,

--- a/service/src/main/java/org/databiosphere/workspacedataservice/generated/GenericJobServerModel.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/generated/GenericJobServerModel.java
@@ -67,6 +67,8 @@ public class GenericJobServerModel {
 
   private JobTypeEnum jobType;
 
+  private UUID instanceId;
+
   /**
    * Gets or Sets status
    */
@@ -184,6 +186,26 @@ public class GenericJobServerModel {
 
   public void setJobType(JobTypeEnum jobType) {
     this.jobType = jobType;
+  }
+
+  public GenericJobServerModel instanceId(UUID instanceId) {
+    this.instanceId = instanceId;
+    return this;
+  }
+
+  /**
+   * Get instanceId
+   * @return instanceId
+  */
+  @Valid 
+  @Schema(name = "instanceId", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @JsonProperty("instanceId")
+  public UUID getInstanceId() {
+    return instanceId;
+  }
+
+  public void setInstanceId(UUID instanceId) {
+    this.instanceId = instanceId;
   }
 
   public GenericJobServerModel status(StatusEnum status) {
@@ -317,6 +339,7 @@ public class GenericJobServerModel {
     GenericJobServerModel genericJob = (GenericJobServerModel) o;
     return Objects.equals(this.jobId, genericJob.jobId) &&
         Objects.equals(this.jobType, genericJob.jobType) &&
+        Objects.equals(this.instanceId, genericJob.instanceId) &&
         Objects.equals(this.status, genericJob.status) &&
         Objects.equals(this.created, genericJob.created) &&
         Objects.equals(this.updated, genericJob.updated) &&
@@ -327,7 +350,7 @@ public class GenericJobServerModel {
 
   @Override
   public int hashCode() {
-    return Objects.hash(jobId, jobType, status, created, updated, errorMessage, input, result);
+    return Objects.hash(jobId, jobType, instanceId, status, created, updated, errorMessage, input, result);
   }
 
   @Override
@@ -336,6 +359,7 @@ public class GenericJobServerModel {
     sb.append("class GenericJobServerModel {\n");
     sb.append("    jobId: ").append(toIndentedString(jobId)).append("\n");
     sb.append("    jobType: ").append(toIndentedString(jobType)).append("\n");
+    sb.append("    instanceId: ").append(toIndentedString(instanceId)).append("\n");
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
     sb.append("    created: ").append(toIndentedString(created)).append("\n");
     sb.append("    updated: ").append(toIndentedString(updated)).append("\n");

--- a/service/src/main/java/org/databiosphere/workspacedataservice/generated/JobV1ServerModel.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/generated/JobV1ServerModel.java
@@ -66,6 +66,8 @@ public class JobV1ServerModel {
 
   private JobTypeEnum jobType;
 
+  private UUID instanceId;
+
   /**
    * Gets or Sets status
    */
@@ -181,6 +183,26 @@ public class JobV1ServerModel {
     this.jobType = jobType;
   }
 
+  public JobV1ServerModel instanceId(UUID instanceId) {
+    this.instanceId = instanceId;
+    return this;
+  }
+
+  /**
+   * Get instanceId
+   * @return instanceId
+  */
+  @Valid 
+  @Schema(name = "instanceId", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @JsonProperty("instanceId")
+  public UUID getInstanceId() {
+    return instanceId;
+  }
+
+  public void setInstanceId(UUID instanceId) {
+    this.instanceId = instanceId;
+  }
+
   public JobV1ServerModel status(StatusEnum status) {
     this.status = status;
     return this;
@@ -272,6 +294,7 @@ public class JobV1ServerModel {
     JobV1ServerModel jobV1 = (JobV1ServerModel) o;
     return Objects.equals(this.jobId, jobV1.jobId) &&
         Objects.equals(this.jobType, jobV1.jobType) &&
+        Objects.equals(this.instanceId, jobV1.instanceId) &&
         Objects.equals(this.status, jobV1.status) &&
         Objects.equals(this.created, jobV1.created) &&
         Objects.equals(this.updated, jobV1.updated) &&
@@ -280,7 +303,7 @@ public class JobV1ServerModel {
 
   @Override
   public int hashCode() {
-    return Objects.hash(jobId, jobType, status, created, updated, errorMessage);
+    return Objects.hash(jobId, jobType, instanceId, status, created, updated, errorMessage);
   }
 
   @Override
@@ -289,6 +312,7 @@ public class JobV1ServerModel {
     sb.append("class JobV1ServerModel {\n");
     sb.append("    jobId: ").append(toIndentedString(jobId)).append("\n");
     sb.append("    jobType: ").append(toIndentedString(jobType)).append("\n");
+    sb.append("    instanceId: ").append(toIndentedString(instanceId)).append("\n");
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
     sb.append("    created: ").append(toIndentedString(created)).append("\n");
     sb.append("    updated: ").append(toIndentedString(updated)).append("\n");

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
@@ -17,6 +17,7 @@ import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
 import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
 import org.databiosphere.workspacedataservice.sam.SamDao;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthorizationException;
+import org.databiosphere.workspacedataservice.shared.model.InstanceId;
 import org.databiosphere.workspacedataservice.shared.model.Schedulable;
 import org.databiosphere.workspacedataservice.shared.model.job.Job;
 import org.databiosphere.workspacedataservice.shared.model.job.JobInput;
@@ -62,7 +63,8 @@ public class ImportService {
     logger.debug("Data import of type {} requested", importRequest.getType());
 
     ImportJobInput importJobInput = ImportJobInput.from(importRequest);
-    Job<JobInput, JobResult> job = Job.newJob(JobType.DATA_IMPORT, importJobInput);
+    Job<JobInput, JobResult> job =
+        Job.newJob(InstanceId.of(instanceUuid), JobType.DATA_IMPORT, importJobInput);
 
     // persist the full job to WDS's db
     GenericJobServerModel createdJob = jobDao.createJob(job);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/InstanceId.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/InstanceId.java
@@ -10,6 +10,13 @@ import java.util.UUID;
  */
 public record InstanceId(UUID id) {
 
+  // disallow nulls
+  public InstanceId {
+    if (id == null) {
+      throw new IllegalArgumentException("Id cannot be null");
+    }
+  }
+
   /**
    * Create a new InstanceId using the given id
    *
@@ -22,6 +29,6 @@ public record InstanceId(UUID id) {
 
   @Override
   public String toString() {
-    return this.id() == null ? "null" : this.id().toString();
+    return this.id().toString();
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/InstanceId.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/InstanceId.java
@@ -1,0 +1,27 @@
+package org.databiosphere.workspacedataservice.shared.model;
+
+import java.util.UUID;
+
+/**
+ * Model to represent an instance id, which currently is a UUID. Since we use UUIDs throughout our
+ * code for multiple use cases, this wrapper class exists to help disambiguate between those UUIDs.
+ *
+ * @param id the instance's id
+ */
+public record InstanceId(UUID id) {
+
+  /**
+   * Create a new InstanceId using the given id
+   *
+   * @param id the instance's id
+   * @return new InstanceId
+   */
+  public static InstanceId of(UUID id) {
+    return new InstanceId(id);
+  }
+
+  @Override
+  public String toString() {
+    return this.id() == null ? "null" : this.id().toString();
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/job/Job.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/job/Job.java
@@ -3,6 +3,7 @@ package org.databiosphere.workspacedataservice.shared.model.job;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.time.LocalDateTime;
 import java.util.UUID;
+import org.databiosphere.workspacedataservice.shared.model.InstanceId;
 
 /**
  * Represents a long-running, probably asynchronous, process which moves through multiple states
@@ -20,6 +21,9 @@ public class Job<T extends JobInput, U extends JobResult> {
 
   /** type of this job, e.g. PFB import vs. database backup; {@link JobType} */
   private final JobType jobType;
+
+  /** Instance in which this job ran */
+  private final InstanceId instanceId;
 
   /** status of the job; {@link JobStatus} */
   private JobStatus status;
@@ -52,6 +56,7 @@ public class Job<T extends JobInput, U extends JobResult> {
   public Job(
       UUID jobId,
       JobType jobType,
+      InstanceId instanceId,
       JobStatus status,
       String errorMessage,
       LocalDateTime created,
@@ -60,6 +65,7 @@ public class Job<T extends JobInput, U extends JobResult> {
       U result) {
     this.jobId = jobId;
     this.jobType = jobType;
+    this.instanceId = instanceId;
     this.status = status;
     this.errorMessage = errorMessage;
     this.created = created;
@@ -76,11 +82,13 @@ public class Job<T extends JobInput, U extends JobResult> {
    * @param input input arguments for the job
    * @return the job, after creation
    */
-  public static Job<JobInput, JobResult> newJob(JobType jobType, JobInput input) {
+  public static Job<JobInput, JobResult> newJob(
+      InstanceId instanceId, JobType jobType, JobInput input) {
     LocalDateTime now = LocalDateTime.now();
     return new Job<>(
         UUID.randomUUID(),
         jobType,
+        instanceId,
         JobStatus.CREATED,
         /* errorMessage= */ null,
         /* created= */ now,
@@ -105,6 +113,10 @@ public class Job<T extends JobInput, U extends JobResult> {
 
   public JobType getJobType() {
     return jobType;
+  }
+
+  public InstanceId getInstanceId() {
+    return instanceId;
   }
 
   public String getErrorMessage() {

--- a/service/src/main/resources/liquibase/changelog.yaml
+++ b/service/src/main/resources/liquibase/changelog.yaml
@@ -26,3 +26,6 @@ databaseChangeLog:
   - include:
       file: changesets/20240118_number_timestamp_array_conversions.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/20240131_add_instance_to_job.yaml
+      relativeToChangelogFile: true

--- a/service/src/main/resources/liquibase/changesets/20240131_add_instance_to_job.yaml
+++ b/service/src/main/resources/liquibase/changesets/20240131_add_instance_to_job.yaml
@@ -1,0 +1,19 @@
+databaseChangeLog:
+  - changeSet:
+      id: 20240131_add_instance_to_job
+      author: davidan
+      changes:
+        - addColumn:
+            schemaName: sys_wds
+            tableName: job
+            columns:
+              - column:
+                  name: instance_id
+                  type: uuid
+                  # this is not a foreign key to the instance table, to support the ability to
+                  # delete instances without deleting job history, and to support "implicit"
+                  # instances in cWDS
+                  constraints:
+                    # nullable for backwards compatibility; jobs that have already run
+                    # will have no instance_id
+                    nullable: true

--- a/service/src/main/resources/static/swagger/apis-v1.yaml
+++ b/service/src/main/resources/static/swagger/apis-v1.yaml
@@ -172,6 +172,9 @@ components:
         jobType:
           type: string
           enum: [ DATA_IMPORT, UNKNOWN ]
+        instanceId:
+          type: string
+          format: uuid
         status:
           type: string
           enum: [ CREATED, QUEUED, RUNNING, SUCCEEDED, ERROR, CANCELLED, UNKNOWN ]

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/MockBackupRestoreDao.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/MockBackupRestoreDao.java
@@ -46,6 +46,7 @@ public class MockBackupRestoreDao<T extends JobResult> implements BackupRestoreD
           new Job<>(
               trackingId,
               SYNC_BACKUP,
+              /* instanceId= */ null, // backup jobs do not execute within a single instance
               JobStatus.QUEUED,
               "",
               now.toLocalDateTime(),
@@ -59,6 +60,7 @@ public class MockBackupRestoreDao<T extends JobResult> implements BackupRestoreD
           new Job<>(
               trackingId,
               SYNC_RESTORE,
+              /* instanceId= */ null, // restore jobs do not execute within a single instance
               JobStatus.QUEUED,
               "",
               now.toLocalDateTime(),

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/MockCloneDao.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/MockCloneDao.java
@@ -37,7 +37,15 @@ public class MockCloneDao implements CloneDao {
     var cloneEntry = new CloneResponse(sourceWorkspaceId, CloneStatus.BACKUPQUEUED);
     Job<JobInput, CloneResponse> jobEntry =
         new Job<>(
-            trackingId, SYNC_CLONE, JobStatus.QUEUED, "", now, now, JobInput.empty(), cloneEntry);
+            trackingId,
+            SYNC_CLONE,
+            /* instanceId= */ null, // backup jobs do not execute within a single instance
+            JobStatus.QUEUED,
+            "",
+            now,
+            now,
+            JobInput.empty(),
+            cloneEntry);
     clone.add(jobEntry);
   }
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/InstanceIdTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/InstanceIdTest.java
@@ -1,0 +1,37 @@
+package org.databiosphere.workspacedataservice.shared.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class InstanceIdTest {
+
+  @Test
+  void disallowNulls() {
+    assertThrows(IllegalArgumentException.class, () -> InstanceId.of(null));
+  }
+
+  @Test
+  void disallowNullsStaticConstructor() {
+    assertThrows(IllegalArgumentException.class, () -> new InstanceId(null));
+  }
+
+  // does .toString() work just like UUID.toString()?
+  @Test
+  void ValidIdToString() {
+    UUID validId = UUID.randomUUID();
+    assertEquals(validId.toString(), InstanceId.of(validId).toString());
+  }
+
+  // does the InstanceId.of() static constructor work just like the standard constructor?
+  @Test
+  void ofConstructor() {
+    UUID validId = UUID.randomUUID();
+    InstanceId constructed = new InstanceId(validId);
+    InstanceId madeViaOf = InstanceId.of(validId);
+    assertEquals(constructed.id(), madeViaOf.id());
+    assertEquals(constructed, madeViaOf);
+  }
+}


### PR DESCRIPTION
* Add an `instance_id` column to the `sys_wds.job` table
* When saving an async job to the `sys_wds.job` table, persist the instance id to the new `instance_id` column
* Add `instanceId` to the `JobV1` model in swagger and our clients. Since this is additive, and not required, it should be a non-breaking change. Please check my assumption here!
* Add a new `InstanceId` model class which wraps UUID. How do folks feel about this? I think it could be good to start using this in more places - as well as add `WorkspaceId` and `JobId` classes