### PR TITLE
[AJ-1638] Do not require statuses query parameter for list jobs endpoint

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/JobController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/JobController.java
@@ -3,6 +3,7 @@ package org.databiosphere.workspacedataservice.controller;
 import static org.databiosphere.workspacedataservice.generated.GenericJobServerModel.StatusEnum;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
 import org.databiosphere.workspacedataservice.generated.JobApi;
@@ -49,7 +50,9 @@ public class JobController implements JobApi {
       }
     }
     List<GenericJobServerModel> jobList =
-        jobService.getJobsForCollection(CollectionId.of(instanceUuid), statuses);
+        jobService.getJobsForCollection(
+            CollectionId.of(instanceUuid),
+            statuses == null ? Optional.empty() : Optional.of(statuses));
 
     return new ResponseEntity<>(jobList, HttpStatus.OK);
   }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/JobDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/JobDao.java
@@ -1,6 +1,7 @@
 package org.databiosphere.workspacedataservice.dao;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
 import org.databiosphere.workspacedataservice.shared.model.CollectionId;
@@ -31,5 +32,5 @@ public interface JobDao {
   GenericJobServerModel getJob(UUID jobId);
 
   List<GenericJobServerModel> getJobsForCollection(
-      CollectionId collectionId, List<String> statuses);
+      CollectionId collectionId, Optional<List<String>> statuses);
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresJobDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresJobDao.java
@@ -10,6 +10,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
 import org.databiosphere.workspacedataservice.shared.model.CollectionId;
@@ -213,7 +214,7 @@ public class PostgresJobDao implements JobDao {
   }
 
   public List<GenericJobServerModel> getJobsForCollection(
-      CollectionId collectionId, List<String> statuses) {
+      CollectionId collectionId, Optional<List<String>> statuses) {
     // start our sql statement and map of params
     StringBuilder sb =
         new StringBuilder(
@@ -224,9 +225,9 @@ public class PostgresJobDao implements JobDao {
     MapSqlParameterSource params = new MapSqlParameterSource("collection_id", collectionId.id());
 
     // if status is supplied, filter by that
-    if (!statuses.isEmpty()) {
+    if (statuses.isPresent()) {
       sb.append(" and status in (:statuses)");
-      params.addValue("statuses", statuses);
+      params.addValue("statuses", statuses.get());
     }
     return namedTemplate.query(sb.toString(), params, new AsyncJobRowMapper());
   }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/JobService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/JobService.java
@@ -1,6 +1,7 @@
 package org.databiosphere.workspacedataservice.service;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
@@ -34,7 +35,7 @@ public class JobService {
   }
 
   public List<GenericJobServerModel> getJobsForCollection(
-      CollectionId collectionId, List<String> statuses) {
+      CollectionId collectionId, Optional<List<String>> statuses) {
     // verify collection exists
     collectionService.validateCollection(collectionId.id());
     // check permissions

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/JobControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/JobControllerMockMvcTest.java
@@ -11,6 +11,7 @@ import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.dao.CollectionDao;
 import org.databiosphere.workspacedataservice.dao.JobDao;
@@ -84,7 +85,8 @@ class JobControllerMockMvcTest extends MockMvcTestBase {
             GenericJobServerModel.StatusEnum.RUNNING,
             time,
             time));
-    when(jobDao.getJobsForCollection(collectionId, List.of("RUNNING"))).thenReturn(expected);
+    when(jobDao.getJobsForCollection(collectionId, Optional.of(List.of("RUNNING"))))
+        .thenReturn(expected);
 
     // calling the API should result in 200 OK
     MvcResult mvcResult =

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/JobControllerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/JobControllerTest.java
@@ -77,19 +77,16 @@ class JobControllerTest extends TestBase {
   }
 
   @Test
-  void instanceJobsReturnAllNoStatus() {
+  void instanceJobsReturnAll() {
     when(collectionDao.collectionSchemaExists(collectionId.id())).thenReturn(true);
     HttpHeaders headers = new HttpHeaders();
-    // ParameterizedTypeReference<List<GenericJobServerModel>> returnType = new
-    // ParameterizedTypeReference<List<GenericJobServerModel>>() {};
     ResponseEntity<List<GenericJobServerModel>> result =
         restTemplate.exchange(
-            "/job/v1/instance/{instanceUuid}?statuses={statuses}",
+            "/job/v1/instance/{instanceUuid}",
             HttpMethod.GET,
             new HttpEntity<>(headers),
             new ParameterizedTypeReference<List<GenericJobServerModel>>() {},
-            collectionId,
-            "");
+            collectionId);
     List<GenericJobServerModel> jobList = result.getBody();
     assertNotNull(jobList);
     // 3 jobs inserted in beforeAll, only 2 for this instanceId

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/JobServiceControlPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/JobServiceControlPlaneTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.dao.CollectionDao;
 import org.databiosphere.workspacedataservice.dao.JobDao;
@@ -134,7 +135,6 @@ class JobServiceControlPlaneTest extends JobServiceBaseTest {
   @Test
   void listJobsCollectionExists() {
     // Arrange
-    UUID jobId = UUID.randomUUID();
     CollectionId collectionId = CollectionId.of(UUID.randomUUID());
     WorkspaceId workspaceId = WorkspaceId.of(UUID.randomUUID());
     // collection for this job exists
@@ -146,7 +146,7 @@ class JobServiceControlPlaneTest extends JobServiceBaseTest {
     Exception actual =
         assertThrows(
             CollectionException.class,
-            () -> jobService.getJobsForCollection(collectionId, allStatuses));
+            () -> jobService.getJobsForCollection(collectionId, Optional.of(allStatuses)));
 
     // Assert
     assertEquals("Expected a virtual collection", actual.getMessage());
@@ -167,7 +167,8 @@ class JobServiceControlPlaneTest extends JobServiceBaseTest {
         .thenReturn(makeJobList(collectionId, 2));
 
     // Act
-    List<GenericJobServerModel> actual = jobService.getJobsForCollection(collectionId, allStatuses);
+    List<GenericJobServerModel> actual =
+        jobService.getJobsForCollection(collectionId, Optional.of(allStatuses));
 
     // Assert
     // this is verifying permissions only; only smoke-testing correctness of the result
@@ -192,7 +193,7 @@ class JobServiceControlPlaneTest extends JobServiceBaseTest {
     AuthenticationMaskableException actual =
         assertThrows(
             AuthenticationMaskableException.class,
-            () -> jobService.getJobsForCollection(collectionId, allStatuses));
+            () -> jobService.getJobsForCollection(collectionId, Optional.of(allStatuses)));
 
     // Assert
     assertEquals("Collection", actual.getObjectType());

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/JobServiceDataPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/JobServiceDataPlaneTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.config.InstanceProperties;
 import org.databiosphere.workspacedataservice.dao.CollectionDao;
@@ -178,7 +179,7 @@ class JobServiceDataPlaneTest extends JobServiceBaseTest {
     Exception actual =
         assertThrows(
             MissingObjectException.class,
-            () -> jobService.getJobsForCollection(collectionId, allStatuses));
+            () -> jobService.getJobsForCollection(collectionId, Optional.of(allStatuses)));
 
     // Assert
     assertThat(actual.getMessage()).startsWith("Collection");
@@ -199,7 +200,8 @@ class JobServiceDataPlaneTest extends JobServiceBaseTest {
         .thenReturn(makeJobList(collectionId, 2));
 
     // Act
-    List<GenericJobServerModel> actual = jobService.getJobsForCollection(collectionId, allStatuses);
+    List<GenericJobServerModel> actual =
+        jobService.getJobsForCollection(collectionId, Optional.of(allStatuses));
 
     // Assert
     // this is verifying permissions only; only smoke-testing correctness of the result
@@ -223,7 +225,7 @@ class JobServiceDataPlaneTest extends JobServiceBaseTest {
     Exception actual =
         assertThrows(
             MissingObjectException.class,
-            () -> jobService.getJobsForCollection(collectionId, allStatuses));
+            () -> jobService.getJobsForCollection(collectionId, Optional.of(allStatuses)));
 
     // Assert
     assertThat(actual.getMessage()).startsWith("Collection");
@@ -248,7 +250,7 @@ class JobServiceDataPlaneTest extends JobServiceBaseTest {
     Exception actual =
         assertThrows(
             CollectionException.class,
-            () -> jobService.getJobsForCollection(collectionId, allStatuses));
+            () -> jobService.getJobsForCollection(collectionId, Optional.of(allStatuses)));
 
     // Assert
     assertThat(actual.getMessage()).startsWith("Found unexpected workspaceId for collection");


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1638

Currently, listing jobs without providing a `statuses` query parameter results in a 500 errors. This fixes that so that the query parameter is not required.

This also refactors `JobDao.getJobsForCollection` to make the `statuses` argument an `Optional`. I think that more clearly represents the intent of an optional statuses filter vs using an empty list to mean return all statuses.