### PR TITLE
AJ-1649: update to Spring Boot 3.2.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
 plugins {
-    id 'org.springframework.boot' version '3.2.2' apply false
+    id 'org.springframework.boot' version '3.2.3' apply false
     id 'io.spring.dependency-management' version '1.1.4' apply false
     id 'com.google.cloud.tools.jib' version '3.2.1' apply false
     id "org.sonarqube" version "4.4.1.3373" apply false
@@ -41,9 +41,6 @@ subprojects {
             // https://github.com/liquibase/liquibase/pull/5391
             // "This bug existed from 4.22.0 to 4.25.1"
             dependency 'org.liquibase:liquibase-core:4.26.0'
-            dependency 'com.jayway.jsonpath:json-path:2.9.0' // CVE-2023-51074
-            // CVE-2024-1597; we are not vulnerable but upgrading anyway
-            dependency 'org.postgresql:postgresql:42.6.1'
         }
     }
 }

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -138,18 +138,8 @@ dependencies {
         implementation('org.codehaus.jettison:jettison:1.5.4') {
             because("CVE-2022-40149, CVE-2022-40150, CVE-2022-45685, CVE-2022-45693, CVE-2023-1436")
         }
-
-        // TODO: remove when upgrading to a version of spring that has a fixed version of json-path
-        //   json-path required by spring-boot-starter-test:3.2.2
-        //   this is redundant (and ineffective) without an explicit override in the parent project
-        //   build.gradle dependencyManagement, but is included here for documentation purposes
-        testImplementation('com.jayway.jsonpath:json-path:2.9.0') {
-            because("CVE-2023-51074")
-        }
-
         // SEE ALSO:
         //  - org.liquibase:liquibase-core:4.26.0, configured in build.gradle
-        //  - org.postgresql:postgresql:42.6.1, configured in build.gradle
     }
 }
 


### PR DESCRIPTION
This supersedes #578.

Update Spring Boot 3.2.2 -> 3.2.3. See:
* https://spring.io/blog/2024/02/22/spring-boot-3-2-3-available-now
* https://github.com/spring-projects/spring-boot/releases/tag/v3.2.3.

Because Spring Boot updated dependencies in this release, we can remove some of our overrides.

I did not see anything else in the release notes that needs attention.