### PR TITLE
[AJ-1611] Support top level arrays in JSON fields

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -1035,7 +1035,8 @@ public class RecordDao {
       String[] jsonArray = (String[]) object;
       Object[] result = new Object[jsonArray.length];
       for (int i = 0; i < jsonArray.length; i++) {
-        result[i] = objectMapper.readValue(jsonArray[i], Object.class);
+        result[i] =
+            objectMapper.readValue(jsonArray[i], new TypeReference<Map<String, Object>>() {});
       }
       return result;
     }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/DataTypeMapping.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/DataTypeMapping.java
@@ -25,7 +25,8 @@ public enum DataTypeMapping {
   ARRAY_OF_STRING(String[].class, "text[]", true, "?"),
   ARRAY_OF_RELATION(String[].class, "array_of_relation", true, "?"),
   ARRAY_OF_FILE(String[].class, "array_of_file", true, "?"),
-  ARRAY_OF_BOOLEAN(Boolean[].class, "boolean[]", true, "?");
+  ARRAY_OF_BOOLEAN(Boolean[].class, "boolean[]", true, "?"),
+  ARRAY_OF_JSON(String[].class, "jsonb[]", true, "?::jsonb[]");
 
   private final Class javaArrayTypeForDbWrites;
 
@@ -48,7 +49,8 @@ public enum DataTypeMapping {
           new BaseTypeAndArrayTypePair(DATE, ARRAY_OF_DATE),
           new BaseTypeAndArrayTypePair(DATE_TIME, ARRAY_OF_DATE_TIME),
           new BaseTypeAndArrayTypePair(FILE, ARRAY_OF_FILE),
-          new BaseTypeAndArrayTypePair(RELATION, ARRAY_OF_RELATION));
+          new BaseTypeAndArrayTypePair(RELATION, ARRAY_OF_RELATION),
+          new BaseTypeAndArrayTypePair(JSON, ARRAY_OF_JSON));
 
   static {
     Arrays.stream(DataTypeMapping.values())

--- a/service/src/main/java/org/databiosphere/workspacedataservice/tsv/TsvDeserializer.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/tsv/TsvDeserializer.java
@@ -136,6 +136,7 @@ public class TsvDeserializer extends StdDeserializer<RecordAttributes> {
         return objectMapper.readValue(val, new TypeReference<Map<String, Object>>() {});
       } catch (JsonProcessingException jpe) {
         // this shouldn't happen; if inferer.isValidJson(val) passes, so should the .readValue
+        LOGGER.error("Unable to parse validated JSON: {}", val);
         return val;
       }
     }
@@ -220,6 +221,7 @@ public class TsvDeserializer extends StdDeserializer<RecordAttributes> {
         return objectMapper.readValue(on.toString(), new TypeReference<Map<String, Object>>() {});
       } catch (JsonProcessingException jpe) {
         // this shouldn't happen since we've already parsed the array into JSON
+        LOGGER.error("Unable to parse array element JSON: {}", on);
         return on.toString();
       }
     }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/tsv/TsvDeserializer.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/tsv/TsvDeserializer.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.BooleanNode;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.NumericNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -213,6 +214,14 @@ public class TsvDeserializer extends StdDeserializer<RecordAttributes> {
     }
     if (element instanceof BooleanNode bn) {
       return bn.asBoolean();
+    }
+    if (element instanceof ObjectNode on) {
+      try {
+        return objectMapper.readValue(on.toString(), new TypeReference<Map<String, Object>>() {});
+      } catch (JsonProcessingException jpe) {
+        // this shouldn't happen since we've already parsed the array into JSON
+        return on.toString();
+      }
     }
     if (element instanceof TextNode strElement) {
       return cellToAttribute(strElement.toString());

--- a/service/src/test/java/org/databiosphere/workspacedataservice/TestUtils.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/TestUtils.java
@@ -22,6 +22,7 @@ public class TestUtils {
         + "\"array_of_boolean\":[true,false,true,true],\"array_of_date\":[\"2021-11-03\",\"2021-11-04\"],"
         + "\"array_of_date_time\":[\"2021-11-03T07:30:00\",\"2021-11-03T07:30:00\"],"
         + "\"array_of_file\":[\"https://lz1a2b345c67def8a91234bc.blob.core.windows.net/sc-7ad51c5d-eb4c-4685-bffe-62b861f7753f/file.bam\",\"drs://jade.datarepo-dev.broadinstitute.org/v1_9545e956-aa6a-4b84-a037-d0ed164c1890\"],"
+        + "\"array_of_json\":[{\"value\":\"foo\"},{\"value\":\"bar\"},{\"value\":\"baz\"}],"
         + "\"array_of_relation\":[\"terra-wds:/target-record/record_0\",\"terra-wds:/target-record/record_1\"],"
         + "\"array_of_string\":[\"a\",\"b\",\"c\",\"12\"],\"array-of-number\":[1,2,3],\"boolean\":false,\"date\":\"2021-11-03\","
         + "\"date-time\":\"2021-11-03T07:30:00\",\"empty-array\":[],"
@@ -62,7 +63,10 @@ public class TestUtils {
             "array_of_relation",
             List.of(
                 RelationUtils.createRelationString(typeForRelation, "record_0"),
-                RelationUtils.createRelationString(typeForRelation, "record_1")));
+                RelationUtils.createRelationString(typeForRelation, "record_1")))
+        .putAttribute(
+            "array_of_json",
+            List.of(Map.of("value", "foo"), Map.of("value", "bar"), Map.of("value", "baz")));
   }
 
   public static RecordAttributes getAllTypesAttributesForTsv() {
@@ -95,7 +99,9 @@ public class TestUtils {
                 + RelationUtils.createRelationString(typeForRelation, "record_0")
                 + "\",\""
                 + RelationUtils.createRelationString(typeForRelation, "record_1")
-                + "\"]");
+                + "\"]")
+        .putAttribute(
+            "array_of_json", "[{\"value\":\"foo\"},{\"value\":\"bar\"},{\"value\":\"baz\"}]");
   }
 
   public static RecordAttributes generateRandomAttributes() {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -3099,12 +3099,27 @@ class RecordControllerMockMvcTest extends MockMvcTestBase {
             .andReturn();
     RecordTypeSchema schema = fromJson(schemaResult, RecordTypeSchema.class);
 
-    assertEquals("JSON", schema.getAttributeSchema(attributeName).datatype());
+    String expectedType = inputValue instanceof List ? "ARRAY_OF_JSON" : "JSON";
+    assertEquals(expectedType, schema.getAttributeSchema(attributeName).datatype());
   }
 
   static Stream<Arguments> jsonValues() {
     return Stream.of(
-        Arguments.of(Map.of("value", "foo"), Map.of("value", "foo")),
-        Arguments.of("{\"value\":\"foo\"}", Map.of("value", "foo")));
+        Arguments.of(
+            Map.of("string", "foo", "number", 1, "boolean", true),
+            Map.of("string", "foo", "number", BigInteger.valueOf(1), "boolean", Boolean.TRUE)),
+        // TODO: Is this case (creating a JSON attribute by passing a JSON encoded string)
+        // intentionally supported?
+        Arguments.of(
+            "{\"string\":\"foo\",\"number\":1,\"boolean\":true}",
+            Map.of("string", "foo", "number", BigInteger.valueOf(1), "boolean", Boolean.TRUE)),
+        Arguments.of(
+            List.of(
+                Map.of("string", "foo", "number", 1, "boolean", true),
+                Map.of("string", "bar", "number", 2, "boolean", false)),
+            List.of(
+                Map.of("string", "foo", "number", BigInteger.valueOf(1), "boolean", Boolean.TRUE),
+                Map.of(
+                    "string", "bar", "number", BigInteger.valueOf(2), "boolean", Boolean.FALSE))));
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/model/DataTypeMappingTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/model/DataTypeMappingTest.java
@@ -27,6 +27,7 @@ class DataTypeMappingTest {
         Arguments.of(DataTypeMapping.NUMBER, DataTypeMapping.ARRAY_OF_NUMBER),
         Arguments.of(DataTypeMapping.DATE, DataTypeMapping.ARRAY_OF_DATE),
         Arguments.of(DataTypeMapping.DATE_TIME, DataTypeMapping.ARRAY_OF_DATE_TIME),
+        Arguments.of(DataTypeMapping.JSON, DataTypeMapping.ARRAY_OF_JSON),
         Arguments.of(DataTypeMapping.NULL, DataTypeMapping.ARRAY_OF_STRING));
   }
 
@@ -65,6 +66,7 @@ class DataTypeMappingTest {
         Arguments.of(DataTypeMapping.ARRAY_OF_BOOLEAN, DataTypeMapping.BOOLEAN),
         Arguments.of(DataTypeMapping.ARRAY_OF_NUMBER, DataTypeMapping.NUMBER),
         Arguments.of(DataTypeMapping.ARRAY_OF_DATE, DataTypeMapping.DATE),
-        Arguments.of(DataTypeMapping.ARRAY_OF_DATE_TIME, DataTypeMapping.DATE_TIME));
+        Arguments.of(DataTypeMapping.ARRAY_OF_DATE_TIME, DataTypeMapping.DATE_TIME),
+        Arguments.of(DataTypeMapping.ARRAY_OF_JSON, DataTypeMapping.JSON));
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvJsonArgumentsProvider.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvJsonArgumentsProvider.java
@@ -145,6 +145,12 @@ public class TsvJsonArgumentsProvider implements ArgumentsProvider {
             List.of("terra-wds:/type/id", "terra-wds:/type/id2"),
             false),
 
+        // array of JSON objects
+        Arguments.of(
+            "[{\"value\":\"foo\"},{\"value\":\"bar\"},{\"value\":\"baz\"}]",
+            List.of(Map.of("value", "foo"), Map.of("value", "bar"), Map.of("value", "baz")),
+            false),
+
         // mixed array (these deserialize as mixed lists, will be coerced to a single data type
         // later in processing)
         Arguments.of(


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1611

Currently, WDS does not support top level arrays in JSON fields. This adds support for them by implementing an `ARRAY_OF_JSON` type.

Replacement for #508 based on https://github.com/DataBiosphere/terra-workspace-data-service/pull/508#issuecomment-1941879831.

