### PR TITLE
Use `{to,from}Json` in MVC tests.

### DIFF
--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/CapabilitiesControllerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/CapabilitiesControllerTest.java
@@ -5,24 +5,15 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.databiosphere.workspacedataservice.generated.CapabilitiesServerModel;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.io.Resource;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 @DirtiesContext
-@SpringBootTest
-@AutoConfigureMockMvc
-class CapabilitiesControllerTest {
-  @Autowired MockMvc mockMvc;
-  @Autowired ObjectMapper objectMapper;
+class CapabilitiesControllerTest extends MockMvcTestBase {
 
   @Value("classpath:capabilities.json")
   Resource capabilitiesResource;
@@ -30,9 +21,7 @@ class CapabilitiesControllerTest {
   @Test
   void resourceFileIsValid() {
     assertDoesNotThrow(
-        () ->
-            objectMapper.readValue(
-                capabilitiesResource.getInputStream(), CapabilitiesServerModel.class),
+        () -> fromJson(capabilitiesResource.getInputStream(), CapabilitiesServerModel.class),
         "Have you modified capabilities.json? Is it still valid JSON?");
   }
 
@@ -41,12 +30,9 @@ class CapabilitiesControllerTest {
     MvcResult mvcResult =
         mockMvc.perform(get("/capabilities/v1")).andExpect(status().isOk()).andReturn();
 
-    String rawResponse = mvcResult.getResponse().getContentAsString();
-
     // is the response parsable into the capabilities model?
     CapabilitiesServerModel actual =
-        assertDoesNotThrow(
-            () -> objectMapper.readValue(rawResponse, CapabilitiesServerModel.class));
+        assertDoesNotThrow(() -> fromJson(mvcResult, CapabilitiesServerModel.class));
     // is the response non-empty?
     assertThat(actual).isNotEmpty();
   }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/CorsLiveMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/CorsLiveMockMvcTest.java
@@ -7,11 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.util.UUID;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 /**
@@ -22,12 +18,7 @@ import org.springframework.test.web.servlet.MvcResult;
  * <p>See also CorsLocalMockMvcTest for testing CORS behavior in the "local" Spring profile
  */
 @DirtiesContext
-@SpringBootTest
-@AutoConfigureMockMvc
-class CorsLiveMockMvcTest {
-
-  @Autowired MockMvc mockMvc;
-
+class CorsLiveMockMvcTest extends MockMvcTestBase {
   private static final String versionId = "v0.2";
 
   @ParameterizedTest(name = "CORS response headers for non-local profile to {0} should be correct")

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/CorsLocalMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/CorsLocalMockMvcTest.java
@@ -8,12 +8,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.util.UUID;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 /**
@@ -25,12 +21,7 @@ import org.springframework.test.web.servlet.MvcResult;
  */
 @ActiveProfiles(profiles = {"local-cors"})
 @DirtiesContext
-@SpringBootTest
-@AutoConfigureMockMvc
-class CorsLocalMockMvcTest {
-
-  @Autowired MockMvc mockMvc;
-
+class CorsLocalMockMvcTest extends MockMvcTestBase {
   private static final String versionId = "v0.2";
 
   @ParameterizedTest(name = "CORS response headers for the local profile {0} should be correct")

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/ImportControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/ImportControllerMockMvcTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.net.URI;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.dao.InstanceDao;
@@ -12,22 +11,15 @@ import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
 import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 @ActiveProfiles(profiles = {"mock-instance-dao", "mock-sam"})
 @DirtiesContext
-@SpringBootTest
-@AutoConfigureMockMvc
-class ImportControllerMockMvcTest {
+class ImportControllerMockMvcTest extends MockMvcTestBase {
 
-  @Autowired private MockMvc mockMvc;
-  @Autowired private ObjectMapper mapper;
   @Autowired private InstanceDao instanceDao;
 
   @Test
@@ -37,22 +29,18 @@ class ImportControllerMockMvcTest {
     ImportRequestServerModel importRequest =
         new ImportRequestServerModel(
             ImportRequestServerModel.TypeEnum.PFB, new URI("https://terra.bio"));
-    String postBody = mapper.writeValueAsString(importRequest);
 
     // calling the API should result in 201 Created
     MvcResult mvcResult =
         mockMvc
             .perform(
                 post("/{instanceUuid}/import/v1", instanceId)
-                    .content(postBody)
+                    .content(toJson(importRequest))
                     .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isAccepted())
             .andReturn();
 
     // and the API response should be a valid GenericJobServerModel
-    assertDoesNotThrow(
-        () ->
-            mapper.readValue(
-                mvcResult.getResponse().getContentAsString(), GenericJobServerModel.class));
+    assertDoesNotThrow(() -> fromJson(mvcResult, GenericJobServerModel.class));
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/JobControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/JobControllerMockMvcTest.java
@@ -5,29 +5,20 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 @ActiveProfiles(profiles = {"mock-sam"})
 @DirtiesContext
-@SpringBootTest
-@AutoConfigureMockMvc
-class JobControllerMockMvcTest {
-  @Autowired private MockMvc mockMvc;
-  @Autowired private ObjectMapper mapper;
+class JobControllerMockMvcTest extends MockMvcTestBase {
   @MockBean private JobDao jobDao;
 
   @Test
@@ -52,8 +43,7 @@ class JobControllerMockMvcTest {
             .andReturn();
 
     // and the API response should be a valid GenericJobServerModel
-    GenericJobServerModel actual =
-        mapper.readValue(mvcResult.getResponse().getContentAsString(), GenericJobServerModel.class);
+    GenericJobServerModel actual = fromJson(mvcResult, GenericJobServerModel.class);
 
     // which is equal to the expected job
     assertEquals(expected, actual);

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/MockMvcTestBase.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/MockMvcTestBase.java
@@ -1,0 +1,32 @@
+package org.databiosphere.workspacedataservice.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@AutoConfigureMockMvc
+@SpringBootTest
+class MockMvcTestBase {
+  @Autowired private ObjectMapper mapper;
+  @Autowired protected MockMvc mockMvc;
+
+  protected String toJson(Object value) throws JsonProcessingException {
+    return mapper.writeValueAsString(value);
+  }
+
+  protected <T> T fromJson(MvcResult result, Class<T> valueType)
+      throws UnsupportedEncodingException, JsonProcessingException {
+    return mapper.readValue(result.getResponse().getContentAsString(), valueType);
+  }
+
+  protected <T> T fromJson(InputStream inputStream, Class<T> valueType) throws IOException {
+    return mapper.readValue(inputStream, valueType);
+  }
+}


### PR DESCRIPTION
Use `{to,from}Json` in MVC tests.

This shorthand intends to eliminate some of the clumsy and repetitive interaction with `ObjectMapper` and `MvcResult`.

Context:  https://github.com/DataBiosphere/terra-workspace-data-service/pull/479#discussion_r1476545183

This is opportunistic maintenance / refactoring to test code only: [AJ-1533](https://broadworkbench.atlassian.net/browse/AJ-1533)

[AJ-1533]: https://broadworkbench.atlassian.net/browse/AJ-1533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ