### PR TITLE
AJ-1633: Make `SamDao` API require and use stronger types.

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityEventBuilder.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/ActivityEventBuilder.java
@@ -40,7 +40,7 @@ public class ActivityEventBuilder {
       BearerToken token = TokenContextUtil.getToken();
       if (token.nonEmpty()) {
         // resolve the token to a user id via Sam
-        this.subject = samDao.getUserId(token.getValue());
+        this.subject = samDao.getUserId(token);
       } else {
         this.subject = "anonymous";
       }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamDao.java
@@ -6,6 +6,7 @@ import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo;
 import org.databiosphere.workspacedataservice.retry.RestClientRetry;
 import org.databiosphere.workspacedataservice.retry.RestClientRetry.RestCall;
 import org.databiosphere.workspacedataservice.shared.model.BearerToken;
+import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.cache.annotation.Cacheable;
@@ -19,10 +20,10 @@ public class HttpSamDao implements SamDao {
   protected final SamClientFactory samClientFactory;
   private static final Logger LOGGER = LoggerFactory.getLogger(HttpSamDao.class);
   private final RestClientRetry restClientRetry;
-  private final String workspaceId;
+  private final WorkspaceId workspaceId;
 
   public HttpSamDao(
-      SamClientFactory samClientFactory, RestClientRetry restClientRetry, String workspaceId) {
+      SamClientFactory samClientFactory, RestClientRetry restClientRetry, WorkspaceId workspaceId) {
     this.samClientFactory = samClientFactory;
     this.restClientRetry = restClientRetry;
     this.workspaceId = workspaceId;
@@ -73,7 +74,7 @@ public class HttpSamDao implements SamDao {
   }
 
   @Override
-  public boolean hasWriteWorkspacePermission(String workspaceId) {
+  public boolean hasWriteWorkspacePermission(WorkspaceId workspaceId) {
     return hasPermission(
         ACTION_WRITE, "Sam.hasWriteWorkspacePermission", workspaceId, BearerToken.empty());
   }
@@ -84,12 +85,12 @@ public class HttpSamDao implements SamDao {
    * @return true if the user has permission
    */
   @Override
-  public boolean hasReadWorkspacePermission(String workspaceId) {
+  public boolean hasReadWorkspacePermission(WorkspaceId workspaceId) {
     return hasReadWorkspacePermission(workspaceId, BearerToken.empty());
   }
 
   @Override
-  public boolean hasReadWorkspacePermission(String workspaceId, BearerToken token) {
+  public boolean hasReadWorkspacePermission(WorkspaceId workspaceId, BearerToken token) {
     return hasPermission(ACTION_READ, "Sam.hasReadWorkspacePermission", token);
   }
 
@@ -99,7 +100,7 @@ public class HttpSamDao implements SamDao {
   }
 
   private boolean hasPermission(
-      String action, String loggerHint, String workspaceId, BearerToken token) {
+      String action, String loggerHint, WorkspaceId workspaceId, BearerToken token) {
     LOGGER.debug(
         "Checking Sam permission for {}/{}/{} ...",
         SamDao.RESOURCE_NAME_WORKSPACE,
@@ -109,7 +110,8 @@ public class HttpSamDao implements SamDao {
         () ->
             samClientFactory
                 .getResourcesApi(token)
-                .resourcePermissionV2(SamDao.RESOURCE_NAME_WORKSPACE, workspaceId, action);
+                .resourcePermissionV2(
+                    SamDao.RESOURCE_NAME_WORKSPACE, workspaceId.toString(), action);
     return restClientRetry.withRetryAndErrorHandling(samFunction, loggerHint);
   }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamDao.java
@@ -9,7 +9,6 @@ import org.databiosphere.workspacedataservice.shared.model.BearerToken;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.cache.annotation.Cacheable;
-import org.springframework.lang.Nullable;
 
 /**
  * Implementation of SamDao that accepts a SamClientFactory, then asks that factory for a new
@@ -38,13 +37,12 @@ public class HttpSamDao implements SamDao {
    */
   @Override
   public boolean hasCreateCollectionPermission() {
-    return hasCreateCollectionPermission(null);
+    return hasCreateCollectionPermission(BearerToken.empty());
   }
 
   @Override
-  public boolean hasCreateCollectionPermission(@Nullable String token) {
-    return hasPermission(
-        ACTION_WRITE, "Sam.hasCreateCollectionPermission", BearerToken.ofNullable(token));
+  public boolean hasCreateCollectionPermission(BearerToken token) {
+    return hasPermission(ACTION_WRITE, "Sam.hasCreateCollectionPermission", token);
   }
 
   /**
@@ -55,13 +53,12 @@ public class HttpSamDao implements SamDao {
    */
   @Override
   public boolean hasDeleteCollectionPermission() {
-    return hasDeleteCollectionPermission(null);
+    return hasDeleteCollectionPermission(BearerToken.empty());
   }
 
   @Override
-  public boolean hasDeleteCollectionPermission(@Nullable String token) {
-    return hasPermission(
-        ACTION_DELETE, "Sam.hasDeleteCollectionPermission", BearerToken.ofNullable(token));
+  public boolean hasDeleteCollectionPermission(BearerToken token) {
+    return hasPermission(ACTION_DELETE, "Sam.hasDeleteCollectionPermission", token);
   }
 
   /**
@@ -88,13 +85,12 @@ public class HttpSamDao implements SamDao {
    */
   @Override
   public boolean hasReadWorkspacePermission(String workspaceId) {
-    return hasReadWorkspacePermission(workspaceId, null);
+    return hasReadWorkspacePermission(workspaceId, BearerToken.empty());
   }
 
   @Override
-  public boolean hasReadWorkspacePermission(String workspaceId, @Nullable String token) {
-    return hasPermission(
-        ACTION_READ, "Sam.hasReadWorkspacePermission", BearerToken.ofNullable(token));
+  public boolean hasReadWorkspacePermission(String workspaceId, BearerToken token) {
+    return hasPermission(ACTION_READ, "Sam.hasReadWorkspacePermission", token);
   }
 
   // helper implementation for permission checks
@@ -120,14 +116,14 @@ public class HttpSamDao implements SamDao {
   // this cache uses token.hashCode as its key. This prevents any logging such as
   // in CacheLogger from logging the raw token.
   @Cacheable(cacheNames = "tokenResolution", key = "#token.hashCode()")
-  public String getUserId(String token) {
+  public String getUserId(BearerToken token) {
     return getUserInfo(token).getUserSubjectId();
   }
 
-  public UserStatusInfo getUserInfo(String token) {
+  private UserStatusInfo getUserInfo(BearerToken token) {
     LOGGER.debug("Resolving Sam token to UserStatusInfo ...");
     RestCall<UserStatusInfo> samFunction =
-        () -> samClientFactory.getUsersApi(BearerToken.of(token)).getUserStatusInfo();
+        () -> samClientFactory.getUsersApi(token).getUserStatusInfo();
     return restClientRetry.withRetryAndErrorHandling(samFunction, "Sam.getUserInfo");
   }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/MisconfiguredSamDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/MisconfiguredSamDao.java
@@ -2,6 +2,7 @@ package org.databiosphere.workspacedataservice.sam;
 
 import org.broadinstitute.dsde.workbench.client.sam.model.SystemStatus;
 import org.databiosphere.workspacedataservice.shared.model.BearerToken;
+import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,18 +53,18 @@ public class MisconfiguredSamDao implements SamDao {
   }
 
   @Override
-  public boolean hasWriteWorkspacePermission(String workspaceId) {
+  public boolean hasWriteWorkspacePermission(WorkspaceId workspaceId) {
     return hasWriteWorkspacePermission();
   }
 
   @Override
-  public boolean hasReadWorkspacePermission(String workspaceId) {
+  public boolean hasReadWorkspacePermission(WorkspaceId workspaceId) {
     logWarning();
     return false;
   }
 
   @Override
-  public boolean hasReadWorkspacePermission(String workspaceId, BearerToken token) {
+  public boolean hasReadWorkspacePermission(WorkspaceId workspaceId, BearerToken token) {
     return hasReadWorkspacePermission(workspaceId);
   }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/MisconfiguredSamDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/MisconfiguredSamDao.java
@@ -30,8 +30,7 @@ public class MisconfiguredSamDao implements SamDao {
 
   @Override
   public boolean hasCreateCollectionPermission(String token) {
-    logWarning();
-    return false;
+    return hasCreateCollectionPermission();
   }
 
   @Override
@@ -42,8 +41,7 @@ public class MisconfiguredSamDao implements SamDao {
 
   @Override
   public boolean hasDeleteCollectionPermission(String token) {
-    logWarning();
-    return false;
+    return hasDeleteCollectionPermission();
   }
 
   @Override
@@ -53,9 +51,8 @@ public class MisconfiguredSamDao implements SamDao {
   }
 
   @Override
-  public boolean hasWriteWorkspacePermission(String token) {
-    logWarning();
-    return false;
+  public boolean hasWriteWorkspacePermission(String workspaceId) {
+    return hasWriteWorkspacePermission();
   }
 
   @Override
@@ -66,8 +63,7 @@ public class MisconfiguredSamDao implements SamDao {
 
   @Override
   public boolean hasReadWorkspacePermission(String workspaceId, String token) {
-    logWarning();
-    return false;
+    return hasReadWorkspacePermission(workspaceId);
   }
 
   @Override

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/MisconfiguredSamDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/MisconfiguredSamDao.java
@@ -1,6 +1,7 @@
 package org.databiosphere.workspacedataservice.sam;
 
 import org.broadinstitute.dsde.workbench.client.sam.model.SystemStatus;
+import org.databiosphere.workspacedataservice.shared.model.BearerToken;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,7 +30,7 @@ public class MisconfiguredSamDao implements SamDao {
   }
 
   @Override
-  public boolean hasCreateCollectionPermission(String token) {
+  public boolean hasCreateCollectionPermission(BearerToken token) {
     return hasCreateCollectionPermission();
   }
 
@@ -40,7 +41,7 @@ public class MisconfiguredSamDao implements SamDao {
   }
 
   @Override
-  public boolean hasDeleteCollectionPermission(String token) {
+  public boolean hasDeleteCollectionPermission(BearerToken token) {
     return hasDeleteCollectionPermission();
   }
 
@@ -62,12 +63,12 @@ public class MisconfiguredSamDao implements SamDao {
   }
 
   @Override
-  public boolean hasReadWorkspacePermission(String workspaceId, String token) {
+  public boolean hasReadWorkspacePermission(String workspaceId, BearerToken token) {
     return hasReadWorkspacePermission(workspaceId);
   }
 
   @Override
-  public String getUserId(String token) {
+  public String getUserId(BearerToken token) {
     logWarning();
     return "n/a";
   }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/SamConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/SamConfig.java
@@ -1,7 +1,7 @@
 package org.databiosphere.workspacedataservice.sam;
 
-import java.util.UUID;
 import org.databiosphere.workspacedataservice.retry.RestClientRetry;
+import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -43,7 +43,7 @@ public class SamConfig {
     // Try to parse the WORKSPACE_ID env var;
     // return a MisconfiguredSamDao if it can't be parsed.
     try {
-      String workspaceId = UUID.fromString(workspaceIdArgument).toString(); // verify UUID-ness
+      WorkspaceId workspaceId = WorkspaceId.fromString(workspaceIdArgument); // verify UUID-ness
       LOGGER.info(
           "Sam integration will query type={}, resourceId={}, action={}",
           SamDao.RESOURCE_NAME_WORKSPACE,

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/SamDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/SamDao.java
@@ -1,6 +1,7 @@
 package org.databiosphere.workspacedataservice.sam;
 
 import org.broadinstitute.dsde.workbench.client.sam.model.SystemStatus;
+import org.databiosphere.workspacedataservice.shared.model.BearerToken;
 
 /**
  * Interface for SamDao, allowing various dao implementations. Currently, the only implementation is
@@ -28,7 +29,7 @@ public interface SamDao {
    */
   boolean hasCreateCollectionPermission();
 
-  boolean hasCreateCollectionPermission(String token);
+  boolean hasCreateCollectionPermission(BearerToken token);
 
   /**
    * Check if the current user has permission to delete a collection associated with a Sam workspace
@@ -38,7 +39,7 @@ public interface SamDao {
    */
   boolean hasDeleteCollectionPermission();
 
-  boolean hasDeleteCollectionPermission(String token);
+  boolean hasDeleteCollectionPermission(BearerToken token);
 
   /**
    * Check if the current user has permission to read the workspace resource from Sam
@@ -47,7 +48,7 @@ public interface SamDao {
    */
   boolean hasReadWorkspacePermission(String workspaceId);
 
-  boolean hasReadWorkspacePermission(String workspaceId, String token);
+  boolean hasReadWorkspacePermission(String workspaceId, BearerToken token);
 
   /**
    * Check if the current user has permission to write to a workspace resource from Sam
@@ -58,7 +59,7 @@ public interface SamDao {
 
   boolean hasWriteWorkspacePermission(String workspaceId);
 
-  String getUserId(String token);
+  String getUserId(BearerToken token);
 
   /** Gets the up/down system status of Sam. */
   Boolean getSystemStatusOk();

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/SamDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/SamDao.java
@@ -56,7 +56,7 @@ public interface SamDao {
    */
   boolean hasWriteWorkspacePermission();
 
-  boolean hasWriteWorkspacePermission(String token);
+  boolean hasWriteWorkspacePermission(String workspaceId);
 
   String getUserId(String token);
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/SamDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/SamDao.java
@@ -2,6 +2,7 @@ package org.databiosphere.workspacedataservice.sam;
 
 import org.broadinstitute.dsde.workbench.client.sam.model.SystemStatus;
 import org.databiosphere.workspacedataservice.shared.model.BearerToken;
+import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 
 /**
  * Interface for SamDao, allowing various dao implementations. Currently, the only implementation is
@@ -46,9 +47,9 @@ public interface SamDao {
    *
    * @return true if the user has permission
    */
-  boolean hasReadWorkspacePermission(String workspaceId);
+  boolean hasReadWorkspacePermission(WorkspaceId workspaceId);
 
-  boolean hasReadWorkspacePermission(String workspaceId, BearerToken token);
+  boolean hasReadWorkspacePermission(WorkspaceId workspaceId, BearerToken token);
 
   /**
    * Check if the current user has permission to write to a workspace resource from Sam
@@ -57,7 +58,7 @@ public interface SamDao {
    */
   boolean hasWriteWorkspacePermission();
 
-  boolean hasWriteWorkspacePermission(String workspaceId);
+  boolean hasWriteWorkspacePermission(WorkspaceId workspaceId);
 
   String getUserId(BearerToken token);
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/CollectionService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/CollectionService.java
@@ -120,11 +120,11 @@ public class CollectionService {
   }
 
   public boolean canReadCollection(CollectionId collectionId) {
-    return samDao.hasReadWorkspacePermission(getWorkspaceId(collectionId).toString());
+    return samDao.hasReadWorkspacePermission(getWorkspaceId(collectionId));
   }
 
   public boolean canWriteCollection(CollectionId collectionId) {
-    return samDao.hasWriteWorkspacePermission(getWorkspaceId(collectionId).toString());
+    return samDao.hasWriteWorkspacePermission(getWorkspaceId(collectionId));
   }
 
   /**

--- a/service/src/test/java/org/databiosphere/workspacedataservice/pact/SamPactTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/pact/SamPactTest.java
@@ -1,5 +1,6 @@
 package org.databiosphere.workspacedataservice.pact;
 
+import static java.util.UUID.randomUUID;
 import static org.databiosphere.workspacedataservice.TestTags.PACT_TEST;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -13,13 +14,13 @@ import au.com.dius.pact.core.model.PactSpecVersion;
 import au.com.dius.pact.core.model.RequestResponsePact;
 import au.com.dius.pact.core.model.annotations.Pact;
 import java.util.Map;
-import java.util.UUID;
 import org.broadinstitute.dsde.workbench.client.sam.model.SystemStatus;
 import org.databiosphere.workspacedataservice.retry.RestClientRetry;
 import org.databiosphere.workspacedataservice.sam.*;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthenticationException;
 import org.databiosphere.workspacedataservice.service.model.exception.RestServerException;
 import org.databiosphere.workspacedataservice.shared.model.BearerToken;
+import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -179,9 +180,7 @@ class SamPactTest {
   @Test
   @PactTestFor(pactMethod = "statusApiPact", pactVersion = PactSpecVersion.V3)
   void testSamServiceStatusCheck(MockServer mockServer) {
-    SamClientFactory clientFactory = new HttpSamClientFactory(mockServer.getUrl());
-    SamDao samDao =
-        new HttpSamDao(clientFactory, new RestClientRetry(), UUID.randomUUID().toString());
+    SamDao samDao = getSamDao(mockServer, randomWorkspaceId());
 
     SystemStatus samStatus = samDao.getSystemStatus();
     assertTrue(samStatus.getOk());
@@ -190,19 +189,14 @@ class SamPactTest {
   @Test
   @PactTestFor(pactMethod = "downStatusApiPact", pactVersion = PactSpecVersion.V3)
   void testSamServiceDown(MockServer mockServer) {
-    SamClientFactory clientFactory = new HttpSamClientFactory(mockServer.getUrl());
-    SamDao samDao =
-        new HttpSamDao(clientFactory, new RestClientRetry(), UUID.randomUUID().toString());
-    assertThrows(
-        RestServerException.class, () -> samDao.getSystemStatus(), "down Sam should throw 500");
+    SamDao samDao = getSamDao(mockServer, randomWorkspaceId());
+    assertThrows(RestServerException.class, samDao::getSystemStatus, "down Sam should throw 500");
   }
 
   @Test
   @PactTestFor(pactMethod = "userStatusPact", pactVersion = PactSpecVersion.V3)
   void testSamServiceUserStatusInfo(MockServer mockServer) {
-    SamClientFactory clientFactory = new HttpSamClientFactory(mockServer.getUrl());
-    SamDao samDao =
-        new HttpSamDao(clientFactory, new RestClientRetry(), UUID.randomUUID().toString());
+    SamDao samDao = getSamDao(mockServer, randomWorkspaceId());
     String userId = samDao.getUserId(BearerToken.of("accessToken"));
     assertNotNull(userId);
   }
@@ -210,9 +204,7 @@ class SamPactTest {
   @Test
   @PactTestFor(pactMethod = "noUserStatusPact", pactVersion = PactSpecVersion.V3)
   void testSamServiceNoUser(MockServer mockServer) {
-    SamClientFactory clientFactory = new HttpSamClientFactory(mockServer.getUrl());
-    SamDao samDao =
-        new HttpSamDao(clientFactory, new RestClientRetry(), UUID.randomUUID().toString());
+    SamDao samDao = getSamDao(mockServer, randomWorkspaceId());
     BearerToken token = BearerToken.empty();
     assertThrows(
         AuthenticationException.class,
@@ -223,8 +215,7 @@ class SamPactTest {
   @Test
   @PactTestFor(pactMethod = "deleteNoPermissionPact", pactVersion = PactSpecVersion.V3)
   void testSamDeleteNoPermission(MockServer mockServer) {
-    SamClientFactory clientFactory = new HttpSamClientFactory(mockServer.getUrl());
-    SamDao samDao = new HttpSamDao(clientFactory, new RestClientRetry(), dummyResourceId);
+    SamDao samDao = getSamDao(mockServer, dummyWorkspaceId());
 
     assertFalse(samDao.hasDeleteCollectionPermission());
   }
@@ -232,8 +223,7 @@ class SamPactTest {
   @Test
   @PactTestFor(pactMethod = "deletePermissionPact", pactVersion = PactSpecVersion.V3)
   void testSamDeletePermission(MockServer mockServer) {
-    SamClientFactory clientFactory = new HttpSamClientFactory(mockServer.getUrl());
-    SamDao samDao = new HttpSamDao(clientFactory, new RestClientRetry(), dummyResourceId);
+    SamDao samDao = getSamDao(mockServer, dummyWorkspaceId());
 
     assertTrue(samDao.hasDeleteCollectionPermission());
   }
@@ -241,8 +231,7 @@ class SamPactTest {
   @Test
   @PactTestFor(pactMethod = "writeNoPermissionPact", pactVersion = PactSpecVersion.V3)
   void testSamWriteNoPermission(MockServer mockServer) {
-    SamClientFactory clientFactory = new HttpSamClientFactory(mockServer.getUrl());
-    SamDao samDao = new HttpSamDao(clientFactory, new RestClientRetry(), dummyResourceId);
+    SamDao samDao = getSamDao(mockServer, dummyWorkspaceId());
 
     assertFalse(samDao.hasWriteWorkspacePermission());
   }
@@ -250,8 +239,7 @@ class SamPactTest {
   @Test
   @PactTestFor(pactMethod = "writePermissionPact", pactVersion = PactSpecVersion.V3)
   void testSamWritePermission(MockServer mockServer) {
-    SamClientFactory clientFactory = new HttpSamClientFactory(mockServer.getUrl());
-    SamDao samDao = new HttpSamDao(clientFactory, new RestClientRetry(), dummyResourceId);
+    SamDao samDao = getSamDao(mockServer, dummyWorkspaceId());
 
     assertTrue(samDao.hasWriteWorkspacePermission());
   }
@@ -259,10 +247,21 @@ class SamPactTest {
   @Test
   @PactTestFor(pactMethod = "petTokenPact", pactVersion = PactSpecVersion.V3)
   void testPetToken(MockServer mockServer) {
-    SamClientFactory clientFactory = new HttpSamClientFactory(mockServer.getUrl());
-    SamDao samDao =
-        new HttpSamDao(clientFactory, new RestClientRetry(), UUID.randomUUID().toString());
+    SamDao samDao = getSamDao(mockServer, randomWorkspaceId());
     String petToken = samDao.getPetToken();
     assertNotNull(petToken);
+  }
+
+  private SamDao getSamDao(MockServer mockServer, WorkspaceId workspaceId) {
+    SamClientFactory clientFactory = new HttpSamClientFactory(mockServer.getUrl());
+    return new HttpSamDao(clientFactory, new RestClientRetry(), workspaceId);
+  }
+
+  private WorkspaceId randomWorkspaceId() {
+    return WorkspaceId.of(randomUUID());
+  }
+
+  private WorkspaceId dummyWorkspaceId() {
+    return WorkspaceId.fromString(dummyResourceId);
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/pact/SamPactTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/pact/SamPactTest.java
@@ -19,6 +19,7 @@ import org.databiosphere.workspacedataservice.retry.RestClientRetry;
 import org.databiosphere.workspacedataservice.sam.*;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthenticationException;
 import org.databiosphere.workspacedataservice.service.model.exception.RestServerException;
+import org.databiosphere.workspacedataservice.shared.model.BearerToken;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -202,7 +203,7 @@ class SamPactTest {
     SamClientFactory clientFactory = new HttpSamClientFactory(mockServer.getUrl());
     SamDao samDao =
         new HttpSamDao(clientFactory, new RestClientRetry(), UUID.randomUUID().toString());
-    String userId = samDao.getUserId("accessToken");
+    String userId = samDao.getUserId(BearerToken.of("accessToken"));
     assertNotNull(userId);
   }
 
@@ -212,9 +213,10 @@ class SamPactTest {
     SamClientFactory clientFactory = new HttpSamClientFactory(mockServer.getUrl());
     SamDao samDao =
         new HttpSamDao(clientFactory, new RestClientRetry(), UUID.randomUUID().toString());
+    BearerToken token = BearerToken.empty();
     assertThrows(
         AuthenticationException.class,
-        () -> samDao.getUserId(null),
+        () -> samDao.getUserId(token),
         "userId request without token should throw 401");
   }
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/sam/SamDaoInvalidWorkspaceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/sam/SamDaoInvalidWorkspaceTest.java
@@ -37,7 +37,7 @@ class SamDaoInvalidWorkspaceTest extends TestBase {
     assertFalse(samDao.hasDeleteCollectionPermission());
     assertFalse(samDao.hasDeleteCollectionPermission("token"));
     assertFalse(samDao.hasWriteWorkspacePermission());
-    assertFalse(samDao.hasWriteWorkspacePermission("token"));
+    assertFalse(samDao.hasWriteWorkspacePermission("some-workspace-id"));
   }
 
   @Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/sam/SamDaoInvalidWorkspaceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/sam/SamDaoInvalidWorkspaceTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.retry.RestClientRetry;
+import org.databiosphere.workspacedataservice.shared.model.BearerToken;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -33,9 +34,9 @@ class SamDaoInvalidWorkspaceTest extends TestBase {
   @Test
   public void permissionsReturnFalse() {
     assertFalse(samDao.hasCreateCollectionPermission());
-    assertFalse(samDao.hasCreateCollectionPermission("token"));
+    assertFalse(samDao.hasCreateCollectionPermission(BearerToken.of("token")));
     assertFalse(samDao.hasDeleteCollectionPermission());
-    assertFalse(samDao.hasDeleteCollectionPermission("token"));
+    assertFalse(samDao.hasDeleteCollectionPermission(BearerToken.of("token")));
     assertFalse(samDao.hasWriteWorkspacePermission());
     assertFalse(samDao.hasWriteWorkspacePermission("some-workspace-id"));
   }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/sam/SamDaoInvalidWorkspaceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/sam/SamDaoInvalidWorkspaceTest.java
@@ -1,10 +1,12 @@
 package org.databiosphere.workspacedataservice.sam;
 
+import static java.util.UUID.randomUUID;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.retry.RestClientRetry;
 import org.databiosphere.workspacedataservice.shared.model.BearerToken;
+import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -38,7 +40,7 @@ class SamDaoInvalidWorkspaceTest extends TestBase {
     assertFalse(samDao.hasDeleteCollectionPermission());
     assertFalse(samDao.hasDeleteCollectionPermission(BearerToken.of("token")));
     assertFalse(samDao.hasWriteWorkspacePermission());
-    assertFalse(samDao.hasWriteWorkspacePermission("some-workspace-id"));
+    assertFalse(samDao.hasWriteWorkspacePermission(WorkspaceId.of(randomUUID())));
   }
 
   @Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceControlPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceControlPlaneTest.java
@@ -50,7 +50,7 @@ class ImportServiceControlPlaneTest {
     when(collectionDao.getWorkspaceId(collectionId))
         .thenThrow(new EmptyResultDataAccessException("unit test intentional error", 1));
     // sam dao says the user has write permission
-    when(samDao.hasWriteWorkspacePermission(collectionId.toString())).thenReturn(true);
+    when(samDao.hasWriteWorkspacePermission(WorkspaceId.of(collectionId.id()))).thenReturn(true);
 
     // ACT/ASSERT
     // extract the UUID here so the lambda below has only one invocation possibly throwing a runtime
@@ -69,7 +69,7 @@ class ImportServiceControlPlaneTest {
     when(collectionDao.getWorkspaceId(collectionId))
         .thenThrow(new EmptyResultDataAccessException("unit test intentional error", 1));
     // sam dao says the user does not have write permission
-    when(samDao.hasWriteWorkspacePermission(collectionId.toString())).thenReturn(false);
+    when(samDao.hasWriteWorkspacePermission(WorkspaceId.of(collectionId.id()))).thenReturn(false);
 
     // ACT/ASSERT
     // extract the UUID here so the lambda below has only one invocation possibly throwing a runtime
@@ -93,7 +93,7 @@ class ImportServiceControlPlaneTest {
     // collection dao says the collection DOES exist, which is an error in the control plane
     when(collectionDao.getWorkspaceId(collectionId)).thenReturn(WorkspaceId.of(UUID.randomUUID()));
     // sam dao says the user does have write permission
-    when(samDao.hasWriteWorkspacePermission(collectionId.toString())).thenReturn(true);
+    when(samDao.hasWriteWorkspacePermission(WorkspaceId.of(collectionId.id()))).thenReturn(true);
 
     // ACT/ASSERT
     // extract the UUID here so the lambda below has only one invocation possibly throwing a runtime

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceDataPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceDataPlaneTest.java
@@ -56,7 +56,7 @@ class ImportServiceDataPlaneTest {
     when(collectionDao.collectionSchemaExists(collectionId.id())).thenReturn(true);
     when(collectionDao.getWorkspaceId(collectionId)).thenReturn(workspaceId);
     // sam dao says the user has write permission
-    when(samDao.hasWriteWorkspacePermission(workspaceId.toString())).thenReturn(true);
+    when(samDao.hasWriteWorkspacePermission(workspaceId)).thenReturn(true);
 
     // ACT/ASSERT
     // extract the UUID here so the lambda below has only one invocation possibly throwing a runtime
@@ -74,7 +74,7 @@ class ImportServiceDataPlaneTest {
     when(collectionDao.collectionSchemaExists(collectionId.id())).thenReturn(true);
     when(collectionDao.getWorkspaceId(collectionId)).thenReturn(workspaceId);
     // sam dao says the user has write permission
-    when(samDao.hasWriteWorkspacePermission(workspaceId.toString())).thenReturn(false);
+    when(samDao.hasWriteWorkspacePermission(workspaceId)).thenReturn(false);
 
     // ACT/ASSERT
     // extract the UUID here so the lambda below has only one invocation possibly throwing a runtime
@@ -99,7 +99,7 @@ class ImportServiceDataPlaneTest {
     when(collectionDao.collectionSchemaExists(collectionId.id())).thenReturn(true);
     when(collectionDao.getWorkspaceId(collectionId)).thenReturn(workspaceId);
     // sam dao says the user has write permission
-    when(samDao.hasWriteWorkspacePermission(workspaceId.toString())).thenReturn(false);
+    when(samDao.hasWriteWorkspacePermission(workspaceId)).thenReturn(false);
 
     // ACT/ASSERT
     // extract the UUID here so the lambda below has only one invocation possibly throwing a runtime
@@ -119,7 +119,7 @@ class ImportServiceDataPlaneTest {
     when(collectionDao.getWorkspaceId(collectionId))
         .thenThrow(new EmptyResultDataAccessException("unit test intentional error", 1));
     // sam dao says the user has write permission
-    when(samDao.hasWriteWorkspacePermission(collectionId.toString())).thenReturn(false);
+    when(samDao.hasWriteWorkspacePermission(WorkspaceId.of(collectionId.id()))).thenReturn(false);
 
     // ACT/ASSERT
     // extract the UUID here so the lambda below has only one invocation possibly throwing a runtime

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/JobServiceControlPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/JobServiceControlPlaneTest.java
@@ -73,7 +73,7 @@ class JobServiceControlPlaneTest extends JobServiceBaseTest {
     // collection for this job exists
     when(collectionDao.getWorkspaceId(collectionId)).thenReturn(workspaceId);
     // user has permission to that workspace
-    when(samDao.hasReadWorkspacePermission(workspaceId.toString())).thenReturn(true);
+    when(samDao.hasReadWorkspacePermission(workspaceId)).thenReturn(true);
 
     // Act / assert
     Exception actual = assertThrows(CollectionException.class, () -> jobService.getJob(jobId));
@@ -95,7 +95,7 @@ class JobServiceControlPlaneTest extends JobServiceBaseTest {
     when(collectionDao.getWorkspaceId(collectionId))
         .thenThrow(new EmptyResultDataAccessException("unit test intentional error", 1));
     // user has permission to the workspace with the same id as the collection
-    when(samDao.hasReadWorkspacePermission(collectionId.toString())).thenReturn(true);
+    when(samDao.hasReadWorkspacePermission(WorkspaceId.of(collectionId.id()))).thenReturn(true);
 
     // Act
     GenericJobServerModel actual = jobService.getJob(jobId);
@@ -117,7 +117,7 @@ class JobServiceControlPlaneTest extends JobServiceBaseTest {
     when(collectionDao.getWorkspaceId(collectionId))
         .thenThrow(new EmptyResultDataAccessException("unit test intentional error", 1));
     // user has permission to the workspace with the same id as the collection
-    when(samDao.hasReadWorkspacePermission(collectionId.toString())).thenReturn(false);
+    when(samDao.hasReadWorkspacePermission(WorkspaceId.of(collectionId.id()))).thenReturn(false);
 
     // Act / assert
     AuthenticationMaskableException actual =
@@ -140,7 +140,7 @@ class JobServiceControlPlaneTest extends JobServiceBaseTest {
     // collection for this job exists
     when(collectionDao.getWorkspaceId(collectionId)).thenReturn(workspaceId);
     // user has permission to that workspace
-    when(samDao.hasReadWorkspacePermission(workspaceId.toString())).thenReturn(true);
+    when(samDao.hasReadWorkspacePermission(workspaceId)).thenReturn(true);
 
     // Act / assert
     Exception actual =
@@ -161,7 +161,7 @@ class JobServiceControlPlaneTest extends JobServiceBaseTest {
     when(collectionDao.getWorkspaceId(collectionId))
         .thenThrow(new EmptyResultDataAccessException("unit test intentional error", 1));
     // user has permission to the workspace with the same id as the collection
-    when(samDao.hasReadWorkspacePermission(collectionId.toString())).thenReturn(true);
+    when(samDao.hasReadWorkspacePermission(WorkspaceId.of(collectionId.id()))).thenReturn(true);
     // return some jobs when listing this collection
     when(jobDao.getJobsForCollection(eq(collectionId), any()))
         .thenReturn(makeJobList(collectionId, 2));
@@ -184,7 +184,7 @@ class JobServiceControlPlaneTest extends JobServiceBaseTest {
     when(collectionDao.getWorkspaceId(collectionId))
         .thenThrow(new EmptyResultDataAccessException("unit test intentional error", 1));
     // user has permission to the workspace with the same id as the collection
-    when(samDao.hasReadWorkspacePermission(collectionId.toString())).thenReturn(false);
+    when(samDao.hasReadWorkspacePermission(WorkspaceId.of(collectionId.id()))).thenReturn(false);
     // return some jobs when listing this collection
     when(jobDao.getJobsForCollection(eq(collectionId), any()))
         .thenReturn(makeJobList(collectionId, 3));

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/JobServiceDataPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/JobServiceDataPlaneTest.java
@@ -81,7 +81,7 @@ class JobServiceDataPlaneTest extends JobServiceBaseTest {
     // collection for this job exists and is associated with the $WORKSPACE_ID workspace
     when(collectionDao.getWorkspaceId(collectionId)).thenReturn(getEnvWorkspaceId());
     // user has permission to that workspace
-    when(samDao.hasReadWorkspacePermission(getEnvWorkspaceId().toString())).thenReturn(true);
+    when(samDao.hasReadWorkspacePermission(getEnvWorkspaceId())).thenReturn(true);
 
     // Act
     GenericJobServerModel actual = jobService.getJob(jobId);
@@ -102,7 +102,7 @@ class JobServiceDataPlaneTest extends JobServiceBaseTest {
     // collection for this job exists and is associated with the $WORKSPACE_ID workspace
     when(collectionDao.getWorkspaceId(collectionId)).thenReturn(getEnvWorkspaceId());
     // user has permission to that workspace
-    when(samDao.hasReadWorkspacePermission(getEnvWorkspaceId().toString())).thenReturn(false);
+    when(samDao.hasReadWorkspacePermission(getEnvWorkspaceId())).thenReturn(false);
 
     // Act / assert
     AuthenticationMaskableException actual =
@@ -126,7 +126,7 @@ class JobServiceDataPlaneTest extends JobServiceBaseTest {
     // $WORKSPACE_ID workspace
     when(collectionDao.getWorkspaceId(collectionId)).thenReturn(workspaceId);
     // user has permission to that workspace
-    when(samDao.hasReadWorkspacePermission(workspaceId.toString())).thenReturn(true);
+    when(samDao.hasReadWorkspacePermission(workspaceId)).thenReturn(true);
 
     // Act / assert
     Exception actual = assertThrows(CollectionException.class, () -> jobService.getJob(jobId));
@@ -152,7 +152,7 @@ class JobServiceDataPlaneTest extends JobServiceBaseTest {
     when(collectionDao.getWorkspaceId(collectionId))
         .thenThrow(new EmptyResultDataAccessException("unit test intentional error", 1));
     // user has permission to that workspace
-    when(samDao.hasReadWorkspacePermission(workspaceId.toString())).thenReturn(true);
+    when(samDao.hasReadWorkspacePermission(workspaceId)).thenReturn(true);
 
     // Act / assert
     AuthenticationMaskableException actual =
@@ -194,7 +194,7 @@ class JobServiceDataPlaneTest extends JobServiceBaseTest {
     when(collectionDao.collectionSchemaExists(collectionId.id())).thenReturn(true);
     when(collectionDao.getWorkspaceId(collectionId)).thenReturn(getEnvWorkspaceId());
     // user has permission to that workspace
-    when(samDao.hasReadWorkspacePermission(getEnvWorkspaceId().toString())).thenReturn(true);
+    when(samDao.hasReadWorkspacePermission(getEnvWorkspaceId())).thenReturn(true);
     // return some jobs when listing this collection
     when(jobDao.getJobsForCollection(eq(collectionId), any()))
         .thenReturn(makeJobList(collectionId, 2));
@@ -216,7 +216,7 @@ class JobServiceDataPlaneTest extends JobServiceBaseTest {
     // collection exists and is associated with the $WORKSPACE_ID workspace
     when(collectionDao.getWorkspaceId(collectionId)).thenReturn(getEnvWorkspaceId());
     // user has permission to that workspace
-    when(samDao.hasReadWorkspacePermission(getEnvWorkspaceId().toString())).thenReturn(false);
+    when(samDao.hasReadWorkspacePermission(getEnvWorkspaceId())).thenReturn(false);
     // return some jobs when listing this collection
     when(jobDao.getJobsForCollection(eq(collectionId), any()))
         .thenReturn(makeJobList(collectionId, 3));
@@ -241,7 +241,7 @@ class JobServiceDataPlaneTest extends JobServiceBaseTest {
     when(collectionDao.collectionSchemaExists(collectionId.id())).thenReturn(true);
     when(collectionDao.getWorkspaceId(collectionId)).thenReturn(workspaceId);
     // user has permission to that workspace
-    when(samDao.hasReadWorkspacePermission(workspaceId.toString())).thenReturn(true);
+    when(samDao.hasReadWorkspacePermission(workspaceId)).thenReturn(true);
     // return some jobs when listing this collection
     when(jobDao.getJobsForCollection(eq(collectionId), any()))
         .thenReturn(makeJobList(collectionId, 4));


### PR DESCRIPTION
Prefactors for [AJ-1633](https://broadworkbench.atlassian.net/browse/AJ-1633), broken into discrete commits for easier review (one per bullet).

* The single `String` parameter of `hasWriteWorkspacePermission` was named as though it were an auth token, but all places (except one) where it was used (in tests and prod) it was being treated as a workspaceId.  This clarifies the parameter name, and wires it through correctly to be used for the auth check.
* Strengthen `SamDao` API typing by requiring a `BearerToken` instead of a `String` for `token`.
* Strengthen `SamDao` API typing by requiring a `WorkspaceId` instead of a `String` for `workspaceId`.

[AJ-1633]: https://broadworkbench.atlassian.net/browse/AJ-1633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ