### PR TITLE
AJ-1556 update java-pfb

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -83,7 +83,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp' // required by Sam client
     implementation "bio.terra:datarepo-jakarta-client:1.570.0-SNAPSHOT"
     implementation "bio.terra:workspace-manager-client:0.254.983-SNAPSHOT"
-    implementation "bio.terra:java-pfb-library:0.15.0"
+    implementation "bio.terra:java-pfb-library:0.29.0"
     implementation project(path: ':client')
 
     // Parquet, used for TDR snapshot import


### PR DESCRIPTION
I noticed we hadn't updated java-pfb in a while, it's been getting a number of security updates that we probably want to include.

Should we have a better process for keeping java-pfb up-to-date?  Can/Should we tie it to a major version instead of something specific?

Reminder:

PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 
