### PR TITLE
AJ-1629 Bugfix `ConfigurationExceptionDetector`

### DIFF
--- a/service/src/test/java/org/databiosphere/workspacedataservice/common/ConfigurationExceptionDetector.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/common/ConfigurationExceptionDetector.java
@@ -21,14 +21,21 @@ public class ConfigurationExceptionDetector implements TestWatcher {
           "Test failed due to an unhandled ConfigurationException! " + RESOLUTION_HINT, rootCause);
     }
 
-    if (rootCause instanceof AssertionFailedError afe) {
-      if (ConfigurationException.class.equals(afe.getActual().getType())
-          && !ConfigurationException.class.equals(afe.getExpected().getType())) {
-        throw new AssertionError(
-            "Test failed due to an unexpected ConfigurationException! " + RESOLUTION_HINT,
-            rootCause);
-      }
+    if (rootCause instanceof AssertionFailedError afe && isUnexpectedConfigurationException(afe)) {
+      throw new AssertionError(
+          "Test failed due to an unexpected ConfigurationException! " + RESOLUTION_HINT, rootCause);
     }
+  }
+
+  private boolean isUnexpectedConfigurationException(AssertionFailedError afe) {
+    boolean actualValueIsConfigurationException =
+        afe.getActual() != null && afe.getActual().getType().equals(ConfigurationException.class);
+
+    boolean expectedValueIsNot =
+        afe.getExpected() == null
+            || !ConfigurationException.class.equals(afe.getExpected().getType());
+
+    return actualValueIsConfigurationException && expectedValueIsNot;
   }
 
   private Throwable getRootCause(Throwable throwable) {


### PR DESCRIPTION
This is a followup test bugfix to [AJ-1629](https://broadworkbench.atlassian.net/browse/AJ-1629).

Specifically, the `ConfigurationExceptionDetector` would throw a `NullPointerException` for test failures where the actual value was `null`.  This should prevent that.

[AJ-1629]: https://broadworkbench.atlassian.net/browse/AJ-1629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ