### PR TITLE
AJ-1649 Limit impact of retries on test runtime.

### DIFF
--- a/service/src/test/java/org/databiosphere/workspacedataservice/common/TestBase.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/common/TestBase.java
@@ -29,6 +29,9 @@ import org.springframework.test.context.TestPropertySource;
       // data-plane mode requires a workspace-id to be set
       // example uuid from https://en.wikipedia.org/wiki/Universally_unique_identifier
       "twds.instance.workspace-id=123e4567-e89b-12d3-a456-426614174000",
+      // aggressive retry settings so unit tests don't run too long
+      "rest.retry.maxAttempts=2",
+      "rest.retry.backoff.delay=3",
     })
 @ExtendWith(ConfigurationExceptionDetector.class)
 public abstract class TestBase {}


### PR DESCRIPTION
Filing this under maintenance as it's independent of any active spring work [AJ-1649](https://broadworkbench.atlassian.net/browse/AJ-1649).

The primary offender was `CollectionServiceSamExceptionTest` which would take upward of 30 seconds to complete.  However, the intent of doing this in the base class is to bake in the intent more broadly to hopefully prevent future regressions.

Before:
BUILD SUCCESSFUL in 2m 53s

After:
BUILD SUCCESSFUL in 2m 18s

[AJ-1649]: https://broadworkbench.atlassian.net/browse/AJ-1649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ