### PR TITLE
AJ-1560: statuses param

### DIFF
--- a/service/src/main/resources/static/swagger/apis-v1.yaml
+++ b/service/src/main/resources/static/swagger/apis-v1.yaml
@@ -111,6 +111,8 @@ paths:
         - name: statuses
           in: query
           required: false
+          style: form
+          explode: false
           schema:
             type: array
             items:

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/JobControllerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/JobControllerTest.java
@@ -118,4 +118,28 @@ class JobControllerTest extends TestBase {
     assertEquals(StatusEnum.CREATED, jobList.get(0).getStatus());
     assertEquals(StatusEnum.CANCELLED, jobList.get(1).getStatus());
   }
+
+  @Test
+  void instanceJobsWithMultipleDelimitedStatuses() {
+    when(collectionDao.collectionSchemaExists(collectionId.id())).thenReturn(true);
+    assertDoesNotThrow(() -> jobDao.updateStatus(jobId, StatusEnum.CANCELLED));
+    HttpHeaders headers = new HttpHeaders();
+    // ParameterizedTypeReference<List<GenericJobServerModel>> returnType = new
+    // ParameterizedTypeReference<List<GenericJobServerModel>>() {};
+    ResponseEntity<List<GenericJobServerModel>> result =
+        restTemplate.exchange(
+            "/job/v1/instance/{instanceUuid}?statuses={status1},{status2}",
+            HttpMethod.GET,
+            new HttpEntity<>(headers),
+            new ParameterizedTypeReference<List<GenericJobServerModel>>() {},
+            collectionId,
+            "CREATED",
+            "CANCELLED");
+    List<GenericJobServerModel> jobList = result.getBody();
+    assertNotNull(jobList);
+    // 3 jobs inserted in beforeAll, only 2 for this instanceId
+    assertEquals(2, jobList.size());
+    assertEquals(StatusEnum.CREATED, jobList.get(0).getStatus());
+    assertEquals(StatusEnum.CANCELLED, jobList.get(1).getStatus());
+  }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/JobControllerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/JobControllerTest.java
@@ -100,8 +100,6 @@ class JobControllerTest extends TestBase {
     when(collectionDao.collectionSchemaExists(collectionId.id())).thenReturn(true);
     assertDoesNotThrow(() -> jobDao.updateStatus(jobId, StatusEnum.CANCELLED));
     HttpHeaders headers = new HttpHeaders();
-    // ParameterizedTypeReference<List<GenericJobServerModel>> returnType = new
-    // ParameterizedTypeReference<List<GenericJobServerModel>>() {};
     ResponseEntity<List<GenericJobServerModel>> result =
         restTemplate.exchange(
             "/job/v1/instance/{instanceUuid}?statuses={status1}&statuses={status2}",
@@ -124,8 +122,6 @@ class JobControllerTest extends TestBase {
     when(collectionDao.collectionSchemaExists(collectionId.id())).thenReturn(true);
     assertDoesNotThrow(() -> jobDao.updateStatus(jobId, StatusEnum.CANCELLED));
     HttpHeaders headers = new HttpHeaders();
-    // ParameterizedTypeReference<List<GenericJobServerModel>> returnType = new
-    // ParameterizedTypeReference<List<GenericJobServerModel>>() {};
     ResponseEntity<List<GenericJobServerModel>> result =
         restTemplate.exchange(
             "/job/v1/instance/{instanceUuid}?statuses={status1},{status2}",


### PR DESCRIPTION
Tweak swagger-ui so it generates the `statuses` parameter using a single comma-delimited value instead of multiple duplicate query params.

This *only* affects the urls that swagger-ui generates. It doesn't change what's allowed by the API, as illustrated by unit tests. But since end users sometimes rely on swagger-ui for API documentation, it's good to give them the structure we prefer.

Before:
![Screenshot 2-26-2024 at 03 49 PM](https://github.com/DataBiosphere/terra-workspace-data-service/assets/6041577/e924c7bd-d65c-49e8-b807-527fd7c68e30)


After:
![Screenshot 2-26-2024 at 03 52 PM](https://github.com/DataBiosphere/terra-workspace-data-service/assets/6041577/614af18a-863e-4e5d-848d-80c398a66f73)
