### PR TITLE
AJ-1563 Clean up internal APIs

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/DataTypeInferer.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/DataTypeInferer.java
@@ -21,6 +21,7 @@ import static org.databiosphere.workspacedataservice.service.model.DataTypeMappi
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.mu.util.stream.BiStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -59,7 +60,7 @@ public class DataTypeInferer {
     return result;
   }
 
-  public Map<String, DataTypeMapping> inferTypes(List<Record> records) {
+  Map<String, DataTypeMapping> inferTypes(List<Record> records) {
     Map<String, DataTypeMapping> result = new HashMap<>();
     for (Record rcd : records) {
       if (rcd.getAttributes() == null) {
@@ -144,7 +145,8 @@ public class DataTypeInferer {
    * @param val the value for which to infer a type
    * @return the data type we want to use for this value
    */
-  public DataTypeMapping inferType(Object val) {
+  @VisibleForTesting
+  DataTypeMapping inferType(Object val) {
     // null does not tell us much, this results in a text data type in the db if
     // everything in batch is null
     // if there are non-null values in the batch this return value will let those

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/DataTypeInfererTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/DataTypeInfererTest.java
@@ -1,4 +1,4 @@
-package org.databiosphere.workspacedataservice;
+package org.databiosphere.workspacedataservice.service;
 
 import static com.google.common.collect.MoreCollectors.onlyElement;
 import static java.util.Collections.emptyList;
@@ -16,9 +16,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.databiosphere.workspacedataservice.service.DataTypeInferer;
-import org.databiosphere.workspacedataservice.service.DataTypeInfererConfig;
-import org.databiosphere.workspacedataservice.service.JsonConfig;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
 import org.databiosphere.workspacedataservice.service.model.Relation;
 import org.databiosphere.workspacedataservice.shared.model.Record;


### PR DESCRIPTION
This is prefactoring for [AJ-1563](https://broadworkbench.atlassian.net/browse/AJ-1563).  Some of the internal APIs used by `BatchWriteService` can be tightened up with a little bit of refactoring in internal method signatures.

The commits are self-contained and might be easier to review individually.

[AJ-1563]: https://broadworkbench.atlassian.net/browse/AJ-1563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ