### PR TITLE
Test enforces platform annotation for @RestController APIs

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/CapabilitiesController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/CapabilitiesController.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.InputStream;
+import org.databiosphere.workspacedataservice.annotations.DeploymentMode.DataPlane;
 import org.databiosphere.workspacedataservice.generated.CapabilitiesApi;
 import org.databiosphere.workspacedataservice.generated.CapabilitiesServerModel;
 import org.slf4j.Logger;
@@ -13,6 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Controller for capabilities-related APIs */
+@DataPlane
 @RestController
 public class CapabilitiesController implements CapabilitiesApi {
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/CloningController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/CloningController.java
@@ -3,6 +3,7 @@ package org.databiosphere.workspacedataservice.controller;
 import static org.databiosphere.workspacedataservice.service.RecordUtils.validateVersion;
 
 import java.util.UUID;
+import org.databiosphere.workspacedataservice.annotations.DeploymentMode.DataPlane;
 import org.databiosphere.workspacedataservice.service.BackupRestoreService;
 import org.databiosphere.workspacedataservice.shared.model.BackupResponse;
 import org.databiosphere.workspacedataservice.shared.model.BackupRestoreRequest;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+@DataPlane
 @RestController
 public class CloningController {
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/ImportController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/ImportController.java
@@ -1,6 +1,7 @@
 package org.databiosphere.workspacedataservice.controller;
 
 import java.util.UUID;
+import org.databiosphere.workspacedataservice.annotations.DeploymentMode.DataPlane;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
 import org.databiosphere.workspacedataservice.generated.ImportApi;
 import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
@@ -9,6 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
+@DataPlane
 @RestController
 public class ImportController implements ImportApi {
   private final ImportService importService;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/JobController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/JobController.java
@@ -4,6 +4,8 @@ import static org.databiosphere.workspacedataservice.generated.GenericJobServerM
 
 import java.util.List;
 import java.util.UUID;
+import org.databiosphere.workspacedataservice.annotations.DeploymentMode.ControlPlane;
+import org.databiosphere.workspacedataservice.annotations.DeploymentMode.DataPlane;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
 import org.databiosphere.workspacedataservice.generated.JobApi;
 import org.databiosphere.workspacedataservice.service.JobService;
@@ -14,6 +16,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Controller for job-related APIs */
+@DataPlane
+@ControlPlane
 @RestController
 public class JobController implements JobApi {
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.databiosphere.workspacedataservice.annotations.DeploymentMode.DataPlane;
 import org.databiosphere.workspacedataservice.retry.RetryableApi;
 import org.databiosphere.workspacedataservice.service.CollectionService;
 import org.databiosphere.workspacedataservice.service.RecordOrchestratorService;
@@ -34,6 +35,7 @@ import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
+@DataPlane
 @RestController
 public class RecordController {
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/annotations/AnnotatedApisTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/annotations/AnnotatedApisTest.java
@@ -1,0 +1,39 @@
+package org.databiosphere.workspacedataservice.annotations;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.core.type.filter.AnnotationTypeFilter;
+import org.springframework.web.bind.annotation.RestController;
+
+@SpringBootTest
+class AnnotatedApisTest {
+
+  @Test
+  void controllersMustHaveDeploymentAnnotation() {
+    // scanner that detects classes annotated with @RestController
+    ClassPathScanningCandidateComponentProvider scanner =
+        new ClassPathScanningCandidateComponentProvider(false);
+    scanner.addIncludeFilter(new AnnotationTypeFilter(RestController.class));
+    Set<BeanDefinition> restControllerComponents =
+        scanner.findCandidateComponents("org.databiosphere.workspacedataservice.controller");
+
+    for (BeanDefinition beanDefinition : restControllerComponents) {
+      // extract the class from the bean, then check its annotations for either a DataPlane or
+      // ControlPlane annotation
+      Class<?> cls = assertDoesNotThrow(() -> Class.forName(beanDefinition.getBeanClassName()));
+      assertTrue(
+          Arrays.stream(cls.getAnnotations())
+              .anyMatch(
+                  n ->
+                      n.annotationType().equals(DeploymentMode.DataPlane.class)
+                          || n.annotationType().equals(DeploymentMode.ControlPlane.class)));
+    }
+  }
+}


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1562
Problem: "All APIs should be required at compile time to provide a platform annotation somehow; this will prevent unintentionally exposing APIs"

Solution: Unit test enforces all `@RestController`s have platform annotations `@ControlPlane` and/or `@DataPlane`

------------------
Reminder:

PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 
