### PR TITLE
AJ-1653: remove initialize-collection-on-startup property; add integration tes…

### DIFF
--- a/service/src/integrationTest/java/org/databiosphere/workspacedataservice/IntegrationServiceTestBase.java
+++ b/service/src/integrationTest/java/org/databiosphere/workspacedataservice/IntegrationServiceTestBase.java
@@ -1,0 +1,60 @@
+package org.databiosphere.workspacedataservice;
+
+import java.util.Map;
+import java.util.UUID;
+import org.databiosphere.workspacedataservice.dao.CollectionDao;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+public class IntegrationServiceTestBase {
+
+  /**
+   * Reusable utility to wipe the db of all user state created by integration tests, while leaving
+   * in place the sys_wds.* table definitions (i.e. don't need to re-run Liquibase)
+   *
+   * @param collectionDao dao to use for collection management
+   * @param namedTemplate to use for direct SQL queries
+   */
+  protected void cleanDb(CollectionDao collectionDao, NamedParameterJdbcTemplate namedTemplate) {
+    // drop all rows from backup, clone, restore tables
+    // may need to add the job table at some point; current integration tests do not write to it
+    namedTemplate.getJdbcTemplate().update("delete from sys_wds.backup");
+    namedTemplate.getJdbcTemplate().update("delete from sys_wds.clone");
+    namedTemplate.getJdbcTemplate().update("delete from sys_wds.restore");
+
+    // delete all collections that are currently known to WDS
+    collectionDao.listCollectionSchemas().forEach(collectionDao::dropSchema);
+
+    // and drop any orphaned Postgres schemas
+    dropOrphanedSchemas(namedTemplate);
+  }
+
+  /**
+   * Clean the db of any orphaned Postgres schemas - schemas that were created by WDS as a
+   * collection but which do not have a corresponding row in sys_wds.collection. This can happen
+   * when restores fail.
+   *
+   * <p>This is a standalone method in order to @SuppressWarnings on it in a targeted fashion. This
+   * method uses string concatenation to build a SQL statement, since we cannot use bind params in a
+   * `drop schema` statement. Since the value we are concatenating already validated as a UUID, we
+   * know it does not contain SQL injection/escape sequences.
+   *
+   * @param namedTemplate to use for direct SQL queries
+   */
+  @SuppressWarnings("squid:S2077")
+  private void dropOrphanedSchemas(NamedParameterJdbcTemplate namedTemplate) {
+    namedTemplate
+        .queryForList(
+            "SELECT schema_name FROM information_schema.schemata;", Map.of(), String.class)
+        .forEach(
+            schemaName -> {
+              // is this a UUID? We only want to drop orphaned schemas whose name is a UUID;
+              // we don't want to drop other critical schemas like "public" or "sys_wds"
+              try {
+                UUID schemaUuid = UUID.fromString(schemaName);
+                namedTemplate.update("DROP schema \"" + schemaUuid + "\" cascade;", Map.of());
+              } catch (IllegalArgumentException iae) {
+                // schema name was not a valid uuid; we should not drop this schema.
+              }
+            });
+  }
+}

--- a/service/src/integrationTest/java/org/databiosphere/workspacedataservice/service/BackupRestoreServiceFailureIntegrationTest.java
+++ b/service/src/integrationTest/java/org/databiosphere/workspacedataservice/service/BackupRestoreServiceFailureIntegrationTest.java
@@ -5,15 +5,19 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.util.UUID;
+import org.databiosphere.workspacedataservice.IntegrationServiceTestBase;
+import org.databiosphere.workspacedataservice.dao.CollectionDao;
 import org.databiosphere.workspacedataservice.shared.model.BackupRestoreRequest;
 import org.databiosphere.workspacedataservice.shared.model.RestoreResponse;
 import org.databiosphere.workspacedataservice.shared.model.job.Job;
 import org.databiosphere.workspacedataservice.shared.model.job.JobInput;
 import org.databiosphere.workspacedataservice.shared.model.job.JobStatus;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
@@ -30,11 +34,18 @@ import org.springframework.test.context.TestPropertySource;
       "twds.instance.source-workspace-id=123e4567-e89b-12d3-a456-426614174001",
       "twds.pg_dump.host="
     })
-class BackupRestoreServiceFailureIntegrationTest {
+class BackupRestoreServiceFailureIntegrationTest extends IntegrationServiceTestBase {
   @Autowired private BackupRestoreService backupRestoreService;
+  @Autowired CollectionDao collectionDao;
+  @Autowired NamedParameterJdbcTemplate namedTemplate;
 
   @Value("${twds.instance.source-workspace-id}")
   private String sourceWorkspaceId;
+
+  @AfterEach
+  void cleanUp() {
+    cleanDb(collectionDao, namedTemplate);
+  }
 
   @Test
   void testRestoreAzureWDSErrorHandling() {

--- a/service/src/integrationTest/java/org/databiosphere/workspacedataservice/service/BackupServiceIntegrationTest.java
+++ b/service/src/integrationTest/java/org/databiosphere/workspacedataservice/service/BackupServiceIntegrationTest.java
@@ -4,13 +4,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.UUID;
+import org.databiosphere.workspacedataservice.IntegrationServiceTestBase;
 import org.databiosphere.workspacedataservice.dao.BackupRestoreDao;
+import org.databiosphere.workspacedataservice.dao.CollectionDao;
 import org.databiosphere.workspacedataservice.shared.model.BackupResponse;
 import org.databiosphere.workspacedataservice.shared.model.BackupRestoreRequest;
 import org.databiosphere.workspacedataservice.shared.model.job.JobStatus;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
@@ -23,10 +27,16 @@ import org.springframework.test.context.TestPropertySource;
       "twds.instance.workspace-id=123e4567-e89b-12d3-a456-426614174000",
       "twds.pg_dump.useAzureIdentity=false"
     })
-class BackupServiceIntegrationTest {
+class BackupServiceIntegrationTest extends IntegrationServiceTestBase {
   @Autowired private BackupRestoreService backupRestoreService;
-
   @Autowired private BackupRestoreDao<BackupResponse> backupDao;
+  @Autowired CollectionDao collectionDao;
+  @Autowired NamedParameterJdbcTemplate namedTemplate;
+
+  @AfterEach
+  void cleanUp() {
+    cleanDb(collectionDao, namedTemplate);
+  }
 
   @Test
   void testBackupAzureWDS() {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/config/InstanceProperties.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/config/InstanceProperties.java
@@ -12,7 +12,6 @@ public class InstanceProperties {
   private UUID workspaceUuid;
   private String sourceWorkspaceId;
   private UUID sourceWorkspaceUuid;
-  private boolean initializeCollectionOnStartup;
 
   public String getWorkspaceId() {
     return workspaceId;
@@ -49,10 +48,6 @@ public class InstanceProperties {
     return sourceWorkspaceId;
   }
 
-  public boolean getInitializeCollectionOnStartup() {
-    return initializeCollectionOnStartup;
-  }
-
   public void setSourceWorkspaceId(String sourceWorkspaceId) {
     this.sourceWorkspaceId = sourceWorkspaceId;
     try {
@@ -60,9 +55,5 @@ public class InstanceProperties {
     } catch (Exception e) {
       // noop; validation of the workspaceId is handled elsewhere. See StartupConfig.
     }
-  }
-
-  public void setInitializeCollectionOnStartup(boolean set) {
-    initializeCollectionOnStartup = set;
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/startup/CollectionInitializer.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/startup/CollectionInitializer.java
@@ -1,7 +1,6 @@
 package org.databiosphere.workspacedataservice.startup;
 
 import org.databiosphere.workspacedataservice.annotations.DeploymentMode.DataPlane;
-import org.databiosphere.workspacedataservice.config.InstanceProperties;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ContextRefreshedEvent;
@@ -12,18 +11,13 @@ import org.springframework.stereotype.Component;
 public class CollectionInitializer implements ApplicationListener<ContextRefreshedEvent> {
 
   private final CollectionInitializerBean collectionInitializerBean;
-  private final boolean runOnStartup;
 
-  public CollectionInitializer(
-      CollectionInitializerBean collectionInitializerBean, InstanceProperties instanceProperties) {
+  public CollectionInitializer(CollectionInitializerBean collectionInitializerBean) {
     this.collectionInitializerBean = collectionInitializerBean;
-    this.runOnStartup = instanceProperties.getInitializeCollectionOnStartup();
   }
 
   @Override
   public void onApplicationEvent(@NotNull ContextRefreshedEvent event) {
-    if (runOnStartup) {
-      collectionInitializerBean.initializeCollection();
-    }
+    collectionInitializerBean.initializeCollection();
   }
 }

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -120,7 +120,6 @@ twds:
   write.batch.size: 5000
   streaming.fetch.size: 5000
   instance:
-    initialize-collection-on-startup: true
     # Workspace Id for launching instance
     workspace-id: ${WORKSPACE_ID:}
     source-workspace-id: ${SOURCE_WORKSPACE_ID:}


### PR DESCRIPTION
…t cleanup

Reminder:

PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 
