### PR TITLE
AJ-1649: Use non-deprecated `buildDirectory`

### DIFF
--- a/client/build.gradle
+++ b/client/build.gradle
@@ -39,7 +39,7 @@ boolean spotlessEnabled = true
 
 spotless {
     java {
-        targetExclude "${buildDir}/**"
+        targetExclude "${layout.buildDirectory.asFile}/**"
         targetExclude "**/swagger-code/**"
         targetExclude "**/generated/**"
         googleJavaFormat('1.18.1')

--- a/client/swagger.gradle
+++ b/client/swagger.gradle
@@ -12,7 +12,7 @@ openApiValidate {
 
 openApiGenerate {
     inputSpec = "$rootDir/service/src/main/resources/static/swagger/openapi-docs.yaml".toString()
-    outputDir = "$buildDir/generated".toString()
+    outputDir = layout.buildDirectory.dir("generated").get().asFile.toString()
     generatorName = 'java'
     library = 'okhttp-gson' // the default
     httpUserAgent = "wds-client/${project.version.toString().replace('-SNAPSHOT', '')}/java"

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -182,7 +182,7 @@ boolean spotlessEnabled = true
 
 spotless {
     java {
-        targetExclude "${buildDir}/**"
+        targetExclude "${layout.buildDirectory.asFile}/**"
         targetExclude "**/swagger-code/**"
         targetExclude "**/generated/**"
         googleJavaFormat('1.18.1')
@@ -238,7 +238,7 @@ jacocoTestReport {
 }
 
 test {
-    systemProperties['pact.rootDir'] = "$buildDir/pacts"
+    systemProperties['pact.rootDir'] = layout.buildDirectory.dir("pacts").get().asFile.toString()
     systemProperties['pact.provider.version'] = "$project.version"
     systemProperties['user.timezone'] = "UTC"
 }


### PR DESCRIPTION
Maintenance fix to use `layout.buildDirectory` instead of deprecated `buildDir`.