### PR TITLE
Custom RestController that supports cloud platform.

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/annotations/DeploymentRestController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/annotations/DeploymentRestController.java
@@ -1,0 +1,48 @@
+package org.databiosphere.workspacedataservice.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+import org.springframework.web.bind.annotation.RestController;
+
+/*A wrapper for our @RestControllers that requires us to specify whether we're exposing our APIs for
+ * the control-plane, data-plane, or both.*/
+public interface DeploymentRestController {
+
+  @Target({ElementType.TYPE})
+  @Retention(RetentionPolicy.RUNTIME)
+  @RestController
+  @Conditional(DeploymentModeCondition.class)
+  public @interface WdsRestController {
+    String[] deploymentModes();
+  }
+}
+
+class DeploymentModeCondition implements Condition {
+
+  @Override
+  public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+    // get the deploymentModes value from the WdsRestController annotation
+    String[] deploymentModes =
+        (String[])
+            metadata
+                .getAnnotationAttributes(DeploymentRestController.WdsRestController.class.getName())
+                .get("deploymentModes");
+
+    // get the actual deployment mode from the environment
+    String actualDeploymentMode = context.getEnvironment().getProperty("env.wds.deploymentMode");
+
+    // check if the actual deployment mode matches any of the required deployment modes
+    for (String deploymentMode : deploymentModes) {
+      if (deploymentMode.equals(actualDeploymentMode)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/CapabilitiesController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/CapabilitiesController.java
@@ -4,16 +4,16 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.InputStream;
+import org.databiosphere.workspacedataservice.annotations.DeploymentRestController.WdsRestController;
 import org.databiosphere.workspacedataservice.generated.CapabilitiesApi;
 import org.databiosphere.workspacedataservice.generated.CapabilitiesServerModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RestController;
 
 /** Controller for capabilities-related APIs */
-@RestController
+@WdsRestController(deploymentModes = {"data-plane"})
 public class CapabilitiesController implements CapabilitiesApi {
 
   private final CapabilitiesServerModel capabilitiesServerModel;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/CloningController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/CloningController.java
@@ -3,6 +3,7 @@ package org.databiosphere.workspacedataservice.controller;
 import static org.databiosphere.workspacedataservice.service.RecordUtils.validateVersion;
 
 import java.util.UUID;
+import org.databiosphere.workspacedataservice.annotations.DeploymentRestController.WdsRestController;
 import org.databiosphere.workspacedataservice.service.BackupRestoreService;
 import org.databiosphere.workspacedataservice.shared.model.BackupResponse;
 import org.databiosphere.workspacedataservice.shared.model.BackupRestoreRequest;
@@ -15,9 +16,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
 
-@RestController
+@WdsRestController(deploymentModes = {"data-plane"})
 public class CloningController {
 
   private final BackupRestoreService backupRestoreService;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/ImportController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/ImportController.java
@@ -1,15 +1,15 @@
 package org.databiosphere.workspacedataservice.controller;
 
 import java.util.UUID;
+import org.databiosphere.workspacedataservice.annotations.DeploymentRestController.WdsRestController;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
 import org.databiosphere.workspacedataservice.generated.ImportApi;
 import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
 import org.databiosphere.workspacedataservice.service.ImportService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RestController;
 
-@RestController
+@WdsRestController(deploymentModes = {"data-plane"})
 public class ImportController implements ImportApi {
   private final ImportService importService;
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/JobController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/JobController.java
@@ -4,6 +4,7 @@ import static org.databiosphere.workspacedataservice.generated.GenericJobServerM
 
 import java.util.List;
 import java.util.UUID;
+import org.databiosphere.workspacedataservice.annotations.DeploymentRestController.WdsRestController;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
 import org.databiosphere.workspacedataservice.generated.JobApi;
 import org.databiosphere.workspacedataservice.service.JobService;
@@ -11,10 +12,9 @@ import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.databiosphere.workspacedataservice.shared.model.job.JobStatus;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RestController;
 
 /** Controller for job-related APIs */
-@RestController
+@WdsRestController(deploymentModes = {"data-plane"})
 public class JobController implements JobApi {
 
   JobService jobService;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.databiosphere.workspacedataservice.annotations.DeploymentRestController.WdsRestController;
 import org.databiosphere.workspacedataservice.retry.RetryableApi;
 import org.databiosphere.workspacedataservice.service.CollectionService;
 import org.databiosphere.workspacedataservice.service.RecordOrchestratorService;
@@ -29,12 +30,11 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
-@RestController
+@WdsRestController(deploymentModes = {"data-plane"})
 public class RecordController {
 
   private final CollectionService collectionService;


### PR DESCRIPTION
Problem: We need to require our APIs be exposed to either data-plane, control-plane, or both. 
While it is possible to have our own annotation implementation of `@RestController` that has a required element to specify, it is impossible for that element to use our existing `@DataPlane` `@ControlPlane` annotations because annotation parameters must be compile-time constants, and they can’t be other annotations. 
This is a workaround so we can get the same behavior as those annotations, but around a custom rest controller. 

------------------
Reminder:

PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 
