### PR TITLE
[AJ-1279] Support conversions between strings and files (without validation)

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -104,6 +104,7 @@ public class RecordDao {
           Set.of(DataTypeMapping.STRING, DataTypeMapping.BOOLEAN),
           Set.of(DataTypeMapping.STRING, DataTypeMapping.DATE),
           Set.of(DataTypeMapping.STRING, DataTypeMapping.DATE_TIME),
+          Set.of(DataTypeMapping.STRING, DataTypeMapping.FILE),
           Set.of(DataTypeMapping.NUMBER, DataTypeMapping.BOOLEAN),
           Set.of(DataTypeMapping.NUMBER, DataTypeMapping.DATE),
           Set.of(DataTypeMapping.NUMBER, DataTypeMapping.DATE_TIME),

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
@@ -768,7 +768,9 @@ class RecordDaoTest {
     "dateConversionExpressions",
     "dateArrayConversionExpressions",
     "datetimeConversionExpressions",
-    "datetimeArrayConversionExpressions"
+    "datetimeArrayConversionExpressions",
+    "fileConversionExpressions",
+    "fileArrayConversionExpressions"
   })
   void testGetPostgresTypeConversionExpression(
       DataTypeMapping dataType, DataTypeMapping newDataType, String expectedExpression) {
@@ -790,6 +792,8 @@ class RecordDaoTest {
         args(STRING, DATE, "\"attr\"::date"),
         // Datetime
         args(STRING, DATE_TIME, "\"attr\"::timestamp with time zone"),
+        // File
+        args(STRING, FILE, "\"attr\"::file"),
         // String array
         args(STRING, ARRAY_OF_STRING, "array_append('{}', \"attr\")::text[]"),
         // Number array
@@ -800,9 +804,9 @@ class RecordDaoTest {
         args(STRING, ARRAY_OF_DATE, "array_append('{}', \"attr\")::date[]"),
         // Datetime array
         args(
-            STRING,
-            ARRAY_OF_DATE_TIME,
-            "array_append('{}', \"attr\")::timestamp with time zone[]"));
+            STRING, ARRAY_OF_DATE_TIME, "array_append('{}', \"attr\")::timestamp with time zone[]"),
+        // File array
+        args(STRING, ARRAY_OF_FILE, "array_append('{}', \"attr\")::array_of_file"));
   }
 
   static Stream<Arguments> stringArrayConversionExpressions() {
@@ -814,7 +818,9 @@ class RecordDaoTest {
         // Date array
         args(ARRAY_OF_STRING, ARRAY_OF_DATE, "\"attr\"::date[]"),
         // Datetime array
-        args(ARRAY_OF_STRING, ARRAY_OF_DATE_TIME, "\"attr\"::timestamp with time zone[]"));
+        args(ARRAY_OF_STRING, ARRAY_OF_DATE_TIME, "\"attr\"::timestamp with time zone[]"),
+        // File array
+        args(ARRAY_OF_STRING, ARRAY_OF_FILE, "\"attr\"::array_of_file"));
   }
 
   static Stream<Arguments> numberConversionExpressions() {
@@ -951,6 +957,22 @@ class RecordDaoTest {
             "(sys_wds.convert_array_of_timestamps_to_numbers(\"attr\"))::numeric[]"),
         // Date array
         args(ARRAY_OF_DATE_TIME, ARRAY_OF_DATE, "\"attr\"::date[]"));
+  }
+
+  static Stream<Arguments> fileConversionExpressions() {
+    return Stream.of(
+        // String
+        args(FILE, STRING, "\"attr\"::text"),
+        // String array
+        args(FILE, ARRAY_OF_STRING, "array_append('{}', \"attr\")::text[]"),
+        // File array
+        args(FILE, ARRAY_OF_FILE, "array_append('{}', \"attr\")::array_of_file"));
+  }
+
+  static Stream<Arguments> fileArrayConversionExpressions() {
+    return Stream.of(
+        // String array
+        args(ARRAY_OF_FILE, ARRAY_OF_STRING, "\"attr\"::text[]"));
   }
 
   /** Simple helper to provide an even terser shorthand */


### PR DESCRIPTION
Alternative to #493...

This treats the File type as simply an annotation/hint for the user. It allows creating File columns that contain values that are not valid URLs.