### PR TITLE
[AJ-1635] Configure Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    labels:
+      - "dependencies"
+      - "gradle"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "@DataBiosphere/analysisjourneys"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "America/New_York"


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1635

Seeing that we've accumulated several Dependabot alerts, this sets up automated Dependabot updates using the same configuration that we use for [DataBiosphere/java-pfb](https://github.com/DataBiosphere/java-pfb/blob/main/.github/dependabot.yml).