### PR TITLE
AJ-1649: dependency submission should not use setup-java cache

### DIFF
--- a/.github/workflows/submit-dependencies.yml
+++ b/.github/workflows/submit-dependencies.yml
@@ -19,6 +19,5 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: 'gradle'
       - name: Generate and submit dependency graph
         uses: gradle/actions/dependency-submission@v3


### PR DESCRIPTION
The cache in the `setup-java` action is redundant and conflicts with caches from `dependency-submission`. Remove it.

I hypothesize this out-of-date cache is giving us false positive Dependabot warnings. Hopefully by removing it our warnings clear up.

I was able to see that the `dependency-submission` action is reporting stuff simply because it's on the classpath - hypothesis is that a stale cache left stuff on the classpath that is not actually in our current list of dependencies.