### PR TITLE
AJ-1563 Eliminate redundant `ImportMode` arg throughout.

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJob.java
@@ -159,8 +159,7 @@ public class PfbQuartzJob extends QuartzJob {
             recordSinkFactory.buildRecordSink(/* prefix= */ "pfb"),
             targetCollection,
             /* recordType= */ null, // record type is determined later
-            primaryKey,
-            importMode);
+            primaryKey);
 
     if (result != null) {
       result

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJob.java
@@ -177,8 +177,7 @@ public class TdrManifestQuartzJob extends QuartzJob {
           recordSinkFactory.buildRecordSink(/* prefix= */ "tdr"),
           targetCollection,
           table.recordType(),
-          table.primaryKey(),
-          importMode);
+          table.primaryKey());
     } catch (Throwable t) {
       throw new TdrManifestImportException(t.getMessage(), t);
     }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsource/ParquetRecordSource.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsource/ParquetRecordSource.java
@@ -55,4 +55,9 @@ public class ParquetRecordSource implements TwoPassRecordSource {
   public void close() throws IOException {
     parquetReader.close();
   }
+
+  @Override
+  public ImportMode importMode() {
+    return importMode;
+  }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsource/PfbRecordSource.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsource/PfbRecordSource.java
@@ -52,4 +52,9 @@ public class PfbRecordSource implements TwoPassRecordSource {
   public void close() throws IOException {
     inputStream.close();
   }
+
+  @Override
+  public ImportMode importMode() {
+    return importMode;
+  }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsource/RecordSource.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsource/RecordSource.java
@@ -3,6 +3,7 @@ package org.databiosphere.workspacedataservice.recordsource;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
+import org.databiosphere.workspacedataservice.recordsource.TwoPassRecordSource.ImportMode;
 import org.databiosphere.workspacedataservice.shared.model.OperationType;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 
@@ -20,4 +21,8 @@ public interface RecordSource extends Closeable {
   WriteStreamInfo readRecords(int numRecords) throws IOException;
 
   record WriteStreamInfo(List<Record> records, OperationType operationType) {}
+
+  default ImportMode importMode() {
+    return ImportMode.BASE_ATTRIBUTES;
+  }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
@@ -21,7 +21,6 @@ import org.databiosphere.workspacedataservice.recordsource.PrimaryKeyResolver;
 import org.databiosphere.workspacedataservice.recordsource.RecordSource;
 import org.databiosphere.workspacedataservice.recordsource.RecordSourceFactory;
 import org.databiosphere.workspacedataservice.recordsource.TsvRecordSource;
-import org.databiosphere.workspacedataservice.recordsource.TwoPassRecordSource.ImportMode;
 import org.databiosphere.workspacedataservice.sam.SamDao;
 import org.databiosphere.workspacedataservice.service.model.AttributeSchema;
 import org.databiosphere.workspacedataservice.service.model.BatchWriteResult;
@@ -152,8 +151,7 @@ public class RecordOrchestratorService { // TODO give me a better name
             // the extra cast here isn't exactly necessary, but left here to call out the additional
             // tangential responsibility of the TsvRecordSource; this can be removed if we
             // can converge on using PrimaryKeyResolver more generally across all formats.
-            ((PrimaryKeyResolver) recordSource).getPrimaryKey(),
-            ImportMode.BASE_ATTRIBUTES);
+            ((PrimaryKeyResolver) recordSource).getPrimaryKey());
     int qty = result.getUpdatedCount(recordType);
     activityLogger.saveEventForCurrentUser(
         user -> user.upserted().record().withRecordType(recordType).ofQuantity(qty));
@@ -392,8 +390,7 @@ public class RecordOrchestratorService { // TODO give me a better name
             recordSinkFactory.buildRecordSink(/* prefix= */ "json"),
             collectionId,
             recordType,
-            primaryKey.orElse(RECORD_ID),
-            ImportMode.BASE_ATTRIBUTES);
+            primaryKey.orElse(RECORD_ID));
     int qty = result.getUpdatedCount(recordType);
     activityLogger.saveEventForCurrentUser(
         user -> user.modified().record().withRecordType(recordType).ofQuantity(qty));

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobTest.java
@@ -1,12 +1,10 @@
 package org.databiosphere.workspacedataservice.dataimport.pfb;
 
 import static org.databiosphere.workspacedataservice.dataimport.pfb.PfbTestUtils.stubJobContext;
-import static org.databiosphere.workspacedataservice.recordsource.TwoPassRecordSource.ImportMode.BASE_ATTRIBUTES;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -150,7 +148,7 @@ class PfbQuartzJobTest {
     when(wsmDao.enumerateDataRepoSnapshotReferences(any(), anyInt(), anyInt()))
         .thenReturn(new ResourceList());
     // We're not testing this, so it doesn't matter what returns
-    when(batchWriteService.batchWrite(any(), any(), any(), any(), any(), eq(BASE_ATTRIBUTES)))
+    when(batchWriteService.batchWrite(any(), any(), any(), any(), any()))
         .thenReturn(BatchWriteResult.empty());
 
     testSupport.buildPfbQuartzJob().execute(mockContext);
@@ -170,7 +168,7 @@ class PfbQuartzJobTest {
     when(wsmDao.enumerateDataRepoSnapshotReferences(any(), anyInt(), anyInt()))
         .thenReturn(new ResourceList());
     // We're not testing this, so it doesn't matter what returns
-    when(batchWriteService.batchWrite(any(), any(), any(), any(), any(), eq(BASE_ATTRIBUTES)))
+    when(batchWriteService.batchWrite(any(), any(), any(), any(), any()))
         .thenReturn(BatchWriteResult.empty());
 
     testSupport.buildPfbQuartzJob().execute(mockContext);

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/BatchWriteServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/BatchWriteServiceTest.java
@@ -94,8 +94,7 @@ class BatchWriteServiceTest {
                     recordSinkFactory.buildRecordSink(/* prefix= */ "json"),
                     COLLECTION,
                     THING_TYPE,
-                    RECORD_ID,
-                    ImportMode.BASE_ATTRIBUTES));
+                    RECORD_ID));
 
     String errorMessage = ex.getMessage();
     assertEquals("Duplicate field 'key'", errorMessage);
@@ -124,8 +123,7 @@ class BatchWriteServiceTest {
     TsvRecordSource recordSource =
         recordSourceFactory.forTsv(file.getInputStream(), recordType, Optional.of(primaryKey));
     RecordSink recordSink = recordSinkFactory.buildRecordSink(/* prefix= */ "tsv");
-    batchWriteService.batchWrite(
-        recordSource, recordSink, COLLECTION, recordType, primaryKey, ImportMode.BASE_ATTRIBUTES);
+    batchWriteService.batchWrite(recordSource, recordSink, COLLECTION, recordType, primaryKey);
 
     // we should write three batches
     verify(recordService, times(3))
@@ -269,7 +267,6 @@ class BatchWriteServiceTest {
         recordSinkFactory.buildRecordSink(/* prefix= */ "pfb"),
         COLLECTION,
         /* recordType= */ null,
-        primaryKey,
-        importMode);
+        primaryKey);
   }
 }


### PR DESCRIPTION
`ImportMode` is already passed as part of creating the `RecordSource`, and so doesn't need to be explicitly passed down through the callstack.