### PR TITLE
AJ-1649: Dependabot only considers the runtime classpath

### DIFF
--- a/.github/workflows/submit-dependencies.yml
+++ b/.github/workflows/submit-dependencies.yml
@@ -21,3 +21,5 @@ jobs:
           distribution: 'temurin'
       - name: Generate and submit dependency graph
         uses: gradle/actions/dependency-submission@v3
+        env:
+          DEPENDENCY_GRAPH_INCLUDE_CONFIGURATIONS: runtimeClasspath


### PR DESCRIPTION
This change _should_ tell Dependabot to only alert on dependencies in the `runtimeClasspath` - i.e. it won't alert on build-time dependencies, test dependencies, etc.

Is this what we want? Would you prefer to see all dependencies in the Dependabot list?

Caveat: because dependency submission only works on the `main` branch, I can't test this 100% until it's merged. But, from looking at debug logs on manual GHA runs, I am hopeful this helps.