### PR TITLE
AJ-1591: startup validation

### DIFF
--- a/service/src/integrationTest/java/org/databiosphere/workspacedataservice/startup/InstanceInitializerCloneTest.java
+++ b/service/src/integrationTest/java/org/databiosphere/workspacedataservice/startup/InstanceInitializerCloneTest.java
@@ -1,4 +1,4 @@
-package org.databiosphere.workspacedataservice;
+package org.databiosphere.workspacedataservice.startup;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/WorkspaceDataServiceApplication.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/WorkspaceDataServiceApplication.java
@@ -1,10 +1,8 @@
 package org.databiosphere.workspacedataservice;
 
 import com.microsoft.applicationinsights.attach.ApplicationInsights;
-import org.databiosphere.workspacedataservice.config.TwdsProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
@@ -19,7 +17,6 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 @EnableRetry
 @EnableTransactionManagement
 @EnableCaching
-@EnableConfigurationProperties(TwdsProperties.class)
 public class WorkspaceDataServiceApplication {
 
   public static void main(String[] args) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/WorkspaceDataServiceApplication.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/WorkspaceDataServiceApplication.java
@@ -1,8 +1,10 @@
 package org.databiosphere.workspacedataservice;
 
 import com.microsoft.applicationinsights.attach.ApplicationInsights;
+import org.databiosphere.workspacedataservice.config.TwdsProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
@@ -17,6 +19,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 @EnableRetry
 @EnableTransactionManagement
 @EnableCaching
+@EnableConfigurationProperties(TwdsProperties.class)
 public class WorkspaceDataServiceApplication {
 
   public static void main(String[] args) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/WorkspaceDataServiceApplication.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/WorkspaceDataServiceApplication.java
@@ -1,10 +1,8 @@
 package org.databiosphere.workspacedataservice;
 
 import com.microsoft.applicationinsights.attach.ApplicationInsights;
-import org.databiosphere.workspacedataservice.config.WdsTenancyProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
@@ -19,7 +17,6 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 @EnableRetry
 @EnableTransactionManagement
 @EnableCaching
-@EnableConfigurationProperties(WdsTenancyProperties.class)
 public class WorkspaceDataServiceApplication {
 
   public static void main(String[] args) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/config/InstanceProperties.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/config/InstanceProperties.java
@@ -1,0 +1,27 @@
+package org.databiosphere.workspacedataservice.config;
+
+/**
+ * ConfigurationProperties class, loaded as a member of TwdsProperties, representing the
+ * `twds.instance` property hierarchy
+ */
+public class InstanceProperties {
+
+  private String workspaceId;
+  private String sourceWorkspaceId;
+
+  public String getWorkspaceId() {
+    return workspaceId;
+  }
+
+  public void setWorkspaceId(String workspaceId) {
+    this.workspaceId = workspaceId;
+  }
+
+  public String getSourceWorkspaceId() {
+    return sourceWorkspaceId;
+  }
+
+  public void setSourceWorkspaceId(String sourceWorkspaceId) {
+    this.sourceWorkspaceId = sourceWorkspaceId;
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/config/TenancyProperties.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/config/TenancyProperties.java
@@ -1,13 +1,10 @@
 package org.databiosphere.workspacedataservice.config;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
-
 /**
  * Configuration properties related to multi- or single-tenancy of workspaces within this WDS
  * deployment.
  */
-@ConfigurationProperties(prefix = "twds.tenancy")
-public class WdsTenancyProperties {
+public class TenancyProperties {
   private Boolean allowVirtualCollections;
   private Boolean requireEnvWorkspace;
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/config/TwdsProperties.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/config/TwdsProperties.java
@@ -1,0 +1,37 @@
+package org.databiosphere.workspacedataservice.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/** Top-level ConfigurationProperties class representing the "twds" hierarchy of properties. */
+@Configuration
+@ConfigurationProperties(prefix = "twds")
+public class TwdsProperties {
+  InstanceProperties instance;
+  String startupToken;
+  TenancyProperties tenancy;
+
+  public InstanceProperties getInstance() {
+    return instance;
+  }
+
+  public void setInstance(InstanceProperties instance) {
+    this.instance = instance;
+  }
+
+  public String getStartupToken() {
+    return startupToken;
+  }
+
+  public void setStartupToken(String startupToken) {
+    this.startupToken = startupToken;
+  }
+
+  public TenancyProperties getTenancy() {
+    return tenancy;
+  }
+
+  public void setTenancy(TenancyProperties tenancy) {
+    this.tenancy = tenancy;
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/startup/InstanceInitializer.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/startup/InstanceInitializer.java
@@ -1,4 +1,4 @@
-package org.databiosphere.workspacedataservice;
+package org.databiosphere.workspacedataservice.startup;
 
 import org.databiosphere.workspacedataservice.annotations.DeploymentMode.DataPlane;
 import org.jetbrains.annotations.NotNull;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/startup/InstanceInitializerBean.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/startup/InstanceInitializerBean.java
@@ -1,4 +1,4 @@
-package org.databiosphere.workspacedataservice;
+package org.databiosphere.workspacedataservice.startup;
 
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/startup/InstanceInitializerConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/startup/InstanceInitializerConfig.java
@@ -1,4 +1,4 @@
-package org.databiosphere.workspacedataservice;
+package org.databiosphere.workspacedataservice.startup;
 
 import org.databiosphere.workspacedataservice.dao.CloneDao;
 import org.databiosphere.workspacedataservice.dao.InstanceDao;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/startup/StartupConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/startup/StartupConfig.java
@@ -1,0 +1,62 @@
+package org.databiosphere.workspacedataservice.startup;
+
+import java.util.UUID;
+import org.databiosphere.workspacedataservice.config.TwdsProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+/** */
+@Component
+public class StartupConfig {
+
+  private static final Logger logger = LoggerFactory.getLogger(StartupConfig.class);
+
+  private final TwdsProperties twdsProperties;
+
+  public StartupConfig(TwdsProperties twdsProperties) {
+    this.twdsProperties = twdsProperties;
+  }
+
+  /**
+   * Validates configuration properties on startup, to allow for failing fast in case of
+   * misconfiguration.
+   *
+   * @param ignoredEvent the Spring event
+   */
+  @EventListener
+  public void onApplicationEvent(ContextRefreshedEvent ignoredEvent) {
+
+    // validate single- vs. multi-tenancy.
+    // if single-tenant, also validate the workspace id.
+    if (twdsProperties.getTenancy() == null) {
+      logger.warn(
+          "twds.tenancy properties are not defined. "
+              + "Was this deployment started with an active Spring profile of "
+              + "either 'data-plane' or 'control-plane'?");
+    } else {
+      logger.info(
+          "allow virtual collections: {}",
+          twdsProperties.getTenancy().getAllowVirtualCollections());
+      logger.info(
+          "require $WORKSPACE_ID env var: {}",
+          twdsProperties.getTenancy().getRequireEnvWorkspace());
+
+      if (twdsProperties.getTenancy().getRequireEnvWorkspace()) {
+        // attempt to parse the workspace id
+        try {
+          UUID workspaceUuid = UUID.fromString(twdsProperties.getInstance().getWorkspaceId());
+          logger.info("single-tenant workspace id: {}", workspaceUuid);
+        } catch (Exception e) {
+          logger.error(
+              "This deployment requires a $WORKSPACE_ID env var, but its value "
+                  + "could not be parsed to a UUID: {}",
+              e.getMessage());
+          throw e;
+        }
+      }
+    }
+  }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/config/TenancyPropertiesControlPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/config/TenancyPropertiesControlPlaneTest.java
@@ -7,12 +7,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles("control-plane")
-@DirtiesContext
 class TenancyPropertiesControlPlaneTest {
 
   @Autowired TwdsProperties twdsProperties;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/config/TenancyPropertiesControlPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/config/TenancyPropertiesControlPlaneTest.java
@@ -7,10 +7,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles("control-plane")
+@DirtiesContext
 class TenancyPropertiesControlPlaneTest {
 
   @Autowired TwdsProperties twdsProperties;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/config/TenancyPropertiesControlPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/config/TenancyPropertiesControlPlaneTest.java
@@ -1,6 +1,7 @@
 package org.databiosphere.workspacedataservice.config;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
@@ -13,6 +14,11 @@ import org.springframework.test.context.ActiveProfiles;
 class TenancyPropertiesControlPlaneTest {
 
   @Autowired TwdsProperties twdsProperties;
+
+  @Test
+  void nonNullTenancy() {
+    assertNotNull(twdsProperties.getTenancy());
+  }
 
   @Test
   void allowVirtualCollections() {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/config/TenancyPropertiesControlPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/config/TenancyPropertiesControlPlaneTest.java
@@ -9,18 +9,18 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
-@ActiveProfiles("data-plane")
-class WdsTenancyPropertiesDataPlaneTest {
+@ActiveProfiles("control-plane")
+class TenancyPropertiesControlPlaneTest {
 
-  @Autowired WdsTenancyProperties wdsTenancyProperties;
+  @Autowired TwdsProperties twdsProperties;
 
   @Test
   void allowVirtualCollections() {
-    assertFalse(wdsTenancyProperties.getAllowVirtualCollections());
+    assertTrue(twdsProperties.getTenancy().getAllowVirtualCollections());
   }
 
   @Test
   void requireEnvWorkspace() {
-    assertTrue(wdsTenancyProperties.getRequireEnvWorkspace());
+    assertFalse(twdsProperties.getTenancy().getRequireEnvWorkspace());
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/config/TenancyPropertiesDataPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/config/TenancyPropertiesDataPlaneTest.java
@@ -1,6 +1,7 @@
 package org.databiosphere.workspacedataservice.config;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
@@ -13,6 +14,11 @@ import org.springframework.test.context.ActiveProfiles;
 class TenancyPropertiesDataPlaneTest {
 
   @Autowired TwdsProperties twdsProperties;
+
+  @Test
+  void nonNullTenancy() {
+    assertNotNull(twdsProperties.getTenancy());
+  }
 
   @Test
   void allowVirtualCollections() {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/config/TenancyPropertiesDataPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/config/TenancyPropertiesDataPlaneTest.java
@@ -9,18 +9,18 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
-@ActiveProfiles("control-plane")
-class WdsTenancyPropertiesControlPlaneTest {
+@ActiveProfiles("data-plane")
+class TenancyPropertiesDataPlaneTest {
 
-  @Autowired WdsTenancyProperties wdsTenancyProperties;
+  @Autowired TwdsProperties twdsProperties;
 
   @Test
   void allowVirtualCollections() {
-    assertTrue(wdsTenancyProperties.getAllowVirtualCollections());
+    assertFalse(twdsProperties.getTenancy().getAllowVirtualCollections());
   }
 
   @Test
   void requireEnvWorkspace() {
-    assertFalse(wdsTenancyProperties.getRequireEnvWorkspace());
+    assertTrue(twdsProperties.getTenancy().getRequireEnvWorkspace());
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/config/TenancyPropertiesDataPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/config/TenancyPropertiesDataPlaneTest.java
@@ -9,7 +9,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest
+// the "data-plane" profile enforces validity of twds.instance.workspace-id, so we need to set that
+@SpringBootTest(properties = {"twds.instance.workspace-id=00ddba11-0000-0000-0000-000000000000"})
 @ActiveProfiles("data-plane")
 class TenancyPropertiesDataPlaneTest {
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/config/TenancyPropertiesDataPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/config/TenancyPropertiesDataPlaneTest.java
@@ -7,10 +7,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles("data-plane")
+@DirtiesContext
 class TenancyPropertiesDataPlaneTest {
 
   @Autowired TwdsProperties twdsProperties;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/config/TenancyPropertiesDataPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/config/TenancyPropertiesDataPlaneTest.java
@@ -7,12 +7,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles("data-plane")
-@DirtiesContext
 class TenancyPropertiesDataPlaneTest {
 
   @Autowired TwdsProperties twdsProperties;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/config/TenancyPropertiesNoProfileTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/config/TenancyPropertiesNoProfileTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
 /**
@@ -12,6 +13,7 @@ import org.springframework.test.context.ActiveProfiles;
  */
 @SpringBootTest
 @ActiveProfiles("neither-data-plane-nor-control-plane")
+@DirtiesContext
 class TenancyPropertiesNoProfileTest {
 
   @Autowired TwdsProperties twdsProperties;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/config/TenancyPropertiesNoProfileTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/config/TenancyPropertiesNoProfileTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
 /**
@@ -13,7 +12,6 @@ import org.springframework.test.context.ActiveProfiles;
  */
 @SpringBootTest
 @ActiveProfiles("neither-data-plane-nor-control-plane")
-@DirtiesContext
 class TenancyPropertiesNoProfileTest {
 
   @Autowired TwdsProperties twdsProperties;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/config/TenancyPropertiesNoProfileTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/config/TenancyPropertiesNoProfileTest.java
@@ -8,22 +8,16 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 /**
- * when neither the "data-plane" nor "control-plane" profile is active, WdsTenancyProperties are
- * null
+ * when neither the "data-plane" nor "control-plane" profile is active, TenancyProperties are null
  */
 @SpringBootTest
 @ActiveProfiles("neither-data-plane-nor-control-plane")
-class WdsTenancyPropertiesNoProfileTest {
+class TenancyPropertiesNoProfileTest {
 
-  @Autowired WdsTenancyProperties wdsTenancyProperties;
-
-  @Test
-  void allowVirtualCollections() {
-    assertNull(wdsTenancyProperties.getAllowVirtualCollections());
-  }
+  @Autowired TwdsProperties twdsProperties;
 
   @Test
-  void requireEnvWorkspace() {
-    assertNull(wdsTenancyProperties.getRequireEnvWorkspace());
+  void nullTenancy() {
+    assertNull(twdsProperties.getTenancy());
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/startup/InstanceInitializerBeanTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/startup/InstanceInitializerBeanTest.java
@@ -1,4 +1,4 @@
-package org.databiosphere.workspacedataservice;
+package org.databiosphere.workspacedataservice.startup;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/startup/InstanceInitializerNoWorkspaceIdTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/startup/InstanceInitializerNoWorkspaceIdTest.java
@@ -1,4 +1,4 @@
-package org.databiosphere.workspacedataservice;
+package org.databiosphere.workspacedataservice.startup;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;


### PR DESCRIPTION
Some more prefactoring to help out eventually with #489 

In this PR:
* create a new "startup" package
* move InstanceInitializer* classes into the startup package
* expand our ConfigurationProperties classes to include the top-level `twds` property hierarchy and, importantly, the `twds.instance.workspace-id` property (which is populated from the `$WORKSPACE_ID` env var)
* add a new `StartupConfig` class in the startup package, which is responsible for performing some on-startup validations including validating the `twds.instance.workspace-id` property

NOT in this PR to save scope:
* I did not attempt to consolidate InstanceInitializer stuff into StartupConfig, but I think that would be possible if we wanted to do it
* I did not attempt to update any other classes that read from or require the `twds.instance.workspace-id` property. For instance, the `PfbQuartzJob` bean will fail if `$WORKSPACE_ID` is not a valid UUID, and I didn't try to change that
* I did not build out classes for ALL properties under `twds`; I figured we could do that as we need them