### PR TITLE
AJ-1556: quiet down logback status during startup

### DIFF
--- a/service/src/main/resources/logback-spring.xml
+++ b/service/src/main/resources/logback-spring.xml
@@ -10,6 +10,10 @@
   <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
   <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
 
+  <!-- Quiet down logback during startup. If you are trying to change or debug logging setup,
+           you may want to comment out this line during your development efforts. -->
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
+
   <appender name="Sentry" class="io.sentry.logback.SentryAppender">
     <!-- Optionally change minimum Event level. Default for Events is ERROR -->
     <minimumEventLevel>ERROR</minimumEventLevel>


### PR DESCRIPTION
Registers a no-op logback status listener to prevent the ~75 lines of logback configuration details that are logged at every startup.

See https://logback.qos.ch/manual/configuration.html#dumpingStatusData

This eliminates the log lines that include, for instance:
```
10:08:05,572 |-INFO in ch.qos.logback.classic.util.ContextInitializer@40258c2f - Constructed configurator of type class ch.qos.logback.classic.joran.SerializedModelConfigurator
10:08:05,574 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback-test.scmo]
10:08:05,574 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback.scmo]
10:08:05,574 |-INFO in ch.qos.logback.classic.util.ContextInitializer@40258c2f - ch.qos.logback.classic.joran.SerializedModelConfigurator.configure() call lasted 2 milliseconds. ExecutionStatus=INVOKE_NEXT_IF_ANY
10:08:05,574 |-INFO in ch.qos.logback.classic.util.ContextInitializer@40258c2f - Trying to configure with ch.qos.logback.classic.util.DefaultJoranConfigurator
```

Hopefully no merge conflicts with #486.