### PR TITLE
[AJ-1420] Fail terra-helmfile PR job if no JIRA ticket provided

### DIFF
--- a/.github/workflows/publish-app-version.yml
+++ b/.github/workflows/publish-app-version.yml
@@ -16,7 +16,6 @@ jobs:
   create-terra-helmfile-pr:
     name: Create terra-helmfile PR for latest WDS version
     runs-on: ubuntu-latest
-    needs: publish-docker-job
     steps:
       - name: Look for AJ (Analysis Journeys) Jira ID in the manual workflow trigger message
         id: find-jira-id

--- a/.github/workflows/publish-app-version.yml
+++ b/.github/workflows/publish-app-version.yml
@@ -24,7 +24,8 @@ jobs:
           set +e
           JIRA_ID=$(echo "${{ inputs.jiraId }}" | grep -iEo -m 1 'AJ-[0-9]+' | head -1 || '')
           if [[ -z "$JIRA_ID" ]]; then
-            echo "JIRA_ID=missing" >> $GITHUB_OUTPUT
+            echo "JIRA_ID missing, PR to terra-helmfile will not be created" 1>&2
+            exit 1;
           else
             echo "JIRA_ID=${JIRA_ID}" >> $GITHUB_OUTPUT
           fi
@@ -45,10 +46,6 @@ jobs:
           HELM_NEW_TAG: ${{ inputs.new-tag }}
         run: |
           set -e
-          if [[ $JIRA_ID == "missing" ]]; then
-            echo "JIRA_ID missing, PR to terra-helmfile will not be created"
-            exit 0;
-          fi
           cd terra-helmfile
           HELM_CUR_TAG=$(grep "/terra-workspace-data-service:" charts/wds/values.yaml | sed "s,.*/terra-workspace-data-service:,,")
           git checkout -b ${JIRA_ID}-auto-update-${HELM_NEW_TAG}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -7,7 +7,7 @@ on:
         # Friendly description to be shown in the UI instead of 'name'
         description: 'Jira ID'
         # Default value if no value is explicitly provided
-        default: 'Required: Include latest Jira ID'
+        default: 'AJ-###'
         # Input has to be provided for the workflow to run
         required: true
         # The data type of the input


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1420

Running the `tag` workflow asks for the ID of a ticket. It uses that JIRA ticket ID to create a PR to terra-helmfile.

Currently, if no valid ticket ID is found, the `find-jira-id` step outputs "missing". If the terra-helmfile PR step sees that the JIRA ID is "missing", it prints a message and exits cleanly, which results in the job showing as successful.

This changes it so that if no ticket ID is found, the `find-jira-id` step fails, which would make the terra-helmfile PR job show as failed.

It also changes the default placeholder for the JIRA ID input field to "AJ-###".