### PR TITLE
[AJ-1279] Support converting between string and file data types

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -104,6 +104,7 @@ public class RecordDao {
           Set.of(DataTypeMapping.STRING, DataTypeMapping.BOOLEAN),
           Set.of(DataTypeMapping.STRING, DataTypeMapping.DATE),
           Set.of(DataTypeMapping.STRING, DataTypeMapping.DATE_TIME),
+          Set.of(DataTypeMapping.STRING, DataTypeMapping.FILE),
           Set.of(DataTypeMapping.NUMBER, DataTypeMapping.BOOLEAN),
           Set.of(DataTypeMapping.NUMBER, DataTypeMapping.DATE),
           Set.of(DataTypeMapping.NUMBER, DataTypeMapping.DATE_TIME),
@@ -1159,6 +1160,16 @@ public class RecordDao {
         if (dataType.getBaseType() == DataTypeMapping.DATE) {
           expression += "::bigint";
         }
+      }
+    }
+
+    // Validate URLs when converting strings to files.
+    if (dataType.getBaseType().equals(DataTypeMapping.STRING)
+        && newDataType.getBaseType().equals(DataTypeMapping.FILE)) {
+      if (dataType.isArrayType()) {
+        expression = "sys_wds.validate_file_urls(" + expression + ")";
+      } else {
+        expression = "sys_wds.validate_file_url(" + expression + ")";
       }
     }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/DataTypeInferer.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/DataTypeInferer.java
@@ -308,6 +308,7 @@ public class DataTypeInferer {
     }
   }
 
+  /** Changes to this function should also be reflected in the sys_wds.is_file_url SQL function. */
   private boolean isFileType(String possibleFile) {
     URI fileUri;
     try {

--- a/service/src/main/resources/liquibase/changelog.yaml
+++ b/service/src/main/resources/liquibase/changelog.yaml
@@ -29,3 +29,6 @@ databaseChangeLog:
   - include:
       file: changesets/20240131_add_instance_to_job.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/20240205_string_to_file_conversions.yaml
+      relativeToChangelogFile: true

--- a/service/src/main/resources/liquibase/changesets/20240205_string_to_file_conversions.yaml
+++ b/service/src/main/resources/liquibase/changesets/20240205_string_to_file_conversions.yaml
@@ -1,0 +1,60 @@
+databaseChangeLog:
+  - changeSet:
+      id:  20240205_string_to_file_conversions
+      author:  nwatts
+      changes:
+        - sql:
+            dbms:  postgresql
+            splitStatements: false
+            sql:  |
+              create or replace function sys_wds.parse_token(str text, token_alias text) returns text as $$
+              begin
+                return token from ts_parse('default', str) natural join ts_token_type('default') tokens where tokens.alias = token_alias;
+              end
+              $$ language plpgsql immutable;
+        - sql:
+            dbms: postgresql
+            splitStatements: false
+            sql: |
+              create or replace function sys_wds.is_file_url(str text) returns boolean as $$
+              declare
+                protocol text;
+                host text;
+              begin
+                protocol := lower(sys_wds.parse_token(str, 'protocol'));
+                host := lower(sys_wds.parse_token(str, 'host'));
+
+                if protocol = 'drs://' or (protocol = 'https://' and host like '%.blob.core.windows.net') then
+                  return true;
+                else
+                  return false;
+                end if;
+              end
+              $$ language plpgsql immutable;
+        - sql:
+            dbms: postgresql
+            splitStatements: false
+            sql: |
+              create or replace function sys_wds.validate_file_url(str text) returns text as $$
+              begin
+                if sys_wds.is_file_url(str) then
+                  return str;
+                else
+                  raise invalid_text_representation;
+                end if;
+              end
+              $$ language plpgsql immutable;
+        - sql:
+            dbms: postgresql
+            splitStatements: false
+            sql: |
+              create or replace function sys_wds.validate_file_urls(strings text[]) returns text as $$
+              begin
+                for i in array_lower(strings, 1)..array_upper(strings, 1) loop
+                  if not sys_wds.is_file_url(strings[i]) then
+                    raise invalid_text_representation;
+                  end if;
+                end loop;
+                return strings;
+              end
+              $$ language plpgsql immutable;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
@@ -768,7 +768,9 @@ class RecordDaoTest {
     "dateConversionExpressions",
     "dateArrayConversionExpressions",
     "datetimeConversionExpressions",
-    "datetimeArrayConversionExpressions"
+    "datetimeArrayConversionExpressions",
+    "fileConversionExpressions",
+    "fileArrayConversionExpressions"
   })
   void testGetPostgresTypeConversionExpression(
       DataTypeMapping dataType, DataTypeMapping newDataType, String expectedExpression) {
@@ -790,6 +792,8 @@ class RecordDaoTest {
         args(STRING, DATE, "\"attr\"::date"),
         // Datetime
         args(STRING, DATE_TIME, "\"attr\"::timestamp with time zone"),
+        // File
+        args(STRING, FILE, "sys_wds.validate_file_url(\"attr\")::file"),
         // String array
         args(STRING, ARRAY_OF_STRING, "array_append('{}', \"attr\")::text[]"),
         // Number array
@@ -800,9 +804,12 @@ class RecordDaoTest {
         args(STRING, ARRAY_OF_DATE, "array_append('{}', \"attr\")::date[]"),
         // Datetime array
         args(
+            STRING, ARRAY_OF_DATE_TIME, "array_append('{}', \"attr\")::timestamp with time zone[]"),
+        // File array
+        args(
             STRING,
-            ARRAY_OF_DATE_TIME,
-            "array_append('{}', \"attr\")::timestamp with time zone[]"));
+            ARRAY_OF_FILE,
+            "array_append('{}', sys_wds.validate_file_url(\"attr\"))::array_of_file"));
   }
 
   static Stream<Arguments> stringArrayConversionExpressions() {
@@ -814,7 +821,10 @@ class RecordDaoTest {
         // Date array
         args(ARRAY_OF_STRING, ARRAY_OF_DATE, "\"attr\"::date[]"),
         // Datetime array
-        args(ARRAY_OF_STRING, ARRAY_OF_DATE_TIME, "\"attr\"::timestamp with time zone[]"));
+        args(ARRAY_OF_STRING, ARRAY_OF_DATE_TIME, "\"attr\"::timestamp with time zone[]"),
+        // File array
+        args(
+            ARRAY_OF_STRING, ARRAY_OF_FILE, "sys_wds.validate_file_urls(\"attr\")::array_of_file"));
   }
 
   static Stream<Arguments> numberConversionExpressions() {
@@ -951,6 +961,22 @@ class RecordDaoTest {
             "(sys_wds.convert_array_of_timestamps_to_numbers(\"attr\"))::numeric[]"),
         // Date array
         args(ARRAY_OF_DATE_TIME, ARRAY_OF_DATE, "\"attr\"::date[]"));
+  }
+
+  static Stream<Arguments> fileConversionExpressions() {
+    return Stream.of(
+        // String
+        args(FILE, STRING, "\"attr\"::text"),
+        // String array
+        args(FILE, ARRAY_OF_STRING, "array_append('{}', \"attr\")::text[]"),
+        // File array
+        args(FILE, ARRAY_OF_FILE, "array_append('{}', \"attr\")::array_of_file"));
+  }
+
+  static Stream<Arguments> fileArrayConversionExpressions() {
+    return Stream.of(
+        // String array
+        args(ARRAY_OF_FILE, ARRAY_OF_STRING, "\"attr\"::text[]"));
   }
 
   /** Simple helper to provide an even terser shorthand */

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
@@ -9,16 +9,20 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.databiosphere.workspacedataservice.dao.InstanceDao;
+import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.databiosphere.workspacedataservice.service.model.AttributeSchema;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
 import org.databiosphere.workspacedataservice.service.model.RecordTypeSchema;
+import org.databiosphere.workspacedataservice.service.model.RelationCollection;
 import org.databiosphere.workspacedataservice.service.model.exception.ConflictException;
 import org.databiosphere.workspacedataservice.service.model.exception.MissingObjectException;
 import org.databiosphere.workspacedataservice.service.model.exception.ValidationException;
@@ -48,6 +52,7 @@ import org.springframework.web.server.ResponseStatusException;
 class RecordOrchestratorServiceTest {
 
   @Autowired private InstanceDao instanceDao;
+  @Autowired private RecordDao recordDao;
   @Autowired private RecordOrchestratorService recordOrchestratorService;
 
   private static final UUID INSTANCE = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
@@ -217,7 +222,9 @@ class RecordOrchestratorServiceTest {
     "updateAttributeDataTypeDateConversions",
     "updateAttributeDataTypeDateArrayConversions",
     "updateAttributeDataTypeDatetimeConversions",
-    "updateAttributeDataTypeDatetimeArrayConversions"
+    "updateAttributeDataTypeDatetimeArrayConversions",
+    "updateAttributeDataTypeFileConversions",
+    "updateAttributeDataTypeFileArrayConversions"
   })
   void updateAttributeDataType(
       Object attributeValue,
@@ -226,6 +233,17 @@ class RecordOrchestratorServiceTest {
       Object expectedFinalAttributeValue) {
     // Arrange
     String attributeName = "testAttribute";
+
+    // Create the record type before adding any data.
+    // This is necessary for the string to file tests because it prevents
+    // the initial data type from being inferred as file.
+    recordDao.createRecordType(
+        INSTANCE,
+        Map.of(attributeName, expectedInitialDataType),
+        TEST_TYPE,
+        new RelationCollection(Collections.emptySet(), Collections.emptySet()),
+        PRIMARY_KEY);
+
     RecordAttributes recordAttributes =
         RecordAttributes.empty().putAttribute(attributeName, attributeValue);
     RecordRequest recordRequest = new RecordRequest(recordAttributes);
@@ -272,6 +290,12 @@ class RecordOrchestratorServiceTest {
             DataTypeMapping.STRING,
             DataTypeMapping.DATE_TIME,
             LocalDateTime.of(2024, 1, 24, 2, 30, 0)),
+        // File
+        Arguments.of(
+            "https://lz813a3d637adefec2c6e88f.blob.core.windows.net/sc-e18cfbc3-7115-4a37-add7-1d95d3ecfa14/file.txt",
+            DataTypeMapping.STRING,
+            DataTypeMapping.FILE,
+            "https://lz813a3d637adefec2c6e88f.blob.core.windows.net/sc-e18cfbc3-7115-4a37-add7-1d95d3ecfa14/file.txt"),
         // String array
         Arguments.of(
             "foo", DataTypeMapping.STRING, DataTypeMapping.ARRAY_OF_STRING, new String[] {"foo"}),
@@ -298,7 +322,15 @@ class RecordOrchestratorServiceTest {
             "2024/01/24 02:30:00",
             DataTypeMapping.STRING,
             DataTypeMapping.ARRAY_OF_DATE_TIME,
-            new LocalDateTime[] {LocalDateTime.of(2024, 1, 24, 2, 30, 0)}));
+            new LocalDateTime[] {LocalDateTime.of(2024, 1, 24, 2, 30, 0)}),
+        // File array
+        Arguments.of(
+            "https://lz813a3d637adefec2c6e88f.blob.core.windows.net/sc-e18cfbc3-7115-4a37-add7-1d95d3ecfa14/file.txt",
+            DataTypeMapping.STRING,
+            DataTypeMapping.ARRAY_OF_FILE,
+            new String[] {
+              "https://lz813a3d637adefec2c6e88f.blob.core.windows.net/sc-e18cfbc3-7115-4a37-add7-1d95d3ecfa14/file.txt"
+            }));
   }
 
   static Stream<Arguments> updateAttributeDataTypeStringArrayConversions() {
@@ -326,7 +358,16 @@ class RecordOrchestratorServiceTest {
             List.of("2024/01/24 02:30:00"),
             DataTypeMapping.ARRAY_OF_STRING,
             DataTypeMapping.ARRAY_OF_DATE_TIME,
-            new LocalDateTime[] {LocalDateTime.of(2024, 1, 24, 2, 30, 0)}));
+            new LocalDateTime[] {LocalDateTime.of(2024, 1, 24, 2, 30, 0)}),
+        // File array
+        Arguments.of(
+            List.of(
+                "https://lz813a3d637adefec2c6e88f.blob.core.windows.net/sc-e18cfbc3-7115-4a37-add7-1d95d3ecfa14/file.txt"),
+            DataTypeMapping.ARRAY_OF_STRING,
+            DataTypeMapping.ARRAY_OF_FILE,
+            new String[] {
+              "https://lz813a3d637adefec2c6e88f.blob.core.windows.net/sc-e18cfbc3-7115-4a37-add7-1d95d3ecfa14/file.txt"
+            }));
   }
 
   static Stream<Arguments> updateAttributeDataTypeNumberConversions() {
@@ -605,6 +646,45 @@ class RecordOrchestratorServiceTest {
             new LocalDate[] {LocalDate.of(2024, 1, 24)}));
   }
 
+  static Stream<Arguments> updateAttributeDataTypeFileConversions() {
+    return Stream.of(
+        // String
+        Arguments.of(
+            "https://lz813a3d637adefec2c6e88f.blob.core.windows.net/sc-e18cfbc3-7115-4a37-add7-1d95d3ecfa14/file.txt",
+            DataTypeMapping.FILE,
+            DataTypeMapping.STRING,
+            "https://lz813a3d637adefec2c6e88f.blob.core.windows.net/sc-e18cfbc3-7115-4a37-add7-1d95d3ecfa14/file.txt"),
+        // String array
+        Arguments.of(
+            "https://lz813a3d637adefec2c6e88f.blob.core.windows.net/sc-e18cfbc3-7115-4a37-add7-1d95d3ecfa14/file.txt",
+            DataTypeMapping.FILE,
+            DataTypeMapping.ARRAY_OF_STRING,
+            new String[] {
+              "https://lz813a3d637adefec2c6e88f.blob.core.windows.net/sc-e18cfbc3-7115-4a37-add7-1d95d3ecfa14/file.txt"
+            }),
+        // File array
+        Arguments.of(
+            "https://lz813a3d637adefec2c6e88f.blob.core.windows.net/sc-e18cfbc3-7115-4a37-add7-1d95d3ecfa14/file.txt",
+            DataTypeMapping.FILE,
+            DataTypeMapping.ARRAY_OF_FILE,
+            new String[] {
+              "https://lz813a3d637adefec2c6e88f.blob.core.windows.net/sc-e18cfbc3-7115-4a37-add7-1d95d3ecfa14/file.txt"
+            }));
+  }
+
+  static Stream<Arguments> updateAttributeDataTypeFileArrayConversions() {
+    return Stream.of(
+        // String array
+        Arguments.of(
+            List.of(
+                "https://lz813a3d637adefec2c6e88f.blob.core.windows.net/sc-e18cfbc3-7115-4a37-add7-1d95d3ecfa14/file.txt"),
+            DataTypeMapping.ARRAY_OF_FILE,
+            DataTypeMapping.ARRAY_OF_STRING,
+            new String[] {
+              "https://lz813a3d637adefec2c6e88f.blob.core.windows.net/sc-e18cfbc3-7115-4a37-add7-1d95d3ecfa14/file.txt"
+            }));
+  }
+
   @Test
   void updateAttributeDataTypePrimaryKey() {
     // Arrange
@@ -734,7 +814,9 @@ class RecordOrchestratorServiceTest {
   static Stream<Arguments> unableToConvertValuesTestCases() {
     return Stream.of(
         Arguments.of("foo", DataTypeMapping.NUMBER),
-        Arguments.of(1000000000000000L, DataTypeMapping.DATE_TIME));
+        Arguments.of(1000000000000000L, DataTypeMapping.DATE_TIME),
+        Arguments.of("hello world", DataTypeMapping.FILE),
+        Arguments.of("https://example.com", DataTypeMapping.FILE));
   }
 
   @ParameterizedTest(name = "rejects requests to convert from {1} to {2}")


### PR DESCRIPTION
This adds support for converting an attribute's data type between string and file. When converting from string to file, an SQL function is used to validate that all values match the patterns expected for file URLs.