### PR TITLE
AJ-1668: cwds openapi spec needs securitySchemes

### DIFF
--- a/service/src/main/resources/static/swagger/cwds-api-docs.yaml
+++ b/service/src/main/resources/static/swagger/cwds-api-docs.yaml
@@ -48,3 +48,10 @@ paths:
     $ref: 'openapi-docs.yaml#/paths/~1status'
   /version:
     $ref: 'openapi-docs.yaml#/paths/~1version'
+
+components:
+  # within each group, components should be listed alphabetically.
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer


### PR DESCRIPTION
[AJ-1668](https://broadworkbench.atlassian.net/browse/AJ-1668)

swagger-ui for cwds does not pop up a dialog to enter your bearer token. This PR fixes that.

[AJ-1668]: https://broadworkbench.atlassian.net/browse/AJ-1668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ