### PR TITLE
AJ-1649: dependency updates

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     implementation 'org.ehcache:ehcache:3.10.8:jakarta'
     implementation 'org.hashids:hashids:1.0.3'
     implementation 'jakarta.ws.rs:jakarta.ws.rs-api'
-    implementation 'com.google.mug:mug:6.6'
+    implementation 'com.google.mug:mug:7.1'
 
     // required by openapi-generated models and api interfaces
     implementation 'jakarta.validation:jakarta.validation-api'

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -44,9 +44,8 @@ ext {
 dependencies {
     // Azure libraries
     implementation 'com.microsoft.azure:applicationinsights-runtime-attach:3.4.19'
-    implementation 'com.azure:azure-storage-blob:12.25.1'
-    implementation 'com.azure:azure-identity:1.11.2' // authentication in azure environment
-    implementation 'com.azure:azure-identity-extensions:1.1.12' // postgres password plugin
+    implementation 'com.azure:azure-storage-blob:12.25.2'
+    implementation 'com.azure:azure-identity-extensions:1.1.13' // postgres password plugin
 
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -116,7 +116,7 @@ dependencies {
     implementation "org.glassfish.jersey.core:jersey-common"
 
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
-    runtimeOnly 'org.webjars.npm:swagger-ui-dist:5.11.7'
+    runtimeOnly 'org.webjars.npm:swagger-ui-dist:5.11.8'
     testImplementation 'io.micrometer:micrometer-observation-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.junit.jupiter:junit-jupiter'


### PR DESCRIPTION
* Bump org.webjars.npm:swagger-ui-dist from 5.11.7 to 5.11.8; supersedes #579
* Bump com.google.mug:mug from 6.6 to 7.1; supersedes #576
* Bump com.azure:azure-identity-extensions from 1.1.12 to 1.1.13; supersedes #575
* remove com.azure:azure-identity as a direct dependency, since azure-identity-extensions pulls it in transitively