### PR TITLE
AJ-1565: wait for Quartz jobs to complete on shutdown

### DIFF
--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -99,6 +99,7 @@ spring:
     # It is also not cluster-aware; when WDS runs as a multi-replica cluster, Quartz jobs will
     # always run on the replica where they were created.
     job-store-type: memory
+    wait-for-jobs-to-complete-on-shutdown: true
 
 #   # activate the "local" profile to turn on CORS response headers,
 #   # which may be necessary for local development.


### PR DESCRIPTION
[AJ-1565](https://broadworkbench.atlassian.net/browse/AJ-1565)

Configure Quartz to attempt to wait for jobs to complete before WDS shuts down. This does not fully guarantee that jobs in flight will succeed.

When shutting down a pod, k8s will first send a SIGTERM. WDS will receive that, and after this PR will try to finish out Quartz jobs before going down. However, k8s will only wait a certain amount of time and then send a SIGKILL, which will interrupt anything in flight.

To more fully complete AJ-1565, we probably want to (in a separate PR):
- [ ] configure the `terminationGracePeriodSeconds` value for WDS pods
- [ ] configure a [`PreStop` hook](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks) which would ask k8s to wait before issuing a SIGTERM

[AJ-1565]: https://broadworkbench.atlassian.net/browse/AJ-1565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ