### PR TITLE
[AJ-1652] Handle primary keys specified in request body

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordService.java
@@ -25,11 +25,11 @@ import org.databiosphere.workspacedataservice.service.model.RelationCollection;
 import org.databiosphere.workspacedataservice.service.model.RelationValue;
 import org.databiosphere.workspacedataservice.service.model.ReservedNames;
 import org.databiosphere.workspacedataservice.service.model.exception.BatchWriteException;
+import org.databiosphere.workspacedataservice.service.model.exception.ConflictingPrimaryKeysException;
 import org.databiosphere.workspacedataservice.service.model.exception.InvalidNameException;
 import org.databiosphere.workspacedataservice.service.model.exception.InvalidRelationException;
 import org.databiosphere.workspacedataservice.service.model.exception.MissingObjectException;
 import org.databiosphere.workspacedataservice.service.model.exception.NewPrimaryKeyException;
-import org.databiosphere.workspacedataservice.service.model.exception.ValidationException;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
 import org.databiosphere.workspacedataservice.shared.model.RecordRequest;
@@ -314,7 +314,7 @@ public class RecordService {
     String primaryKey = recordDao.getPrimaryKeyColumn(recordType, collectionId);
     if (incomingAttrs.containsAttribute(primaryKey)
         && incomingAttrs.getAttributeValue(primaryKey) != recordId) {
-      throw new ValidationException("Primary key in payload does not match primary key in URL");
+      throw new ConflictingPrimaryKeysException();
     }
     RecordAttributes allAttrs = singleRecord.putAllAttributes(incomingAttrs).getAttributes();
     Map<String, DataTypeMapping> typeMapping = inferer.inferTypes(incomingAttrs);
@@ -343,7 +343,7 @@ public class RecordService {
       if (primaryKey.isPresent()
           && attributesInRequest.containsAttribute(primaryKey.get())
           && attributesInRequest.getAttributeValue(primaryKey.get()) != recordId) {
-        throw new ValidationException("Primary key in payload does not match primary key in URL");
+        throw new ConflictingPrimaryKeysException();
       }
       RecordResponse response =
           new RecordResponse(recordId, recordType, recordRequest.recordAttributes());
@@ -355,7 +355,7 @@ public class RecordService {
       String existingPrimaryKey = validatePrimaryKey(collectionId, recordType, primaryKey);
       if (attributesInRequest.containsAttribute(existingPrimaryKey)
           && attributesInRequest.getAttributeValue(existingPrimaryKey) != recordId) {
-        throw new ValidationException("Primary key in payload does not match primary key in URL");
+        throw new ConflictingPrimaryKeysException();
       }
       Map<String, DataTypeMapping> existingTableSchema =
           recordDao.getExistingTableSchema(collectionId, recordType);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/ConflictingPrimaryKeysException.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/ConflictingPrimaryKeysException.java
@@ -1,0 +1,7 @@
+package org.databiosphere.workspacedataservice.service.model.exception;
+
+public class ConflictingPrimaryKeysException extends ValidationException {
+  public ConflictingPrimaryKeysException() {
+    super("Primary key in payload does not match primary key in URL");
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributes.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributes.java
@@ -70,6 +70,10 @@ public class RecordAttributes {
     return this.attributes.get(attributeName);
   }
 
+  public boolean containsAttribute(String attributeName) {
+    return this.attributes.containsKey(attributeName);
+  }
+
   public Set<Map.Entry<String, Object>> attributeSet() {
     return this.attributes.entrySet();
   }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -774,7 +774,7 @@ class RecordControllerMockMvcTest extends MockMvcTestBase {
                     "attr1")
                 .content(toJson(recordRequest))
                 .contentType(MediaType.APPLICATION_JSON))
-        .andExpect(status().isCreated());
+        .andExpect(status().isBadRequest());
   }
 
   @Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
@@ -179,8 +180,9 @@ class RecordOrchestratorServiceTest {
     assertEquals(HttpStatus.OK, response.getStatusCode());
   }
 
-  @Test
-  void upsertExistingRecordWithDifferentPrimaryKey() {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void upsertExistingRecordWithDifferentPrimaryKey(boolean primaryKeyInQuery) {
     // Arrange
     recordOrchestratorService.upsertSingleRecord(
         COLLECTION,
@@ -203,7 +205,7 @@ class RecordOrchestratorServiceTest {
                     VERSION,
                     TEST_TYPE,
                     RECORD_ID,
-                    Optional.of(PRIMARY_KEY),
+                    primaryKeyInQuery ? Optional.of(PRIMARY_KEY) : Optional.empty(),
                     recordRequest),
             "upsertSingleRecord should have thrown an error");
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
@@ -119,6 +119,144 @@ class RecordOrchestratorServiceTest {
   }
 
   @Test
+  void upsertNewRecordWithMatchingPrimaryKey() {
+    // Arrange
+    RecordRequest recordRequest =
+        new RecordRequest(RecordAttributes.empty().putAttribute(PRIMARY_KEY, RECORD_ID));
+
+    // Act
+    ResponseEntity<RecordResponse> response =
+        recordOrchestratorService.upsertSingleRecord(
+            COLLECTION, VERSION, TEST_TYPE, RECORD_ID, Optional.of(PRIMARY_KEY), recordRequest);
+
+    // Assert
+    assertEquals(HttpStatus.CREATED, response.getStatusCode());
+  }
+
+  @Test
+  void upsertNewRecordWithDifferentPrimaryKey() {
+    // Arrange
+    RecordRequest recordRequest =
+        new RecordRequest(RecordAttributes.empty().putAttribute(PRIMARY_KEY, "someOtherValue"));
+
+    // Act/Assert
+    ValidationException e =
+        assertThrows(
+            ValidationException.class,
+            () ->
+                recordOrchestratorService.upsertSingleRecord(
+                    COLLECTION,
+                    VERSION,
+                    TEST_TYPE,
+                    RECORD_ID,
+                    Optional.of(PRIMARY_KEY),
+                    recordRequest),
+            "upsertSingleRecord should have thrown an error");
+
+    assertEquals("Primary key in payload does not match primary key in URL", e.getMessage());
+  }
+
+  @Test
+  void upsertExistingRecordWithMatchingPrimaryKey() {
+    // Arrange
+    recordOrchestratorService.upsertSingleRecord(
+        COLLECTION,
+        VERSION,
+        TEST_TYPE,
+        RECORD_ID,
+        Optional.of(PRIMARY_KEY),
+        new RecordRequest(RecordAttributes.empty()));
+
+    RecordRequest recordRequest =
+        new RecordRequest(RecordAttributes.empty().putAttribute(PRIMARY_KEY, RECORD_ID));
+
+    // Act
+    ResponseEntity<RecordResponse> response =
+        recordOrchestratorService.upsertSingleRecord(
+            COLLECTION, VERSION, TEST_TYPE, RECORD_ID, Optional.of(PRIMARY_KEY), recordRequest);
+
+    // Assert
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+  }
+
+  @Test
+  void upsertExistingRecordWithDifferentPrimaryKey() {
+    // Arrange
+    recordOrchestratorService.upsertSingleRecord(
+        COLLECTION,
+        VERSION,
+        TEST_TYPE,
+        RECORD_ID,
+        Optional.of(PRIMARY_KEY),
+        new RecordRequest(RecordAttributes.empty()));
+
+    RecordRequest recordRequest =
+        new RecordRequest(RecordAttributes.empty().putAttribute(PRIMARY_KEY, "someOtherValue"));
+
+    // Act/Assert
+    ValidationException e =
+        assertThrows(
+            ValidationException.class,
+            () ->
+                recordOrchestratorService.upsertSingleRecord(
+                    COLLECTION,
+                    VERSION,
+                    TEST_TYPE,
+                    RECORD_ID,
+                    Optional.of(PRIMARY_KEY),
+                    recordRequest),
+            "upsertSingleRecord should have thrown an error");
+
+    assertEquals("Primary key in payload does not match primary key in URL", e.getMessage());
+  }
+
+  @Test
+  void updateRecordWithMatchingPrimaryKey() {
+    // Arrange
+    recordOrchestratorService.upsertSingleRecord(
+        COLLECTION,
+        VERSION,
+        TEST_TYPE,
+        RECORD_ID,
+        Optional.of(PRIMARY_KEY),
+        new RecordRequest(RecordAttributes.empty()));
+
+    RecordRequest recordRequest =
+        new RecordRequest(RecordAttributes.empty().putAttribute(PRIMARY_KEY, RECORD_ID));
+
+    // Act
+    RecordResponse response =
+        recordOrchestratorService.updateSingleRecord(
+            COLLECTION, VERSION, TEST_TYPE, RECORD_ID, recordRequest);
+  }
+
+  @Test
+  void updateRecordWithDifferentPrimaryKey() {
+    // Arrange
+    recordOrchestratorService.upsertSingleRecord(
+        COLLECTION,
+        VERSION,
+        TEST_TYPE,
+        RECORD_ID,
+        Optional.of(PRIMARY_KEY),
+        new RecordRequest(RecordAttributes.empty()));
+
+    RecordRequest recordRequest =
+        new RecordRequest(RecordAttributes.empty().putAttribute(PRIMARY_KEY, "someOtherValue"));
+
+    // Act/Assert
+    ValidationException e =
+        assertThrows(
+            ValidationException.class,
+            () ->
+                recordOrchestratorService.updateSingleRecord(
+                    COLLECTION, VERSION, TEST_TYPE, RECORD_ID, recordRequest),
+            "updateSingleRecord should have thrown an error");
+
+    assertEquals("Primary key in payload does not match primary key in URL", e.getMessage());
+  }
+
+  @Test
   void deleteSingleRecord() {
     testCreateRecord(RECORD_ID, TEST_KEY, TEST_VAL);
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
@@ -19,6 +19,7 @@ import org.databiosphere.workspacedataservice.dao.CollectionDao;
 import org.databiosphere.workspacedataservice.service.model.AttributeSchema;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
 import org.databiosphere.workspacedataservice.service.model.RecordTypeSchema;
+import org.databiosphere.workspacedataservice.service.model.ReservedNames;
 import org.databiosphere.workspacedataservice.service.model.exception.ConflictException;
 import org.databiosphere.workspacedataservice.service.model.exception.ConflictingPrimaryKeysException;
 import org.databiosphere.workspacedataservice.service.model.exception.MissingObjectException;
@@ -148,6 +149,22 @@ class RecordOrchestratorServiceTest {
         () ->
             recordOrchestratorService.upsertSingleRecord(
                 COLLECTION, VERSION, TEST_TYPE, RECORD_ID, primaryKey, recordRequest),
+        "upsertSingleRecord should have thrown an error");
+  }
+
+  @Test
+  void upsertNewRecordWithDifferentDefaultPrimaryKey() {
+    // Arrange
+    RecordRequest recordRequest =
+        new RecordRequest(
+            RecordAttributes.empty().putAttribute(ReservedNames.RECORD_ID, "someOtherValue"));
+
+    // Act/Assert
+    assertThrows(
+        ConflictingPrimaryKeysException.class,
+        () ->
+            recordOrchestratorService.upsertSingleRecord(
+                COLLECTION, VERSION, TEST_TYPE, RECORD_ID, Optional.empty(), recordRequest),
         "upsertSingleRecord should have thrown an error");
   }
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
@@ -20,6 +20,7 @@ import org.databiosphere.workspacedataservice.service.model.AttributeSchema;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
 import org.databiosphere.workspacedataservice.service.model.RecordTypeSchema;
 import org.databiosphere.workspacedataservice.service.model.exception.ConflictException;
+import org.databiosphere.workspacedataservice.service.model.exception.ConflictingPrimaryKeysException;
 import org.databiosphere.workspacedataservice.service.model.exception.MissingObjectException;
 import org.databiosphere.workspacedataservice.service.model.exception.ValidationException;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
@@ -142,15 +143,12 @@ class RecordOrchestratorServiceTest {
 
     // Act/Assert
     Optional<String> primaryKey = Optional.of(PRIMARY_KEY);
-    ValidationException e =
-        assertThrows(
-            ValidationException.class,
-            () ->
-                recordOrchestratorService.upsertSingleRecord(
-                    COLLECTION, VERSION, TEST_TYPE, RECORD_ID, primaryKey, recordRequest),
-            "upsertSingleRecord should have thrown an error");
-
-    assertEquals("Primary key in payload does not match primary key in URL", e.getMessage());
+    assertThrows(
+        ConflictingPrimaryKeysException.class,
+        () ->
+            recordOrchestratorService.upsertSingleRecord(
+                COLLECTION, VERSION, TEST_TYPE, RECORD_ID, primaryKey, recordRequest),
+        "upsertSingleRecord should have thrown an error");
   }
 
   @Test
@@ -194,15 +192,12 @@ class RecordOrchestratorServiceTest {
 
     // Act/Assert
     Optional<String> primaryKey = primaryKeyInQuery ? Optional.of(PRIMARY_KEY) : Optional.empty();
-    ValidationException e =
-        assertThrows(
-            ValidationException.class,
-            () ->
-                recordOrchestratorService.upsertSingleRecord(
-                    COLLECTION, VERSION, TEST_TYPE, RECORD_ID, primaryKey, recordRequest),
-            "upsertSingleRecord should have thrown an error");
-
-    assertEquals("Primary key in payload does not match primary key in URL", e.getMessage());
+    assertThrows(
+        ConflictingPrimaryKeysException.class,
+        () ->
+            recordOrchestratorService.upsertSingleRecord(
+                COLLECTION, VERSION, TEST_TYPE, RECORD_ID, primaryKey, recordRequest),
+        "upsertSingleRecord should have thrown an error");
   }
 
   @Test
@@ -243,15 +238,12 @@ class RecordOrchestratorServiceTest {
         new RecordRequest(RecordAttributes.empty().putAttribute(PRIMARY_KEY, "someOtherValue"));
 
     // Act/Assert
-    ValidationException e =
-        assertThrows(
-            ValidationException.class,
-            () ->
-                recordOrchestratorService.updateSingleRecord(
-                    COLLECTION, VERSION, TEST_TYPE, RECORD_ID, recordRequest),
-            "updateSingleRecord should have thrown an error");
-
-    assertEquals("Primary key in payload does not match primary key in URL", e.getMessage());
+    assertThrows(
+        ConflictingPrimaryKeysException.class,
+        () ->
+            recordOrchestratorService.updateSingleRecord(
+                COLLECTION, VERSION, TEST_TYPE, RECORD_ID, recordRequest),
+        "updateSingleRecord should have thrown an error");
   }
 
   @Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
@@ -172,9 +172,10 @@ class RecordOrchestratorServiceTest {
         new RecordRequest(RecordAttributes.empty().putAttribute(PRIMARY_KEY, RECORD_ID));
 
     // Act
+    Optional<String> primaryKey = Optional.of(PRIMARY_KEY);
     ResponseEntity<RecordResponse> response =
         recordOrchestratorService.upsertSingleRecord(
-            COLLECTION, VERSION, TEST_TYPE, RECORD_ID, Optional.of(PRIMARY_KEY), recordRequest);
+            COLLECTION, VERSION, TEST_TYPE, RECORD_ID, primaryKey, recordRequest);
 
     // Assert
     assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -196,17 +197,13 @@ class RecordOrchestratorServiceTest {
         new RecordRequest(RecordAttributes.empty().putAttribute(PRIMARY_KEY, "someOtherValue"));
 
     // Act/Assert
+    Optional<String> primaryKey = primaryKeyInQuery ? Optional.of(PRIMARY_KEY) : Optional.empty();
     ValidationException e =
         assertThrows(
             ValidationException.class,
             () ->
                 recordOrchestratorService.upsertSingleRecord(
-                    COLLECTION,
-                    VERSION,
-                    TEST_TYPE,
-                    RECORD_ID,
-                    primaryKeyInQuery ? Optional.of(PRIMARY_KEY) : Optional.empty(),
-                    recordRequest),
+                    COLLECTION, VERSION, TEST_TYPE, RECORD_ID, primaryKey, recordRequest),
             "upsertSingleRecord should have thrown an error");
 
     assertEquals("Primary key in payload does not match primary key in URL", e.getMessage());
@@ -230,6 +227,9 @@ class RecordOrchestratorServiceTest {
     RecordResponse response =
         recordOrchestratorService.updateSingleRecord(
             COLLECTION, VERSION, TEST_TYPE, RECORD_ID, recordRequest);
+
+    // Assert
+    assertEquals(RECORD_ID, response.recordId());
   }
 
   @Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
@@ -141,17 +141,13 @@ class RecordOrchestratorServiceTest {
         new RecordRequest(RecordAttributes.empty().putAttribute(PRIMARY_KEY, "someOtherValue"));
 
     // Act/Assert
+    Optional<String> primaryKey = Optional.of(PRIMARY_KEY);
     ValidationException e =
         assertThrows(
             ValidationException.class,
             () ->
                 recordOrchestratorService.upsertSingleRecord(
-                    COLLECTION,
-                    VERSION,
-                    TEST_TYPE,
-                    RECORD_ID,
-                    Optional.of(PRIMARY_KEY),
-                    recordRequest),
+                    COLLECTION, VERSION, TEST_TYPE, RECORD_ID, primaryKey, recordRequest),
             "upsertSingleRecord should have thrown an error");
 
     assertEquals("Primary key in payload does not match primary key in URL", e.getMessage());

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
@@ -153,6 +153,22 @@ class RecordOrchestratorServiceTest {
   }
 
   @Test
+  void upsertNewRecordWithMatchingDefaultPrimaryKey() {
+    // Arrange
+    RecordRequest recordRequest =
+        new RecordRequest(
+            RecordAttributes.empty().putAttribute(ReservedNames.RECORD_ID, RECORD_ID));
+
+    // Act
+    ResponseEntity<RecordResponse> response =
+        recordOrchestratorService.upsertSingleRecord(
+            COLLECTION, VERSION, TEST_TYPE, RECORD_ID, Optional.empty(), recordRequest);
+
+    // Assert
+    assertEquals(HttpStatus.CREATED, response.getStatusCode());
+  }
+
+  @Test
   void upsertNewRecordWithDifferentDefaultPrimaryKey() {
     // Arrange
     RecordRequest recordRequest =


### PR DESCRIPTION
PUT and PATCH requests to `/{instanceId}/records/{version}/{recordType}/{recordId}` specify the record's primary key value in the URL via the `recordId` path parameter and, for PUT requests, the `primaryKey` query parameter. However, they may also specify the primary key value in the attributes in the request body.

Currently, WDS doesn't handle this consistently.
- Creating a new record, whether or not the two primary key values match, the request succeeds.
- Updating an existing record, whether or not the two primary key values match, results in an SQL error.

This updates that endpoint to require that, if a primary key value is specified in the request body, it must match the one in the URL. It they do match, the request now succeeds instead of producing an SQL error.
