### PR TITLE
[AJ-1611] Support top level arrays in JSON fields

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -722,7 +722,10 @@ public class RecordDao {
         return LocalDateTime.parse(sVal, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
       }
     }
-    if (attVal instanceof Map<?, ?>) {
+    // There are two possibilities for JSON data types...
+    // One, the value is a Map or List that needs to be serialized to a JSON string.
+    // Two, the value is a String that's already JSON encoded.
+    if (typeMapping == DataTypeMapping.JSON && !(attVal instanceof String)) {
       try {
         return objectMapper.writeValueAsString(attVal);
       } catch (JsonProcessingException e) {
@@ -983,8 +986,7 @@ public class RecordDao {
         return getArrayValue(pgArray.getArray(), typeMapping);
       }
       if (typeMapping == DataTypeMapping.JSON) {
-        return objectMapper.readValue(
-            object.toString(), new TypeReference<Map<String, Object>>() {});
+        return objectMapper.readValue(object.toString(), new TypeReference<Object>() {});
       }
       return object;
     }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -7,7 +7,6 @@ import static org.databiosphere.workspacedataservice.service.model.ReservedNames
 import static org.databiosphere.workspacedataservice.service.model.exception.InvalidNameException.NameType.ATTRIBUTE;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
@@ -986,7 +985,7 @@ public class RecordDao {
         return getArrayValue(pgArray.getArray(), typeMapping);
       }
       if (typeMapping == DataTypeMapping.JSON) {
-        return objectMapper.readValue(object.toString(), new TypeReference<Object>() {});
+        return objectMapper.readValue(object.toString(), Object.class);
       }
       return object;
     }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/DataTypeInferer.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/DataTypeInferer.java
@@ -21,6 +21,7 @@ import static org.databiosphere.workspacedataservice.service.model.DataTypeMappi
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Streams;
 import com.google.mu.util.stream.BiStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -203,7 +204,13 @@ public class DataTypeInferer {
 
   public boolean isValidJson(String val) {
     JsonNode jsonNode = parseToJsonNode(val);
-    return jsonNode != null && jsonNode.isObject();
+    // Arrays of primitive types should be inferred as ARRAY_OF_STRING, ARRAY_OF_NUMBER, etc.
+    // Arrays should only be inferred as JSON if they contain an object or array.
+    return jsonNode != null
+        && (jsonNode.isObject()
+            || (jsonNode.isArray()
+                && Streams.stream(jsonNode.elements())
+                    .anyMatch(childNode -> childNode.isObject() || childNode.isArray())));
   }
 
   public boolean isArray(String val) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/DataTypeInferer.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/DataTypeInferer.java
@@ -204,13 +204,21 @@ public class DataTypeInferer {
 
   public boolean isValidJson(String val) {
     JsonNode jsonNode = parseToJsonNode(val);
+
+    if (jsonNode == null) {
+      return false;
+    }
+
+    boolean isObject = jsonNode.isObject();
+
     // Arrays of primitive types should be inferred as ARRAY_OF_STRING, ARRAY_OF_NUMBER, etc.
     // Arrays should only be inferred as JSON if they contain an object or array.
-    return jsonNode != null
-        && (jsonNode.isObject()
-            || (jsonNode.isArray()
-                && Streams.stream(jsonNode.elements())
-                    .anyMatch(childNode -> childNode.isObject() || childNode.isArray())));
+    boolean isValidArray =
+        jsonNode.isArray()
+            && Streams.stream(jsonNode.elements())
+                .anyMatch(childNode -> childNode.isObject() || childNode.isArray());
+
+    return isObject || isValidArray;
   }
 
   public boolean isArray(String val) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/DataTypeMapping.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/DataTypeMapping.java
@@ -48,7 +48,8 @@ public enum DataTypeMapping {
           new BaseTypeAndArrayTypePair(DATE, ARRAY_OF_DATE),
           new BaseTypeAndArrayTypePair(DATE_TIME, ARRAY_OF_DATE_TIME),
           new BaseTypeAndArrayTypePair(FILE, ARRAY_OF_FILE),
-          new BaseTypeAndArrayTypePair(RELATION, ARRAY_OF_RELATION));
+          new BaseTypeAndArrayTypePair(RELATION, ARRAY_OF_RELATION),
+          new BaseTypeAndArrayTypePair(JSON, JSON));
 
   static {
     Arrays.stream(DataTypeMapping.values())

--- a/service/src/main/java/org/databiosphere/workspacedataservice/tsv/TsvDeserializer.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/tsv/TsvDeserializer.java
@@ -128,11 +128,11 @@ public class TsvDeserializer extends StdDeserializer<RecordAttributes> {
         return new BigDecimal(val);
       }
     }
-    // JSON objects
+    // JSON objects and arrays
     // TODO: change the "is*" methods in inferer to return their value so we don't parse twice?
     if (inferer.isValidJson(val)) {
       try {
-        return objectMapper.readValue(val, new TypeReference<Map<String, Object>>() {});
+        return objectMapper.readValue(val, new TypeReference<Object>() {});
       } catch (JsonProcessingException jpe) {
         // this shouldn't happen; if inferer.isValidJson(val) passes, so should the .readValue
         return val;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/tsv/TsvDeserializer.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/tsv/TsvDeserializer.java
@@ -2,7 +2,6 @@ package org.databiosphere.workspacedataservice.tsv;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -132,7 +131,7 @@ public class TsvDeserializer extends StdDeserializer<RecordAttributes> {
     // TODO: change the "is*" methods in inferer to return their value so we don't parse twice?
     if (inferer.isValidJson(val)) {
       try {
-        return objectMapper.readValue(val, new TypeReference<Object>() {});
+        return objectMapper.readValue(val, Object.class);
       } catch (JsonProcessingException jpe) {
         // this shouldn't happen; if inferer.isValidJson(val) passes, so should the .readValue
         return val;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/DataTypeInfererTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/DataTypeInfererTest.java
@@ -42,7 +42,8 @@ class DataTypeInfererTest {
     expected.put("array_of_string", DataTypeMapping.ARRAY_OF_STRING);
     expected.put("string_val", DataTypeMapping.STRING);
     expected.put("int_val", DataTypeMapping.NUMBER);
-    expected.put("json_val", DataTypeMapping.JSON);
+    expected.put("json_object", DataTypeMapping.JSON);
+    expected.put("json_array", DataTypeMapping.JSON);
     expected.put("date_val", DataTypeMapping.DATE);
     expected.put("date_time_val", DataTypeMapping.DATE_TIME);
     expected.put("file_val", DataTypeMapping.FILE);
@@ -96,6 +97,8 @@ class DataTypeInfererTest {
     assertThat(inferer.isValidJson(Boolean.TRUE.toString())).isFalse();
     assertThat(inferer.isValidJson("True")).isFalse();
     assertThat(inferer.isValidJson("{\"foo\":\"bar\"}")).isTrue();
+    assertThat(inferer.isValidJson("[{\"value\":1}, {\"value\":2}, {\"value\":3}]")).isTrue();
+    assertThat(inferer.isValidJson("[\"foo\", \"bar\", \"baz\"]")).isFalse();
   }
 
   @Test
@@ -241,7 +244,8 @@ class DataTypeInfererTest {
         ofEntries(
             entry("int_val", new BigDecimal("4747")),
             entry("string_val", "Abracadabra Open Sesame"),
-            entry("json_val", "{\"list\": [\"a\", \"b\"]}"),
+            entry("json_object", "{\"list\": [\"a\", \"b\"]}"),
+            entry("json_array", "[{\"value\": 1}, {\"value\": 2}, {\"value\": 3}]"),
             entry("date_val", "2001-11-03"),
             entry("date_time_val", "2001-11-03T10:00:00"),
             entry("number_or_string", "47"),

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -3105,6 +3105,12 @@ class RecordControllerMockMvcTest extends MockMvcTestBase {
   static Stream<Arguments> jsonValues() {
     return Stream.of(
         Arguments.of(Map.of("value", "foo"), Map.of("value", "foo")),
-        Arguments.of("{\"value\":\"foo\"}", Map.of("value", "foo")));
+        Arguments.of("{\"value\":\"foo\"}", Map.of("value", "foo")),
+        Arguments.of(
+            List.of(Map.of("value", "foo"), Map.of("value", "bar")),
+            List.of(Map.of("value", "foo"), Map.of("value", "bar"))),
+        Arguments.of(
+            "[{\"value\":\"foo\"},{\"value\":\"bar\"}]",
+            List.of(Map.of("value", "foo"), Map.of("value", "bar"))));
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -3104,13 +3104,25 @@ class RecordControllerMockMvcTest extends MockMvcTestBase {
 
   static Stream<Arguments> jsonValues() {
     return Stream.of(
-        Arguments.of(Map.of("value", "foo"), Map.of("value", "foo")),
-        Arguments.of("{\"value\":\"foo\"}", Map.of("value", "foo")),
         Arguments.of(
-            List.of(Map.of("value", "foo"), Map.of("value", "bar")),
-            List.of(Map.of("value", "foo"), Map.of("value", "bar"))),
+            Map.of("string", "foo", "number", 1, "boolean", true),
+            Map.of("string", "foo", "number", BigInteger.valueOf(1), "boolean", Boolean.TRUE)),
         Arguments.of(
-            "[{\"value\":\"foo\"},{\"value\":\"bar\"}]",
-            List.of(Map.of("value", "foo"), Map.of("value", "bar"))));
+            "{\"string\":\"foo\",\"number\":1,\"boolean\":true}",
+            Map.of("string", "foo", "number", BigInteger.valueOf(1), "boolean", Boolean.TRUE)),
+        Arguments.of(
+            List.of(
+                Map.of("string", "foo", "number", 1, "boolean", true),
+                Map.of("string", "bar", "number", 2, "boolean", false)),
+            List.of(
+                Map.of("string", "foo", "number", BigInteger.valueOf(1), "boolean", Boolean.TRUE),
+                Map.of(
+                    "string", "bar", "number", BigInteger.valueOf(2), "boolean", Boolean.FALSE))),
+        Arguments.of(
+            "[{\"string\":\"foo\",\"number\":1,\"boolean\":true},{\"string\":\"bar\",\"number\":2,\"boolean\":false}]",
+            List.of(
+                Map.of("string", "foo", "number", BigInteger.valueOf(1), "boolean", Boolean.TRUE),
+                Map.of(
+                    "string", "bar", "number", BigInteger.valueOf(2), "boolean", Boolean.FALSE))));
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/model/DataTypeMappingTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/model/DataTypeMappingTest.java
@@ -27,6 +27,7 @@ class DataTypeMappingTest {
         Arguments.of(DataTypeMapping.NUMBER, DataTypeMapping.ARRAY_OF_NUMBER),
         Arguments.of(DataTypeMapping.DATE, DataTypeMapping.ARRAY_OF_DATE),
         Arguments.of(DataTypeMapping.DATE_TIME, DataTypeMapping.ARRAY_OF_DATE_TIME),
+        Arguments.of(DataTypeMapping.JSON, DataTypeMapping.JSON),
         Arguments.of(DataTypeMapping.NULL, DataTypeMapping.ARRAY_OF_STRING));
   }
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvJsonArgumentsProvider.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvJsonArgumentsProvider.java
@@ -80,6 +80,10 @@ public class TsvJsonArgumentsProvider implements ArgumentsProvider {
         // json packet
         Arguments.of(
             "{\"foo\":\"bar\", \"baz\": \"qux\"}", Map.of("foo", "bar", "baz", "qux"), false),
+        Arguments.of(
+            "[{\"value\":\"foo\"},{\"value\":\"bar\"},{\"value\":\"baz\"}]",
+            List.of(Map.of("value", "foo"), Map.of("value", "bar"), Map.of("value", "baz")),
+            false),
 
         // ========== arrays ==========
 


### PR DESCRIPTION
Currently, WDS does not support top level arrays in JSON fields. This adds support for them.