### PR TITLE
[AJ-1618] Split terra-helmfile PR out of publish-docker workflow

### DIFF
--- a/.github/workflows/publish-app-version.yml
+++ b/.github/workflows/publish-app-version.yml
@@ -1,4 +1,4 @@
-name: Publish new version to terra-helmfile
+name: Publish new app version to terra-helmfile
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -5,15 +5,10 @@ on:
       new-tag:
         required: true
         type: string
-      jiraId:
-        required: true
-        type: string
     secrets:
       ACR_SP_PASSWORD:
         required: true
       ACR_SP_USER:
-        required: true
-      BROADBOT_TOKEN:
         required: true
 
 env:
@@ -35,18 +30,6 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-
-      - name: Look for AJ (Analysis Journeys) Jira ID in the manual workflow trigger message
-        id: find-jira-id
-        run: |
-          set +e
-          JIRA_ID=$(echo "${{ inputs.jiraId }}" | grep -iEo -m 1 'AJ-[0-9]+' | head -1 || '')
-          if [[ -z "$JIRA_ID" ]]; then
-            echo "JIRA_ID=missing" >> $GITHUB_OUTPUT
-          else
-            echo "JIRA_ID=${JIRA_ID}" >> $GITHUB_OUTPUT
-          fi
-          set -e
 
       - name: Set commit short hash
         id: setHash
@@ -115,33 +98,3 @@ jobs:
           --username ${{ secrets.ACR_SP_USER }} \
           --password-stdin
           docker push --all-tags ${{ steps.acr-image-name.outputs.name }}
-
-      - name: Clone terra-helmfile
-        uses: actions/checkout@v4
-        with:
-          repository: broadinstitute/terra-helmfile
-          token: ${{ secrets.BROADBOT_TOKEN }} # Has to be set at checkout AND later when pushing to work
-          path: terra-helmfile
-
-      - name: Create terra-helmfile PR for latest WDS version
-        env:
-          BROADBOT_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
-          GH_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
-        run: |
-          set -e
-          JIRA_ID=${{ steps.find-jira-id.outputs.JIRA_ID }}
-          if [[ $JIRA_ID == "missing" ]]; then
-            echo "JIRA_ID missing, PR to terra-helmfile will not be created"
-            exit 0;
-          fi
-          cd terra-helmfile
-          HELM_CUR_TAG=$(grep "/terra-workspace-data-service:" charts/wds/values.yaml | sed "s,.*/terra-workspace-data-service:,,")
-          HELM_NEW_TAG=${{ inputs.new-tag }}
-          git checkout -b ${JIRA_ID}-auto-update-${HELM_NEW_TAG}
-          [[ -n "$HELM_CUR_TAG" && -n "$HELM_NEW_TAG" ]]
-          sed -i "s/$HELM_CUR_TAG/$HELM_NEW_TAG/" charts/wds/values.yaml
-          git config --global user.name "broadbot"
-          git config --global user.email "broadbot@broadinstitute.org"
-          git commit -am "${JIRA_ID}: Auto update WDS version to $HELM_NEW_TAG"
-          git push -u origin ${JIRA_ID}-auto-update-${HELM_NEW_TAG}
-          gh pr create --title "${JIRA_ID}: auto update WDS version to $HELM_NEW_TAG" --body "${JIRA_ID} helm chart update" --label "automerge"

--- a/.github/workflows/publish-version.yml
+++ b/.github/workflows/publish-version.yml
@@ -1,0 +1,61 @@
+name: Publish new version to terra-helmfile
+on:
+  workflow_call:
+    inputs:
+      new-tag:
+        required: true
+        type: string
+      jiraId:
+        required: true
+        type: string
+    secrets:
+      BROADBOT_TOKEN:
+        required: true
+
+jobs:
+  create-terra-helmfile-pr:
+    name: Create terra-helmfile PR for latest WDS version
+    runs-on: ubuntu-latest
+    needs: publish-docker-job
+    steps:
+      - name: Look for AJ (Analysis Journeys) Jira ID in the manual workflow trigger message
+        id: find-jira-id
+        run: |
+          set +e
+          JIRA_ID=$(echo "${{ inputs.jiraId }}" | grep -iEo -m 1 'AJ-[0-9]+' | head -1 || '')
+          if [[ -z "$JIRA_ID" ]]; then
+            echo "JIRA_ID=missing" >> $GITHUB_OUTPUT
+          else
+            echo "JIRA_ID=${JIRA_ID}" >> $GITHUB_OUTPUT
+          fi
+          set -e
+
+      - name: Clone terra-helmfile
+        uses: actions/checkout@v4
+        with:
+          repository: broadinstitute/terra-helmfile
+          token: ${{ secrets.BROADBOT_TOKEN }} # Has to be set at checkout AND later when pushing to work
+          path: terra-helmfile
+
+      - name: Create terra-helmfile PR for latest WDS version
+        env:
+          BROADBOT_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
+          GH_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
+          JIRA_ID: ${{ steps.find-jira-id.outputs.JIRA_ID }}
+          HELM_NEW_TAG: ${{ inputs.new-tag }}
+        run: |
+          set -e
+          if [[ $JIRA_ID == "missing" ]]; then
+            echo "JIRA_ID missing, PR to terra-helmfile will not be created"
+            exit 0;
+          fi
+          cd terra-helmfile
+          HELM_CUR_TAG=$(grep "/terra-workspace-data-service:" charts/wds/values.yaml | sed "s,.*/terra-workspace-data-service:,,")
+          git checkout -b ${JIRA_ID}-auto-update-${HELM_NEW_TAG}
+          [[ -n "$HELM_CUR_TAG" && -n "$HELM_NEW_TAG" ]]
+          sed -i "s/$HELM_CUR_TAG/$HELM_NEW_TAG/" charts/wds/values.yaml
+          git config --global user.name "broadbot"
+          git config --global user.email "broadbot@broadinstitute.org"
+          git commit -am "${JIRA_ID}: Auto update WDS version to $HELM_NEW_TAG"
+          git push -u origin ${JIRA_ID}-auto-update-${HELM_NEW_TAG}
+          gh pr create --title "${JIRA_ID}: auto update WDS version to $HELM_NEW_TAG" --body "${JIRA_ID} helm chart update" --label "automerge"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -75,9 +75,9 @@ jobs:
           config-name: release-drafter-config.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  publish-job:
+  publish-app-version-job:
     needs: [tag-job, docker-image-job]
-    uses: ./.github/workflows/publish-version.yml
+    uses: ./.github/workflows/publish-app-version.yml
     with:
       new-tag: ${{ needs.tag-job.outputs.new_tag }}
       jiraId: ${{ inputs.jiraId }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -53,11 +53,9 @@ jobs:
     uses: ./.github/workflows/publish-docker.yml
     with:
       new-tag: ${{ needs.tag-job.outputs.new_tag }}
-      jiraId: ${{ inputs.jiraId }}
     secrets:
       ACR_SP_PASSWORD: ${{ secrets.ACR_SP_PASSWORD }}
       ACR_SP_USER: ${{ secrets.ACR_SP_USER }}
-      BROADBOT_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
   release-job:
     needs: tag-job
     permissions:
@@ -77,3 +75,11 @@ jobs:
           config-name: release-drafter-config.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  publish-job:
+    needs: [tag-job, docker-image-job]
+    uses: ./.github/workflows/publish-version.yml
+    with:
+      new-tag: ${{ needs.tag-job.outputs.new_tag }}
+      jiraId: ${{ inputs.jiraId }}
+    secrets:
+      BROADBOT_TOKEN: ${{ secrets.BROADBOT_TOKEN }}


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1618

A bit of "prefactoring" for AJ-1618... This splits the creation of a terra-helmfile PR out of the publish-docker workflow into a separate publish-version workflow (suggestions for a better name welcome). This refines publish-docker to its stated purpose ("Publish Docker Images to GCR and ACR") and limits the BroadBot token to a smaller workflow.

The intent is to then add a second job to the publish-version workflow to notify Sherlock of a new cWDS version.