### PR TITLE
AJ-1633: Finish wiring up `deleteCollection`

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/config/TenancyProperties.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/config/TenancyProperties.java
@@ -7,6 +7,7 @@ package org.databiosphere.workspacedataservice.config;
 public class TenancyProperties {
   private boolean allowVirtualCollections;
   private boolean requireEnvWorkspace;
+  private boolean enforceCollectionsMatchWorkspaceId;
 
   /**
    * Does this WDS deployment allow virtual collections? That is, does it allow for a collection
@@ -26,8 +27,7 @@ public class TenancyProperties {
 
   /**
    * Does this WDS deployment require a $WORKSPACE_ID environment variable to be set? When this env
-   * var is set, the WDS deployment is tied to a single workspace, and all collections within this
-   * WDS will be associated with that workspace.
+   * var is set, the WDS deployment is tied to a single workspace.
    *
    * @return Does this WDS deployment require a $WORKSPACE_ID environment variable to be set?
    */
@@ -37,5 +37,19 @@ public class TenancyProperties {
 
   void setRequireEnvWorkspace(boolean requireEnvWorkspace) {
     this.requireEnvWorkspace = requireEnvWorkspace;
+  }
+
+  void setEnforceCollectionsMatchWorkspaceId(boolean enforceCollectionsMatchWorkspaceId) {
+    this.enforceCollectionsMatchWorkspaceId = enforceCollectionsMatchWorkspaceId;
+  }
+
+  /**
+   * Does this WDS deployment enforce that all collections within this WDS are associated with the
+   * $WORKSPACE_ID environment variable?
+   *
+   * @return Does this WDS deployment enforce that all collections must match $WORKSPACE_ID?
+   */
+  public boolean getEnforceCollectionsMatchWorkspaceId() {
+    return enforceCollectionsMatchWorkspaceId;
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamAuthorizationDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamAuthorizationDao.java
@@ -25,32 +25,6 @@ public class HttpSamAuthorizationDao implements SamAuthorizationDao {
   }
 
   /**
-   * Check if the current user has permission to create a collection by writing to the "workspace"
-   * resource in Sam. Implemented as a check for write permission on the workspace which will
-   * contain this collection.
-   *
-   * @return true if the user has permission
-   */
-  @Override
-  public boolean hasCreateCollectionPermission() {
-    return hasPermission(ACTION_WRITE, "Sam.hasCreateCollectionPermission");
-  }
-
-  /**
-   * Check if the current user has permission to delete a collection from the "workspace" resource
-   * in Sam. Implemented as a check for delete permission on the resource.
-   *
-   * @return true if the user has permission
-   */
-  @Override
-  public boolean hasDeleteCollectionPermission() {
-    // TODO(jladieu): rather than check `ACTION_DELETE` on workspace this should check
-    //  `ACTION_WRITE`; this method should cease to exist and be replaced by a method in
-    //  `CollectionService` that calls `hasWriteWorkspacePermission`
-    return hasPermission(ACTION_DELETE, "Sam.hasDeleteCollectionPermission");
-  }
-
-  /**
    * Check if the current user has permission to write to the "workspace" resource from Sam.
    * Implemented as a check for write permission on the resource.
    *
@@ -74,16 +48,12 @@ public class HttpSamAuthorizationDao implements SamAuthorizationDao {
   /** check for permission using the configured {@link WorkspaceId} */
   private boolean hasPermission(String action, String loggerHint) {
     LOGGER.debug(
-        "Checking Sam permission for {}/{}/{} ...",
-        SamAuthorizationDao.RESOURCE_NAME_WORKSPACE,
-        workspaceId,
-        action);
+        "Checking Sam permission for {}/{}/{} ...", RESOURCE_NAME_WORKSPACE, workspaceId, action);
     RestCall<Boolean> samFunction =
         () ->
             samClientFactory
                 .getResourcesApi()
-                .resourcePermissionV2(
-                    SamAuthorizationDao.RESOURCE_NAME_WORKSPACE, workspaceId.toString(), action);
+                .resourcePermissionV2(RESOURCE_NAME_WORKSPACE, workspaceId.toString(), action);
     return restClientRetry.withRetryAndErrorHandling(samFunction, loggerHint);
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/SamAuthorizationDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/SamAuthorizationDao.java
@@ -7,27 +7,8 @@ public interface SamAuthorizationDao {
   /** Sam action name for write permission */
   String ACTION_WRITE = "write";
 
-  /** Sam action name for delete permission */
-  String ACTION_DELETE = "delete";
-
   /** Sam action name for read permission */
   String ACTION_READ = "read";
-
-  /**
-   * Check if the current user has permission to create a collection associated with a Sam workspace
-   * resource
-   *
-   * @return true if the user has permission
-   */
-  boolean hasCreateCollectionPermission();
-
-  /**
-   * Check if the current user has permission to delete a collection associated with a Sam workspace
-   * resource
-   *
-   * @return true if the user has permission
-   */
-  boolean hasDeleteCollectionPermission();
 
   /**
    * Check if the current user has permission to read the workspace resource from Sam

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/SamAuthorizationDaoFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/SamAuthorizationDaoFactory.java
@@ -1,6 +1,5 @@
 package org.databiosphere.workspacedataservice.sam;
 
-import static org.databiosphere.workspacedataservice.sam.SamAuthorizationDao.ACTION_DELETE;
 import static org.databiosphere.workspacedataservice.sam.SamAuthorizationDao.ACTION_READ;
 import static org.databiosphere.workspacedataservice.sam.SamAuthorizationDao.ACTION_WRITE;
 
@@ -27,7 +26,7 @@ public class SamAuthorizationDaoFactory {
         "Sam integration will query type={}, resourceId={}, actions={}",
         SamAuthorizationDao.RESOURCE_NAME_WORKSPACE,
         workspaceId,
-        Set.of(ACTION_READ, ACTION_WRITE, ACTION_DELETE));
+        Set.of(ACTION_READ, ACTION_WRITE));
     return new HttpSamAuthorizationDao(samClientFactory, restClientRetry, workspaceId);
   }
 }

--- a/service/src/main/resources/application-control-plane.yml
+++ b/service/src/main/resources/application-control-plane.yml
@@ -5,7 +5,8 @@ twds:
     allow-virtual-collections: true
     # Should this WDS deployment require a valid $WORKSPACE_ID env var?
     require-env-workspace: false
-
+    # Should this WDS deployment require collections to belong to the workspace with $WORKSPACE_ID?
+    enforce-collections-match-workspace-id: false
   data-import:
     batch-write-record-sink: "rawls"
     project-id: ${SERVICE_GOOGLE_PROJECT}

--- a/service/src/main/resources/application-data-plane.yml
+++ b/service/src/main/resources/application-data-plane.yml
@@ -5,6 +5,8 @@ twds:
     allow-virtual-collections: false
     # Should this WDS deployment require a valid $WORKSPACE_ID env var?
     require-env-workspace: true
+    # Should this WDS deployment require collections to belong to the workspace with $WORKSPACE_ID?
+    enforce-collections-match-workspace-id: true
   data-import:
     batch-write-record-sink: "wds"
 

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -132,6 +132,7 @@ twds:
   tenancy:
     allow-virtual-collections: false
     require-env-workspace: true
+    enforce-collections-match-workspace-id: true
   data-import:
     batch-write-record-sink: "wds"
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/config/TwdsPropertiesControlPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/config/TwdsPropertiesControlPlaneTest.java
@@ -49,4 +49,9 @@ class TwdsPropertiesControlPlaneTest {
   void requireEnvWorkspace() {
     assertFalse(tenancyProperties.getRequireEnvWorkspace());
   }
+
+  @Test
+  void enforceCollectionsMatchWorkspaceId() {
+    assertFalse(tenancyProperties.getEnforceCollectionsMatchWorkspaceId());
+  }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/config/TwdsPropertiesDataPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/config/TwdsPropertiesDataPlaneTest.java
@@ -47,4 +47,9 @@ class TwdsPropertiesDataPlaneTest {
   void requireEnvWorkspace() {
     assertTrue(tenancyProperties.getRequireEnvWorkspace());
   }
+
+  @Test
+  void enforceCollectionsMatchWorkspaceId() {
+    assertTrue(tenancyProperties.getEnforceCollectionsMatchWorkspaceId());
+  }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/MockCollectionDao.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/MockCollectionDao.java
@@ -71,7 +71,7 @@ public class MockCollectionDao implements CollectionDao {
   }
 
   @Override
-  public WorkspaceId getWorkspaceId(CollectionId instanceId) {
+  public WorkspaceId getWorkspaceId(CollectionId collectionId) {
     return workspaceId;
   }
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/MockCollectionDao.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/MockCollectionDao.java
@@ -14,9 +14,10 @@ public class MockCollectionDao implements CollectionDao {
 
   // backing "database" for this mock
   private final Set<UUID> collections = ConcurrentHashMap.newKeySet();
+  private final WorkspaceId workspaceId;
 
-  public MockCollectionDao() {
-    super();
+  public MockCollectionDao(WorkspaceId workspaceId) {
+    this.workspaceId = workspaceId;
   }
 
   @Override
@@ -71,7 +72,7 @@ public class MockCollectionDao implements CollectionDao {
 
   @Override
   public WorkspaceId getWorkspaceId(CollectionId instanceId) {
-    return WorkspaceId.of(instanceId.id());
+    return workspaceId;
   }
 
   // convenience for unit tests: removes all collections

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/MockCollectionDaoConfig.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/MockCollectionDaoConfig.java
@@ -1,5 +1,7 @@
 package org.databiosphere.workspacedataservice.dao;
 
+import org.databiosphere.workspacedataservice.annotations.SingleTenant;
+import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -10,7 +12,7 @@ public class MockCollectionDaoConfig {
   @Bean
   @Profile("mock-collection-dao")
   @Primary
-  CollectionDao mockCollectionDao() {
-    return new MockCollectionDao();
+  CollectionDao mockCollectionDao(@SingleTenant WorkspaceId workspaceId) {
+    return new MockCollectionDao(workspaceId);
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/pact/SamPactTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/pact/SamPactTest.java
@@ -97,13 +97,13 @@ class SamPactTest {
   }
 
   @Pact(consumer = "wds", provider = "sam")
-  public RequestResponsePact deletePermissionPact(PactDslWithProvider builder) {
+  public RequestResponsePact readPermissionPact(PactDslWithProvider builder) {
     return builder
-        .given("user has delete permission", Map.of("dummyResourceId", dummyResourceId))
-        .uponReceiving("a request for delete permission on workspace")
+        .given("user has read permission", Map.of("dummyResourceId", dummyResourceId))
+        .uponReceiving("a request for read permission on workspace")
         .pathFromProviderState(
-            "/api/resources/v2/workspace/${dummyResourceId}/action/delete",
-            String.format("/api/resources/v2/workspace/%s/action/delete", dummyResourceId))
+            "/api/resources/v2/workspace/${dummyResourceId}/action/read",
+            String.format("/api/resources/v2/workspace/%s/action/read", dummyResourceId))
         .method("GET")
         .willRespondWith()
         .status(200)
@@ -112,13 +112,13 @@ class SamPactTest {
   }
 
   @Pact(consumer = "wds", provider = "sam")
-  public RequestResponsePact deleteNoPermissionPact(PactDslWithProvider builder) {
+  public RequestResponsePact readNoPermissionPact(PactDslWithProvider builder) {
     return builder
-        .given("user does not have delete permission", Map.of("dummyResourceId", dummyResourceId))
-        .uponReceiving("a request for delete permission on workspace")
+        .given("user does not have read permission", Map.of("dummyResourceId", dummyResourceId))
+        .uponReceiving("a request for read permission on workspace")
         .pathFromProviderState(
-            "/api/resources/v2/workspace/${dummyResourceId}/action/delete",
-            String.format("/api/resources/v2/workspace/%s/action/delete", dummyResourceId))
+            "/api/resources/v2/workspace/${dummyResourceId}/action/read",
+            String.format("/api/resources/v2/workspace/%s/action/read", dummyResourceId))
         .method("GET")
         .willRespondWith()
         .status(200)
@@ -212,21 +212,21 @@ class SamPactTest {
   }
 
   @Test
-  @PactTestFor(pactMethod = "deleteNoPermissionPact", pactVersion = PactSpecVersion.V3)
-  void testSamDeleteNoPermission(MockServer mockServer) {
+  @PactTestFor(pactMethod = "readNoPermissionPact", pactVersion = PactSpecVersion.V3)
+  void testSamReadNoPermission(MockServer mockServer) {
     SamAuthorizationDao samAuthorizationDao =
         getSamAuthorizationDao(mockServer, dummyWorkspaceId());
 
-    assertFalse(samAuthorizationDao.hasDeleteCollectionPermission());
+    assertFalse(samAuthorizationDao.hasReadWorkspacePermission());
   }
 
   @Test
-  @PactTestFor(pactMethod = "deletePermissionPact", pactVersion = PactSpecVersion.V3)
-  void testSamDeletePermission(MockServer mockServer) {
+  @PactTestFor(pactMethod = "readPermissionPact", pactVersion = PactSpecVersion.V3)
+  void testSamReadPermission(MockServer mockServer) {
     SamAuthorizationDao samAuthorizationDao =
         getSamAuthorizationDao(mockServer, dummyWorkspaceId());
 
-    assertTrue(samAuthorizationDao.hasDeleteCollectionPermission());
+    assertTrue(samAuthorizationDao.hasReadWorkspacePermission());
   }
 
   @Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/sam/MockSamAuthorizationDao.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/sam/MockSamAuthorizationDao.java
@@ -26,16 +26,6 @@ public class MockSamAuthorizationDao implements SamAuthorizationDao {
   }
 
   @Override
-  public boolean hasCreateCollectionPermission() {
-    return defaultReturnValue;
-  }
-
-  @Override
-  public boolean hasDeleteCollectionPermission() {
-    return defaultReturnValue;
-  }
-
-  @Override
   public boolean hasReadWorkspacePermission() {
     return defaultReturnValue;
   }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceGetWorkspaceIdTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceGetWorkspaceIdTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.dao.CollectionDao;
+import org.databiosphere.workspacedataservice.service.model.exception.CollectionException;
 import org.databiosphere.workspacedataservice.service.model.exception.MissingObjectException;
 import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
@@ -74,7 +75,7 @@ class CollectionServiceGetWorkspaceIdTest extends TestBase {
   }
 
   @Test
-  void mismatchingWorkspaceId() {
+  void nonDefaultWorkspaceId() {
     // collection dao returns a value not equal to the workspace id set in $WORKSPACE_ID
     WorkspaceId mismatchingWorkspaceId = WorkspaceId.of(UUID.randomUUID());
     when(mockCollectionDao.getWorkspaceId(any(CollectionId.class)))
@@ -82,6 +83,6 @@ class CollectionServiceGetWorkspaceIdTest extends TestBase {
 
     CollectionId collectionId = CollectionId.of(UUID.randomUUID());
     // expect getWorkspaceId to throw, since it found an unexpected workspace id
-    assertThat(collectionService.getWorkspaceId(collectionId)).isEqualTo(mismatchingWorkspaceId);
+    assertThrows(CollectionException.class, () -> collectionService.getWorkspaceId(collectionId));
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceGetWorkspaceIdTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceGetWorkspaceIdTest.java
@@ -74,13 +74,14 @@ class CollectionServiceGetWorkspaceIdTest extends TestBase {
   }
 
   @Test
-  void unexpectedWorkspaceId() {
+  void mismatchingWorkspaceId() {
     // collection dao returns a value not equal to the workspace id set in $WORKSPACE_ID
+    WorkspaceId mismatchingWorkspaceId = WorkspaceId.of(UUID.randomUUID());
     when(mockCollectionDao.getWorkspaceId(any(CollectionId.class)))
-        .thenReturn(WorkspaceId.of(UUID.randomUUID()));
+        .thenReturn(mismatchingWorkspaceId);
 
     CollectionId collectionId = CollectionId.of(UUID.randomUUID());
     // expect getWorkspaceId to throw, since it found an unexpected workspace id
-    assertThrows(RuntimeException.class, () -> collectionService.getWorkspaceId(collectionId));
+    assertThat(collectionService.getWorkspaceId(collectionId)).isEqualTo(mismatchingWorkspaceId);
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceNoPermissionSamTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceNoPermissionSamTest.java
@@ -61,7 +61,6 @@ class CollectionServiceNoPermissionSamTest extends TestBase {
 
   @Test
   void testDeleteCollectionNoPermission() throws ApiException {
-
     // return the mock ResourcesApi from the mock SamClientFactory
     given(mockSamClientFactory.getResourcesApi()).willReturn(mockResourcesApi);
 
@@ -77,7 +76,7 @@ class CollectionServiceNoPermissionSamTest extends TestBase {
     assertThrows(
         AuthorizationException.class,
         () -> collectionService.deleteCollection(collectionId, VERSION),
-        "deleteCollection should throw if caller does not have delete permission to the workspace resource in Sam");
+        "deleteCollection should throw if caller does not have write permission to the workspace resource in Sam");
     List<UUID> allCollections = collectionService.listCollections(VERSION);
     assertTrue(allCollections.contains(collectionId), "should not have deleted the collection.");
   }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceSamExceptionTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceSamExceptionTest.java
@@ -2,6 +2,7 @@ package org.databiosphere.workspacedataservice.service;
 
 import static org.databiosphere.workspacedataservice.service.RecordUtils.VERSION;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.TestInstance.*;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -38,19 +39,25 @@ import org.springframework.test.context.ActiveProfiles;
  * CollectionService.deleteCollection.
  *
  * <p>Both createCollection and deleteCollection call Sam. If Sam returns an exception, we want
- * createCollection and deleteCollection to respond appropriately: - if Sam returns an ApiException
- * with status code 401, they should throw AuthenticationException. - if Sam returns an ApiException
- * with status code 403, they should throw AuthorizationException. - if Sam returns an ApiException
- * with a well-known status code like 404 or 503, they should throw a RestException with the same
- * status code. - if Sam returns an ApiException with a non-standard status code such as 0, which
- * happens in the case of a connection failure, they should throw a RestException with a 500 error
- * code. - if Sam returns some other exception such as NullPointerException, they should throw a
- * RestException with a 500 error code.
+ * createCollection and deleteCollection to respond appropriately:
+ *
+ * <ul>
+ *   <li>if Sam returns an ApiException with status code 401, they should throw
+ *       AuthenticationException.
+ *   <li>if Sam returns an ApiException with status code 403, they should throw
+ *       AuthorizationException.
+ *   <li>if Sam returns an ApiException with a well-known status code like 404 or 503, they should
+ *       throw a RestException with the same status code.
+ *   <li>if Sam returns an ApiException with a non-standard status code such as 0, which happens in
+ *       the case of a connection failure, they should throw a RestException with a 500 error code.
+ *   <li>if Sam returns some other exception such as NullPointerException, they should throw a
+ *       RestException with a 500 error code.
+ * </ul>
  */
 @ActiveProfiles(profiles = "mock-collection-dao")
 @DirtiesContext
 @SpringBootTest
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestInstance(Lifecycle.PER_CLASS)
 class CollectionServiceSamExceptionTest extends TestBase {
 
   @Autowired private CollectionService collectionService;
@@ -248,7 +255,7 @@ class CollectionServiceSamExceptionTest extends TestBase {
         assertThrows(
             RestException.class,
             () -> collectionService.deleteCollection(collectionId, VERSION),
-            "deleteCollection should throw if caller does not have delete permission to the workspace resource in Sam");
+            "deleteCollection should throw if caller does not have write permission to the workspace resource in Sam");
     assertEquals(
         expectedSamExceptionCode,
         samException.getStatusCode().value(),

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceSamTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceSamTest.java
@@ -124,7 +124,7 @@ class CollectionServiceSamTest extends TestBase {
         .resourcePermissionV2(
             SamAuthorizationDao.RESOURCE_NAME_WORKSPACE,
             parentWorkspaceId,
-            SamAuthorizationDao.ACTION_DELETE);
+            SamAuthorizationDao.ACTION_WRITE);
 
     // and that should be the only call we made to Sam
     verifyNoMoreInteractions(mockResourcesApi);

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceDataPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceDataPlaneTest.java
@@ -17,6 +17,7 @@ import org.databiosphere.workspacedataservice.sam.MockSamAuthorizationDao;
 import org.databiosphere.workspacedataservice.sam.SamAuthorizationDao;
 import org.databiosphere.workspacedataservice.sam.SamAuthorizationDaoFactory;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthenticationMaskableException;
+import org.databiosphere.workspacedataservice.service.model.exception.CollectionException;
 import org.databiosphere.workspacedataservice.service.model.exception.MissingObjectException;
 import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
@@ -97,7 +98,7 @@ class ImportServiceDataPlaneTest {
 
   /* collection exists, workspace does not match env var */
   @Test
-  void nonDefaultCollection() {
+  void unexpectedWorkspaceId() {
     // ARRANGE
     WorkspaceId nonMatchingWorkspaceId = WorkspaceId.of(UUID.randomUUID());
     // collection dao says the collection exists and returns an unexpected workspace id
@@ -111,7 +112,8 @@ class ImportServiceDataPlaneTest {
     // exception
     UUID collectionUuid = collectionId.id();
     // perform the import request
-    assertDoesNotThrow(() -> importService.createImport(collectionUuid, importRequest));
+    assertThrows(
+        CollectionException.class, () -> importService.createImport(collectionUuid, importRequest));
   }
 
   /* collection does not exist */

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/JobServiceDataPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/JobServiceDataPlaneTest.java
@@ -20,6 +20,7 @@ import org.databiosphere.workspacedataservice.sam.MockSamAuthorizationDao;
 import org.databiosphere.workspacedataservice.sam.SamAuthorizationDao;
 import org.databiosphere.workspacedataservice.sam.SamAuthorizationDaoFactory;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthenticationMaskableException;
+import org.databiosphere.workspacedataservice.service.model.exception.CollectionException;
 import org.databiosphere.workspacedataservice.service.model.exception.MissingObjectException;
 import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
@@ -125,10 +126,10 @@ class JobServiceDataPlaneTest extends JobServiceBaseTest {
     stubReadWorkspacePermission(nonMatchingWorkspaceId).thenReturn(true);
 
     // Act / assert
-    GenericJobServerModel actual = jobService.getJob(jobId);
+    Exception actual = assertThrows(CollectionException.class, () -> jobService.getJob(jobId));
 
     // Assert
-    assertThat(actual).isEqualTo(expectedJob);
+    assertThat(actual.getMessage()).startsWith("Found unexpected workspaceId for collection");
   }
 
   /**
@@ -244,12 +245,13 @@ class JobServiceDataPlaneTest extends JobServiceBaseTest {
         .thenReturn(makeJobList(collectionId, 4));
 
     // Act / assert
-    List<GenericJobServerModel> actual =
-        jobService.getJobsForCollection(collectionId, Optional.of(allStatuses));
+    Exception actual =
+        assertThrows(
+            CollectionException.class,
+            () -> jobService.getJobsForCollection(collectionId, Optional.of(allStatuses)));
 
     // Assert
-    // this is verifying workspaceId behavior only; only smoke-testing correctness of the result
-    assertThat(actual).hasSize(4);
+    assertThat(actual.getMessage()).startsWith("Found unexpected workspaceId for collection");
   }
 
   // ==================================================

--- a/service/src/test/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerBeanTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerBeanTest.java
@@ -12,17 +12,8 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.locks.Lock;
-import org.databiosphere.workspacedataservice.activitylog.ActivityLoggerConfig;
 import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.dao.*;
-import org.databiosphere.workspacedataservice.leonardo.LeonardoConfig;
-import org.databiosphere.workspacedataservice.retry.RestClientRetry;
-import org.databiosphere.workspacedataservice.sam.MockSamClientFactoryConfig;
-import org.databiosphere.workspacedataservice.sam.SamConfig;
-import org.databiosphere.workspacedataservice.service.BackupRestoreService;
-import org.databiosphere.workspacedataservice.sourcewds.WorkspaceDataServiceConfig;
-import org.databiosphere.workspacedataservice.storage.AzureBlobStorage;
-import org.databiosphere.workspacedataservice.workspacemanager.WorkspaceManagerConfig;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -47,25 +38,11 @@ import org.springframework.test.context.TestPropertySource;
 @TestPropertySource(
     properties = {"twds.instance.workspace-id=90e1b179-9f83-4a6f-a8c2-db083df4cd03"})
 @DirtiesContext
-@SpringBootTest(
-    classes = {
-      CollectionInitializerConfig.class,
-      MockCollectionDaoConfig.class,
-      MockRestoreDaoConfig.class,
-      MockBackupDaoConfig.class,
-      LeonardoConfig.class,
-      WorkspaceDataServiceConfig.class,
-      MockCloneDaoConfig.class,
-      BackupRestoreService.class,
-      AzureBlobStorage.class,
-      WorkspaceManagerConfig.class,
-      ActivityLoggerConfig.class,
-      SamConfig.class,
-      MockSamClientFactoryConfig.class,
-      RestClientRetry.class
-    })
+@SpringBootTest
 class CollectionInitializerBeanTest extends TestBase {
-
+  // Don't run the CollectionInitializer on startup, so this test can start with a clean slate.
+  // By making an (empty) mock bean to replace CollectionInitializer, we ensure it is a noop.
+  @MockBean CollectionInitializer collectionInitializer;
   @Autowired CollectionInitializerBean collectionInitializerBean;
   @MockBean JdbcLockRegistry registry;
   @SpyBean CollectionDao collectionDao;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerNoWorkspaceIdTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerNoWorkspaceIdTest.java
@@ -8,19 +8,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.context.annotation.FilterType.*;
 
 import java.util.concurrent.locks.Lock;
-import org.databiosphere.workspacedataservice.activitylog.ActivityLoggerConfig;
 import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.dao.*;
-import org.databiosphere.workspacedataservice.leonardo.LeonardoConfig;
-import org.databiosphere.workspacedataservice.retry.RestClientRetry;
-import org.databiosphere.workspacedataservice.sam.MockSamClientFactoryConfig;
-import org.databiosphere.workspacedataservice.sam.SamConfig;
-import org.databiosphere.workspacedataservice.service.BackupRestoreService;
-import org.databiosphere.workspacedataservice.sourcewds.WorkspaceDataServiceConfig;
-import org.databiosphere.workspacedataservice.storage.AzureBlobStorage;
-import org.databiosphere.workspacedataservice.workspacemanager.WorkspaceManagerConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,37 +21,18 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.integration.jdbc.lock.JdbcLockRegistry;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 
-@ActiveProfiles({
-  "mock-collection-dao",
-  "mock-backup-dao",
-  "mock-restore-dao",
-  "mock-clone-dao",
-  "local-cors"
-})
 @TestPropertySource(properties = {"twds.instance.workspace-id="})
 @DirtiesContext
-@SpringBootTest(
-    classes = {
-      CollectionInitializerConfig.class,
-      MockCollectionDaoConfig.class,
-      MockRestoreDaoConfig.class,
-      MockBackupDaoConfig.class,
-      LeonardoConfig.class,
-      WorkspaceDataServiceConfig.class,
-      MockCloneDaoConfig.class,
-      BackupRestoreService.class,
-      AzureBlobStorage.class,
-      WorkspaceManagerConfig.class,
-      ActivityLoggerConfig.class,
-      SamConfig.class,
-      MockSamClientFactoryConfig.class,
-      RestClientRetry.class
-    })
+@SpringBootTest
 class CollectionInitializerNoWorkspaceIdTest extends TestBase {
+  // Don't run the CollectionInitializer on startup, so this test can start with a clean slate.
+  // By making an (empty) mock bean to replace CollectionInitializer, we ensure it is a noop.
+  @MockBean CollectionInitializer collectionInitializer;
 
+  // Don't run StartupConfig to bypass the intentional crash on missing WORKSPACE_ID
+  @MockBean StartupConfig startupConfig;
   @Autowired CollectionInitializerBean collectionInitializerBean;
   @MockBean JdbcLockRegistry registry;
   @SpyBean CollectionDao collectionDao;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerNoWorkspaceIdTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerNoWorkspaceIdTest.java
@@ -8,11 +8,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.springframework.context.annotation.FilterType.*;
 
 import java.util.concurrent.locks.Lock;
 import org.databiosphere.workspacedataservice.common.TestBase;
-import org.databiosphere.workspacedataservice.dao.*;
+import org.databiosphere.workspacedataservice.dao.CollectionDao;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvErrorMessageTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvErrorMessageTest.java
@@ -23,10 +23,16 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 
 @ActiveProfiles(profiles = "mock-sam")
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestPropertySource(
+    properties = {
+      "twds.instance.workspace-id=123e4567-e89b-12d3-a456-426614174000",
+      "twds.tenancy.enforce-collections-match-workspace-id=false",
+    })
 class TsvErrorMessageTest extends TestBase {
 
   @Autowired CollectionService collectionService;


### PR DESCRIPTION
For [AJ-1633](https://broadworkbench.atlassian.net/browse/AJ-1633), branch based off https://github.com/DataBiosphere/terra-workspace-data-service/pull/594

* Stop checking `delete` workspace permission to determine if it's ok to delete a collection, instead check `write` workspace.
* Eliminate redundant `SamAuthorizationDao` methods which are subsumed by `SamAuthorizationDao#hasWriteWorkspacePermission`
* Adjust `SamPactTest` to no longer verify `delete` interaction and instead verify previously untested `read` interaction.
* Adjust a bunch of tests which were verifying the safety check behavior which is now removed.
* This allows wiring up `deleteCollection` to correctly look up the `WorkspaceId` for the collection and then check for `write` permission.
* Add `tenancy.enforce-collections-match-workspace-id` which is enabled on `data-plane` but can be disabled for stubborn tests that violate the rule it is checking.

[AJ-1633]: https://broadworkbench.atlassian.net/browse/AJ-1633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ