### PR TITLE
AJ-1556 - Correct misleading error message about cloning

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/InstanceInitializerBean.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/InstanceInitializerBean.java
@@ -276,7 +276,7 @@ public class InstanceInitializerBean {
    */
   private void restoreFromRemoteBackup(String backupFileName, UUID cloneJobId) {
     LOGGER.info(
-        "Restore from the following path on the source workspace storage container: {}",
+        "Restore from the following path on the destination workspace storage container: {}",
         backupFileName);
     cloneDao.updateCloneEntryStatus(cloneJobId, CloneStatus.RESTOREQUEUED);
     var restoreResponse =


### PR DESCRIPTION
My guess it was left from the artifact of us hoping to save the blob into source container - but at this time we do everything in the destination to ensure the user indeed has write access to the blob container. 

Reminder:

PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 
