### PR TITLE
[AJ-1560] Rename query parameter from statuses to status

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/generated/JobApi.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/generated/JobApi.java
@@ -82,7 +82,7 @@ public interface JobApi {
      * GET /job/v1/instance/{instanceUuid} : Get all jobs with a certain status under a particular instance.
      *
      * @param instanceUuid WDS instance id; by convention equal to workspace id (required)
-     * @param statuses  (optional)
+     * @param status  (optional)
      * @return A list of jobs with specified status for Instance Id. (status code 200)
      */
     @Operation(
@@ -105,7 +105,7 @@ public interface JobApi {
     )
     default ResponseEntity<List<GenericJobServerModel>> jobsInInstanceV1(
         @Parameter(name = "instanceUuid", description = "WDS instance id; by convention equal to workspace id", required = true, in = ParameterIn.PATH) @PathVariable("instanceUuid") UUID instanceUuid,
-        @Parameter(name = "statuses", description = "", in = ParameterIn.QUERY) @Valid @RequestParam(value = "statuses", required = false) List<String> statuses
+        @Parameter(name = "status", description = "", in = ParameterIn.QUERY) @Valid @RequestParam(value = "status", required = false) List<String> status
     ) {
         return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
 

--- a/service/src/main/resources/static/swagger/apis-v1.yaml
+++ b/service/src/main/resources/static/swagger/apis-v1.yaml
@@ -108,7 +108,7 @@ paths:
         - Job
       parameters:
         - $ref: '#/components/parameters/instanceUuidPathParam'
-        - name: statuses
+        - name: status
           in: query
           required: false
           schema:

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/JobControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/JobControllerMockMvcTest.java
@@ -92,7 +92,7 @@ class JobControllerMockMvcTest extends MockMvcTestBase {
     MvcResult mvcResult =
         mockMvc
             .perform(
-                get("/job/v1/instance/{instanceUuid}?statuses={statuses}", collectionId, "RUNNING"))
+                get("/job/v1/instance/{instanceUuid}?status={status}", collectionId, "RUNNING"))
             .andExpect(status().isOk())
             .andReturn();
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/JobControllerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/JobControllerTest.java
@@ -104,7 +104,7 @@ class JobControllerTest extends TestBase {
     // ParameterizedTypeReference<List<GenericJobServerModel>>() {};
     ResponseEntity<List<GenericJobServerModel>> result =
         restTemplate.exchange(
-            "/job/v1/instance/{instanceUuid}?statuses={status1}&statuses={status2}",
+            "/job/v1/instance/{instanceUuid}?status={status1}&status={status2}",
             HttpMethod.GET,
             new HttpEntity<>(headers),
             new ParameterizedTypeReference<List<GenericJobServerModel>>() {},


### PR DESCRIPTION
Super nitpicky, but I noticed this while working on #569. Since the `statuses` query parameter for the list import jobs endpoint accepts a _single_ status, I think the parameter name should be singular as well (`status`). I would expect a plural parameter, like `statuses`, to accept multiple values (like a comma separated list or something like that).

Since this API hasn't been released yet, this isn't a breaking change.