### PR TITLE
AJ-1591: no-db solution for instance-to-workspace association

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/InstanceService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/InstanceService.java
@@ -9,8 +9,11 @@ import org.databiosphere.workspacedataservice.dao.InstanceDao;
 import org.databiosphere.workspacedataservice.sam.SamDao;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthorizationException;
 import org.databiosphere.workspacedataservice.service.model.exception.MissingObjectException;
+import org.databiosphere.workspacedataservice.shared.model.InstanceId;
+import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
@@ -22,12 +25,31 @@ public class InstanceService {
   private final SamDao samDao;
   private final ActivityLogger activityLogger;
 
+  private final WorkspaceId workspaceId;
+
   private static final Logger LOGGER = LoggerFactory.getLogger(InstanceService.class);
 
-  public InstanceService(InstanceDao instanceDao, SamDao samDao, ActivityLogger activityLogger) {
+  public InstanceService(
+      InstanceDao instanceDao,
+      SamDao samDao,
+      ActivityLogger activityLogger,
+      @Value("${twds.instance.workspace-id:}") String workspaceIdProperty) {
     this.instanceDao = instanceDao;
     this.samDao = samDao;
     this.activityLogger = activityLogger;
+    // jump through a few hoops to initialize workspaceId to ensure validity.
+    // workspaceId will be null if the WORKSPACE_ID env var is unset/not a valid UUID.
+    UUID workspaceUuid = null;
+    try {
+      workspaceUuid = UUID.fromString(workspaceIdProperty);
+    } catch (Exception e) {
+      LOGGER.warn("WORKSPACE_ID could not be parsed into a UUID: {}", workspaceIdProperty);
+    }
+    if (workspaceUuid == null) {
+      workspaceId = null;
+    } else {
+      workspaceId = WorkspaceId.of(workspaceUuid);
+    }
   }
 
   public List<UUID> listInstances(String version) {
@@ -89,5 +111,26 @@ public class InstanceService {
     if (!instanceDao.instanceSchemaExists(instanceId)) {
       throw new MissingObjectException("Instance");
     }
+  }
+
+  /**
+   * Return the workspace that contains the specified instance. The logic for this method is:
+   *
+   * <p>- if the WORKSPACE_ID env var is set, return its value. This will be true for all data plane
+   * WDSes, as long as WDS is deployed per-workspace.
+   *
+   * <p>- else, return the InstanceId value as the WorkspaceId. This perpetuates the assumption that
+   * instance and workspace ids are the same. But, this will be true in the GCP control plane as
+   * long as Rawls continues to manage data tables, since "instance" is a WDS concept and does not
+   * exist in Rawls.
+   *
+   * @param instanceId the instance for which to look up the workspace
+   * @return the workspace containing the given instance.
+   */
+  public WorkspaceId getWorkspaceId(InstanceId instanceId) {
+    if (workspaceId == null) {
+      return WorkspaceId.of(instanceId.id());
+    }
+    return workspaceId;
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/InstanceService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/InstanceService.java
@@ -3,6 +3,7 @@ package org.databiosphere.workspacedataservice.service;
 import static org.databiosphere.workspacedataservice.service.RecordUtils.validateVersion;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
 import org.databiosphere.workspacedataservice.dao.InstanceDao;
@@ -128,9 +129,6 @@ public class InstanceService {
    * @return the workspace containing the given instance.
    */
   public WorkspaceId getWorkspaceId(InstanceId instanceId) {
-    if (workspaceId == null) {
-      return WorkspaceId.of(instanceId.id());
-    }
-    return workspaceId;
+    return Objects.requireNonNullElseGet(workspaceId, () -> WorkspaceId.of(instanceId.id()));
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/InstanceId.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/InstanceId.java
@@ -27,6 +27,16 @@ public record InstanceId(UUID id) {
     return new InstanceId(id);
   }
 
+  /**
+   * Create a new InstanceId using the given id
+   *
+   * @param id the instance's id
+   * @return new InstanceId
+   */
+  public static InstanceId fromString(String id) {
+    return InstanceId.of(UUID.fromString(id));
+  }
+
   @Override
   public String toString() {
     return this.id().toString();

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/WorkspaceId.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/WorkspaceId.java
@@ -1,0 +1,41 @@
+package org.databiosphere.workspacedataservice.shared.model;
+
+import java.util.UUID;
+
+/**
+ * Model to represent a workspace id, which currently is a UUID. Since we use UUIDs throughout our
+ * code for multiple use cases, this wrapper class exists to help disambiguate between those UUIDs.
+ *
+ * @param id the workspace's id
+ */
+public record WorkspaceId(UUID id) {
+
+  // disallow nulls
+  public WorkspaceId {
+    if (id == null) {
+      throw new IllegalArgumentException("Id cannot be null");
+    }
+  }
+
+  /**
+   * Create a new WorkspaceId using the given id
+   *
+   * @param id the workspace's id
+   * @return new WorkspaceId
+   */
+  public static WorkspaceId of(UUID id) {
+    return new WorkspaceId(id);
+  }
+
+  /**
+   * Create a new WorkspaceId using the given id
+   *
+   * @par public static WorkspaceId fromString(String id) { return
+   *     WorkspaceId.of(UUID.fromString(id)); }am id the workspace's id
+   * @return new WorkspaceId
+   */
+  @Override
+  public String toString() {
+    return this.id().toString();
+  }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceNoPermissionSamTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceNoPermissionSamTest.java
@@ -9,16 +9,13 @@ import java.util.List;
 import java.util.UUID;
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
 import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
-import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
 import org.databiosphere.workspacedataservice.activitylog.ActivityLoggerConfig;
 import org.databiosphere.workspacedataservice.dao.InstanceDao;
 import org.databiosphere.workspacedataservice.dao.MockInstanceDaoConfig;
 import org.databiosphere.workspacedataservice.retry.RestClientRetry;
 import org.databiosphere.workspacedataservice.sam.SamClientFactory;
 import org.databiosphere.workspacedataservice.sam.SamConfig;
-import org.databiosphere.workspacedataservice.sam.SamDao;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthorizationException;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.mockito.Mockito;
@@ -40,11 +37,9 @@ import org.springframework.test.context.ActiveProfiles;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class InstanceServiceNoPermissionSamTest {
 
-  private InstanceService instanceService;
+  @Autowired private InstanceService instanceService;
 
   @Autowired private InstanceDao instanceDao;
-  @Autowired private SamDao samDao;
-  @Autowired private ActivityLogger activityLogger;
 
   // mock for the SamClientFactory; since this is a Spring bean we can use @MockBean
   @MockBean SamClientFactory mockSamClientFactory;
@@ -52,11 +47,6 @@ class InstanceServiceNoPermissionSamTest {
   // mock for the ResourcesApi class inside the Sam client; since this is not a Spring bean we have
   // to mock it manually
   final ResourcesApi mockResourcesApi = Mockito.mock(ResourcesApi.class);
-
-  @BeforeEach
-  void setUp() {
-    instanceService = new InstanceService(instanceDao, samDao, activityLogger);
-  }
 
   @Test
   void testCreateInstanceNoPermission() throws ApiException {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceNoPermissionSamTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceNoPermissionSamTest.java
@@ -9,12 +9,8 @@ import java.util.List;
 import java.util.UUID;
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
 import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
-import org.databiosphere.workspacedataservice.activitylog.ActivityLoggerConfig;
 import org.databiosphere.workspacedataservice.dao.InstanceDao;
-import org.databiosphere.workspacedataservice.dao.MockInstanceDaoConfig;
-import org.databiosphere.workspacedataservice.retry.RestClientRetry;
 import org.databiosphere.workspacedataservice.sam.SamClientFactory;
-import org.databiosphere.workspacedataservice.sam.SamConfig;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthorizationException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -27,13 +23,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles(profiles = "mock-instance-dao")
 @DirtiesContext
-@SpringBootTest(
-    classes = {
-      MockInstanceDaoConfig.class,
-      SamConfig.class,
-      ActivityLoggerConfig.class,
-      RestClientRetry.class
-    })
+@SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class InstanceServiceNoPermissionSamTest {
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceNoWorkspaceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceNoWorkspaceTest.java
@@ -1,0 +1,39 @@
+package org.databiosphere.workspacedataservice.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.UUID;
+import org.databiosphere.workspacedataservice.shared.model.InstanceId;
+import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+
+@DirtiesContext
+@SpringBootTest
+@TestPropertySource(properties = {"twds.instance.workspace-id="})
+class InstanceServiceNoWorkspaceTest {
+
+  @Autowired private InstanceService instanceService;
+
+  @Value("${twds.instance.workspace-id:}")
+  private String workspaceIdProperty;
+
+  @Test
+  void assumptions() {
+    // ensure the test is set up correctly, with an empty twds.instance.workspace-id property
+    assertThat(workspaceIdProperty).isEmpty();
+  }
+
+  // when twds.instance.workspace-id is empty, instanceService.getWorkspaceId will echo the
+  // instanceid back as the workspace id
+  @Test
+  void getWorkspaceId() {
+    InstanceId instanceId = InstanceId.of(UUID.randomUUID());
+    assertEquals(WorkspaceId.of(instanceId.id()), instanceService.getWorkspaceId(instanceId));
+  }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamExceptionTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamExceptionTest.java
@@ -13,12 +13,8 @@ import java.util.UUID;
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
 import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
 import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
-import org.databiosphere.workspacedataservice.activitylog.ActivityLoggerConfig;
 import org.databiosphere.workspacedataservice.dao.InstanceDao;
-import org.databiosphere.workspacedataservice.dao.MockInstanceDaoConfig;
-import org.databiosphere.workspacedataservice.retry.RestClientRetry;
 import org.databiosphere.workspacedataservice.sam.SamClientFactory;
-import org.databiosphere.workspacedataservice.sam.SamConfig;
 import org.databiosphere.workspacedataservice.sam.SamDao;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthenticationException;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthorizationException;
@@ -55,13 +51,7 @@ import org.springframework.test.context.TestPropertySource;
  */
 @ActiveProfiles(profiles = "mock-instance-dao")
 @DirtiesContext
-@SpringBootTest(
-    classes = {
-      MockInstanceDaoConfig.class,
-      SamConfig.class,
-      ActivityLoggerConfig.class,
-      RestClientRetry.class
-    })
+@SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestPropertySource(
     properties = {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamExceptionTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamExceptionTest.java
@@ -69,7 +69,7 @@ import org.springframework.test.context.TestPropertySource;
     }) // example uuid from https://en.wikipedia.org/wiki/Universally_unique_identifier
 class InstanceServiceSamExceptionTest {
 
-  private InstanceService instanceService;
+  @Autowired private InstanceService instanceService;
 
   @Autowired private InstanceDao instanceDao;
   @Autowired private SamDao samDao;
@@ -87,8 +87,6 @@ class InstanceServiceSamExceptionTest {
 
   @BeforeEach
   void setUp() {
-    instanceService = new InstanceService(instanceDao, samDao, activityLogger);
-
     // return the mock ResourcesApi from the mock SamClientFactory
     given(mockSamClientFactory.getResourcesApi(null)).willReturn(mockResourcesApi);
   }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamTest.java
@@ -45,7 +45,7 @@ import org.springframework.test.context.TestPropertySource;
     }) // example uuid from https://en.wikipedia.org/wiki/Universally_unique_identifier
 class InstanceServiceSamTest {
 
-  private InstanceService instanceService;
+  @Autowired private InstanceService instanceService;
 
   @Autowired private InstanceDao instanceDao;
   @Autowired private SamDao samDao;
@@ -63,8 +63,6 @@ class InstanceServiceSamTest {
 
   @BeforeEach
   void setUp() throws ApiException {
-    instanceService = new InstanceService(instanceDao, samDao, activityLogger);
-
     // return the mock ResourcesApi from the mock SamClientFactory
     given(mockSamClientFactory.getResourcesApi(null)).willReturn(mockResourcesApi);
     // Sam permission check will always return true

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceSamTest.java
@@ -9,12 +9,8 @@ import org.broadinstitute.dsde.workbench.client.sam.ApiException;
 import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
 import org.broadinstitute.dsde.workbench.client.sam.model.CreateResourceRequestV2;
 import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
-import org.databiosphere.workspacedataservice.activitylog.ActivityLoggerConfig;
 import org.databiosphere.workspacedataservice.dao.InstanceDao;
-import org.databiosphere.workspacedataservice.dao.MockInstanceDaoConfig;
-import org.databiosphere.workspacedataservice.retry.RestClientRetry;
 import org.databiosphere.workspacedataservice.sam.SamClientFactory;
-import org.databiosphere.workspacedataservice.sam.SamConfig;
 import org.databiosphere.workspacedataservice.sam.SamDao;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,13 +27,7 @@ import org.springframework.test.context.TestPropertySource;
 
 @ActiveProfiles(profiles = "mock-instance-dao")
 @DirtiesContext
-@SpringBootTest(
-    classes = {
-      MockInstanceDaoConfig.class,
-      SamConfig.class,
-      ActivityLoggerConfig.class,
-      RestClientRetry.class
-    })
+@SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestPropertySource(
     properties = {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/InstanceServiceTest.java
@@ -6,19 +6,18 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 import java.util.UUID;
-import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
 import org.databiosphere.workspacedataservice.activitylog.ActivityLoggerConfig;
 import org.databiosphere.workspacedataservice.dao.InstanceDao;
 import org.databiosphere.workspacedataservice.dao.MockInstanceDaoConfig;
 import org.databiosphere.workspacedataservice.retry.RestClientRetry;
 import org.databiosphere.workspacedataservice.sam.MockSamClientFactoryConfig;
 import org.databiosphere.workspacedataservice.sam.SamConfig;
-import org.databiosphere.workspacedataservice.sam.SamDao;
 import org.databiosphere.workspacedataservice.service.model.exception.MissingObjectException;
+import org.databiosphere.workspacedataservice.shared.model.InstanceId;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
@@ -27,6 +26,7 @@ import org.springframework.test.context.ActiveProfiles;
 @DirtiesContext
 @SpringBootTest(
     classes = {
+      InstanceService.class,
       MockInstanceDaoConfig.class,
       SamConfig.class,
       MockSamClientFactoryConfig.class,
@@ -35,17 +35,13 @@ import org.springframework.test.context.ActiveProfiles;
     })
 class InstanceServiceTest {
 
-  private InstanceService instanceService;
+  @Autowired private InstanceService instanceService;
   @Autowired private InstanceDao instanceDao;
-  @Autowired private SamDao samDao;
-  @Autowired private ActivityLogger activityLogger;
+
+  @Value("${twds.instance.workspace-id:}")
+  private String workspaceIdProperty;
 
   private static final UUID INSTANCE = UUID.fromString("111e9999-e89b-12d3-a456-426614174000");
-
-  @BeforeEach
-  void setUp() {
-    instanceService = new InstanceService(instanceDao, samDao, activityLogger);
-  }
 
   @AfterEach
   void tearDown() {
@@ -95,5 +91,12 @@ class InstanceServiceTest {
         MissingObjectException.class,
         () -> instanceService.validateInstance(INSTANCE),
         "validateInstance should have thrown an error");
+  }
+
+  @Test
+  void getWorkspaceId() {
+    assertEquals(
+        workspaceIdProperty,
+        instanceService.getWorkspaceId(InstanceId.of(UUID.randomUUID())).toString());
   }
 }


### PR DESCRIPTION
Create a new method - `InstanceService.getWorkspaceId()` - which returns the proper workspace to use when authenticating to an instance. As compared to https://github.com/DataBiosphere/terra-workspace-data-service/pull/489, this PR makes no changes to the db. Instead, it relies heavily on assumptions which are _currently_ safe:
* in Azure, we deploy WDS per-workspace and set a `$WORKSPACE_ID` value for each deployment
* in the upcoming cWDS, since data tables will continue to be powered by Rawls, we can assume `instanceId=workspaceId`.

I really want to break that last assumption, but I don't want to break it at the expense of convoluted code which could incur bugs. So, here's a simple solution.