### PR TITLE
AJ-1630: Throw error on missing collection

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/CollectionService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/CollectionService.java
@@ -155,14 +155,9 @@ public class CollectionService {
         throw new CollectionException("Expected a virtual collection");
       }
     } catch (EmptyResultDataAccessException e) {
-      // does this deployment allow for virtual collections?
-      // TODO AJ-1630: enable this error for data-plane WDS, which does not allow virtual
-      // collections
-      /*
       if (!tenancyProperties.getAllowVirtualCollections()) {
         throw new MissingObjectException("Collection");
       }
-      */
     }
 
     // safety check: if we found a workspace id in the db, it indicates we are in a data-plane

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceGetWorkspaceIdTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceGetWorkspaceIdTest.java
@@ -1,5 +1,6 @@
 package org.databiosphere.workspacedataservice.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -8,6 +9,7 @@ import static org.mockito.Mockito.when;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.dao.CollectionDao;
+import org.databiosphere.workspacedataservice.service.model.exception.MissingObjectException;
 import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.junit.jupiter.api.BeforeEach;
@@ -61,9 +63,14 @@ class CollectionServiceGetWorkspaceIdTest extends TestBase {
         .thenThrow(new EmptyResultDataAccessException("unit test intentional exception", 1));
 
     CollectionId collectionId = CollectionId.of(UUID.randomUUID());
-    // expect getWorkspaceId to return the collection id as the workspace id; this is a virtual
-    // collection
-    assertEquals(collectionId.id(), collectionService.getWorkspaceId(collectionId).id());
+
+    // Act / assert
+    MissingObjectException actual =
+        assertThrows(
+            MissingObjectException.class, () -> collectionService.getWorkspaceId(collectionId));
+
+    // Assert
+    assertThat(actual).hasMessageContaining("Collection does not exist");
   }
 
   @Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/JobServiceDataPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/JobServiceDataPlaneTest.java
@@ -155,11 +155,11 @@ class JobServiceDataPlaneTest extends JobServiceBaseTest {
     when(samDao.hasReadWorkspacePermission(workspaceId)).thenReturn(true);
 
     // Act / assert
-    AuthenticationMaskableException actual =
-        assertThrows(AuthenticationMaskableException.class, () -> jobService.getJob(jobId));
+    MissingObjectException actual =
+        assertThrows(MissingObjectException.class, () -> jobService.getJob(jobId));
 
     // Assert
-    assertEquals("Job", actual.getObjectType());
+    assertThat(actual).hasMessageContaining("Collection does not exist");
   }
 
   // ==================================================


### PR DESCRIPTION
[AJ-1630](https://broadworkbench.atlassian.net/browse/AJ-1630): In the data-plane, when `twds.tenancy.allow-virtual-collections` is false, `CollectionService` should throw an error if a collection is missing.

[AJ-1630]: https://broadworkbench.atlassian.net/browse/AJ-1630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ