### PR TITLE
AJ-1586: pubsub needs to handle futures

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/pubsub/PubSub.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/pubsub/PubSub.java
@@ -1,5 +1,13 @@
 package org.databiosphere.workspacedataservice.pubsub;
 
 public interface PubSub {
-  void publish(String message);
+
+  /**
+   * Publish a GCP Pub/Sub message to a topic, wait for the message to complete publishing, and
+   * return the result of the publish call.
+   *
+   * @param message the message to publish
+   * @return result of the publish call
+   */
+  String publishSync(String message);
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSink.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSink.java
@@ -121,7 +121,7 @@ public class RawlsRecordSink implements RecordSink {
         String.format(
             "{\"workspaceId\": \"%s\", \"userEmail\": \"%s\", \"jobId\": \"%s\", \"upsertFile\": \"%s\", \"isUpsert\": \"true\", \"isCWDS\": \"true\"}",
             workspaceId, user, jobId, upsertFile);
-    pubSub.publish(message);
+    pubSub.publishSync(message);
   }
 
   private Entity toEntity(Record record) {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/pubsub/ImportPubSubTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/pubsub/ImportPubSubTest.java
@@ -13,6 +13,6 @@ public class ImportPubSubTest {
 
   @Test
   void testPubSub() {
-    importPubSub.publish("testing");
+    importPubSub.publishSync("testing");
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/pubsub/MockPubSub.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/pubsub/MockPubSub.java
@@ -2,7 +2,7 @@ package org.databiosphere.workspacedataservice.pubsub;
 
 public class MockPubSub implements PubSub {
 
-  public void publish(String message) {
-    // no-op
+  public String publishSync(String message) {
+    return this.getClass().getName();
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkTest.java
@@ -199,7 +199,7 @@ class RawlsRecordSinkTest extends TestBase {
 
     ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
 
-    verify(pubSub, times(1)).publish(argumentCaptor.capture());
+    verify(pubSub, times(1)).publishSync(argumentCaptor.capture());
 
     assertThat(argumentCaptor.getValue()).isEqualTo(expectedMessage);
   }


### PR DESCRIPTION
This is a PR into #596, not into `main`.

The pubsub library works in futures, not in synchronous calls. This is why tests look like they run forever. This PR handles the future and waits for it to complete, turning it into a synchronous call.

Note that the `ImportPubSubTest` is now failing, because publishing fails. Previously we never got the notification that publishing was failing.