### PR TITLE
AJ-1649: remove extraneous comma

### DIFF
--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -54,7 +54,7 @@ jobs:
         if: steps.FirstAttemptCreateBee.outcome == 'failure'
         uses: ./.github/actions/create-bee
         with:
-          bee_name: ${{ env.BEE_NAME }},
+          bee_name: ${{ env.BEE_NAME }}
           token: ${{ env.TOKEN }}
 
   attach-landing-zone-to-bee-workflow:


### PR DESCRIPTION
This should address intermittent errors in our e2e tests. We just had one last night, and the error message was:
```
--name: "wds-8017616954-1-dev," is not a valid environment name: environment name
must match regular expression \\A[a-z][a-z0-9]*(-[a-z0-9]+)*\\z"
```
if you look very carefully at the error message, you'll see that the name `"wds-8017616954-1-dev,"` _has a trailing comma_ which makes it invalid.

The reason this is so intermittent is that it only happens in the retry case of creating a bee.

![Screenshot 2-23-2024 at 10 12 AM](https://github.com/DataBiosphere/terra-workspace-data-service/assets/6041577/369a8ba6-c176-4c64-84d3-aa76f9a5e371)
