### PR TITLE
AJ-1556: switch to gradle-maintained dependency submission

### DIFF
--- a/.github/workflows/submit-dependencies.yml
+++ b/.github/workflows/submit-dependencies.yml
@@ -14,5 +14,11 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'gradle'
       - name: Generate and submit dependency graph
         uses: gradle/actions/dependency-submission@v3

--- a/.github/workflows/submit-dependencies.yml
+++ b/.github/workflows/submit-dependencies.yml
@@ -12,19 +12,7 @@ jobs:
     permissions: # The Dependency Submission API requires write permission
       contents: write
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up JDK
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'gradle'
-
-      - name: Submit Dependencies
-        uses: mikepenz/gradle-dependency-submission@v0.9.0
-        with:
-          gradle-build-module: |-
-            :service
-            :client
-
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Generate and submit dependency graph
+        uses: gradle/actions/dependency-submission@v3


### PR DESCRIPTION
The action we were using for dependency submission - https://github.com/marketplace/actions/gradle-dependency-submission - is deprecated. This switches us to use the recommended solution which is provided directly by gradle.

I manually kicked off the action in this PR at https://github.com/DataBiosphere/terra-workspace-data-service/actions/runs/7889889650/job/21530809619 and saw it succeed.