### PR TITLE
AJ-1629: Fail with explanation on missing profile.

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/startup/StartupConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/startup/StartupConfig.java
@@ -1,5 +1,8 @@
 package org.databiosphere.workspacedataservice.startup;
 
+import static java.util.Arrays.stream;
+
+import java.util.Set;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.config.ConfigurationException;
 import org.databiosphere.workspacedataservice.config.InstanceProperties;
@@ -8,20 +11,26 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.EventListener;
+import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
 /** */
 @Component
 public class StartupConfig {
-
+  private static final Set<String> REQUIRED_PROFILES = Set.of("data-plane", "control-plane");
   private static final Logger logger = LoggerFactory.getLogger(StartupConfig.class);
 
   private final InstanceProperties instanceProperties;
   private final TenancyProperties tenancyProperties;
+  private final Environment environment;
 
-  public StartupConfig(InstanceProperties instanceProperties, TenancyProperties tenancyProperties) {
+  public StartupConfig(
+      Environment environment,
+      InstanceProperties instanceProperties,
+      TenancyProperties tenancyProperties) {
     this.instanceProperties = instanceProperties;
     this.tenancyProperties = tenancyProperties;
+    this.environment = environment;
   }
 
   /**
@@ -32,6 +41,7 @@ public class StartupConfig {
    */
   @EventListener
   public void onApplicationEvent(ContextRefreshedEvent ignoredEvent) {
+    assertDeploymentModeProfileEnabled();
     logger.info("allow virtual collections: {}", tenancyProperties.getAllowVirtualCollections());
     logger.info("require $WORKSPACE_ID env var: {}", tenancyProperties.getRequireEnvWorkspace());
 
@@ -47,6 +57,17 @@ public class StartupConfig {
                 + e.getMessage(),
             e);
       }
+    }
+  }
+
+  private void assertDeploymentModeProfileEnabled() {
+    boolean matchingProfileFound =
+        stream(environment.getActiveProfiles()).anyMatch(REQUIRED_PROFILES::contains);
+
+    if (!matchingProfileFound) {
+      throw new ConfigurationException(
+          "This deployment requires at least one of the following active profiles: %s"
+              .formatted(REQUIRED_PROFILES));
     }
   }
 }

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -126,6 +126,14 @@ twds:
     source-workspace-id: ${SOURCE_WORKSPACE_ID:}
   # short-lived credentials to use during cloning
   startup-token: ${STARTUP_TOKEN:}
+  # tenancy & data-import defaults match data-plane, but the source of truth for these configs
+  # should be application-data-plane.yml or application-control-plane.yml; they are provided here
+  # to allow Spring to boot without crashing and allow StartupConfig to run and check preconditions
+  tenancy:
+    allow-virtual-collections: false
+    require-env-workspace: true
+  data-import:
+    batch-write-record-sink: "wds"
 
   pg_dump:
     path: ${PGDUMP_PATH:/usr/bin/pg_dump}


### PR DESCRIPTION
[AJ-1629](https://broadworkbench.atlassian.net/browse/AJ-1629): When starting WDS without a data-plane or control-plane profile, crash with a message explaining that they are needed, rather than letting Spring fail due to bean misconfiguration a bit later on.

To cause error:
```
./gradlew bootRun
```
Expect crash with stacktrace starting with:

`org.databiosphere.workspacedataservice.config.ConfigurationException: This deployment requires at least one of the following active profiles: [data-plane, control-plane]`

To make error not happen:
```
./gradlew bootRun --args='--spring.profiles.active=data-plane'
```

[AJ-1629]: https://broadworkbench.atlassian.net/browse/AJ-1629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ