### PR TITLE
AJ-1633: Strengthen `SamClientFactory` API typing.

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamClientFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamClientFactory.java
@@ -35,7 +35,7 @@ public class HttpSamClientFactory implements SamClientFactory {
     // this requires we import terra-common-lib
   }
 
-  private ApiClient getApiClient(String authToken) {
+  private ApiClient getApiClient(BearerToken authToken) {
     // create a new Sam client
     ApiClient apiClient = new ApiClient();
     apiClient.setHttpClient(commonHttpClient);
@@ -44,7 +44,8 @@ public class HttpSamClientFactory implements SamClientFactory {
       apiClient.setBasePath(samUrl);
     }
 
-    // grab the current user's bearer token (see BearerTokenFilter) or use parameter value
+    // use the parameter value or fall back to the current user's bearer token (see
+    // BearerTokenFilter)
     BearerToken token = TokenContextUtil.getToken(authToken);
 
     // add the user's bearer token to the client
@@ -65,7 +66,7 @@ public class HttpSamClientFactory implements SamClientFactory {
    *
    * @return the usable Sam client
    */
-  public ResourcesApi getResourcesApi(String token) {
+  public ResourcesApi getResourcesApi(BearerToken token) {
     ApiClient apiClient = getApiClient(token);
     ResourcesApi resourcesApi = new ResourcesApi();
     resourcesApi.setApiClient(apiClient);
@@ -78,21 +79,21 @@ public class HttpSamClientFactory implements SamClientFactory {
    *
    * @return the usable Sam client
    */
-  public StatusApi getStatusApi() {
-    ApiClient apiClient = getApiClient(null);
+  public StatusApi getStatusApi(BearerToken token) {
+    ApiClient apiClient = getApiClient(token);
     StatusApi statusApi = new StatusApi();
     statusApi.setApiClient(apiClient);
     return statusApi;
   }
 
-  public UsersApi getUsersApi(String token) {
+  public UsersApi getUsersApi(BearerToken token) {
     ApiClient apiClient = getApiClient(token);
     UsersApi usersApi = new UsersApi();
     usersApi.setApiClient(apiClient);
     return usersApi;
   }
 
-  public GoogleApi getGoogleApi(String token) {
+  public GoogleApi getGoogleApi(BearerToken token) {
     ApiClient apiClient = getApiClient(token);
     GoogleApi googleApi = new GoogleApi();
     googleApi.setApiClient(apiClient);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/SamClientFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/SamClientFactory.java
@@ -4,19 +4,27 @@ import org.broadinstitute.dsde.workbench.client.sam.api.GoogleApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.StatusApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.UsersApi;
+import org.databiosphere.workspacedataservice.shared.model.BearerToken;
 
 /**
- * interface for SamClientFactory, allowing various implementations: - HttpSamClientFactory, which
- * generates an ApiClient and ResourcesApi from the Sam client library; - MockSamClientFactory,
- * which generates a mock ResourcesApi for unit testing or local development
+ * interface for SamClientFactory, allowing various implementations:
+ *
+ * <ul>
+ *   <li>HttpSamClientFactory, which generates an ApiClient and ResourcesApi from the Sam client
+ *       library;
+ *   <li>MockSamClientFactory, which generates a mock ResourcesApi for unit testing or local
+ *       development.
+ * </ul>
  */
 public interface SamClientFactory {
 
-  ResourcesApi getResourcesApi(String token);
+  // TODO(jladieu): defer creation of SamClientFactory until when it's needed, then create it with
+  //   an injected BearerToken; this will let us drop the BearerToken parameter from the API
+  ResourcesApi getResourcesApi(BearerToken token);
 
-  StatusApi getStatusApi();
+  StatusApi getStatusApi(BearerToken token);
 
-  UsersApi getUsersApi(String token);
+  UsersApi getUsersApi(BearerToken token);
 
-  GoogleApi getGoogleApi(String token);
+  GoogleApi getGoogleApi(BearerToken token);
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.sam;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/BearerToken.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/BearerToken.java
@@ -1,6 +1,8 @@
 package org.databiosphere.workspacedataservice.shared.model;
 
 import java.util.Objects;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
 
 /**
  * Record class to represent an auth token; use this instead of String for more type safety and
@@ -13,20 +15,26 @@ public class BearerToken {
 
   private final String value;
 
-  private BearerToken(String value) {
+  private BearerToken(@Nullable String value) {
     this.value = value;
   }
 
   /** returns an empty BearerToken; that is, a BearerToken whose `value` is null */
   public static BearerToken empty() {
-    return new BearerToken(null);
+    return new BearerToken(/* value= */ null);
   }
 
   /** returns a BearerToken with the specified `value` */
-  public static BearerToken of(String val) {
+  public static BearerToken ofNullable(@Nullable String val) {
     return new BearerToken(val);
   }
 
+  /** returns a BearerToken with the specified `value` */
+  public static BearerToken of(@NonNull String val) {
+    return ofNullable(val);
+  }
+
+  @Nullable
   public String getValue() {
     return value;
   }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/ActivityEventBuilderTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/ActivityEventBuilderTest.java
@@ -15,6 +15,7 @@ import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.sam.BearerTokenFilter;
 import org.databiosphere.workspacedataservice.sam.SamClientFactory;
 import org.databiosphere.workspacedataservice.service.CollectionService;
+import org.databiosphere.workspacedataservice.shared.model.BearerToken;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -46,8 +47,9 @@ class ActivityEventBuilderTest extends TestBase {
 
   @BeforeEach
   void setUp() {
-    given(mockSamClientFactory.getUsersApi(any())).willReturn(mockUsersApi);
-    given(mockSamClientFactory.getResourcesApi(any())).willReturn(mockResourcesApi);
+    given(mockSamClientFactory.getUsersApi(any(BearerToken.class))).willReturn(mockUsersApi);
+    given(mockSamClientFactory.getResourcesApi(any(BearerToken.class)))
+        .willReturn(mockResourcesApi);
   }
 
   @Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/sam/MockSamClientFactory.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/sam/MockSamClientFactory.java
@@ -4,25 +4,26 @@ import org.broadinstitute.dsde.workbench.client.sam.api.GoogleApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.StatusApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.UsersApi;
+import org.databiosphere.workspacedataservice.shared.model.BearerToken;
 
 /** Mock for SamClientFactory, which returns a MockSamResourcesApi. For use in unit tests. */
 public class MockSamClientFactory implements SamClientFactory {
 
-  public ResourcesApi getResourcesApi(String token) {
+  public ResourcesApi getResourcesApi(BearerToken token) {
     return new MockSamResourcesApi();
   }
 
-  public StatusApi getStatusApi() {
-    return new StatusApi();
+  public StatusApi getStatusApi(BearerToken token) {
+    return new MockStatusApi();
   }
 
   @Override
-  public UsersApi getUsersApi(String token) {
+  public UsersApi getUsersApi(BearerToken token) {
     return new MockSamUsersApi();
   }
 
   @Override
-  public GoogleApi getGoogleApi(String token) {
+  public GoogleApi getGoogleApi(BearerToken token) {
     return new MockSamGoogleApi();
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/sam/MockStatusApi.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/sam/MockStatusApi.java
@@ -1,0 +1,11 @@
+package org.databiosphere.workspacedataservice.sam;
+
+import org.broadinstitute.dsde.workbench.client.sam.api.StatusApi;
+import org.broadinstitute.dsde.workbench.client.sam.model.SystemStatus;
+
+public class MockStatusApi extends StatusApi {
+  @Override
+  public SystemStatus getSystemStatus() {
+    return new SystemStatus().ok(true);
+  }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/sam/TokenContextUtilTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/sam/TokenContextUtilTest.java
@@ -1,5 +1,6 @@
 package org.databiosphere.workspacedataservice.sam;
 
+import static java.util.Objects.requireNonNull;
 import static org.databiosphere.workspacedataservice.sam.BearerTokenFilter.ATTRIBUTE_NAME_TOKEN;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -19,7 +20,7 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 class TokenContextUtilTest {
 
   @Test
-  void nonNullInitialValueAndNoOrElse() {
+  void nonNullInitialStringValueAndNoOrElse() {
     String expected = RandomStringUtils.randomAlphanumeric(10);
 
     // set a dummy value into request attributes
@@ -42,7 +43,54 @@ class TokenContextUtilTest {
   }
 
   @Test
-  void nonNullInitialValue() {
+  void nonNullInitialBearerTokenValueAndNoOrElse() {
+    String expected = RandomStringUtils.randomAlphanumeric(10);
+
+    // set a dummy value into request attributes
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    RequestAttributes requestAttributes = new ServletRequestAttributes(request);
+    requestAttributes.setAttribute(ATTRIBUTE_NAME_TOKEN, "dummy request value", SCOPE_REQUEST);
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+    try {
+      // and set a dummy value into job attributes
+      JobContextHolder.init();
+      JobContextHolder.setAttribute(ATTRIBUTE_NAME_TOKEN, "dummy job value");
+
+      // call getToken with a non-null initialValue
+      BearerToken actual = TokenContextUtil.getToken(BearerToken.of(expected));
+      assertEquals(BearerToken.of(expected), actual);
+    } finally {
+      JobContextHolder.destroy();
+    }
+  }
+
+  @Test
+  void nonNullInitialStringValue() {
+    BearerToken expected = BearerToken.of(RandomStringUtils.randomAlphanumeric(10));
+
+    // set a dummy value into request attributes
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    RequestAttributes requestAttributes = new ServletRequestAttributes(request);
+    requestAttributes.setAttribute(ATTRIBUTE_NAME_TOKEN, "dummy request value", SCOPE_REQUEST);
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+    try {
+      // and set a dummy value into job attributes
+      JobContextHolder.init();
+      JobContextHolder.setAttribute(ATTRIBUTE_NAME_TOKEN, "dummy job value");
+
+      // call getToken with a non-null initialValue
+      BearerToken actual =
+          TokenContextUtil.getToken(expected, () -> BearerToken.of("dummy orElse value"));
+      assertEquals(expected, actual);
+    } finally {
+      JobContextHolder.destroy();
+    }
+  }
+
+  @Test
+  void nonNullInitialBearerTokenValue() {
     BearerToken expected = BearerToken.of(RandomStringUtils.randomAlphanumeric(10));
 
     // set a dummy value into request attributes
@@ -72,7 +120,8 @@ class TokenContextUtilTest {
     // set the expected token into request attributes
     MockHttpServletRequest request = new MockHttpServletRequest();
     RequestAttributes requestAttributes = new ServletRequestAttributes(request);
-    requestAttributes.setAttribute(ATTRIBUTE_NAME_TOKEN, expected.getValue(), SCOPE_REQUEST);
+    requestAttributes.setAttribute(
+        ATTRIBUTE_NAME_TOKEN, requireNonNull(expected.getValue()), SCOPE_REQUEST);
     RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
 
     try {
@@ -83,6 +132,32 @@ class TokenContextUtilTest {
       // call getToken with a null initialValue
       BearerToken actual =
           TokenContextUtil.getToken(null, () -> BearerToken.of("dummy orElse value"));
+      assertEquals(expected, actual);
+    } finally {
+      JobContextHolder.destroy();
+    }
+  }
+
+  @Test
+  void valueInRequestEmptyInitialValue() {
+    BearerToken expected = BearerToken.of(RandomStringUtils.randomAlphanumeric(10));
+
+    // set the expected token into request attributes
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    RequestAttributes requestAttributes = new ServletRequestAttributes(request);
+    requestAttributes.setAttribute(
+        ATTRIBUTE_NAME_TOKEN, requireNonNull(expected.getValue()), SCOPE_REQUEST);
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+    try {
+      // and set a dummy value into job attributes
+      JobContextHolder.init();
+      JobContextHolder.setAttribute(ATTRIBUTE_NAME_TOKEN, "dummy job value");
+
+      // call getToken with a null initialValue
+      BearerToken actual =
+          TokenContextUtil.getToken(
+              BearerToken.empty(), () -> BearerToken.of("dummy orElse value"));
       assertEquals(expected, actual);
     } finally {
       JobContextHolder.destroy();
@@ -110,6 +185,27 @@ class TokenContextUtilTest {
   }
 
   @Test
+  void valueInJobEmptyInitialValue() {
+    BearerToken expected = BearerToken.of(RandomStringUtils.randomAlphanumeric(10));
+
+    // set request attributes to empty
+    RequestContextHolder.setRequestAttributes(null);
+
+    try {
+      // set the expected token into job attributes
+      JobContextHolder.init();
+      JobContextHolder.setAttribute(ATTRIBUTE_NAME_TOKEN, expected.getValue());
+      // call getToken with a null initialValue
+      BearerToken actual =
+          TokenContextUtil.getToken(
+              BearerToken.empty(), () -> BearerToken.of("dummy orElse value"));
+      assertEquals(expected, actual);
+    } finally {
+      JobContextHolder.destroy();
+    }
+  }
+
+  @Test
   void callOrElse() {
     BearerToken expected = BearerToken.of(RandomStringUtils.randomAlphanumeric(10));
     // set request attributes to empty
@@ -118,6 +214,18 @@ class TokenContextUtilTest {
     JobContextHolder.destroy();
     // call getToken with a null initialValue and an orElse that returns the expected value
     BearerToken actual = TokenContextUtil.getToken(null, () -> expected);
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void callOrElseEmptyInitialValue() {
+    BearerToken expected = BearerToken.of(RandomStringUtils.randomAlphanumeric(10));
+    // set request attributes to empty
+    RequestContextHolder.setRequestAttributes(null);
+    // ensure job attributes are empty
+    JobContextHolder.destroy();
+    // call getToken with a null initialValue and an orElse that returns the expected value
+    BearerToken actual = TokenContextUtil.getToken(BearerToken.empty(), () -> expected);
     assertEquals(expected, actual);
   }
 
@@ -143,13 +251,35 @@ class TokenContextUtilTest {
   }
 
   @Test
-  void noOrElseSpecified() {
+  void noOrElseSpecifiedUsingNullStringValue() {
     // set request attributes to empty
     RequestContextHolder.setRequestAttributes(null);
     // ensure job attributes are empty
     JobContextHolder.destroy();
     // call getToken with a null initialValue and an orElse that returns the expected value
     BearerToken actual = TokenContextUtil.getToken((String) null);
+    assertTrue(actual.isEmpty());
+  }
+
+  @Test
+  void noOrElseSpecifiedUsingNullBearerTokenValue() {
+    // set request attributes to empty
+    RequestContextHolder.setRequestAttributes(null);
+    // ensure job attributes are empty
+    JobContextHolder.destroy();
+    // call getToken with a null initialValue
+    BearerToken actual = TokenContextUtil.getToken((BearerToken) null);
+    assertTrue(actual.isEmpty());
+  }
+
+  @Test
+  void noOrElseSpecifiedUsingEmptyBearerTokenValue() {
+    // set request attributes to empty
+    RequestContextHolder.setRequestAttributes(null);
+    // ensure job attributes are empty
+    JobContextHolder.destroy();
+    // call getToken with an empty BearerToken
+    BearerToken actual = TokenContextUtil.getToken(BearerToken.empty());
     assertTrue(actual.isEmpty());
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceNoPermissionSamTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceNoPermissionSamTest.java
@@ -2,6 +2,7 @@ package org.databiosphere.workspacedataservice.service;
 
 import static org.databiosphere.workspacedataservice.service.RecordUtils.VERSION;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 
@@ -13,6 +14,7 @@ import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.dao.CollectionDao;
 import org.databiosphere.workspacedataservice.sam.SamClientFactory;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthorizationException;
+import org.databiosphere.workspacedataservice.shared.model.BearerToken;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.mockito.Mockito;
@@ -43,7 +45,8 @@ class CollectionServiceNoPermissionSamTest extends TestBase {
   void testCreateCollectionNoPermission() throws ApiException {
 
     // return the mock ResourcesApi from the mock SamClientFactory
-    given(mockSamClientFactory.getResourcesApi(null)).willReturn(mockResourcesApi);
+    given(mockSamClientFactory.getResourcesApi(any(BearerToken.class)))
+        .willReturn(mockResourcesApi);
 
     // Call to check permissions in Sam does not throw an exception, but returns false -
     // i.e. the current user does not have permission
@@ -63,7 +66,8 @@ class CollectionServiceNoPermissionSamTest extends TestBase {
   void testDeleteCollectionNoPermission() throws ApiException {
 
     // return the mock ResourcesApi from the mock SamClientFactory
-    given(mockSamClientFactory.getResourcesApi(null)).willReturn(mockResourcesApi);
+    given(mockSamClientFactory.getResourcesApi(any(BearerToken.class)))
+        .willReturn(mockResourcesApi);
 
     // Call to check permissions in Sam does not throw an exception, but returns false -
     // i.e. the current user does not have permission

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceSamExceptionTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceSamExceptionTest.java
@@ -2,6 +2,7 @@ package org.databiosphere.workspacedataservice.service;
 
 import static org.databiosphere.workspacedataservice.service.RecordUtils.VERSION;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -18,6 +19,7 @@ import org.databiosphere.workspacedataservice.sam.SamClientFactory;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthenticationException;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthorizationException;
 import org.databiosphere.workspacedataservice.service.model.exception.RestException;
+import org.databiosphere.workspacedataservice.shared.model.BearerToken;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -69,7 +71,8 @@ class CollectionServiceSamExceptionTest extends TestBase {
   @BeforeEach
   void setUp() {
     // return the mock ResourcesApi from the mock SamClientFactory
-    given(mockSamClientFactory.getResourcesApi(null)).willReturn(mockResourcesApi);
+    given(mockSamClientFactory.getResourcesApi(any(BearerToken.class)))
+        .willReturn(mockResourcesApi);
   }
 
   @AfterEach

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceSamTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceSamTest.java
@@ -12,6 +12,7 @@ import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.dao.CollectionDao;
 import org.databiosphere.workspacedataservice.sam.SamClientFactory;
 import org.databiosphere.workspacedataservice.sam.SamDao;
+import org.databiosphere.workspacedataservice.shared.model.BearerToken;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -46,7 +47,8 @@ class CollectionServiceSamTest extends TestBase {
   @BeforeEach
   void setUp() throws ApiException {
     // return the mock ResourcesApi from the mock SamClientFactory
-    given(mockSamClientFactory.getResourcesApi(null)).willReturn(mockResourcesApi);
+    given(mockSamClientFactory.getResourcesApi(any(BearerToken.class)))
+        .willReturn(mockResourcesApi);
     // Sam permission check will always return true
     given(mockResourcesApi.resourcePermissionV2(anyString(), anyString(), anyString()))
         .willReturn(true);

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -35,6 +34,7 @@ import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
 import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
 import org.databiosphere.workspacedataservice.sam.SamClientFactory;
 import org.databiosphere.workspacedataservice.sam.SamDao;
+import org.databiosphere.workspacedataservice.shared.model.BearerToken;
 import org.databiosphere.workspacedataservice.shared.model.Schedulable;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.junit.jupiter.api.BeforeEach;
@@ -84,12 +84,12 @@ class ImportServiceTest extends TestBase {
     }
 
     // return the mock ResourcesApi from the mock SamClientFactory
-    given(mockSamClientFactory.getResourcesApi(nullable(String.class)))
+    given(mockSamClientFactory.getResourcesApi(any(BearerToken.class)))
         .willReturn(mockSamResourcesApi);
     // Sam permission check will always return true
     given(mockSamResourcesApi.resourcePermissionV2(anyString(), anyString(), anyString()))
         .willReturn(true);
-    given(mockSamClientFactory.getGoogleApi(null)).willReturn(mockSamGoogleApi);
+    given(mockSamClientFactory.getGoogleApi(any(BearerToken.class))).willReturn(mockSamGoogleApi);
     // Pet token request returns "arbitraryToken"
     given(mockSamGoogleApi.getArbitraryPetServiceAccountToken(any())).willReturn("arbitraryToken");
 
@@ -218,7 +218,7 @@ class ImportServiceTest extends TestBase {
   @EnumSource(ImportRequestServerModel.TypeEnum.class)
   void doesNotCreateJobWithoutPetToken(ImportRequestServerModel.TypeEnum importType)
       throws ApiException {
-    given(mockSamClientFactory.getGoogleApi(null)).willReturn(mockSamGoogleApi);
+    given(mockSamClientFactory.getGoogleApi(any(BearerToken.class))).willReturn(mockSamGoogleApi);
     // Sam permission check will always return true
     given(mockSamGoogleApi.getArbitraryPetServiceAccountToken(any()))
         .willThrow(new ApiException("token failure for unit test"));

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/PermissionsStatusServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/PermissionsStatusServiceTest.java
@@ -9,6 +9,7 @@ import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.sam.HttpSamDao;
 import org.databiosphere.workspacedataservice.sam.PermissionsStatusService;
 import org.databiosphere.workspacedataservice.sam.SamClientFactory;
+import org.databiosphere.workspacedataservice.shared.model.BearerToken;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -41,7 +42,7 @@ class PermissionsStatusServiceTest extends TestBase {
   @BeforeEach
   void setUp() {
     // return the mock StatusApi from the mock SamClientFactory
-    given(mockSamClientFactory.getStatusApi()).willReturn(mockStatusApi);
+    given(mockSamClientFactory.getStatusApi(any(BearerToken.class))).willReturn(mockStatusApi);
     Mockito.clearInvocations(mockStatusApi);
     Mockito.clearInvocations(mockHealthBuilder);
   }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorSamTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorSamTest.java
@@ -3,6 +3,7 @@ package org.databiosphere.workspacedataservice.service;
 import static org.databiosphere.workspacedataservice.service.RecordUtils.VERSION;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 
@@ -14,6 +15,7 @@ import org.databiosphere.workspacedataservice.dao.CollectionDao;
 import org.databiosphere.workspacedataservice.sam.SamClientFactory;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthorizationException;
 import org.databiosphere.workspacedataservice.service.model.exception.RestException;
+import org.databiosphere.workspacedataservice.shared.model.BearerToken;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -51,7 +53,8 @@ class RecordOrchestratorSamTest extends TestBase {
     if (!collectionDao.collectionSchemaExists(COLLECTION)) {
       collectionDao.createSchema(COLLECTION);
     }
-    given(mockSamClientFactory.getResourcesApi(null)).willReturn(mockResourcesApi);
+    given(mockSamClientFactory.getResourcesApi(any(BearerToken.class)))
+        .willReturn(mockResourcesApi);
 
     // clear call history for the mock
     Mockito.reset(mockResourcesApi);

--- a/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/BearerTokenTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/BearerTokenTest.java
@@ -9,7 +9,7 @@ class BearerTokenTest {
 
   @Test
   void nullIsEmpty() {
-    assertTrue(BearerToken.of(null).isEmpty());
+    assertTrue(BearerToken.ofNullable(null).isEmpty());
   }
 
   // empty string will cause 401s in practice, but BearerToken is only lightweight validation


### PR DESCRIPTION
Prefactor for [AJ-1633](https://broadworkbench.atlassian.net/browse/AJ-1633)

* Declare the package as `@NonNullApi`; this will make the IDE provide warnings to guide clients to deal with null-safety.
* Make all methods expect a `BearerToken` rather than a String.
* For non-authenticated usages, it's still possible to pass in `BearerToken.empty()`.
* Require a `BearerToken` on the `getStatusApi` call, even though it's not needed.  This is for consistency.

Next steps are to propagate this strong typing upward into the `SamDao` and friends, all in service to making it easier to further refactor & refine to wire through a `WorkspaceId` for auth purposes.

[AJ-1633]: https://broadworkbench.atlassian.net/browse/AJ-1633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ