### PR TITLE
AJ-1665: Enable `@NonNullApi` throughout.

### DIFF
--- a/scripts/generate-package-info.sh
+++ b/scripts/generate-package-info.sh
@@ -69,6 +69,12 @@ find . -type f -name "*.java" | sed 's|/[^/]*$||' | sort -u | while read -r dir;
     # Convert directory to package name using Bash parameter expansion
     package_name=${clean_dir//\//.}
 
+    # Skip directories whose package name includes 'generated'
+    if [[ $package_name == *"generated"* ]]; then
+        [[ $VERBOSE -eq 1 ]] && echo "Skipping generated package: $package_name"
+        continue
+    fi
+
     # Call function to generate package-info.java
     generate_package_info "$START_DIR_ABS/$clean_dir" "$package_name" "$FORCE" "$VERBOSE"
 done

--- a/scripts/generate-package-info.sh
+++ b/scripts/generate-package-info.sh
@@ -49,9 +49,11 @@ generate_package_info() {
     # Generate package-info.java content
     {
       echo "@NonNullApi"
+      echo "@NonNullFields"
       echo "package $package_name;"
       echo ""
       echo "import org.springframework.lang.NonNullApi;"
+      echo "import org.springframework.lang.NonNullFields;"
     } > "$package_info_path"
     echo "Generated package-info.java for package $package_name in $target_dir"
 }

--- a/scripts/generate-package-info.sh
+++ b/scripts/generate-package-info.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# Initialize variables
+START_DIR=""
+FORCE=0
+VERBOSE=0
+
+# Parse command-line arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        -f|--force) FORCE=1; shift ;;
+        -v|--verbose) VERBOSE=1; shift ;;
+        *) if [[ -z "$START_DIR" ]]; then START_DIR="$1"; else echo "Unknown parameter passed: $1"; exit 1; fi; shift ;;
+    esac
+done
+
+# Check if the starting directory is provided
+if [[ -z "$START_DIR" ]]; then
+    echo "Usage: $0 <starting-directory> [-f|--force] [-v|--verbose]"
+    exit 1
+fi
+
+# Convert absolute path to relative path based on starting directory
+cd "$START_DIR" || exit
+START_DIR_ABS=$(pwd)
+
+
+# Function to generate package-info.java
+generate_package_info() {
+    local target_dir=$1
+    local package_name=$2
+    local force=$3
+    local verbose=$4
+
+    # Ensure target directory exists (sanity check, though not strictly necessary)
+    mkdir -p "$target_dir"
+
+    # Define the path for the package-info.java file
+    local package_info_path="${target_dir}/package-info.java"
+
+    # Check if package-info.java exists and if force is not enabled, skip
+    if [[ -f "$package_info_path" && $force -eq 0 ]]; then
+      if [[ $verbose -eq 1 ]]; then
+          echo "package-info.java already exists in $target_dir, skipping..."
+      fi
+      return
+    fi
+
+    # Generate package-info.java content
+    {
+      echo "@NonNullApi"
+      echo "package $package_name;"
+      echo ""
+      echo "import org.springframework.lang.NonNullApi;"
+    } > "$package_info_path"
+    echo "Generated package-info.java for package $package_name in $target_dir"
+}
+
+# Find directories containing .java files, generate package-info.java
+find . -type f -name "*.java" | sed 's|/[^/]*$||' | sort -u | while read -r dir; do
+    # Skip if no directory (current directory case)
+    [[ -z "$dir" || "$dir" == "." ]] && continue
+
+    # Remove leading './' using Bash parameter expansion
+    clean_dir=${dir#./}
+
+    # Convert directory to package name using Bash parameter expansion
+    package_name=${clean_dir//\//.}
+
+    # Call function to generate package-info.java
+    generate_package_info "$START_DIR_ABS/$clean_dir" "$package_name" "$FORCE" "$VERBOSE"
+done
+
+echo "Completed generating package-info.java files."

--- a/service/src/main/java/bio/terra/common/db/package-info.java
+++ b/service/src/main/java/bio/terra/common/db/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package bio.terra.common.db;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/main/java/bio/terra/common/db/package-info.java
+++ b/service/src/main/java/bio/terra/common/db/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package bio.terra.common.db;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/main/java/bio/terra/common/retry/package-info.java
+++ b/service/src/main/java/bio/terra/common/retry/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package bio.terra.common.retry;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/main/java/bio/terra/common/retry/package-info.java
+++ b/service/src/main/java/bio/terra/common/retry/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package bio.terra.common.retry;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/main/java/bio/terra/common/retry/transaction/package-info.java
+++ b/service/src/main/java/bio/terra/common/retry/transaction/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package bio.terra.common.retry.transaction;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/main/java/bio/terra/common/retry/transaction/package-info.java
+++ b/service/src/main/java/bio/terra/common/retry/transaction/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package bio.terra.common.retry.transaction;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.activitylog;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/activitylog/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.activitylog;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/annotations/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/annotations/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.annotations;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/annotations/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/annotations/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.annotations;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/cache/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/cache/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.cache;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/cache/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/cache/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.cache;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/config/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/config/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.config;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/config/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/config/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.config;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/ControllerConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/ControllerConfig.java
@@ -3,7 +3,6 @@ package org.databiosphere.workspacedataservice.controller;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-import org.springframework.lang.NonNull;
 import org.springframework.web.servlet.config.annotation.AsyncSupportConfigurer;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -26,7 +25,7 @@ public class ControllerConfig {
   public WebMvcConfigurer corsConfigurer() {
     return new WebMvcConfigurer() {
       @Override
-      public void addCorsMappings(@NonNull CorsRegistry registry) {
+      public void addCorsMappings(CorsRegistry registry) {
         registry
             .addMapping("/**")
             .allowedMethods("DELETE", "GET", "HEAD", "PATCH", "POST", "PUT")
@@ -40,7 +39,7 @@ public class ControllerConfig {
   public WebMvcConfigurer asyncConfigurer() {
     return new WebMvcConfigurer() {
       @Override
-      public void configureAsyncSupport(@NonNull AsyncSupportConfigurer configurer) {
+      public void configureAsyncSupport(AsyncSupportConfigurer configurer) {
         configurer.setDefaultTimeout(-1);
       }
     };

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.controller;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.controller;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.dao;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.dao;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.dataimport;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.dataimport;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/pfb/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/pfb/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.dataimport.pfb;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/pfb/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/pfb/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.dataimport.pfb;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.dataimport.tdr;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.dataimport.tdr;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/datarepo/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/datarepo/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.datarepo;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/datarepo/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/datarepo/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.datarepo;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/distributed/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/distributed/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.distributed;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/distributed/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/distributed/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.distributed;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/generated/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/generated/package-info.java
@@ -1,6 +1,0 @@
-@NonNullApi
-@NonNullFields
-package org.databiosphere.workspacedataservice.generated;
-
-import org.springframework.lang.NonNullApi;
-import org.springframework.lang.NonNullFields;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/generated/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/generated/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.generated;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/generated/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/generated/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.generated;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/jobexec/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/jobexec/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.jobexec;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/jobexec/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/jobexec/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.jobexec;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/leonardo/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/leonardo/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.leonardo;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/leonardo/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/leonardo/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.leonardo;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/logging/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/logging/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.logging;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/logging/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/logging/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.logging;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/metrics/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/metrics/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.metrics;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/metrics/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/metrics/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.metrics;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/process/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/process/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.process;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/process/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/process/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.process;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.recordsink;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.recordsink;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsource/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsource/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.recordsource;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsource/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsource/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.recordsource;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/retry/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/retry/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.retry;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/retry/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/retry/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.retry;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.sam;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.service.model.exception;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.service.model.exception;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.service.model;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.service.model;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.service;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.service;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/job/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/job/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.shared.model.job;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/job/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/job/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.shared.model.job;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.shared.model;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.shared.model;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.shared;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.shared;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sourcewds/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sourcewds/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.sourcewds;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sourcewds/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sourcewds/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.sourcewds;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/startup/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/startup/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.startup;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/startup/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/startup/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.startup;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/storage/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/storage/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.storage;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/storage/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/storage/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.storage;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/tsv/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/tsv/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.tsv;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/tsv/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/tsv/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.tsv;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/workspacemanager/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/workspacemanager/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.workspacemanager;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/workspacemanager/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/workspacemanager/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.workspacemanager;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.activitylog;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.activitylog;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/annotations/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/annotations/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.annotations;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/annotations/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/annotations/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.annotations;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/common/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/common/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.common;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/common/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/common/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.common;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/config/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/config/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.config;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/config/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/config/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.config;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.controller;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.controller;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.dao;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.dao;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.dataimport;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.dataimport;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.dataimport.pfb;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.dataimport.pfb;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.dataimport.tdr;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.dataimport.tdr;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/datarepo/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/datarepo/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.datarepo;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/datarepo/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/datarepo/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.datarepo;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/jobexec/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/jobexec/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.jobexec;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/jobexec/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/jobexec/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.jobexec;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/leonardo/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/leonardo/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.leonardo;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/leonardo/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/leonardo/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.leonardo;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/metrics/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/metrics/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.metrics;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/metrics/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/metrics/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.metrics;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/observability/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/observability/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.observability;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/observability/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/observability/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.observability;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/pact/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/pact/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.pact;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/pact/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/pact/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.pact;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/process/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/process/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.process;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/process/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/process/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.process;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.recordsink;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.recordsink;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/recordsource/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/recordsource/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.recordsource;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/recordsource/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/recordsource/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.recordsource;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/retry/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/retry/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.retry;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/retry/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/retry/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.retry;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/sam/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/sam/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.sam;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/sam/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/sam/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.sam;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/model/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/model/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.service.model;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/model/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/model/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.service.model;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.service;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.service;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/job/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/job/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.shared.model.job;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/job/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/job/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.shared.model.job;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.shared.model;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.shared.model;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/shared/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/shared/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.shared;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/shared/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/shared/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.shared;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/sourcewds/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/sourcewds/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.sourcewds;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/sourcewds/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/sourcewds/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.sourcewds;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/startup/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/startup/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.startup;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/startup/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/startup/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.startup;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/storage/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/storage/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.storage;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/storage/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/storage/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.storage;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.tsv;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.tsv;
+
+import org.springframework.lang.NonNullApi;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/workspacemanager/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/workspacemanager/package-info.java
@@ -1,4 +1,6 @@
 @NonNullApi
+@NonNullFields
 package org.databiosphere.workspacedataservice.workspacemanager;
 
 import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/workspacemanager/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/workspacemanager/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.databiosphere.workspacedataservice.workspacemanager;
+
+import org.springframework.lang.NonNullApi;


### PR DESCRIPTION
[AJ-1665](https://broadworkbench.atlassian.net/browse/AJ-1665)

* Add `@NonNullApi` & `@NonNullFields` to each package, giving the IDE a hint to guide all code to be explicit about nullability. ([Ref](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/lang/NonNullApi.html))
* Add `generate-package-info.sh` to automatically regenerate `package-info.java` files, which would otherwise be very tedious in the event we want to change their contents globally.
* Remove `@NonNull` annotation where used, it's assumed everywhere now!

Changes generated by running the following:
```
./scripts/generate-package-info.sh service/src/main/java --force
./scripts/generate-package-info.sh service/src/test/java --force
```
[AJ-1665]: https://broadworkbench.atlassian.net/browse/AJ-1665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ