### PR TITLE
AJ-1556: streamline github workflows

### DIFF
--- a/.github/workflows/build-and-integration-test.yml
+++ b/.github/workflows/build-and-integration-test.yml
@@ -9,13 +9,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout sources
+        uses: actions/checkout@v4
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: 'gradle'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Build all projects without running tests
         run: ./gradlew --build-cache build -x test
@@ -37,7 +39,8 @@ jobs:
         ports: [ "5432:5432" ]
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout sources
+        uses: actions/checkout@v4
 
       - name: Install pg_dump
         run: sudo apt install postgresql-14 postgresql-contrib
@@ -48,26 +51,14 @@ jobs:
         run: psql -h 127.0.0.1 -U postgres -f ./local-dev/local-postgres-init.sql
 
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: 'gradle'
 
-      - name: Cache Gradle packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Build, assemble, and integration test
         id: build-test
         run: ./gradlew integrationTest
-
-      - name: Upload Test Reports
-        if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: Test Reports
-          path: service/build/reports

--- a/.github/workflows/build-and-integration-test.yml
+++ b/.github/workflows/build-and-integration-test.yml
@@ -62,3 +62,11 @@ jobs:
       - name: Build, assemble, and integration test
         id: build-test
         run: ./gradlew integrationTest
+
+      - name: Upload Test Reports
+        if: steps.build-test.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: Test Reports
+          path: service/build/reports
+          retention-days: 14

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,13 +11,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout sources
+        uses: actions/checkout@v4
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: 'gradle'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Build all projects without running tests
         run: ./gradlew --build-cache build -x test
@@ -50,11 +52,13 @@ jobs:
         run: psql -h 127.0.0.1 -U postgres -f ./local-dev/local-postgres-init.sql
 
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Cache SonarCloud packages
         uses: actions/cache@v3
@@ -62,13 +66,6 @@ jobs:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
-
-      - name: Cache Gradle packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle
 
       - name: Build, assemble, and test
         id: build-test
@@ -80,10 +77,3 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./gradlew --build-cache sonar
-
-      - name: Upload Test Reports
-        if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: Test Reports
-          path: service/build/reports

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -77,3 +77,11 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./gradlew --build-cache sonar
+
+      - name: Upload Test Reports
+        if: steps.build-test.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: Test Reports
+          path: service/build/reports
+          retention-days: 14

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/publish-java-client.yml
+++ b/.github/workflows/publish-java-client.yml
@@ -18,17 +18,13 @@ jobs:
         with:
           ref: main
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
 
-      - name: Cache Gradle packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Build all projects without running tests
         run: ./gradlew --build-cache build -x test

--- a/.github/workflows/publish-pacts.yml
+++ b/.github/workflows/publish-pacts.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Checkout current code
         uses: actions/checkout@v4
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/publish-pacts.yml
+++ b/.github/workflows/publish-pacts.yml
@@ -96,6 +96,8 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
       - name: Run consumer tests
         run: ./gradlew pactTests
 

--- a/.github/workflows/release-python-client.yml
+++ b/.github/workflows/release-python-client.yml
@@ -74,11 +74,13 @@ jobs:
           docker run -v ${{ github.workspace }}/service/src/test/resources/nginx.conf:/etc/nginx/nginx.conf:ro -v ${{ github.workspace }}/service/src/test/resources:/usr/share/nginx/html -p 9889:80 -d nginx:1.23.3
 
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Run WDS service and tests
         run: |

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -72,7 +72,7 @@ jobs:
           run_name: "${{ env.ATTACH_BP_TO_LZ_RUN_NAME }}"
           bee_name: ${{ env.BEE_NAME }}
           token: '${{ env.TOKEN }}'
-          project_name: ${{needs.params-gen.outputs.project-name }}
+          project_name: ${{ needs.params-gen.outputs.project-name }}
 
       - name: retry dispatch to terra-github-workflows in case of failure
         if: steps.FirstAttemptLandingZone.outcome == 'failure'
@@ -81,7 +81,7 @@ jobs:
           run_name: "${{ env.ATTACH_BP_TO_LZ_RUN_NAME }}-retry"
           bee_name: ${{ env.BEE_NAME }}
           token: '${{ env.TOKEN }}'
-          project_name: ${{needs.params-gen.outputs.project-name }}
+          project_name: ${{ needs.params-gen.outputs.project-name }}
 
   run-e2e-test-job:
     needs:

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -40,48 +40,48 @@ jobs:
       id-token: write
     steps:
       - name: Get actions
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: dispatch to terra-github-workflows
         id: FirstAttemptCreateBee
         continue-on-error: true
         uses: ./.github/actions/create-bee
         with:
-            bee_name: ${{ env.BEE_NAME }}
-            token: '${{ env.TOKEN }}'
+          bee_name: ${{ env.BEE_NAME }}
+          token: '${{ env.TOKEN }}'
 
       - name: retry dispatch to terra-github-workflows in case of failure
         if: steps.FirstAttemptCreateBee.outcome == 'failure'
         uses: ./.github/actions/create-bee
         with:
-            bee_name: ${{ env.BEE_NAME }},
-            token: ${{ env.TOKEN }}
+          bee_name: ${{ env.BEE_NAME }},
+          token: ${{ env.TOKEN }}
 
   attach-landing-zone-to-bee-workflow:
     runs-on: ubuntu-latest
     needs: [ init-github-context, create-bee-workflow, params-gen ]
     steps:
       - name: Get actions
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: dispatch to terra-github-workflows
         id: FirstAttemptLandingZone
         continue-on-error: true
         uses: ./.github/actions/landing-zone-attach
         with:
-            run_name: "${{ env.ATTACH_BP_TO_LZ_RUN_NAME }}"
-            bee_name: ${{ env.BEE_NAME }}
-            token: '${{ env.TOKEN }}'
-            project_name: ${{needs.params-gen.outputs.project-name }}
+          run_name: "${{ env.ATTACH_BP_TO_LZ_RUN_NAME }}"
+          bee_name: ${{ env.BEE_NAME }}
+          token: '${{ env.TOKEN }}'
+          project_name: ${{needs.params-gen.outputs.project-name }}
 
       - name: retry dispatch to terra-github-workflows in case of failure
         if: steps.FirstAttemptLandingZone.outcome == 'failure'
         uses: ./.github/actions/landing-zone-attach
         with:
-            run_name: "${{ env.ATTACH_BP_TO_LZ_RUN_NAME }}-retry"
-            bee_name: ${{ env.BEE_NAME }}
-            token: '${{ env.TOKEN }}'
-            project_name: ${{needs.params-gen.outputs.project-name }}
+          run_name: "${{ env.ATTACH_BP_TO_LZ_RUN_NAME }}-retry"
+          bee_name: ${{ env.BEE_NAME }}
+          token: '${{ env.TOKEN }}'
+          project_name: ${{needs.params-gen.outputs.project-name }}
 
   run-e2e-test-job:
     needs:


### PR DESCRIPTION
Cleans up our GHAs. In this PR:

1. Update `actions/setup-java` to `v4` wherever it is out of date
2. Update `actions/checkout` to `v4` wherever it is out of date
3. Add `gradle/actions/setup-gradle@v3` wherever we use gradle. See https://github.com/marketplace/actions/build-with-gradle for more info; this action was not available when 
4. Remove `setup-java`'s gradle cache in favor of the one in `setup-gradle`
5. Remove explicit caching of gradle stuff via `actions/cache` in favor of the one in `setup-gradle`
6.  Change "Upload Test Reports" steps to only upload reports if tests failed, to save time … does anyone look at these?
