### PR TITLE
AJ-1563 Make primaryKey non-optional during batch write.

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJob.java
@@ -10,7 +10,6 @@ import bio.terra.pfb.PfbReader;
 import io.micrometer.observation.ObservationRegistry;
 import java.net.URL;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.Spliterator;
 import java.util.Spliterators;
@@ -144,7 +143,7 @@ public class PfbQuartzJob extends QuartzJob {
       TwoPassStreamingWriteHandler.ImportMode importMode) {
     BatchWriteResult result =
         batchWriteService.batchWritePfbStream(
-            dataStream, targetInstance, Optional.of(ID_FIELD), importMode);
+            dataStream, targetInstance, /* primaryKey= */ ID_FIELD, importMode);
 
     if (result != null) {
       result

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordstream/TsvStreamWriteHandler.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordstream/TsvStreamWriteHandler.java
@@ -29,17 +29,15 @@ import org.databiosphere.workspacedataservice.shared.model.RecordType;
 public class TsvStreamWriteHandler implements StreamingWriteHandler {
 
   private final Spliterator<Record> recordSpliterator;
-
   private final InputStream inputStream;
   private final MappingIterator<RecordAttributes> tsvIterator;
-
-  private final String resolvedPrimaryKey;
+  private final String primaryKey;
 
   public TsvStreamWriteHandler(
       InputStream inputStream,
       ObjectReader tsvReader,
       RecordType recordType,
-      Optional<String> primaryKey)
+      Optional<String> optionalPrimaryKey)
       throws IOException {
     this.inputStream = inputStream;
     try {
@@ -84,22 +82,24 @@ public class TsvStreamWriteHandler implements StreamingWriteHandler {
     }
 
     // if a primary key is specified, check if it is present in the TSV
-    if (primaryKey.isPresent() && !colNames.contains(primaryKey.get())) {
-      throw new InvalidTsvException(
-          "Uploaded TSV is either missing the "
-              + primaryKey.get()
-              + " column or has a null or empty string value in that column");
-    }
+    optionalPrimaryKey.ifPresent(
+        pk -> {
+          if (!colNames.contains(pk)) {
+            throw new InvalidTsvException(
+                "Uploaded TSV is either missing the "
+                    + pk
+                    + " column or has a null or empty string value in that column");
+          }
+        });
 
     // if primary key is not specified, use the leftmost column
-    String resolvedPK = primaryKey.orElseGet(() -> colNames.get(0));
-    resolvedPrimaryKey = resolvedPK;
+    this.primaryKey = optionalPrimaryKey.orElseGet(() -> colNames.get(0));
 
     // convert the tsvIterator, which is a MappingIterator<RecordAttributes>, to a Stream<Record>
     Stream<RecordAttributes> tsvStream =
         StreamSupport.stream(
             Spliterators.spliteratorUnknownSize(tsvIterator, Spliterator.ORDERED), false);
-    recordSpliterator = rowsToRecords(tsvStream, recordType, resolvedPK).spliterator();
+    recordSpliterator = rowsToRecords(tsvStream, recordType).spliterator();
   }
 
   /**
@@ -137,7 +137,7 @@ public class TsvStreamWriteHandler implements StreamingWriteHandler {
     tsvIterator.close();
   }
 
-  private Record tsvRowToRecord(RecordAttributes row, RecordType recordType, String primaryKey) {
+  private Record tsvRowToRecord(RecordAttributes row, RecordType recordType) {
     Object recordId = row.getAttributeValue(primaryKey);
     if (recordId == null || StringUtils.isBlank(recordId.toString())) {
       throw new InvalidTsvException(
@@ -150,12 +150,11 @@ public class TsvStreamWriteHandler implements StreamingWriteHandler {
     return new Record(recordId.toString(), recordType, row);
   }
 
-  private Stream<Record> rowsToRecords(
-      Stream<RecordAttributes> rows, RecordType recordType, String primaryKey) {
+  private Stream<Record> rowsToRecords(Stream<RecordAttributes> rows, RecordType recordType) {
     HashSet<String> recordIds = new HashSet<>(); // this set may be slow for very large TSVs
     return rows.map(
         m -> {
-          Record r = tsvRowToRecord(m, recordType, primaryKey);
+          Record r = tsvRowToRecord(m, recordType);
           if (!recordIds.add(r.getId())) {
             throw new InvalidTsvException("TSVs cannot contain duplicate primary key values");
           }
@@ -163,7 +162,7 @@ public class TsvStreamWriteHandler implements StreamingWriteHandler {
         });
   }
 
-  public String getResolvedPrimaryKey() {
-    return resolvedPrimaryKey;
+  public String getPrimaryKey() {
+    return primaryKey;
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
@@ -1,6 +1,7 @@
 package org.databiosphere.workspacedataservice.service;
 
 import static org.databiosphere.workspacedataservice.service.RecordUtils.validateVersion;
+import static org.databiosphere.workspacedataservice.service.model.ReservedNames.RECORD_ID;
 
 import bio.terra.common.db.ReadTransaction;
 import java.io.IOException;
@@ -348,7 +349,9 @@ public class RecordOrchestratorService { // TODO give me a better name
       recordService.validatePrimaryKey(instanceId, recordType, primaryKey);
     }
 
-    int qty = batchWriteService.batchWriteJsonStream(is, instanceId, recordType, primaryKey);
+    int qty =
+        batchWriteService.batchWriteJsonStream(
+            is, instanceId, recordType, primaryKey.orElse(RECORD_ID));
     activityLogger.saveEventForCurrentUser(
         user -> user.modified().record().withRecordType(recordType).ofQuantity(qty));
     return qty;


### PR DESCRIPTION
This is prefactoring for [AJ-1563](https://broadworkbench.atlassian.net/browse/AJ-1563).  The primary key isn't really optional once batch writing has begun, so we resolve the optional earlier in the callstack for JSON stream and TSV stream.

[AJ-1563]: https://broadworkbench.atlassian.net/browse/AJ-1563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ