### PR TITLE
AJ-1556 Bump `json-path` to 2.9.0 for dependabot.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ subprojects {
         }
         dependencies {
             dependency 'org.liquibase:liquibase-core:4.25.1'
+            dependency 'com.jayway.jsonpath:json-path:2.9.0' // CVE-2023-51074
         }
     }
 }

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -138,6 +138,14 @@ dependencies {
         implementation('org.codehaus.jettison:jettison:1.5.4') {
             because("CVE-2022-40149, CVE-2022-40150, CVE-2022-45685, CVE-2022-45693, CVE-2023-1436")
         }
+
+        // TODO: remove when upgrading to a version of spring that has a fixed version of json-path
+        //   json-path required by spring-boot-starter-test:3.2.2
+        //   this is redundant (and ineffective) without an explicit override in the parent project
+        //   build.gradle dependencyManagement, but is included here for documentation purposes
+        testImplementation('com.jayway.jsonpath:json-path:2.9.0') {
+            because("CVE-2023-51074")
+        }
     }
 }
 


### PR DESCRIPTION
Maintenance Ticket: https://broadworkbench.atlassian.net/browse/AJ-1556
Finding: https://github.com/DataBiosphere/terra-workspace-data-service/security/dependabot/65
CVE: https://nvd.nist.gov/vuln/detail/CVE-2023-51074

[AJ-1556]: https://broadworkbench.atlassian.net/browse/AJ-1556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ