### PR TITLE
AJ-1629 Make `data-plane` default profile

### DIFF
--- a/.github/workflows/release-python-client.yml
+++ b/.github/workflows/release-python-client.yml
@@ -89,7 +89,7 @@ jobs:
           export WORKSPACE_MANAGER_URL=http://localhost:9889
           export WORKSPACE_ID=123e4567-e89b-12d3-a456-426614174000
           ./gradlew --build-cache build -x test
-          ./gradlew bootRun &
+          ./gradlew bootRun --args='--spring.profiles.active=data-plane' &
           count=20
           until $(curl --output /dev/null --silent --head --fail http://localhost:8080/status); do
             printf '.'

--- a/.github/workflows/release-python-client.yml
+++ b/.github/workflows/release-python-client.yml
@@ -88,8 +88,9 @@ jobs:
           export DATA_REPO_URL=http://localhost:9889
           export WORKSPACE_MANAGER_URL=http://localhost:9889
           export WORKSPACE_ID=123e4567-e89b-12d3-a456-426614174000
+          export SPRING_PROFILES_ACTIVE=data-plane
           ./gradlew --build-cache build -x test
-          ./gradlew bootRun --args='--spring.profiles.active=data-plane' &
+          ./gradlew bootRun &
           count=20
           until $(curl --output /dev/null --silent --head --fail http://localhost:8080/status); do
             printf '.'

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ export SAM_URL=http://localhost:9889
 To run WDS locally, you can either use the command line:
 
 ```bash
-./gradlew bootRun
+./gradlew bootRun --args='--spring.profiles.active=data-plane'
 ```
 
 Or, from Intellij, go

--- a/README.md
+++ b/README.md
@@ -37,14 +37,16 @@ Instead use the `run_postgres.sh` script to set up a docker container running po
 
 #### Environment Variables
 
-For WDS to work properly, a spring profile needs to be set so that several environment variables are
-populated correctly.
+For WDS to work properly, several environment variables need to be set, and exactly one of the
+following active profiles must be set:
 
-To run WDS locally and therefore use the local application properties, set the profile the following
-way:
+- control-plane
+- data-plane
+
+To run WDS locally and therefore use the local application properties, set the profile as follows:
 
 ```bash
-export SPRING_PROFILES_ACTIVE=local
+export SPRING_PROFILES_ACTIVE=local,data-plane
 ```
 
 Other profiles that are available are:
@@ -59,9 +61,10 @@ Other profiles that are available are:
 You are unlikely to use prod and bee when running locally, those profiles are leveraged when WDS is
 deployed in Terra.
 
-If you would like to not use a profile (i.e. not set SPRING_PROFILES_ACTIVE variable), you can set
-the following environment variables manually. The variables that need to be set are described below.
-You can also add them to your `~/.zshrc` or similar shell profile.
+If you would like to not use the local profile, you can set some of the environment variables
+manually. The variables that need to be set are described below. You can also add them to your
+`~/.zshrc` or similar shell profile. However, in order for the app to run correctly, you still
+have to at least specify data-plane or control-plane.
 
 ##### SAM_URL
 
@@ -137,7 +140,7 @@ export SAM_URL=http://localhost:9889
 To run WDS locally, you can either use the command line:
 
 ```bash
-./gradlew bootRun --args='--spring.profiles.active=data-plane'
+./gradlew bootRun
 ```
 
 Or, from Intellij, go

--- a/service/src/main/java/org/databiosphere/workspacedataservice/config/ConfigurationException.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/config/ConfigurationException.java
@@ -1,0 +1,12 @@
+package org.databiosphere.workspacedataservice.config;
+
+/** Thrown when there's a problem with the application configuration. */
+public class ConfigurationException extends RuntimeException {
+  public ConfigurationException(String message) {
+    super(message);
+  }
+
+  public ConfigurationException(String message, Throwable throwable) {
+    super(message, throwable);
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RecordSinkFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RecordSinkFactory.java
@@ -3,6 +3,7 @@ package org.databiosphere.workspacedataservice.recordsink;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.UUID;
 import java.util.function.Consumer;
+import org.databiosphere.workspacedataservice.config.ConfigurationException;
 import org.databiosphere.workspacedataservice.config.TwdsProperties;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.databiosphere.workspacedataservice.recordsink.RawlsRecordSink.RawlsJsonConsumer;
@@ -54,14 +55,7 @@ public class RecordSinkFactory {
   //   the prefix as part of supporting the prefix assignment.
   public RecordSink buildRecordSink(UUID collectionId, String prefix) {
     if (twdsProperties.getDataImport() == null) {
-      logger
-          .atWarn()
-          .log(
-              "twds.data-import properties are not defined. "
-                  + "Start this deployment with active Spring profile of "
-                  + "either 'data-plane' or 'control-plane'. "
-                  + "Defaulting to batch-write-record-sink=wds");
-      return wdsRecordSink(collectionId);
+      throw new ConfigurationException("twds.data-import properties are not defined");
     }
 
     switch (twdsProperties.getDataImport().getBatchWriteRecordSink()) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/startup/StartupConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/startup/StartupConfig.java
@@ -1,6 +1,7 @@
 package org.databiosphere.workspacedataservice.startup;
 
 import java.util.UUID;
+import org.databiosphere.workspacedataservice.config.ConfigurationException;
 import org.databiosphere.workspacedataservice.config.TwdsProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,11 +51,11 @@ public class StartupConfig {
           UUID workspaceUuid = UUID.fromString(twdsProperties.getInstance().getWorkspaceId());
           logger.info("single-tenant workspace id: {}", workspaceUuid);
         } catch (Exception e) {
-          logger.error(
+          throw new ConfigurationException(
               "This deployment requires a $WORKSPACE_ID env var, but its value "
-                  + "could not be parsed to a UUID: {}",
-              e.getMessage());
-          throw e;
+                  + "could not be parsed to a UUID: "
+                  + e.getMessage(),
+              e);
         }
       }
     }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/GeneratedClientTests.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/GeneratedClientTests.java
@@ -20,6 +20,7 @@ import org.databiosphere.workspacedata.model.RecordTypeSchema;
 import org.databiosphere.workspacedata.model.SearchRequest;
 import org.databiosphere.workspacedata.model.StatusResponse;
 import org.databiosphere.workspacedata.model.TsvUploadResponse;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,7 +32,7 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles(profiles = "mock-sam")
 @DirtiesContext
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-class GeneratedClientTests {
+class GeneratedClientTests extends TestBase {
 
   private ApiClient apiClient;
   @LocalServerPort int port;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/ActivityEventBuilderTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/ActivityEventBuilderTest.java
@@ -11,6 +11,7 @@ import org.broadinstitute.dsde.workbench.client.sam.ApiException;
 import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.UsersApi;
 import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.sam.BearerTokenFilter;
 import org.databiosphere.workspacedataservice.sam.SamClientFactory;
 import org.databiosphere.workspacedataservice.service.CollectionService;
@@ -34,7 +35,7 @@ import org.springframework.web.context.request.RequestContextHolder;
 @SpringBootTest
 @AutoConfigureMockMvc
 @ExtendWith(OutputCaptureExtension.class)
-public class ActivityEventBuilderTest {
+public class ActivityEventBuilderTest extends TestBase {
 
   @Autowired CollectionService collectionService;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/AvailabilityTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/AvailabilityTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.availability.ApplicationAvailability;
@@ -18,7 +19,7 @@ import org.springframework.test.web.servlet.ResultActions;
 
 @AutoConfigureMockMvc
 @SpringBootTest
-class AvailabilityTest {
+class AvailabilityTest extends TestBase {
 
   @Autowired private MockMvc mvc;
   @Autowired private ApplicationContext context;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/LogStatementTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/LogStatementTest.java
@@ -11,6 +11,7 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.datarepo.DataRepoClientFactory;
 import org.databiosphere.workspacedataservice.service.CollectionService;
 import org.databiosphere.workspacedataservice.service.RecordOrchestratorService;
@@ -39,7 +40,7 @@ import org.springframework.web.multipart.MultipartFile;
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @SpringBootTest
 @ExtendWith(OutputCaptureExtension.class)
-public class LogStatementTest {
+public class LogStatementTest extends TestBase {
 
   private final String VERSION = "v0.2";
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/common/ConfigurationExceptionDetector.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/common/ConfigurationExceptionDetector.java
@@ -1,0 +1,38 @@
+package org.databiosphere.workspacedataservice.common;
+
+import org.databiosphere.workspacedataservice.config.ConfigurationException;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestWatcher;
+import org.opentest4j.AssertionFailedError;
+
+/** Detects unhandled ConfigurationExceptions and provides a resolution hint. */
+public class ConfigurationExceptionDetector implements TestWatcher {
+
+  private static final String RESOLUTION_HINT =
+      "You may need to specify @ActiveProfiles with \"data-plane\" or \"control-plane\" or extend %s"
+          .formatted(TestBase.class.getSimpleName());
+
+  @Override
+  public void testFailed(ExtensionContext context, Throwable cause) {
+    // Check if the cause or any cause in the chain is the specific RuntimeException
+    Throwable rootCause = getRootCause(cause);
+    if (rootCause instanceof ConfigurationException) {
+      throw new AssertionError(
+          "Test failed due to an unhandled ConfigurationException! " + RESOLUTION_HINT, rootCause);
+    }
+
+    if (rootCause instanceof AssertionFailedError afe) {
+      if (ConfigurationException.class.equals(afe.getActual().getType())
+          && !ConfigurationException.class.equals(afe.getExpected().getType())) {
+        throw new AssertionError(
+            "Test failed due to an unexpected ConfigurationException! " + RESOLUTION_HINT,
+            rootCause);
+      }
+    }
+  }
+
+  private Throwable getRootCause(Throwable throwable) {
+    Throwable cause = throwable.getCause();
+    return (cause == null || cause == throwable) ? throwable : getRootCause(cause);
+  }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/common/TestBase.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/common/TestBase.java
@@ -23,7 +23,6 @@ import org.springframework.test.context.TestPropertySource;
  * which will automatically provide a hint if it detects a test failure due to a {@link
  * ConfigurationException}.
  */
-@SpringBootTest
 @ActiveProfiles({"data-plane"})
 @TestPropertySource(
     properties = {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/common/TestBase.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/common/TestBase.java
@@ -1,0 +1,35 @@
+package org.databiosphere.workspacedataservice.common;
+
+import org.databiosphere.workspacedataservice.config.ConfigurationException;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * Optional base class for any test class annotated with {@link SpringBootTest} to automatically
+ * enable the "data-plane" profile and a "workspace-id".
+ *
+ * <p>Subclasses can append additional active profiles by using the {@link ActiveProfiles}
+ * annotation.
+ *
+ * <p>To explicitly override the "data-plane" profile, subclasses can use
+ * {@code @ActiveProfiles(value={"some-profile"}, inheritProfiles=false)}.
+ *
+ * <p>To explicitly override the "workspace-id" that is configured, subclasses can use
+ * {@code @TestPropertySource(properties={"twds.instance.workspace-id=<...>"})}.
+ *
+ * <p>Note: extending this class also extends the {@link ConfigurationExceptionDetector} class,
+ * which will automatically provide a hint if it detects a test failure due to a {@link
+ * ConfigurationException}.
+ */
+@SpringBootTest
+@ActiveProfiles({"data-plane"})
+@TestPropertySource(
+    properties = {
+      // data-plane mode requires a workspace-id to be set
+      // example uuid from https://en.wikipedia.org/wiki/Universally_unique_identifier
+      "twds.instance.workspace-id=123e4567-e89b-12d3-a456-426614174000",
+    })
+@ExtendWith(ConfigurationExceptionDetector.class)
+public abstract class TestBase {}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/ConcurrentDataTypeChangesTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/ConcurrentDataTypeChangesTest.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
 import org.databiosphere.workspacedataservice.shared.model.RecordRequest;
 import org.databiosphere.workspacedataservice.shared.model.RecordResponse;
@@ -31,7 +32,7 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles(profiles = "mock-sam")
 @DirtiesContext
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-class ConcurrentDataTypeChangesTest {
+class ConcurrentDataTypeChangesTest extends TestBase {
   @Autowired private TestRestTemplate restTemplate;
   private HttpHeaders headers;
   private UUID instanceId;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackMDCRequestResponseTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackMDCRequestResponseTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.util.List;
 import java.util.UUID;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.service.MDCServletRequestListener;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
@@ -25,7 +26,7 @@ import org.springframework.test.annotation.DirtiesContext;
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     properties = {"spring.main.allow-bean-definition-overriding=true"})
-class FullStackMDCRequestResponseTest {
+class FullStackMDCRequestResponseTest extends TestBase {
 
   // hmmmmm https://github.com/gradle/gradle/issues/5975
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.function.Supplier;
 import org.databiosphere.workspacedata.model.ErrorResponse;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.service.RelationUtils;
 import org.databiosphere.workspacedataservice.shared.model.BatchOperation;
 import org.databiosphere.workspacedataservice.shared.model.OperationType;
@@ -60,7 +61,7 @@ import org.springframework.transaction.annotation.Transactional;
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     properties = {"spring.main.allow-bean-definition-overriding=true"})
 @Import(SmallBatchWriteTestConfig.class)
-class FullStackRecordControllerTest {
+class FullStackRecordControllerTest extends TestBase {
   @Autowired private TestRestTemplate restTemplate;
   private HttpHeaders headers;
   private UUID instanceId;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/GlobalExceptionHandlerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/GlobalExceptionHandlerTest.java
@@ -5,12 +5,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class GlobalExceptionHandlerTest {
+class GlobalExceptionHandlerTest extends TestBase {
   @Autowired private GlobalExceptionHandler globalExceptionHandler;
 
   @Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/ImportControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/ImportControllerMockMvcTest.java
@@ -16,7 +16,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MvcResult;
 
-@ActiveProfiles(profiles = {"mock-collection-dao", "mock-sam"})
+@ActiveProfiles(profiles = {"mock-instance-dao", "mock-sam"})
 @DirtiesContext
 class ImportControllerMockMvcTest extends MockMvcTestBase {
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/ImportControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/ImportControllerMockMvcTest.java
@@ -16,7 +16,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MvcResult;
 
-@ActiveProfiles(profiles = {"mock-instance-dao", "mock-sam"})
+@ActiveProfiles(profiles = {"mock-collection-dao", "mock-sam"})
 @DirtiesContext
 class ImportControllerMockMvcTest extends MockMvcTestBase {
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/JobControllerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/JobControllerTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.UUID;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.dao.CollectionDao;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
@@ -39,7 +40,7 @@ import org.springframework.test.context.ActiveProfiles;
 @DirtiesContext
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-class JobControllerTest {
+class JobControllerTest extends TestBase {
   @Autowired private NamedParameterJdbcTemplate namedTemplate;
 
   @Autowired private TestRestTemplate restTemplate;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/MockMvcTestBase.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/MockMvcTestBase.java
@@ -5,15 +5,18 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 @AutoConfigureMockMvc
 @SpringBootTest
-class MockMvcTestBase {
+@ActiveProfiles({"mock-sam"})
+class MockMvcTestBase extends TestBase {
   @Autowired private ObjectMapper mapper;
   @Autowired protected MockMvc mockMvc;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/MockMvcTestBase.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/MockMvcTestBase.java
@@ -9,13 +9,11 @@ import org.databiosphere.workspacedataservice.common.TestBase;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 @AutoConfigureMockMvc
 @SpringBootTest
-@ActiveProfiles({"mock-sam"})
 class MockMvcTestBase extends TestBase {
   @Autowired private ObjectMapper mapper;
   @Autowired protected MockMvc mockMvc;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
@@ -19,6 +19,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Stream;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
 import org.databiosphere.workspacedataservice.shared.model.BatchResponse;
@@ -51,7 +52,7 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles(profiles = "mock-sam")
 @DirtiesContext
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-class TsvDownloadTest {
+class TsvDownloadTest extends TestBase {
 
   @Autowired private TestRestTemplate restTemplate;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvInputFormatsTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvInputFormatsTest.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
@@ -32,7 +33,7 @@ import org.springframework.transaction.annotation.Transactional;
 @DirtiesContext
 @SpringBootTest
 @AutoConfigureMockMvc
-class TsvInputFormatsTest {
+class TsvInputFormatsTest extends TestBase {
 
   @Autowired private MockMvc mockMvc;
   @Autowired RecordDao recordDao;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/PostgresCollectionDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/PostgresCollectionDaoTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,7 +26,7 @@ import org.springframework.test.context.TestPropertySource;
     properties = {
       "twds.instance.workspace-id=80000000-4000-4000-4000-120000000000",
     })
-class PostgresCollectionDaoTest {
+class PostgresCollectionDaoTest extends TestBase {
 
   @Autowired CollectionDao collectionDao;
   @Autowired NamedParameterJdbcTemplate namedParameterJdbcTemplate;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/PostgresJobDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/PostgresJobDaoTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.UUID;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
 import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.databiosphere.workspacedataservice.shared.model.job.Job;
@@ -30,7 +31,7 @@ import org.springframework.test.annotation.DirtiesContext;
 @DirtiesContext
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @SpringBootTest
-class PostgresJobDaoTest {
+class PostgresJobDaoTest extends TestBase {
 
   // createJob
   // updateStatus x 3

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/QuartzSchedulerDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/QuartzSchedulerDaoTest.java
@@ -8,6 +8,7 @@ import java.io.Serializable;
 import java.util.Date;
 import java.util.Map;
 import java.util.Set;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.shared.model.Schedulable;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -24,7 +25,7 @@ import org.springframework.test.annotation.DirtiesContext;
 
 @DirtiesContext
 @SpringBootTest
-class QuartzSchedulerDaoTest {
+class QuartzSchedulerDaoTest extends TestBase {
 
   @MockBean Scheduler scheduler;
   @Autowired SchedulerDao schedulerDao;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
@@ -19,6 +19,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.service.DataTypeInferer;
 import org.databiosphere.workspacedataservice.service.RelationUtils;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
@@ -48,7 +49,7 @@ import org.springframework.web.server.ResponseStatusException;
 @DirtiesContext
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class RecordDaoTest {
+class RecordDaoTest extends TestBase {
 
   private static final String PRIMARY_KEY = "row_id";
   @Autowired RecordDao recordDao;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/FileDownloadHelperTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/FileDownloadHelperTest.java
@@ -3,13 +3,14 @@ package org.databiosphere.workspacedataservice.dataimport;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.io.IOException;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.io.Resource;
 
 @SpringBootTest
-class FileDownloadHelperTest {
+class FileDownloadHelperTest extends TestBase {
 
   @Value("classpath:parquet/empty.parquet")
   Resource emptyParquet;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/WdsSnapshotSupportTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/WdsSnapshotSupportTest.java
@@ -21,6 +21,7 @@ import java.util.UUID;
 import java.util.stream.IntStream;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.retry.RestClientRetry;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
@@ -35,7 +36,7 @@ import org.springframework.test.annotation.DirtiesContext;
 
 @DirtiesContext
 @SpringBootTest
-class WsmSnapshotSupportTest {
+class WsmSnapshotSupportTest extends TestBase {
 
   @MockBean JobDao jobDao;
   @MockBean WorkspaceManagerDao wsmDao;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobTest.java
@@ -22,6 +22,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.service.BatchWriteService;
 import org.databiosphere.workspacedataservice.service.model.BatchWriteResult;
@@ -41,7 +42,7 @@ import org.springframework.test.annotation.DirtiesContext;
 
 @DirtiesContext
 @SpringBootTest
-class PfbQuartzJobTest {
+class PfbQuartzJobTest extends TestBase {
   @MockBean JobDao jobDao;
   @MockBean WorkspaceManagerDao wsmDao;
   @MockBean BatchWriteService batchWriteService;
@@ -54,8 +55,6 @@ class PfbQuartzJobTest {
 
   @Value("classpath:avro/test.avro")
   Resource testAvroResource;
-
-  private static final String COLLECTION = "aaaabbbb-cccc-dddd-1111-222233334444";
 
   @Test
   void linkAllNewSnapshots() {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbRecordConverterTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbRecordConverterTest.java
@@ -24,6 +24,7 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.recordsource.RecordSource.ImportMode;
 import org.databiosphere.workspacedataservice.service.JsonConfig;
 import org.databiosphere.workspacedataservice.service.RelationUtils;
@@ -37,7 +38,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest(classes = {JsonConfig.class, PfbRecordConverter.class})
-class PfbRecordConverterTest {
+class PfbRecordConverterTest extends TestBase {
 
   @Autowired private PfbRecordConverter converter;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobE2ETest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobE2ETest.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.dao.SchedulerDao;
 import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
 import org.databiosphere.workspacedataservice.service.CollectionService;
@@ -59,7 +60,7 @@ import org.springframework.test.context.ActiveProfiles;
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @AutoConfigureMockMvc
-public class TdrManifestQuartzJobE2ETest {
+public class TdrManifestQuartzJobE2ETest extends TestBase {
   @Autowired private RecordOrchestratorService recordOrchestratorService;
   @Autowired private ImportService importService;
   @Autowired private CollectionService collectionService;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobTest.java
@@ -16,6 +16,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.parquet.hadoop.util.HadoopInputFile;
 import org.apache.parquet.io.InputFile;
 import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.dataimport.FileDownloadHelper;
 import org.databiosphere.workspacedataservice.dataimport.tdr.TdrManifestExemplarData.AzureSmall;
@@ -36,7 +37,7 @@ import org.springframework.test.annotation.DirtiesContext;
 
 @DirtiesContext
 @SpringBootTest
-public class TdrManifestQuartzJobTest {
+public class TdrManifestQuartzJobTest extends TestBase {
 
   @MockBean JobDao jobDao;
   @MockBean WorkspaceManagerDao wsmDao;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/datarepo/DataRepoDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/datarepo/DataRepoDaoTest.java
@@ -9,6 +9,7 @@ import bio.terra.datarepo.api.RepositoryApi;
 import bio.terra.datarepo.client.ApiException;
 import bio.terra.datarepo.model.SnapshotModel;
 import java.util.UUID;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.dao.CollectionDao;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.junit.jupiter.api.AfterEach;
@@ -23,7 +24,7 @@ import org.springframework.test.annotation.DirtiesContext;
 
 @DirtiesContext
 @SpringBootTest
-class DataRepoDaoTest {
+class DataRepoDaoTest extends TestBase {
 
   @Autowired DataRepoDao dataRepoDao;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/jobexec/QuartzJobTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/jobexec/QuartzJobTest.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
 import org.databiosphere.workspacedataservice.observability.TestObservationRegistryConfig;
@@ -46,7 +47,7 @@ import org.springframework.context.annotation.Import;
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Import(TestObservationRegistryConfig.class)
-class QuartzJobTest {
+class QuartzJobTest extends TestBase {
 
   @MockBean JobDao jobDao;
   @Autowired MeterRegistry meterRegistry;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/leonardo/LeonardoDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/leonardo/LeonardoDaoTest.java
@@ -17,6 +17,7 @@ import org.broadinstitute.dsde.workbench.client.leonardo.model.AppStatus;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.AppType;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.AuditInfo;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.ListAppResponse;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.retry.RestClientRetry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,7 +32,7 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(classes = {LeonardoConfig.class, RestClientRetry.class})
 @TestPropertySource(
     properties = {"twds.instance.workspace-id=90e1b179-9f83-4a6f-a8c2-db083df4cd03"})
-class LeonardoDaoTest {
+class LeonardoDaoTest extends TestBase {
   @Autowired LeonardoDao leonardoDao;
 
   @MockBean LeonardoClientFactory leonardoClientFactory;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/metrics/MetricsConfigTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/metrics/MetricsConfigTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Set;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -23,7 +24,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @DirtiesContext
 @SpringBootTest(properties = "management.prometheus.metrics.export.enabled=true")
 @AutoConfigureMockMvc
-class MetricsConfigTest {
+class MetricsConfigTest extends TestBase {
   @Autowired private BuildProperties buildProperties;
   @Autowired private MockMvc mockMvc;
   @Autowired private MeterRegistry metrics;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkTest.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.recordsink.RawlsModel.AddListMember;
 import org.databiosphere.workspacedataservice.recordsink.RawlsModel.AddUpdateAttribute;
 import org.databiosphere.workspacedataservice.recordsink.RawlsModel.AttributeOperation;
@@ -35,7 +36,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class RawlsRecordSinkTest {
+class RawlsRecordSinkTest extends TestBase {
   @Autowired private ObjectMapper mapper;
   private RecordSink recordSink;
   private StringWriter recordedJson;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/recordsource/JsonRecordSourceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/recordsource/JsonRecordSourceTest.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.stream.Stream;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.service.JsonConfig;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -19,7 +20,7 @@ import org.springframework.test.annotation.DirtiesContext;
 
 @DirtiesContext
 @SpringBootTest(classes = {JsonConfig.class})
-public class JsonRecordSourceTest {
+public class JsonRecordSourceTest extends TestBase {
 
   @Autowired ObjectMapper objectMapper; // as defined in JsonConfig
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/recordsource/PfbRecordSourceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/recordsource/PfbRecordSourceTest.java
@@ -15,6 +15,7 @@ import java.net.URL;
 import java.util.List;
 import org.apache.avro.file.DataFileStream;
 import org.apache.avro.generic.GenericRecord;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.recordsource.RecordSource.ImportMode;
 import org.databiosphere.workspacedataservice.recordsource.RecordSource.WriteStreamInfo;
 import org.databiosphere.workspacedataservice.service.JsonConfig;
@@ -28,7 +29,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest(classes = {JsonConfig.class})
-class PfbRecordSourceTest {
+class PfbRecordSourceTest extends TestBase {
   @Autowired private ObjectMapper objectMapper;
 
   // does PfbRecordSource properly know how to page through a DataFileStream<GenericRecord>?

--- a/service/src/test/java/org/databiosphere/workspacedataservice/recordsource/StreamingTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/recordsource/StreamingTest.java
@@ -7,6 +7,7 @@ import static org.databiosphere.workspacedataservice.shared.model.OperationType.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.List;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.recordsource.RecordSource.WriteStreamInfo;
 import org.databiosphere.workspacedataservice.service.JsonConfig;
 import org.databiosphere.workspacedataservice.shared.model.Record;
@@ -17,7 +18,7 @@ import org.springframework.test.annotation.DirtiesContext;
 
 @DirtiesContext
 @SpringBootTest(classes = JsonConfig.class)
-class StreamingTest {
+class StreamingTest extends TestBase {
 
   @Autowired private ObjectMapper objectMapper;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/retry/RestClientRetryTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/retry/RestClientRetryTest.java
@@ -8,6 +8,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.retry.RestClientRetry.RestCall;
 import org.databiosphere.workspacedataservice.retry.RestClientRetry.VoidRestCall;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthenticationException;
@@ -32,7 +33,7 @@ import org.springframework.test.annotation.DirtiesContext;
       "rest.retry.backoff.delay=10"
     }) // aggressive retry settings so unit test doesn't run too long
 @EnableRetry
-class RestClientRetryTest {
+class RestClientRetryTest extends TestBase {
 
   @Autowired RestClientRetry restClientRetry;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/retry/TransactionRetryTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/retry/TransactionRetryTest.java
@@ -3,6 +3,7 @@ package org.databiosphere.workspacedataservice.retry;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.stream.Stream;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -25,7 +26,7 @@ import org.springframework.transaction.CannotCreateTransactionException;
       "terra.common.retry.transaction.slowRetryMultiplier=1.1",
       "terra.common.retry.transaction.fastRetryMaxAttempts=2"
     })
-class TransactionRetryTest {
+class TransactionRetryTest extends TestBase {
 
   @Autowired TransactionRetryTestBean transactionRetryTestBean;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/sam/BearerTokenFilterTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/sam/BearerTokenFilterTest.java
@@ -7,6 +7,7 @@ import static org.springframework.web.context.request.RequestAttributes.SCOPE_RE
 
 import java.util.stream.Stream;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -22,7 +23,7 @@ import org.springframework.web.context.request.RequestContextHolder;
 /** Tests for @see BearerTokenFilter */
 @DirtiesContext
 @SpringBootTest
-class BearerTokenFilterTest {
+class BearerTokenFilterTest extends TestBase {
 
   private static Stream<Arguments> provideAuthorizationHeaders() {
     /* Arguments are sets:

--- a/service/src/test/java/org/databiosphere/workspacedataservice/sam/SamDaoInvalidWorkspaceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/sam/SamDaoInvalidWorkspaceTest.java
@@ -2,21 +2,26 @@ package org.databiosphere.workspacedataservice.sam;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.retry.RestClientRetry;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
 
 /**
  * When the WORKSPACE_ID env var is not a valid UUID, ensure that all Sam checks return false, and
  * we get an exception from Sam status checks.
  */
 @DirtiesContext
-@SpringBootTest(
-    classes = {SamConfig.class, RestClientRetry.class},
-    properties = {"twds.instance.workspace-id=not-a-real-id"})
-public class SamDaoInvalidWorkspaceTest {
+@SpringBootTest(classes = {SamConfig.class, RestClientRetry.class})
+@TestPropertySource(
+    properties = {
+      // explicitly set the workspace-id to something invalid
+      "twds.instance.workspace-id=not-a-real-id",
+    })
+public class SamDaoInvalidWorkspaceTest extends TestBase {
 
   @Autowired SamDao samDao;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/BackupRestoreServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/BackupRestoreServiceTest.java
@@ -3,6 +3,7 @@ package org.databiosphere.workspacedataservice.service;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import java.util.List;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -17,7 +18,7 @@ import org.springframework.test.context.TestPropertySource;
       "twds.pg_dump.path=/unit/test/pg_dump",
       "twds.pg_dump.psqlPath=/unit/test/psql"
     })
-class BackupRestoreServiceTest {
+class BackupRestoreServiceTest extends TestBase {
   @Autowired private BackupRestoreService backupRestoreService;
 
   @Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/BatchWriteServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/BatchWriteServiceTest.java
@@ -25,6 +25,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.avro.file.DataFileStream;
 import org.apache.avro.generic.GenericRecord;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.dao.CollectionDao;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.databiosphere.workspacedataservice.dataimport.pfb.PfbTestUtils;
@@ -54,7 +55,7 @@ import org.springframework.test.context.TestPropertySource;
 @DirtiesContext
 @SpringBootTest
 @TestPropertySource(properties = {"twds.write.batch.size=2"})
-class BatchWriteServiceTest {
+class BatchWriteServiceTest extends TestBase {
 
   @Autowired private RecordSourceFactory recordSourceFactory;
   @Autowired private RecordSinkFactory recordSinkFactory;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceGetWorkspaceIdTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceGetWorkspaceIdTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.util.UUID;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.dao.CollectionDao;
 import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
@@ -29,7 +30,7 @@ import org.springframework.test.context.TestPropertySource;
     properties = {
       "twds.instance.workspace-id=4fbac661-2ea2-4592-af6d-3c3f710b0456",
     })
-class CollectionServiceGetWorkspaceIdTest {
+class CollectionServiceGetWorkspaceIdTest extends TestBase {
 
   @Autowired private CollectionService collectionService;
   @MockBean private CollectionDao mockCollectionDao;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceNoPermissionSamTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceNoPermissionSamTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.UUID;
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
 import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.dao.CollectionDao;
 import org.databiosphere.workspacedataservice.sam.SamClientFactory;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthorizationException;
@@ -25,7 +26,7 @@ import org.springframework.test.context.ActiveProfiles;
 @DirtiesContext
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class CollectionServiceNoPermissionSamTest {
+class CollectionServiceNoPermissionSamTest extends TestBase {
 
   @Autowired private CollectionService collectionService;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceNoWorkspaceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceNoWorkspaceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.UUID;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.junit.jupiter.api.Test;
@@ -11,12 +12,16 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 
 @DirtiesContext
 @SpringBootTest
+@ActiveProfiles(
+    value = {"control-plane"},
+    inheritProfiles = false)
 @TestPropertySource(properties = {"twds.instance.workspace-id="})
-class CollectionServiceNoWorkspaceTest {
+class CollectionServiceNoWorkspaceTest extends TestBase {
 
   @Autowired private CollectionService collectionService;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceSamExceptionTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceSamExceptionTest.java
@@ -12,10 +12,9 @@ import java.util.List;
 import java.util.UUID;
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
 import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
-import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.dao.CollectionDao;
 import org.databiosphere.workspacedataservice.sam.SamClientFactory;
-import org.databiosphere.workspacedataservice.sam.SamDao;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthenticationException;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthorizationException;
 import org.databiosphere.workspacedataservice.service.model.exception.RestException;
@@ -33,7 +32,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 
 /**
  * Tests for Sam exception handling inside CollectionService.createCollection and
@@ -53,17 +51,10 @@ import org.springframework.test.context.TestPropertySource;
 @DirtiesContext
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@TestPropertySource(
-    properties = {
-      "twds.instance.workspace-id=123e4567-e89b-12d3-a456-426614174000"
-    }) // example uuid from https://en.wikipedia.org/wiki/Universally_unique_identifier
-class CollectionServiceSamExceptionTest {
+class CollectionServiceSamExceptionTest extends TestBase {
 
   @Autowired private CollectionService collectionService;
-
   @Autowired private CollectionDao collectionDao;
-  @Autowired private SamDao samDao;
-  @Autowired private ActivityLogger activityLogger;
 
   // mock for the SamClientFactory; since this is a Spring bean we can use @MockBean
   @MockBean SamClientFactory mockSamClientFactory;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceSamTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceSamTest.java
@@ -8,7 +8,7 @@ import java.util.UUID;
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
 import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
 import org.broadinstitute.dsde.workbench.client.sam.model.CreateResourceRequestV2;
-import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.dao.CollectionDao;
 import org.databiosphere.workspacedataservice.sam.SamClientFactory;
 import org.databiosphere.workspacedataservice.sam.SamDao;
@@ -23,23 +23,15 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 
 @ActiveProfiles(profiles = "mock-collection-dao")
 @DirtiesContext
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@TestPropertySource(
-    properties = {
-      "twds.instance.workspace-id=123e4567-e89b-12d3-a456-426614174000"
-    }) // example uuid from https://en.wikipedia.org/wiki/Universally_unique_identifier
-class CollectionServiceSamTest {
+class CollectionServiceSamTest extends TestBase {
 
   @Autowired private CollectionService collectionService;
-
   @Autowired private CollectionDao collectionDao;
-  @Autowired private SamDao samDao;
-  @Autowired private ActivityLogger activityLogger;
 
   // mock for the SamClientFactory; since this is a Spring bean we can use @MockBean
   @MockBean SamClientFactory mockSamClientFactory;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.List;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.activitylog.ActivityLoggerConfig;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.config.TwdsProperties;
 import org.databiosphere.workspacedataservice.dao.CollectionDao;
 import org.databiosphere.workspacedataservice.dao.MockCollectionDaoConfig;
@@ -33,7 +34,7 @@ import org.springframework.test.context.ActiveProfiles;
       RestClientRetry.class,
       TwdsProperties.class
     })
-class CollectionServiceTest {
+class CollectionServiceTest extends TestBase {
 
   @Autowired private CollectionService collectionService;
   @Autowired private CollectionDao collectionDao;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/DataTypeInfererTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/DataTypeInfererTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
 import org.databiosphere.workspacedataservice.service.model.Relation;
 import org.databiosphere.workspacedataservice.shared.model.Record;
@@ -28,7 +29,7 @@ import org.springframework.test.annotation.DirtiesContext;
 
 @DirtiesContext
 @SpringBootTest(classes = {JsonConfig.class, DataTypeInfererConfig.class})
-class DataTypeInfererTest {
+class DataTypeInfererTest extends TestBase {
 
   @Autowired DataTypeInferer inferer;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceTest.java
@@ -22,6 +22,7 @@ import java.util.stream.Stream;
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
 import org.broadinstitute.dsde.workbench.client.sam.api.GoogleApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.dao.SchedulerDao;
 import org.databiosphere.workspacedataservice.dataimport.pfb.PfbQuartzJob;
@@ -50,7 +51,7 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles(profiles = {"mock-sam", "mock-collection-dao"})
 @DirtiesContext
 @SpringBootTest
-class ImportServiceTest {
+class ImportServiceTest extends TestBase {
 
   @Autowired ImportService importService;
   @Autowired CollectionService collectionService;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/PermissionsStatusServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/PermissionsStatusServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.*;
 
 import org.broadinstitute.dsde.workbench.client.sam.api.StatusApi;
 import org.broadinstitute.dsde.workbench.client.sam.model.SystemStatus;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.sam.HttpSamDao;
 import org.databiosphere.workspacedataservice.sam.PermissionsStatusService;
 import org.databiosphere.workspacedataservice.sam.SamClientFactory;
@@ -19,15 +20,10 @@ import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.TestPropertySource;
 
 @DirtiesContext
 @SpringBootTest(properties = "spring.cache.type=NONE")
-@TestPropertySource(
-    properties = {
-      "twds.instance.workspace-id=123e4567-e89b-12d3-a456-426614174000"
-    }) // example uuid from https://en.wikipedia.org/wiki/Universally_unique_identifier
-class PermissionsStatusServiceTest {
+class PermissionsStatusServiceTest extends TestBase {
 
   @Autowired private PermissionsStatusService samStatusService;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorSamTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorSamTest.java
@@ -9,6 +9,7 @@ import static org.mockito.BDDMockito.given;
 import java.util.UUID;
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
 import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.dao.CollectionDao;
 import org.databiosphere.workspacedataservice.sam.SamClientFactory;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthorizationException;
@@ -32,7 +33,7 @@ import org.springframework.test.context.ActiveProfiles;
     }) // aggressive retry settings so unit test doesn't run too long)
 @ActiveProfiles(profiles = {"mock-sam", "mock-collection-dao"})
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class RecordOrchestratorSamTest {
+class RecordOrchestratorSamTest extends TestBase {
 
   @Autowired private CollectionDao collectionDao;
   @Autowired private RecordOrchestratorService recordOrchestratorService;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.dao.CollectionDao;
 import org.databiosphere.workspacedataservice.service.model.AttributeSchema;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
@@ -45,7 +46,7 @@ import org.springframework.web.server.ResponseStatusException;
 @ActiveProfiles(profiles = {"mock-sam"})
 @DirtiesContext
 @SpringBootTest
-class RecordOrchestratorServiceTest {
+class RecordOrchestratorServiceTest extends TestBase {
 
   @Autowired private CollectionDao collectionDao;
   @Autowired private RecordOrchestratorService recordOrchestratorService;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordServiceTest.java
@@ -16,6 +16,7 @@ import java.math.BigDecimal;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.databiosphere.workspacedataservice.observability.TestObservationRegistryConfig;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
@@ -33,7 +34,7 @@ import org.springframework.test.context.ActiveProfiles;
 @SpringBootTest
 @ActiveProfiles(profiles = {"mock-sam"})
 @Import(TestObservationRegistryConfig.class)
-class RecordServiceTest {
+class RecordServiceTest extends TestBase {
 
   @Autowired DataTypeInferer inferer;
   @Autowired CollectionService collectionService;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordRequestTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordRequestTest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.math.BigInteger;
 import java.util.Map;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.service.JsonConfig;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -16,7 +17,7 @@ import org.springframework.test.annotation.DirtiesContext;
 @DirtiesContext
 @SpringBootTest(classes = JsonConfig.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class RecordRequestTest {
+public class RecordRequestTest extends TestBase {
 
   @Autowired private ObjectMapper jacksonObjectMapper;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordResponseTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordResponseTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Map;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.service.JsonConfig;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -16,7 +17,7 @@ import org.springframework.util.StringUtils;
 @DirtiesContext
 @SpringBootTest(classes = JsonConfig.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class RecordResponseTest {
+public class RecordResponseTest extends TestBase {
 
   @Autowired private ObjectMapper jacksonObjectMapper;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordTest.java
@@ -9,6 +9,7 @@ import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.service.JsonConfig;
 import org.databiosphere.workspacedataservice.service.model.exception.InvalidNameException;
 import org.junit.jupiter.api.Test;
@@ -20,7 +21,7 @@ import org.springframework.test.annotation.DirtiesContext;
 @DirtiesContext
 @SpringBootTest(classes = JsonConfig.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class RecordTest {
+class RecordTest extends TestBase {
 
   @Autowired private ObjectMapper jacksonObjectMapper;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/sourcewds/CloneOlderWdsTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/sourcewds/CloneOlderWdsTest.java
@@ -4,12 +4,13 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.databiosphere.workspacedata.model.BackupJob;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class CloneOlderWdsTest {
+class CloneOlderWdsTest extends TestBase {
 
   @Autowired ObjectMapper objectMapper;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/sourcewds/HttpWorkspaceDataServiceClientFactoryTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/sourcewds/HttpWorkspaceDataServiceClientFactoryTest.java
@@ -7,12 +7,13 @@ import java.util.Set;
 import org.databiosphere.workspacedata.client.ApiClient;
 import org.databiosphere.workspacedata.client.auth.Authentication;
 import org.databiosphere.workspacedata.client.auth.HttpBearerAuth;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class HttpWorkspaceDataServiceClientFactoryTest {
+class HttpWorkspaceDataServiceClientFactoryTest extends TestBase {
 
   @Autowired private WorkspaceDataServiceClientFactory workspaceDataServiceClientFactory;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerBeanTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerBeanTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.locks.Lock;
 import org.databiosphere.workspacedataservice.activitylog.ActivityLoggerConfig;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.dao.*;
 import org.databiosphere.workspacedataservice.leonardo.LeonardoConfig;
 import org.databiosphere.workspacedataservice.retry.RestClientRetry;
@@ -63,7 +64,7 @@ import org.springframework.test.context.TestPropertySource;
       MockSamClientFactoryConfig.class,
       RestClientRetry.class
     })
-class CollectionInitializerBeanTest {
+class CollectionInitializerBeanTest extends TestBase {
 
   @Autowired CollectionInitializerBean collectionInitializerBean;
   @MockBean JdbcLockRegistry registry;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerNoWorkspaceIdTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerNoWorkspaceIdTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.concurrent.locks.Lock;
 import org.databiosphere.workspacedataservice.activitylog.ActivityLoggerConfig;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.dao.*;
 import org.databiosphere.workspacedataservice.leonardo.LeonardoConfig;
 import org.databiosphere.workspacedataservice.retry.RestClientRetry;
@@ -57,7 +58,7 @@ import org.springframework.test.context.TestPropertySource;
       MockSamClientFactoryConfig.class,
       RestClientRetry.class
     })
-class CollectionInitializerNoWorkspaceIdTest {
+class CollectionInitializerNoWorkspaceIdTest extends TestBase {
 
   @Autowired CollectionInitializerBean collectionInitializerBean;
   @MockBean JdbcLockRegistry registry;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvDeserializerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvDeserializerTest.java
@@ -10,6 +10,7 @@ import java.math.BigInteger;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.service.DataTypeInfererConfig;
 import org.databiosphere.workspacedataservice.service.JsonConfig;
 import org.junit.jupiter.api.Test;
@@ -26,7 +27,7 @@ import org.springframework.test.annotation.DirtiesContext;
  */
 @DirtiesContext
 @SpringBootTest(classes = {DataTypeInfererConfig.class, JsonConfig.class, TsvConfig.class})
-class TsvDeserializerTest {
+class TsvDeserializerTest extends TestBase {
 
   @Autowired TsvDeserializer tsvDeserializer;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvErrorMessageTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvErrorMessageTest.java
@@ -8,6 +8,7 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.service.CollectionService;
 import org.databiosphere.workspacedataservice.service.RecordOrchestratorService;
 import org.databiosphere.workspacedataservice.service.model.exception.InvalidTsvException;
@@ -28,7 +29,7 @@ import org.springframework.test.context.ActiveProfiles;
 @DirtiesContext
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class TsvErrorMessageTest {
+public class TsvErrorMessageTest extends TestBase {
 
   @Autowired CollectionService collectionService;
   @Autowired RecordOrchestratorService recordOrchestratorService;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvJsonEquivalenceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvJsonEquivalenceTest.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.List;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.service.DataTypeInfererConfig;
 import org.databiosphere.workspacedataservice.service.JsonConfig;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
@@ -29,7 +30,7 @@ import org.springframework.test.annotation.DirtiesContext;
  */
 @DirtiesContext
 @SpringBootTest(classes = {DataTypeInfererConfig.class, JsonConfig.class, TsvConfig.class})
-class TsvJsonEquivalenceTest {
+class TsvJsonEquivalenceTest extends TestBase {
 
   @Autowired private ObjectReader tsvReader;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/workspacemanager/WorkspaceManagerDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/workspacemanager/WorkspaceManagerDaoTest.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.retry.RestClientRetry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -34,14 +35,11 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 
 @ActiveProfiles(profiles = "mock-sam")
 @DirtiesContext
 @SpringBootTest(classes = {WorkspaceManagerConfig.class, RestClientRetry.class})
-@TestPropertySource(
-    properties = {"twds.instance.workspace-id=123e4567-e89b-12d3-a456-426614174000"})
-class WorkspaceManagerDaoTest {
+class WorkspaceManagerDaoTest extends TestBase {
 
   @Autowired WorkspaceManagerDao workspaceManagerDao;
 


### PR DESCRIPTION
[AJ-1629](https://broadworkbench.atlassian.net/browse/AJ-1629) seeks to make WDS require either the `data-plane` or the `control-plane` profile to be specified in order to run.  This starts by making `data-plane` the default for test cases that extend `TestBase`.

In addition, since `data-plane` requires a `workspace-id` to be configured, it also defaults that value to a commonly used UUID, which eliminates that concern from several individual tests.

A `ConfigurationExceptionDetector` is also added to detect when a test fails due to a `ConfigurationException`, and provides a hint of how to resolve.

[AJ-1629]: https://broadworkbench.atlassian.net/browse/AJ-1629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ