### PR TITLE
[AJ-1605] Make RecordRowMapper sensitive to attribute case

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -922,7 +922,8 @@ public class RecordDao {
         }
       }
       if (primaryKeyColumnIndex == -1) {
-        throw new RuntimeException("Primary key column not found");
+        throw new RuntimeException(
+            "Primary key column \"%s\" not found".formatted(primaryKeyColumn));
       }
 
       try {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -909,10 +909,10 @@ public class RecordDao {
       ResultSetMetaData metaData = rs.getMetaData();
 
       int primaryKeyColumnIndex = -1;
-      for (int i = 1; i <= metaData.getColumnCount(); i++) {
-        String columnName = metaData.getColumnName(i);
+      for (int columnIndex = 1; columnIndex <= metaData.getColumnCount(); columnIndex++) {
+        String columnName = metaData.getColumnName(columnIndex);
         if (columnName.equals(primaryKeyColumn)) {
-          primaryKeyColumnIndex = i;
+          primaryKeyColumnIndex = columnIndex;
           break;
         }
       }
@@ -932,10 +932,10 @@ public class RecordDao {
         ResultSetMetaData metaData = rs.getMetaData();
         RecordAttributes attributes = RecordAttributes.empty(primaryKeyColumn);
 
-        for (int j = 1; j <= metaData.getColumnCount(); j++) {
-          String columnName = metaData.getColumnName(j);
+        for (int columnIndex = 1; columnIndex <= metaData.getColumnCount(); columnIndex++) {
+          String columnName = metaData.getColumnName(columnIndex);
           if (columnName.equals(primaryKeyColumn)) {
-            attributes.putAttribute(primaryKeyColumn, rs.getString(j));
+            attributes.putAttribute(primaryKeyColumn, rs.getString(columnIndex));
             continue;
           }
           if (referenceColToTable.size() > 0
@@ -944,10 +944,11 @@ public class RecordDao {
             attributes.putAttribute(
                 columnName,
                 RelationUtils.createRelationString(
-                    referenceColToTable.get(columnName), rs.getString(j)));
+                    referenceColToTable.get(columnName), rs.getString(columnIndex)));
           } else {
             attributes.putAttribute(
-                columnName, getAttributeValueForType(rs.getObject(j), schema.get(columnName)));
+                columnName,
+                getAttributeValueForType(rs.getObject(columnIndex), schema.get(columnName)));
           }
         }
         return attributes;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -908,6 +908,11 @@ public class RecordDao {
     public Record mapRow(ResultSet rs, int rowNum) throws SQLException {
       ResultSetMetaData metaData = rs.getMetaData();
 
+      // ResultSet's getter methods (getString, etc.) do not respect case of column names.
+      // If multiple columns have the same name differing only in case (for example, "attr" vs
+      // "Attr"),
+      // then getter methods will return the value of the first matching column.
+      // Because of this, we must get values by column index instead of name.
       int primaryKeyColumnIndex = -1;
       for (int columnIndex = 1; columnIndex <= metaData.getColumnCount(); columnIndex++) {
         String columnName = metaData.getColumnName(columnIndex);
@@ -932,6 +937,11 @@ public class RecordDao {
         ResultSetMetaData metaData = rs.getMetaData();
         RecordAttributes attributes = RecordAttributes.empty(primaryKeyColumn);
 
+        // ResultSet's getter methods (getString, etc.) do not respect case of column names.
+        // If multiple columns have the same name differing only in case (for example, "attr" vs
+        // "Attr"),
+        // then getter methods will return the value of the first matching column.
+        // Because of this, we must get values by column index instead of name.
         for (int columnIndex = 1; columnIndex <= metaData.getColumnCount(); columnIndex++) {
           String columnName = metaData.getColumnName(columnIndex);
           if (columnName.equals(primaryKeyColumn)) {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
@@ -173,6 +173,41 @@ class RecordDaoTest {
   }
 
   @Test
+  void testGetRecordAttributeCaseSensitivity() {
+    // Arrange
+    RecordType recordType = RecordType.valueOf("aRecord");
+    Record upsertedRecord =
+        new Record(
+            "1",
+            recordType,
+            RecordAttributes.empty()
+                .putAttribute("FOO", "FOO")
+                .putAttribute("foo", "foo")
+                .putAttribute("Foo", "Foo"));
+
+    recordDao.createRecordType(
+        instanceId,
+        Map.of("FOO", STRING, "foo", STRING, "Foo", STRING),
+        recordType,
+        new RelationCollection(Collections.emptySet(), Collections.emptySet()),
+        "id");
+    recordDao.batchUpsert(
+        instanceId,
+        recordType,
+        Collections.singletonList(upsertedRecord),
+        Map.of("FOO", STRING, "foo", STRING, "Foo", STRING));
+
+    // Act
+    List<Record> queryRes = recordDao.queryForRecords(recordType, 10, 0, "ASC", null, instanceId);
+
+    // Assert
+    Record returnedRecord = queryRes.get(0);
+    assertEquals("FOO", returnedRecord.getAttributes().getAttributeValue("FOO"));
+    assertEquals("foo", returnedRecord.getAttributes().getAttributeValue("foo"));
+    assertEquals("Foo", returnedRecord.getAttributes().getAttributeValue("Foo"));
+  }
+
+  @Test
   void deleteAndQueryFunkyPrimaryKeyValues() {
     RecordType funkyPk = RecordType.valueOf("funkyPk");
     String sample_id = "Sample ID";


### PR DESCRIPTION
Currently, WDS supports inserting records with attributes that differ only in case. For example, a record with two attributes: "Value" and "value". Such records are stored correctly in the database, but when queried through WDS, the same value will be returned for both attributes.

For example, a record inserted as `{"value": "foo", "Value": "bar"}` would be returned as `{"value": "foo", "Value": "foo"}`.

This is because of an issue in RecordRowMapper. It gets column values from the ResultSet by column name.

From [java.sql.ResultSet's documentation](https://docs.oracle.com/en/java/javase/17/docs/api/java.sql/java/sql/ResultSet.html):
> Column names used as input to getter methods are case insensitive. When a getter method is called with a column name and several columns have the same name, the value of the first matching column will be returned. The column name option is designed to be used when column names are used in the SQL query that generated the result set. For columns that are NOT explicitly named in the query, it is best to use column numbers. If column names are used, the programmer should take care to guarantee that they uniquely refer to the intended columns, which can be assured with the SQL AS clause.

The solution is to get attribute values by column index instead of name. For the `getAttributes` method, this is a trivial change. Getting the primary key column in the `mapRow` method was a little more cumbersome.