### PR TITLE
AJ-1629: Drop unneeded `public` modifier from tests.

### DIFF
--- a/service/src/integrationTest/java/org/databiosphere/workspacedataservice/service/BackupRestoreServiceFailureIntegrationTest.java
+++ b/service/src/integrationTest/java/org/databiosphere/workspacedataservice/service/BackupRestoreServiceFailureIntegrationTest.java
@@ -30,7 +30,7 @@ import org.springframework.test.context.TestPropertySource;
       "twds.instance.source-workspace-id=123e4567-e89b-12d3-a456-426614174001",
       "twds.pg_dump.host="
     })
-public class BackupRestoreServiceFailureIntegrationTest {
+class BackupRestoreServiceFailureIntegrationTest {
   @Autowired private BackupRestoreService backupRestoreService;
 
   @Value("${twds.instance.source-workspace-id}")

--- a/service/src/integrationTest/java/org/databiosphere/workspacedataservice/service/RestoreServiceIntegrationTest.java
+++ b/service/src/integrationTest/java/org/databiosphere/workspacedataservice/service/RestoreServiceIntegrationTest.java
@@ -30,7 +30,7 @@ import org.springframework.test.context.TestPropertySource;
       "twds.instance.source-workspace-id=10000000-0000-0000-0000-000000000111",
       "twds.pg_dump.useAzureIdentity=false"
     })
-public class RestoreServiceIntegrationTest {
+class RestoreServiceIntegrationTest {
   @Autowired private BackupRestoreService backupRestoreService;
 
   @Autowired CollectionDao collectionDao;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/ActivityEventBuilderTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/ActivityEventBuilderTest.java
@@ -35,7 +35,7 @@ import org.springframework.web.context.request.RequestContextHolder;
 @SpringBootTest
 @AutoConfigureMockMvc
 @ExtendWith(OutputCaptureExtension.class)
-public class ActivityEventBuilderTest extends TestBase {
+class ActivityEventBuilderTest extends TestBase {
 
   @Autowired CollectionService collectionService;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/LogStatementTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/LogStatementTest.java
@@ -38,7 +38,7 @@ import org.springframework.web.multipart.MultipartFile;
 @ActiveProfiles(profiles = {"mock-sam"})
 @SpringBootTest
 @ExtendWith(OutputCaptureExtension.class)
-public class LogStatementTest extends TestBase {
+class LogStatementTest extends TestBase {
 
   private final String VERSION = "v0.2";
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/SmallBatchWriteTestConfig.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/SmallBatchWriteTestConfig.java
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Bean;
  * set a small batch size for the test.
  */
 @TestConfiguration
-public class SmallBatchWriteTestConfig {
+class SmallBatchWriteTestConfig {
 
   @Bean
   public BatchWriteService batchWriteService(DataTypeInferer dataTypeInferer) {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobE2ETest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobE2ETest.java
@@ -55,7 +55,7 @@ import org.springframework.test.context.ActiveProfiles;
 @DirtiesContext
 @SpringBootTest
 @AutoConfigureMockMvc
-public class TdrManifestQuartzJobE2ETest extends TestBase {
+class TdrManifestQuartzJobE2ETest extends TestBase {
   @Autowired private RecordOrchestratorService recordOrchestratorService;
   @Autowired private ImportService importService;
   @Autowired private CollectionService collectionService;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobTest.java
@@ -37,7 +37,7 @@ import org.springframework.test.annotation.DirtiesContext;
 
 @DirtiesContext
 @SpringBootTest
-public class TdrManifestQuartzJobTest extends TestBase {
+class TdrManifestQuartzJobTest extends TestBase {
 
   @MockBean JobDao jobDao;
   @MockBean WorkspaceManagerDao wsmDao;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/pact/WsmPactTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/pact/WsmPactTest.java
@@ -45,7 +45,7 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 @Tag(PACT_TEST)
 @PactConsumerTest
 @PactTestFor(providerName = "workspacemanager", pactVersion = PactSpecVersion.V3)
-public class WsmPactTest {
+class WsmPactTest {
   // copied from DslPart.UUID_REGEX, used to configure Pact to accept a wildcard UUID as the
   // workspaceId path param
   private static final String UUID_REGEX_PATTERN =

--- a/service/src/test/java/org/databiosphere/workspacedataservice/recordsource/JsonRecordSourceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/recordsource/JsonRecordSourceTest.java
@@ -17,8 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-public class JsonRecordSourceTest extends TestBase {
-
+class JsonRecordSourceTest extends TestBase {
   @Autowired ObjectMapper objectMapper; // as defined in JsonConfig
 
   private static Stream<Arguments> parserFeatures() {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/sam/SamDaoInvalidWorkspaceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/sam/SamDaoInvalidWorkspaceTest.java
@@ -21,7 +21,7 @@ import org.springframework.test.context.TestPropertySource;
       // explicitly set the workspace-id to something invalid
       "twds.instance.workspace-id=not-a-real-id",
     })
-public class SamDaoInvalidWorkspaceTest extends TestBase {
+class SamDaoInvalidWorkspaceTest extends TestBase {
 
   @Autowired SamDao samDao;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordRequestTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordRequestTest.java
@@ -14,7 +14,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class RecordRequestTest extends TestBase {
+class RecordRequestTest extends TestBase {
 
   @Autowired private ObjectMapper jacksonObjectMapper;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordResponseTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordResponseTest.java
@@ -14,7 +14,7 @@ import org.springframework.util.StringUtils;
 
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class RecordResponseTest extends TestBase {
+class RecordResponseTest extends TestBase {
 
   @Autowired private ObjectMapper jacksonObjectMapper;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvErrorMessageTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvErrorMessageTest.java
@@ -27,7 +27,7 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles(profiles = "mock-sam")
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class TsvErrorMessageTest extends TestBase {
+class TsvErrorMessageTest extends TestBase {
 
   @Autowired CollectionService collectionService;
   @Autowired RecordOrchestratorService recordOrchestratorService;


### PR DESCRIPTION
Per Sonar java:S5786: JUnit5 test classes and methods should have default package visibility