### PR TITLE
AJ-1589 Simplify `BatchWriteService` internal APIs.

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJob.java
@@ -159,8 +159,7 @@ public class PfbQuartzJob extends QuartzJob {
             recordSinkFactory.buildRecordSink(/* prefix= */ "pfb"),
             targetCollection,
             /* recordType= */ null, // record type is determined later
-            primaryKey,
-            importMode);
+            primaryKey);
 
     if (result != null) {
       result

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJob.java
@@ -142,24 +142,17 @@ public class PfbQuartzJob extends QuartzJob {
    * Given a DataFileStream representing a PFB, import all the tables and rows inside that PFB.
    *
    * @param dataStream stream representing the PFB.
-   * @param targetCollection the UUID of the WDS collection being imported to
+   * @param collectionId the UUID of the WDS collection being imported to
    * @param importMode indicating whether to import all data in the tables or only the relations
    */
   BatchWriteResult importTables(
-      DataFileStream<GenericRecord> dataStream, UUID targetCollection, ImportMode importMode) {
-
-    // As of this writing, the only use case is import from the UCSC AnVIL Data Browser. In this
-    // single use case, the `primaryKey` argument will always be "id".  However, as we add use cases
-    // and import PFBs from other providers, this may change, and we will encounter different
-    // `primaryKey` argument values.
-    String primaryKey = ID_FIELD;
+      DataFileStream<GenericRecord> dataStream, UUID collectionId, ImportMode importMode) {
     BatchWriteResult result =
         batchWriteService.batchWrite(
             recordSourceFactory.forPfb(dataStream, importMode),
-            recordSinkFactory.buildRecordSink(/* prefix= */ "pfb"),
-            targetCollection,
+            recordSinkFactory.buildRecordSink(collectionId, /* prefix= */ "pfb"),
             /* recordType= */ null, // record type is determined later
-            primaryKey);
+            /* primaryKey= */ ID_FIELD); // PFBs currently only use ID_FIELD as primary key
 
     if (result != null) {
       result

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJob.java
@@ -177,8 +177,7 @@ public class TdrManifestQuartzJob extends QuartzJob {
           recordSinkFactory.buildRecordSink(/* prefix= */ "tdr"),
           targetCollection,
           table.recordType(),
-          table.primaryKey(),
-          importMode);
+          table.primaryKey());
     } catch (Throwable t) {
       throw new TdrManifestImportException(t.getMessage(), t);
     }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJob.java
@@ -156,16 +156,13 @@ public class TdrManifestQuartzJob extends QuartzJob {
    *
    * @param inputFile Parquet file to be imported.
    * @param table info about the table to be imported
-   * @param targetCollection collection into which to import
+   * @param collectionId collection into which to import
    * @param importMode mode for this invocation
    * @return statistics on what was imported
    */
   @VisibleForTesting
   BatchWriteResult importTable(
-      InputFile inputFile,
-      TdrManifestImportTable table,
-      UUID targetCollection,
-      ImportMode importMode) {
+      InputFile inputFile, TdrManifestImportTable table, UUID collectionId, ImportMode importMode) {
     // upsert this parquet file's contents
     try (ParquetReader<GenericRecord> avroParquetReader =
         AvroParquetReader.<GenericRecord>builder(inputFile)
@@ -174,8 +171,7 @@ public class TdrManifestQuartzJob extends QuartzJob {
       logger.info("batch-writing records for file ...");
       return batchWriteService.batchWrite(
           recordSourceFactory.forTdrImport(avroParquetReader, table, importMode),
-          recordSinkFactory.buildRecordSink(/* prefix= */ "tdr"),
-          targetCollection,
+          recordSinkFactory.buildRecordSink(collectionId, /* prefix= */ "tdr"),
           table.recordType(),
           table.primaryKey());
     } catch (Throwable t) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSink.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSink.java
@@ -21,7 +21,6 @@ import org.databiosphere.workspacedataservice.recordsink.RawlsModel.Entity;
 import org.databiosphere.workspacedataservice.recordsink.RawlsModel.RemoveAttribute;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
 import org.databiosphere.workspacedataservice.service.model.exception.BatchWriteException;
-import org.databiosphere.workspacedataservice.shared.model.OperationType;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 
@@ -57,24 +56,26 @@ public class RawlsRecordSink implements RecordSink {
       RecordType recordType,
       Map<String, DataTypeMapping> schema,
       List<Record> records,
-      String recordTypePrimaryKey) {
+      String primaryKey) {
     // This is a no-op for Rawls as the schema changes occur as a side effect of writeBatch
     return schema;
   }
 
   @Override
-  public void writeBatch(
+  public void upsertBatch(
       RecordType recordType,
-      Map<String, DataTypeMapping> schema,
-      OperationType opType,
+      Map<String, DataTypeMapping> schema, // ignored
       List<Record> records,
-      String primaryKey)
-      throws BatchWriteException, IOException {
-    // TODO: this method signature has a lot of unused arguments, can the interface be tidied up to
-    //  not require all these?
+      String primaryKey // ignored
+      ) throws BatchWriteException, IOException {
     ImmutableList.Builder<Entity> entities = ImmutableList.builder();
     records.stream().map(this::toEntity).forEach(entities::add);
     jsonConsumer.accept(mapper.writeValueAsString(entities.build()));
+  }
+
+  @Override
+  public void deleteBatch(RecordType recordType, List<Record> records) throws BatchWriteException {
+    throw new UnsupportedOperationException("RawlsRecordSink does not support deleteBatch");
   }
 
   private Entity toEntity(Record record) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSink.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSink.java
@@ -11,7 +11,6 @@ import java.lang.annotation.Target;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import org.databiosphere.workspacedataservice.recordsink.RawlsModel.AddListMember;
@@ -55,7 +54,6 @@ public class RawlsRecordSink implements RecordSink {
 
   @Override
   public Map<String, DataTypeMapping> createOrModifyRecordType(
-      UUID collectionId,
       RecordType recordType,
       Map<String, DataTypeMapping> schema,
       List<Record> records,
@@ -66,7 +64,6 @@ public class RawlsRecordSink implements RecordSink {
 
   @Override
   public void writeBatch(
-      UUID collectionId,
       RecordType recordType,
       Map<String, DataTypeMapping> schema,
       OperationType opType,

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RecordSink.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RecordSink.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.Map;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
 import org.databiosphere.workspacedataservice.service.model.exception.BatchWriteException;
-import org.databiosphere.workspacedataservice.shared.model.OperationType;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 
@@ -21,12 +20,15 @@ public interface RecordSink {
       List<Record> records,
       String recordTypePrimaryKey);
 
-  /** Perform the given {@link OperationType} on the batch of records. */
-  void writeBatch(
+  /** Upsert the given batch of records. */
+  void upsertBatch(
       RecordType recordType,
       Map<String, DataTypeMapping> schema,
-      OperationType opType,
       List<Record> records,
       String primaryKey)
+      throws BatchWriteException, IOException;
+
+  /** Delete the given batch of records. */
+  void deleteBatch(RecordType recordType, List<Record> records)
       throws BatchWriteException, IOException;
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RecordSink.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RecordSink.java
@@ -3,7 +3,6 @@ package org.databiosphere.workspacedataservice.recordsink;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
 import org.databiosphere.workspacedataservice.service.model.exception.BatchWriteException;
 import org.databiosphere.workspacedataservice.shared.model.OperationType;
@@ -17,7 +16,6 @@ import org.databiosphere.workspacedataservice.shared.model.RecordType;
 public interface RecordSink {
   /** Create or modify the schema for a record type and write the records. */
   Map<String, DataTypeMapping> createOrModifyRecordType(
-      UUID collectionId,
       RecordType recordType,
       Map<String, DataTypeMapping> schema,
       List<Record> records,
@@ -25,7 +23,6 @@ public interface RecordSink {
 
   /** Perform the given {@link OperationType} on the batch of records. */
   void writeBatch(
-      UUID collectionId,
       RecordType recordType,
       Map<String, DataTypeMapping> schema,
       OperationType opType,

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RecordSinkFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RecordSinkFactory.java
@@ -22,7 +22,6 @@ public class RecordSinkFactory {
   private RecordService recordService;
   private RecordDao recordDao;
   private DataTypeInferer dataTypeInferer;
-
   private Consumer<String> jsonConsumer;
 
   public RecordSinkFactory(TwdsProperties twdsProperties, ObjectMapper mapper) {
@@ -35,12 +34,12 @@ public class RecordSinkFactory {
     this.recordService = recordService;
   }
 
-  @Autowired(required = false) // RecordService only required for RecordSinkMode.WDS
+  @Autowired(required = false) // RecordDao only required for RecordSinkMode.WDS
   public void setRecordDao(RecordDao recordDao) {
     this.recordDao = recordDao;
   }
 
-  @Autowired(required = false) // RecordService only required for RecordSinkMode.WDS
+  @Autowired(required = false) // DataTypeInferer only required for RecordSinkMode.WDS
   public void setDataTypeInferer(DataTypeInferer dataTypeInferer) {
     this.dataTypeInferer = dataTypeInferer;
   }
@@ -50,7 +49,9 @@ public class RecordSinkFactory {
     this.jsonConsumer = jsonConsumer;
   }
 
-  // TODO(AJ-1589): make prefix assignment dynamic
+  // TODO(AJ-1589): make prefix assignment dynamic. However, of note: the prefix is currently
+  //   ignored for RecordSinkMode.WDS.  In this case, it might be worth adding support for omitting
+  //   the prefix as part of supporting the prefix assignment.
   public RecordSink buildRecordSink(UUID collectionId, String prefix) {
     if (twdsProperties.getDataImport() == null) {
       logger

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RecordSinkFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RecordSinkFactory.java
@@ -1,9 +1,12 @@
 package org.databiosphere.workspacedataservice.recordsink;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.UUID;
 import java.util.function.Consumer;
 import org.databiosphere.workspacedataservice.config.TwdsProperties;
+import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.databiosphere.workspacedataservice.recordsink.RawlsRecordSink.RawlsJsonConsumer;
+import org.databiosphere.workspacedataservice.service.DataTypeInferer;
 import org.databiosphere.workspacedataservice.service.RecordService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,6 +20,9 @@ public class RecordSinkFactory {
   private final TwdsProperties twdsProperties;
   private final ObjectMapper mapper;
   private RecordService recordService;
+  private RecordDao recordDao;
+  private DataTypeInferer dataTypeInferer;
+
   private Consumer<String> jsonConsumer;
 
   public RecordSinkFactory(TwdsProperties twdsProperties, ObjectMapper mapper) {
@@ -29,13 +35,23 @@ public class RecordSinkFactory {
     this.recordService = recordService;
   }
 
+  @Autowired(required = false) // RecordService only required for RecordSinkMode.WDS
+  public void setRecordDao(RecordDao recordDao) {
+    this.recordDao = recordDao;
+  }
+
+  @Autowired(required = false) // RecordService only required for RecordSinkMode.WDS
+  public void setDataTypeInferer(DataTypeInferer dataTypeInferer) {
+    this.dataTypeInferer = dataTypeInferer;
+  }
+
   @Autowired(required = false) // jsonConsumer only required for RecordSinkMode.RAWLS
   public void setJsonConsumer(@RawlsJsonConsumer Consumer<String> jsonConsumer) {
     this.jsonConsumer = jsonConsumer;
   }
 
   // TODO(AJ-1589): make prefix assignment dynamic
-  public RecordSink buildRecordSink(String prefix) {
+  public RecordSink buildRecordSink(UUID collectionId, String prefix) {
     if (twdsProperties.getDataImport() == null) {
       logger
           .atWarn()
@@ -44,19 +60,27 @@ public class RecordSinkFactory {
                   + "Start this deployment with active Spring profile of "
                   + "either 'data-plane' or 'control-plane'. "
                   + "Defaulting to batch-write-record-sink=wds");
-      return recordService;
+      return wdsRecordSink(collectionId);
     }
 
     switch (twdsProperties.getDataImport().getBatchWriteRecordSink()) {
       case WDS -> {
-        return recordService;
+        return wdsRecordSink(collectionId);
       }
       case RAWLS -> {
-        return new RawlsRecordSink(prefix, mapper, jsonConsumer);
+        return rawlsRecordSink(prefix);
       }
       default -> throw new RuntimeException(
           "Unknown RecordSinkMode: %s"
               .formatted(twdsProperties.getDataImport().getBatchWriteRecordSink()));
     }
+  }
+
+  private RecordSink rawlsRecordSink(String prefix) {
+    return new RawlsRecordSink(prefix, mapper, jsonConsumer);
+  }
+
+  private WdsRecordSink wdsRecordSink(UUID collectionId) {
+    return new WdsRecordSink(recordService, recordDao, dataTypeInferer, collectionId);
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/WdsRecordSink.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/WdsRecordSink.java
@@ -8,7 +8,6 @@ import org.databiosphere.workspacedataservice.service.DataTypeInferer;
 import org.databiosphere.workspacedataservice.service.RecordService;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
 import org.databiosphere.workspacedataservice.service.model.exception.BatchWriteException;
-import org.databiosphere.workspacedataservice.shared.model.OperationType;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 
@@ -59,17 +58,17 @@ public class WdsRecordSink implements RecordSink {
   }
 
   @Override
-  public void writeBatch(
+  public void upsertBatch(
       RecordType recordType,
       Map<String, DataTypeMapping> schema,
-      OperationType opType,
       List<Record> records,
       String primaryKey)
       throws BatchWriteException {
-    if (opType == OperationType.UPSERT) {
-      recordService.batchUpsert(collectionId, recordType, records, schema, primaryKey);
-    } else if (opType == OperationType.DELETE) {
-      recordDao.batchDelete(collectionId, recordType, records);
-    }
+    recordService.batchUpsert(collectionId, recordType, records, schema, primaryKey);
+  }
+
+  @Override
+  public void deleteBatch(RecordType recordType, List<Record> records) throws BatchWriteException {
+    recordDao.batchDelete(collectionId, recordType, records);
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/WdsRecordSink.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/WdsRecordSink.java
@@ -1,0 +1,75 @@
+package org.databiosphere.workspacedataservice.recordsink;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.databiosphere.workspacedataservice.dao.RecordDao;
+import org.databiosphere.workspacedataservice.service.DataTypeInferer;
+import org.databiosphere.workspacedataservice.service.RecordService;
+import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
+import org.databiosphere.workspacedataservice.service.model.exception.BatchWriteException;
+import org.databiosphere.workspacedataservice.shared.model.OperationType;
+import org.databiosphere.workspacedataservice.shared.model.Record;
+import org.databiosphere.workspacedataservice.shared.model.RecordType;
+
+/**
+ * {@link RecordSink} implementation that records batches of writes/deletes to the Workspace Data
+ * Service storage, adjusting the schema as needed.
+ */
+public class WdsRecordSink implements RecordSink {
+
+  private final RecordService recordService;
+  private final RecordDao recordDao;
+  private final DataTypeInferer inferer;
+  private final UUID collectionId;
+
+  WdsRecordSink(
+      RecordService recordService,
+      RecordDao recordDao,
+      DataTypeInferer inferer,
+      UUID collectionId) {
+    this.recordService = recordService;
+    this.recordDao = recordDao;
+    this.inferer = inferer;
+    this.collectionId = collectionId;
+  }
+
+  @Override
+  public Map<String, DataTypeMapping> createOrModifyRecordType(
+      RecordType recordType,
+      Map<String, DataTypeMapping> schema,
+      List<Record> records,
+      String recordTypePrimaryKey) {
+    if (!recordDao.recordTypeExists(collectionId, recordType)) {
+      recordDao.createRecordType(
+          collectionId,
+          schema,
+          recordType,
+          inferer.findRelations(records, schema),
+          recordTypePrimaryKey);
+    } else {
+      return recordService.addOrUpdateColumnIfNeeded(
+          collectionId,
+          recordType,
+          schema,
+          recordDao.getExistingTableSchemaLessPrimaryKey(collectionId, recordType),
+          records);
+    }
+    return schema;
+  }
+
+  @Override
+  public void writeBatch(
+      RecordType recordType,
+      Map<String, DataTypeMapping> schema,
+      OperationType opType,
+      List<Record> records,
+      String primaryKey)
+      throws BatchWriteException {
+    if (opType == OperationType.UPSERT) {
+      recordService.batchUpsert(collectionId, recordType, records, schema, primaryKey);
+    } else if (opType == OperationType.DELETE) {
+      recordDao.batchDelete(collectionId, recordType, records);
+    }
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsource/ParquetRecordSource.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsource/ParquetRecordSource.java
@@ -55,4 +55,9 @@ public class ParquetRecordSource implements TwoPassRecordSource {
   public void close() throws IOException {
     parquetReader.close();
   }
+
+  @Override
+  public ImportMode importMode() {
+    return importMode;
+  }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsource/PfbRecordSource.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsource/PfbRecordSource.java
@@ -52,4 +52,9 @@ public class PfbRecordSource implements TwoPassRecordSource {
   public void close() throws IOException {
     inputStream.close();
   }
+
+  @Override
+  public ImportMode importMode() {
+    return importMode;
+  }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsource/RecordSource.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsource/RecordSource.java
@@ -3,6 +3,7 @@ package org.databiosphere.workspacedataservice.recordsource;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
+import org.databiosphere.workspacedataservice.recordsource.TwoPassRecordSource.ImportMode;
 import org.databiosphere.workspacedataservice.shared.model.OperationType;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 
@@ -20,4 +21,8 @@ public interface RecordSource extends Closeable {
   WriteStreamInfo readRecords(int numRecords) throws IOException;
 
   record WriteStreamInfo(List<Record> records, OperationType operationType) {}
+
+  default ImportMode importMode() {
+    return ImportMode.BASE_ATTRIBUTES;
+  }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
@@ -141,12 +141,11 @@ public class RecordOrchestratorService { // TODO give me a better name
 
     TsvRecordSource recordSource =
         recordSourceFactory.forTsv(records.getInputStream(), recordType, primaryKey);
-    RecordSink recordSink = recordSinkFactory.buildRecordSink(/* prefix= */ "tsv");
+    RecordSink recordSink = recordSinkFactory.buildRecordSink(collectionId, /* prefix= */ "tsv");
     BatchWriteResult result =
         batchWriteService.batchWrite(
             recordSource,
             recordSink,
-            collectionId,
             recordType,
             // the extra cast here isn't exactly necessary, but left here to call out the additional
             // tangential responsibility of the TsvRecordSource; this can be removed if we
@@ -387,8 +386,7 @@ public class RecordOrchestratorService { // TODO give me a better name
     BatchWriteResult result =
         batchWriteService.batchWrite(
             recordSource,
-            recordSinkFactory.buildRecordSink(/* prefix= */ "json"),
-            collectionId,
+            recordSinkFactory.buildRecordSink(collectionId, /* prefix= */ "json"),
             recordType,
             primaryKey.orElse(RECORD_ID));
     int qty = result.getUpdatedCount(recordType);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
@@ -21,7 +21,6 @@ import org.databiosphere.workspacedataservice.recordsource.PrimaryKeyResolver;
 import org.databiosphere.workspacedataservice.recordsource.RecordSource;
 import org.databiosphere.workspacedataservice.recordsource.RecordSourceFactory;
 import org.databiosphere.workspacedataservice.recordsource.TsvRecordSource;
-import org.databiosphere.workspacedataservice.recordsource.TwoPassRecordSource.ImportMode;
 import org.databiosphere.workspacedataservice.sam.SamDao;
 import org.databiosphere.workspacedataservice.service.model.AttributeSchema;
 import org.databiosphere.workspacedataservice.service.model.BatchWriteResult;
@@ -152,8 +151,7 @@ public class RecordOrchestratorService { // TODO give me a better name
             // the extra cast here isn't exactly necessary, but left here to call out the additional
             // tangential responsibility of the TsvRecordSource; this can be removed if we
             // can converge on using PrimaryKeyResolver more generally across all formats.
-            ((PrimaryKeyResolver) recordSource).getPrimaryKey(),
-            ImportMode.BASE_ATTRIBUTES);
+            ((PrimaryKeyResolver) recordSource).getPrimaryKey());
     int qty = result.getUpdatedCount(recordType);
     activityLogger.saveEventForCurrentUser(
         user -> user.upserted().record().withRecordType(recordType).ofQuantity(qty));
@@ -392,8 +390,7 @@ public class RecordOrchestratorService { // TODO give me a better name
             recordSinkFactory.buildRecordSink(/* prefix= */ "json"),
             collectionId,
             recordType,
-            primaryKey.orElse(RECORD_ID),
-            ImportMode.BASE_ATTRIBUTES);
+            primaryKey.orElse(RECORD_ID));
     int qty = result.getUpdatedCount(recordType);
     activityLogger.saveEventForCurrentUser(
         user -> user.modified().record().withRecordType(recordType).ofQuantity(qty));

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobTest.java
@@ -148,7 +148,7 @@ class PfbQuartzJobTest {
     when(wsmDao.enumerateDataRepoSnapshotReferences(any(), anyInt(), anyInt()))
         .thenReturn(new ResourceList());
     // We're not testing this, so it doesn't matter what returns
-    when(batchWriteService.batchWrite(any(), any(), any(), any(), any()))
+    when(batchWriteService.batchWrite(any(), any(), any(), any()))
         .thenReturn(BatchWriteResult.empty());
 
     testSupport.buildPfbQuartzJob().execute(mockContext);
@@ -168,7 +168,7 @@ class PfbQuartzJobTest {
     when(wsmDao.enumerateDataRepoSnapshotReferences(any(), anyInt(), anyInt()))
         .thenReturn(new ResourceList());
     // We're not testing this, so it doesn't matter what returns
-    when(batchWriteService.batchWrite(any(), any(), any(), any(), any()))
+    when(batchWriteService.batchWrite(any(), any(), any(), any()))
         .thenReturn(BatchWriteResult.empty());
 
     testSupport.buildPfbQuartzJob().execute(mockContext);

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobTest.java
@@ -1,12 +1,10 @@
 package org.databiosphere.workspacedataservice.dataimport.pfb;
 
 import static org.databiosphere.workspacedataservice.dataimport.pfb.PfbTestUtils.stubJobContext;
-import static org.databiosphere.workspacedataservice.recordsource.TwoPassRecordSource.ImportMode.BASE_ATTRIBUTES;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -150,7 +148,7 @@ class PfbQuartzJobTest {
     when(wsmDao.enumerateDataRepoSnapshotReferences(any(), anyInt(), anyInt()))
         .thenReturn(new ResourceList());
     // We're not testing this, so it doesn't matter what returns
-    when(batchWriteService.batchWrite(any(), any(), any(), any(), any(), eq(BASE_ATTRIBUTES)))
+    when(batchWriteService.batchWrite(any(), any(), any(), any(), any()))
         .thenReturn(BatchWriteResult.empty());
 
     testSupport.buildPfbQuartzJob().execute(mockContext);
@@ -170,7 +168,7 @@ class PfbQuartzJobTest {
     when(wsmDao.enumerateDataRepoSnapshotReferences(any(), anyInt(), anyInt()))
         .thenReturn(new ResourceList());
     // We're not testing this, so it doesn't matter what returns
-    when(batchWriteService.batchWrite(any(), any(), any(), any(), any(), eq(BASE_ATTRIBUTES)))
+    when(batchWriteService.batchWrite(any(), any(), any(), any(), any()))
         .thenReturn(BatchWriteResult.empty());
 
     testSupport.buildPfbQuartzJob().execute(mockContext);

--- a/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkTest.java
@@ -2,7 +2,6 @@ package org.databiosphere.workspacedataservice.recordsink;
 
 import static com.google.common.collect.MoreCollectors.onlyElement;
 import static java.util.Arrays.stream;
-import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.stream.Stream.concat;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -150,10 +149,12 @@ class RawlsRecordSinkTest {
 
   @Test
   void batchDeleteNotSupported() {
+    RecordType ignoredRecordType = RecordType.valueOf("widget");
+    List<Record> ignoredEmptyRecords = List.of();
     var thrown =
         assertThrows(
             UnsupportedOperationException.class,
-            () -> recordSink.deleteBatch(RecordType.valueOf("widget"), emptyList()));
+            () -> recordSink.deleteBatch(ignoredRecordType, ignoredEmptyRecords));
     assertThat(thrown).hasMessageContaining("does not support deleteBatch");
   }
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkTest.java
@@ -16,7 +16,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.databiosphere.workspacedataservice.recordsink.RawlsModel.AddListMember;
@@ -157,7 +156,6 @@ class RawlsRecordSinkTest {
     var recordType = recordList.stream().map(Record::getRecordType).collect(onlyElement());
     try {
       recordSink.writeBatch(
-          /* collectionId= */ UUID.randomUUID(), // currently ignored
           recordType,
           /* schema= */ Map.of(), // currently ignored
           OperationType.UPSERT,

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/BatchWriteServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/BatchWriteServiceTest.java
@@ -91,8 +91,7 @@ class BatchWriteServiceTest {
             () ->
                 batchWriteService.batchWrite(
                     recordSourceFactory.forJson(is),
-                    recordSinkFactory.buildRecordSink(/* prefix= */ "json"),
-                    COLLECTION,
+                    recordSinkFactory.buildRecordSink(COLLECTION, /* prefix= */ "json"),
                     THING_TYPE,
                     RECORD_ID));
 
@@ -122,8 +121,8 @@ class BatchWriteServiceTest {
     // Note that this call to batchWriteTsvStream specifies a non-null RecordType.
     TsvRecordSource recordSource =
         recordSourceFactory.forTsv(file.getInputStream(), recordType, Optional.of(primaryKey));
-    RecordSink recordSink = recordSinkFactory.buildRecordSink(/* prefix= */ "tsv");
-    batchWriteService.batchWrite(recordSource, recordSink, COLLECTION, recordType, primaryKey);
+    RecordSink recordSink = recordSinkFactory.buildRecordSink(COLLECTION, /* prefix= */ "tsv");
+    batchWriteService.batchWrite(recordSource, recordSink, recordType, primaryKey);
 
     // we should write three batches
     verify(recordService, times(3))
@@ -264,8 +263,7 @@ class BatchWriteServiceTest {
       DataFileStream<GenericRecord> pfbStream, String primaryKey, ImportMode importMode) {
     return batchWriteService.batchWrite(
         recordSourceFactory.forPfb(pfbStream, importMode),
-        recordSinkFactory.buildRecordSink(/* prefix= */ "pfb"),
-        COLLECTION,
+        recordSinkFactory.buildRecordSink(COLLECTION, /* prefix= */ "pfb"),
         /* recordType= */ null,
         primaryKey);
   }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/BatchWriteServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/BatchWriteServiceTest.java
@@ -94,8 +94,7 @@ class BatchWriteServiceTest {
                     recordSinkFactory.buildRecordSink(/* prefix= */ "json"),
                     COLLECTION,
                     THING_TYPE,
-                    RECORD_ID,
-                    ImportMode.BASE_ATTRIBUTES));
+                    RECORD_ID));
 
     String errorMessage = ex.getMessage();
     assertEquals("Duplicate field 'key'", errorMessage);
@@ -124,8 +123,7 @@ class BatchWriteServiceTest {
     TsvRecordSource recordSource =
         recordSourceFactory.forTsv(file.getInputStream(), recordType, Optional.of(primaryKey));
     RecordSink recordSink = recordSinkFactory.buildRecordSink(/* prefix= */ "tsv");
-    batchWriteService.batchWrite(
-        recordSource, recordSink, COLLECTION, recordType, primaryKey, ImportMode.BASE_ATTRIBUTES);
+    batchWriteService.batchWrite(recordSource, recordSink, COLLECTION, recordType, primaryKey);
 
     // we should write three batches
     verify(recordService, times(3))
@@ -269,7 +267,6 @@ class BatchWriteServiceTest {
         recordSinkFactory.buildRecordSink(/* prefix= */ "pfb"),
         COLLECTION,
         /* recordType= */ null,
-        primaryKey,
-        importMode);
+        primaryKey);
   }
 }


### PR DESCRIPTION
This is another round of refactoring to simplify the internal interfaces of `BatchWriteService` in prep for making some more tweaks to support [AJ-1589](https://broadworkbench.atlassian.net/browse/AJ-1589).

For easiest review, I recommend scanning the commits individually.

These commits largely attempt to:
- shrink the size of method argument lists the `RecordSink` API to eliminate cases where implementation classes just end up ignoring the arguments because they're not relevant
- shrink the overall size of `consumeWriteStream` to get it a little bit closer to fitting on a page.



[AJ-1589]: https://broadworkbench.atlassian.net/browse/AJ-1589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ