### PR TITLE
Extract `StreamingWriteHandlerFactory`

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordstream/PrimaryKeyResolver.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordstream/PrimaryKeyResolver.java
@@ -2,7 +2,8 @@ package org.databiosphere.workspacedataservice.recordstream;
 
 /**
  * Simple interface to clarify the additional responsibility that {@link TsvStreamWriteHandler}
- * provides.
+ * provides. This interface is not strictly necessary, but I wanted it to be a clear marker of where
+ * the additional responsibility is used to make it easier to refactor and tidy up later.
  */
 public interface PrimaryKeyResolver {
   String getPrimaryKey();

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordstream/PrimaryKeyResolver.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordstream/PrimaryKeyResolver.java
@@ -1,0 +1,9 @@
+package org.databiosphere.workspacedataservice.recordstream;
+
+/**
+ * Simple interface to clarify the additional responsibility that {@link TsvStreamWriteHandler}
+ * provides.
+ */
+public interface PrimaryKeyResolver {
+  String getPrimaryKey();
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordstream/StreamingWriteHandlerFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordstream/StreamingWriteHandlerFactory.java
@@ -1,0 +1,50 @@
+package org.databiosphere.workspacedataservice.recordstream;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Optional;
+import org.apache.avro.file.DataFileStream;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.parquet.hadoop.ParquetReader;
+import org.databiosphere.workspacedataservice.recordstream.TwoPassStreamingWriteHandler.ImportMode;
+import org.databiosphere.workspacedataservice.service.model.TdrManifestImportTable;
+import org.databiosphere.workspacedataservice.shared.model.RecordType;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StreamingWriteHandlerFactory {
+
+  private final ObjectMapper objectMapper;
+  private final ObjectReader objectReader;
+
+  public StreamingWriteHandlerFactory(ObjectMapper objectMapper, ObjectReader objectReader) {
+    this.objectMapper = objectMapper;
+    this.objectReader = objectReader;
+  }
+
+  public StreamingWriteHandler forJson(InputStream inputStream) throws IOException {
+    return new JsonStreamWriteHandler(inputStream, objectMapper);
+  }
+
+  // TsvStreamWriteHandler plays a role in primary key resolution, and so we return this
+  // particular subclass of StreamingWriteHandler so the callsite can use this extra
+  // method on its interface if needed.
+  public TsvStreamWriteHandler forTsv(
+      InputStream inputStream, RecordType recordType, Optional<String> primaryKey) {
+    return new TsvStreamWriteHandler(inputStream, objectReader, recordType, primaryKey);
+  }
+
+  public StreamingWriteHandler forTdrImport(
+      ParquetReader<GenericRecord> parquetReader,
+      TdrManifestImportTable table,
+      ImportMode importMode) {
+    return new ParquetStreamWriteHandler(parquetReader, importMode, table, objectMapper);
+  }
+
+  public StreamingWriteHandler forPfb(
+      DataFileStream<GenericRecord> inputStream, ImportMode importMode) {
+    return new PfbStreamWriteHandler(inputStream, importMode, objectMapper);
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordstream/TsvStreamWriteHandler.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordstream/TsvStreamWriteHandler.java
@@ -26,7 +26,7 @@ import org.databiosphere.workspacedataservice.shared.model.RecordType;
  * Stream-reads inbound TSV data using a Jackson CsvMapper; returns a WriteStreamInfo containing a
  * batch of Records.
  */
-public class TsvStreamWriteHandler implements StreamingWriteHandler {
+public class TsvStreamWriteHandler implements StreamingWriteHandler, PrimaryKeyResolver {
 
   private final Spliterator<Record> recordSpliterator;
   private final InputStream inputStream;
@@ -37,8 +37,7 @@ public class TsvStreamWriteHandler implements StreamingWriteHandler {
       InputStream inputStream,
       ObjectReader tsvReader,
       RecordType recordType,
-      Optional<String> optionalPrimaryKey)
-      throws IOException {
+      Optional<String> optionalPrimaryKey) {
     this.inputStream = inputStream;
     try {
       this.tsvIterator = tsvReader.readValues(inputStream);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
@@ -15,12 +15,19 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
+import org.databiosphere.workspacedataservice.recordstream.PrimaryKeyResolver;
+import org.databiosphere.workspacedataservice.recordstream.StreamingWriteHandler;
+import org.databiosphere.workspacedataservice.recordstream.StreamingWriteHandlerFactory;
+import org.databiosphere.workspacedataservice.recordstream.TsvStreamWriteHandler;
+import org.databiosphere.workspacedataservice.recordstream.TwoPassStreamingWriteHandler.ImportMode;
 import org.databiosphere.workspacedataservice.sam.SamDao;
 import org.databiosphere.workspacedataservice.service.model.AttributeSchema;
+import org.databiosphere.workspacedataservice.service.model.BatchWriteResult;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
 import org.databiosphere.workspacedataservice.service.model.RecordTypeSchema;
 import org.databiosphere.workspacedataservice.service.model.Relation;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthorizationException;
+import org.databiosphere.workspacedataservice.service.model.exception.BadStreamingWriteRequestException;
 import org.databiosphere.workspacedataservice.service.model.exception.ConflictException;
 import org.databiosphere.workspacedataservice.service.model.exception.MissingObjectException;
 import org.databiosphere.workspacedataservice.service.model.exception.ValidationException;
@@ -46,6 +53,7 @@ public class RecordOrchestratorService { // TODO give me a better name
   private static final int MAX_RECORDS = 1_000;
 
   private final RecordDao recordDao;
+  private final StreamingWriteHandlerFactory streamingWriteHandlerFactory;
   private final BatchWriteService batchWriteService;
   private final RecordService recordService;
   private final InstanceService instanceService;
@@ -56,6 +64,7 @@ public class RecordOrchestratorService { // TODO give me a better name
 
   public RecordOrchestratorService(
       RecordDao recordDao,
+      StreamingWriteHandlerFactory streamingWriteHandlerFactory,
       BatchWriteService batchWriteService,
       RecordService recordService,
       InstanceService instanceService,
@@ -63,6 +72,7 @@ public class RecordOrchestratorService { // TODO give me a better name
       ActivityLogger activityLogger,
       TsvSupport tsvSupport) {
     this.recordDao = recordDao;
+    this.streamingWriteHandlerFactory = streamingWriteHandlerFactory;
     this.batchWriteService = batchWriteService;
     this.recordService = recordService;
     this.instanceService = instanceService;
@@ -111,7 +121,7 @@ public class RecordOrchestratorService { // TODO give me a better name
     return new RecordResponse(recordId, recordType, result.getAttributes());
   }
 
-  // N.B. transaction annotated in batchWriteService.batchWriteTsvStream
+  // N.B. transaction annotated in batchWriteService.batchWrite
   public int tsvUpload(
       UUID instanceId,
       String version,
@@ -124,9 +134,20 @@ public class RecordOrchestratorService { // TODO give me a better name
       primaryKey =
           Optional.of(recordService.validatePrimaryKey(instanceId, recordType, primaryKey));
     }
-    int qty =
-        batchWriteService.batchWriteTsvStream(
-            records.getInputStream(), instanceId, recordType, primaryKey);
+
+    TsvStreamWriteHandler streamingWriteHandler =
+        streamingWriteHandlerFactory.forTsv(records.getInputStream(), recordType, primaryKey);
+    BatchWriteResult result =
+        batchWriteService.batchWrite(
+            streamingWriteHandler,
+            instanceId,
+            recordType,
+            // the extra cast here isn't exactly necessary, but left here to call out the additional
+            // tangential responsibility of the TsvStreamWriteHandler; this can be removed if we
+            // can converge on using PrimaryKeyResolver more generally across all formats.
+            ((PrimaryKeyResolver) streamingWriteHandler).getPrimaryKey(),
+            ImportMode.BASE_ATTRIBUTES);
+    int qty = result.getUpdatedCount(recordType);
     activityLogger.saveEventForCurrentUser(
         user -> user.upserted().record().withRecordType(recordType).ofQuantity(qty));
     return qty;
@@ -349,9 +370,21 @@ public class RecordOrchestratorService { // TODO give me a better name
       recordService.validatePrimaryKey(instanceId, recordType, primaryKey);
     }
 
-    int qty =
-        batchWriteService.batchWriteJsonStream(
-            is, instanceId, recordType, primaryKey.orElse(RECORD_ID));
+    StreamingWriteHandler streamingWriteHandler = null;
+    try {
+      streamingWriteHandler = streamingWriteHandlerFactory.forJson(is);
+    } catch (IOException e) {
+      throw new BadStreamingWriteRequestException(e);
+    }
+
+    BatchWriteResult result =
+        batchWriteService.batchWrite(
+            streamingWriteHandler,
+            instanceId,
+            recordType,
+            primaryKey.orElse(RECORD_ID),
+            ImportMode.BASE_ATTRIBUTES);
+    int qty = result.getUpdatedCount(recordType);
     activityLogger.saveEventForCurrentUser(
         user -> user.modified().record().withRecordType(recordType).ofQuantity(qty));
     return qty;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/DataImportException.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/DataImportException.java
@@ -10,7 +10,7 @@ public class DataImportException extends RuntimeException {
     super(message);
   }
 
-  public DataImportException(String message, Exception e) {
-    super(message, e);
+  public DataImportException(String message, Throwable t) {
+    super(message, t);
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/TdrManifestImportException.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/TdrManifestImportException.java
@@ -10,7 +10,7 @@ public class TdrManifestImportException extends DataImportException {
     super(message);
   }
 
-  public TdrManifestImportException(String message, Exception e) {
-    super(message, e);
+  public TdrManifestImportException(String message, Throwable t) {
+    super(message, t);
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/SmallBatchWriteTestConfig.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/SmallBatchWriteTestConfig.java
@@ -1,7 +1,5 @@
 package org.databiosphere.workspacedataservice.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectReader;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.databiosphere.workspacedataservice.service.BatchWriteService;
 import org.databiosphere.workspacedataservice.service.DataTypeInferer;
@@ -18,11 +16,7 @@ public class SmallBatchWriteTestConfig {
 
   @Bean
   public BatchWriteService batchWriteService(
-      RecordDao recordDao,
-      DataTypeInferer inf,
-      ObjectMapper objectMapper,
-      ObjectReader tsvReader,
-      RecordService recordService) {
-    return new BatchWriteService(recordDao, 1, inf, objectMapper, tsvReader, recordService);
+      RecordDao recordDao, DataTypeInferer dataTypeInferer, RecordService recordService) {
+    return new BatchWriteService(recordDao, /* batchSize= */ 1, dataTypeInferer, recordService);
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobTest.java
@@ -150,7 +150,7 @@ class PfbQuartzJobTest {
     when(wsmDao.enumerateDataRepoSnapshotReferences(any(), anyInt(), anyInt()))
         .thenReturn(new ResourceList());
     // We're not testing this, so it doesn't matter what returns
-    when(batchWriteService.batchWritePfbStream(any(), any(), any(), eq(BASE_ATTRIBUTES)))
+    when(batchWriteService.batchWrite(any(), any(), any(), any(), eq(BASE_ATTRIBUTES)))
         .thenReturn(BatchWriteResult.empty());
 
     testSupport.buildPfbQuartzJob().execute(mockContext);
@@ -170,7 +170,7 @@ class PfbQuartzJobTest {
     when(wsmDao.enumerateDataRepoSnapshotReferences(any(), anyInt(), anyInt()))
         .thenReturn(new ResourceList());
     // We're not testing this, so it doesn't matter what returns
-    when(batchWriteService.batchWritePfbStream(any(), any(), any(), eq(BASE_ATTRIBUTES)))
+    when(batchWriteService.batchWrite(any(), any(), any(), any(), eq(BASE_ATTRIBUTES)))
         .thenReturn(BatchWriteResult.empty());
 
     testSupport.buildPfbQuartzJob().execute(mockContext);

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbTestSupport.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbTestSupport.java
@@ -5,6 +5,7 @@ import io.micrometer.observation.ObservationRegistry;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
 import org.databiosphere.workspacedataservice.dao.JobDao;
+import org.databiosphere.workspacedataservice.recordstream.StreamingWriteHandlerFactory;
 import org.databiosphere.workspacedataservice.retry.RestClientRetry;
 import org.databiosphere.workspacedataservice.service.BatchWriteService;
 import org.databiosphere.workspacedataservice.workspacemanager.WorkspaceManagerDao;
@@ -16,6 +17,7 @@ class PfbTestSupport {
   @Autowired private JobDao jobDao;
   @Autowired private WorkspaceManagerDao wsmDao;
   @Autowired private RestClientRetry restClientRetry;
+  @Autowired private StreamingWriteHandlerFactory streamingWriteHandlerFactory;
   @Autowired private BatchWriteService batchWriteService;
   @Autowired private ActivityLogger activityLogger;
   @Autowired private ObjectMapper objectMapper;
@@ -26,6 +28,7 @@ class PfbTestSupport {
         jobDao,
         wsmDao,
         restClientRetry,
+        streamingWriteHandlerFactory,
         batchWriteService,
         activityLogger,
         observationRegistry,

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrTestSupport.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrTestSupport.java
@@ -6,6 +6,7 @@ import java.net.URL;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
 import org.databiosphere.workspacedataservice.dao.JobDao;
+import org.databiosphere.workspacedataservice.recordstream.StreamingWriteHandlerFactory;
 import org.databiosphere.workspacedataservice.retry.RestClientRetry;
 import org.databiosphere.workspacedataservice.service.BatchWriteService;
 import org.databiosphere.workspacedataservice.workspacemanager.WorkspaceManagerDao;
@@ -17,6 +18,7 @@ class TdrTestSupport {
   @Autowired private JobDao jobDao;
   @Autowired private WorkspaceManagerDao wsmDao;
   @Autowired private RestClientRetry restClientRetry;
+  @Autowired private StreamingWriteHandlerFactory streamingWriteHandlerFactory;
   @Autowired private BatchWriteService batchWriteService;
   @Autowired private ActivityLogger activityLogger;
   @Autowired private ObjectMapper objectMapper;
@@ -28,6 +30,7 @@ class TdrTestSupport {
         jobDao,
         wsmDao,
         restClientRetry,
+        streamingWriteHandlerFactory,
         batchWriteService,
         activityLogger,
         workspaceId,

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/BatchWriteServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/BatchWriteServiceTest.java
@@ -197,7 +197,7 @@ class BatchWriteServiceTest {
     Map<String, Integer> counts = Map.of("thing", 5, "item", 10, "widget", 15);
     try (DataFileStream<GenericRecord> pfbStream = PfbTestUtils.mockPfbStream(counts)) {
       BatchWriteResult result =
-          batchWritePfbStream(pfbStream, ID_FIELD, ImportMode.BASE_ATTRIBUTES);
+          batchWritePfbStream(pfbStream, /* primaryKey= */ ID_FIELD, ImportMode.BASE_ATTRIBUTES);
       assertEquals(3, result.entrySet().size());
       assertEquals(5, result.getUpdatedCount(RecordType.valueOf("thing")));
       assertEquals(10, result.getUpdatedCount(RecordType.valueOf("item")));

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/BatchWriteServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/BatchWriteServiceTest.java
@@ -1,8 +1,6 @@
 package org.databiosphere.workspacedataservice.service;
 
 import static org.databiosphere.workspacedataservice.dataimport.pfb.PfbRecordConverter.ID_FIELD;
-import static org.databiosphere.workspacedataservice.recordstream.TwoPassStreamingWriteHandler.ImportMode.BASE_ATTRIBUTES;
-import static org.databiosphere.workspacedataservice.recordstream.TwoPassStreamingWriteHandler.ImportMode.RELATIONS;
 import static org.databiosphere.workspacedataservice.service.model.ReservedNames.RECORD_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -30,6 +28,9 @@ import org.apache.avro.generic.GenericRecord;
 import org.databiosphere.workspacedataservice.dao.InstanceDao;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.databiosphere.workspacedataservice.dataimport.pfb.PfbTestUtils;
+import org.databiosphere.workspacedataservice.recordstream.StreamingWriteHandlerFactory;
+import org.databiosphere.workspacedataservice.recordstream.TsvStreamWriteHandler;
+import org.databiosphere.workspacedataservice.recordstream.TwoPassStreamingWriteHandler.ImportMode;
 import org.databiosphere.workspacedataservice.service.model.BatchWriteResult;
 import org.databiosphere.workspacedataservice.service.model.exception.BadStreamingWriteRequestException;
 import org.databiosphere.workspacedataservice.shared.model.Record;
@@ -53,6 +54,7 @@ import org.springframework.test.context.TestPropertySource;
 @TestPropertySource(properties = {"twds.write.batch.size=2"})
 class BatchWriteServiceTest {
 
+  @Autowired private StreamingWriteHandlerFactory streamingWriteHandlerFactory;
   @Autowired private BatchWriteService batchWriteService;
   @Autowired private InstanceDao instanceDao;
   @MockBean RecordDao recordDao;
@@ -83,7 +85,13 @@ class BatchWriteServiceTest {
     Exception ex =
         assertThrows(
             BadStreamingWriteRequestException.class,
-            () -> batchWriteService.batchWriteJsonStream(is, INSTANCE, THING_TYPE, RECORD_ID));
+            () ->
+                batchWriteService.batchWrite(
+                    streamingWriteHandlerFactory.forJson(is),
+                    INSTANCE,
+                    THING_TYPE,
+                    RECORD_ID,
+                    ImportMode.BASE_ATTRIBUTES));
 
     String errorMessage = ex.getMessage();
     assertEquals("Duplicate field 'key'", errorMessage);
@@ -104,17 +112,20 @@ class BatchWriteServiceTest {
 
     // other params
     RecordType recordType = RecordType.valueOf("myType");
-    Optional<String> primaryKey = Optional.of("id");
+    String primaryKey = "id";
 
     // call the BatchWriteService. Since this test specifies a batch size of 2, the 5 TSV rows will
     // execute in 3 batches.
     // Note that this call to batchWriteTsvStream specifies a non-null RecordType.
-    batchWriteService.batchWriteTsvStream(file.getInputStream(), INSTANCE, recordType, primaryKey);
+    TsvStreamWriteHandler streamWriteHandler =
+        streamingWriteHandlerFactory.forTsv(
+            file.getInputStream(), recordType, Optional.of(primaryKey));
+    batchWriteService.batchWrite(
+        streamWriteHandler, INSTANCE, recordType, primaryKey, ImportMode.BASE_ATTRIBUTES);
 
     // we should write three batches
     verify(recordService, times(3))
-        .batchUpsertWithErrorCapture(
-            eq(INSTANCE), eq(recordType), any(), any(), eq(primaryKey.get()));
+        .batchUpsertWithErrorCapture(eq(INSTANCE), eq(recordType), any(), any(), eq(primaryKey));
 
     // but we should only have inferred the schema once
     verify(inferer, times(1)).inferTypes(ArgumentMatchers.<List<Record>>any());
@@ -143,19 +154,18 @@ class BatchWriteServiceTest {
       //    - 1 call for batch #8 which will be (item, widget)
       //    - 7 more calls for batches #9-15 which will be (widget, widget)
       // * inferTypes once for each of "thing", "item", and "widget"
-      String primaryKey = ID_FIELD;
-      batchWriteService.batchWritePfbStream(pfbStream, INSTANCE, primaryKey, BASE_ATTRIBUTES);
+      batchWritePfbStream(pfbStream, /* primaryKey= */ ID_FIELD, ImportMode.BASE_ATTRIBUTES);
 
       // verify calls to batchUpsertWithErrorCapture
       verify(recordService, times(3))
           .batchUpsertWithErrorCapture(
-              eq(INSTANCE), eq(RecordType.valueOf("thing")), any(), any(), eq(primaryKey));
+              eq(INSTANCE), eq(RecordType.valueOf("thing")), any(), any(), eq(ID_FIELD));
       verify(recordService, times(5))
           .batchUpsertWithErrorCapture(
-              eq(INSTANCE), eq(RecordType.valueOf("item")), any(), any(), eq(primaryKey));
+              eq(INSTANCE), eq(RecordType.valueOf("item")), any(), any(), eq(ID_FIELD));
       verify(recordService, times(8))
           .batchUpsertWithErrorCapture(
-              eq(INSTANCE), eq(RecordType.valueOf("widget")), any(), any(), eq(primaryKey));
+              eq(INSTANCE), eq(RecordType.valueOf("widget")), any(), any(), eq(ID_FIELD));
 
       // but we should only have inferred schemas three times - once for each record Type
       @SuppressWarnings("unchecked")
@@ -187,7 +197,7 @@ class BatchWriteServiceTest {
     Map<String, Integer> counts = Map.of("thing", 5, "item", 10, "widget", 15);
     try (DataFileStream<GenericRecord> pfbStream = PfbTestUtils.mockPfbStream(counts)) {
       BatchWriteResult result =
-          batchWriteService.batchWritePfbStream(pfbStream, INSTANCE, ID_FIELD, BASE_ATTRIBUTES);
+          batchWritePfbStream(pfbStream, ID_FIELD, ImportMode.BASE_ATTRIBUTES);
       assertEquals(3, result.entrySet().size());
       assertEquals(5, result.getUpdatedCount(RecordType.valueOf("thing")));
       assertEquals(10, result.getUpdatedCount(RecordType.valueOf("item")));
@@ -206,7 +216,7 @@ class BatchWriteServiceTest {
     try (DataFileStream<GenericRecord> dataStream =
         PfbReader.getGenericRecordsStream(url.toString())) {
       BatchWriteResult result =
-          batchWriteService.batchWritePfbStream(dataStream, INSTANCE, ID_FIELD, BASE_ATTRIBUTES);
+          batchWritePfbStream(dataStream, /* primaryKey= */ ID_FIELD, ImportMode.BASE_ATTRIBUTES);
 
       assertEquals(2, result.entrySet().size());
       assertEquals(3, result.getUpdatedCount(RecordType.valueOf("data_release")));
@@ -223,7 +233,7 @@ class BatchWriteServiceTest {
     try (DataFileStream<GenericRecord> dataStream =
         PfbReader.getGenericRecordsStream(url.toString())) {
       BatchWriteResult result =
-          batchWriteService.batchWritePfbStream(dataStream, INSTANCE, ID_FIELD, RELATIONS);
+          batchWritePfbStream(dataStream, /* primaryKey= */ ID_FIELD, ImportMode.RELATIONS);
 
       assertEquals(1, result.entrySet().size());
       // The 'files' record type has relations, so it should have been updated
@@ -240,7 +250,7 @@ class BatchWriteServiceTest {
     try (DataFileStream<GenericRecord> dataStream =
         PfbReader.getGenericRecordsStream(url.toString())) {
       BatchWriteResult result =
-          batchWriteService.batchWritePfbStream(dataStream, INSTANCE, ID_FIELD, RELATIONS);
+          batchWritePfbStream(dataStream, /* primaryKey= */ ID_FIELD, ImportMode.RELATIONS);
 
       assertEquals(1, result.entrySet().size());
       // Only one of the data_release records had any relations present
@@ -248,5 +258,15 @@ class BatchWriteServiceTest {
     } catch (IOException e) {
       fail(e.getMessage());
     }
+  }
+
+  private BatchWriteResult batchWritePfbStream(
+      DataFileStream<GenericRecord> pfbStream, String primaryKey, ImportMode importMode) {
+    return batchWriteService.batchWrite(
+        streamingWriteHandlerFactory.forPfb(pfbStream, importMode),
+        INSTANCE,
+        /* recordType= */ null,
+        primaryKey,
+        importMode);
   }
 }


### PR DESCRIPTION
This is prefactoring for [AJ-1563](https://broadworkbench.atlassian.net/browse/AJ-1563). 

Pulling the creation of `StreamingWriteHandler` out to a factory makes it simple enough to create format-specific subclasses at each callsite.

This simplifies `BatchWriteService` by eliminating its concern about to handle the particulars of each format of input.

[AJ-1563]: https://broadworkbench.atlassian.net/browse/AJ-1563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ