### PR TITLE
AJ-1649: postgres dependency to 42.6.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,8 @@ subprojects {
             // "This bug existed from 4.22.0 to 4.25.1"
             dependency 'org.liquibase:liquibase-core:4.26.0'
             dependency 'com.jayway.jsonpath:json-path:2.9.0' // CVE-2023-51074
+            // CVE-2024-1597; we are not vulnerable but upgrading anyway
+            dependency 'org.postgresql:postgresql:42.6.1'
         }
     }
 }

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -149,6 +149,7 @@ dependencies {
 
         // SEE ALSO:
         //  - org.liquibase:liquibase-core:4.26.0, configured in build.gradle
+        //  - org.postgresql:postgresql:42.6.1, configured in build.gradle
     }
 }
 


### PR DESCRIPTION
Addresses a critical security vulnerability _which we are not vulnerable to_ by updating the postgres dependency from 42.6.0 to 42.6.1.

> SQL injection is possible when using the non-default connection property preferQueryMode=simple in combination with application code that has a vulnerable SQL that negates a parameter value.

> There is no vulnerability in the driver when using the default query mode. Users that do not override the query mode are not impacted.

But, let's upgrade anyway to stay on top of it.