### PR TITLE
AJ-1634: reduce log volume, refactor logging config

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresJobDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresJobDao.java
@@ -190,7 +190,7 @@ public class PostgresJobDao implements JobDao {
     // execute the update
     namedTemplate.update(sb.toString(), params);
 
-    logger.debug("Job {} is now in status {}", jobId, status);
+    logger.info("Job {} is now in status {}", jobId, status);
 
     // return the updated job
     return getJob(jobId);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/SamAuthorizationDaoFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/SamAuthorizationDaoFactory.java
@@ -23,7 +23,7 @@ public class SamAuthorizationDaoFactory {
   }
 
   public SamAuthorizationDao getSamAuthorizationDao(WorkspaceId workspaceId) {
-    LOGGER.info(
+    LOGGER.debug(
         "Sam integration will query type={}, resourceId={}, actions={}",
         SamAuthorizationDao.RESOURCE_NAME_WORKSPACE,
         workspaceId,

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
@@ -68,7 +68,7 @@ public class ImportService {
 
     // TODO: translate the ImportRequestServerModel into a Job
     // for now, just make an example job
-    logger.debug("Data import of type {} requested", importRequest.getType());
+    logger.info("Data import of type {} requested", importRequest.getType());
 
     ImportJobInput importJobInput = ImportJobInput.from(importRequest);
     Job<JobInput, JobResult> job =

--- a/service/src/main/resources/application-local.yml
+++ b/service/src/main/resources/application-local.yml
@@ -7,3 +7,14 @@ twds:
   instance:
     # Workspace Id for launching instance
     workspace-id: ${WORKSPACE_ID:123e4567-e89b-12d3-a456-426614174000}
+
+# enable color-coding for logs
+spring:
+  output:
+    ansi:
+      enabled: always
+# use the MDC "requestId" as the log correlation pattern. If/when we use Micrometer tracing to
+# create correlation ids, this should be removed.
+logging:
+  pattern:
+    correlation: "%X{requestId} "

--- a/service/src/main/resources/logback-spring.xml
+++ b/service/src/main/resources/logback-spring.xml
@@ -40,8 +40,7 @@
       <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
         <level>${CONSOLE_LOG_THRESHOLD}</level>
       </filter>
-      <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
-      <charset>${CONSOLE_LOG_CHARSET}</charset>
+      <encoder class="net.logstash.logback.encoder.LogstashEncoder" charset="UTF-8"/>
     </appender>
   </springProfile>
 

--- a/service/src/main/resources/logback-spring.xml
+++ b/service/src/main/resources/logback-spring.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-  
+
   <!-- inspired by Spring default ${FILE_LOG_PATTERN} from defaults.xml, modified to include requestId -->
   <property name="WDS_LOG_PATTERN"
             value="%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}} ${LOG_LEVEL_PATTERN:-%5p} [%X{requestId}] [%t] %-40.40logger{39} : %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}"/>
 
+  <!-- import some Spring defaults -->
   <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
   <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
 
@@ -12,6 +13,7 @@
            you may want to comment out this line during your development efforts. -->
   <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
 
+  <!-- Appender, to send errors to Sentry. Note that WDS will internally disable the Sentry dsn based on environment. -->
   <appender name="Sentry" class="io.sentry.logback.SentryAppender">
     <!-- Optionally change minimum Event level. Default for Events is ERROR -->
     <minimumEventLevel>ERROR</minimumEventLevel>
@@ -19,64 +21,52 @@
     <minimumBreadcrumbLevel>INFO</minimumBreadcrumbLevel>
   </appender>
 
-  <springProfile name="!local">
-    <springProfile name="control-plane">
-      <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-          <level>${CONSOLE_LOG_THRESHOLD}</level>
-        </filter>
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+  <!-- in the data plane, or when running locally, log in plaintext -->
+  <springProfile name="local | data-plane">
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+      <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+        <level>${CONSOLE_LOG_THRESHOLD}</level>
+      </filter>
+      <encoder>
+        <pattern>${WDS_LOG_PATTERN}</pattern>
         <charset>${CONSOLE_LOG_CHARSET}</charset>
-      </appender>
-    </springProfile>
-    <springProfile name="data-plane">
-      <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-          <level>${CONSOLE_LOG_THRESHOLD}</level>
-        </filter>
-        <encoder>
-          <pattern>${WDS_LOG_PATTERN}</pattern>
-          <charset>${CONSOLE_LOG_CHARSET}</charset>
-        </encoder>
-      </appender>
-    </springProfile>
-    <!-- log everything at INFO level -->
-    <root level="info">
-      <appender-ref ref="CONSOLE"/>
-      <appender-ref ref="Sentry"/>
-    </root>
-
-    <!-- log WDS at DEBUG level -->
-    <logger name="org.databiosphere.workspacedataservice" level="debug" additivity="false">
-      <appender-ref ref="CONSOLE"/>
-      <appender-ref ref="Sentry"/>
-    </logger>
-
-    <!-- log WDS Sam integration at DEBUG level -->
-    <logger name="org.databiosphere.workspacedataservice.sam" level="debug" additivity="false">
-      <appender-ref ref="CONSOLE"/>
-      <appender-ref ref="Sentry"/>
-    </logger>
-
-    <!-- log org.springframework.web at DEBUG level -->
-    <logger name="org.springframework.web" level="debug" additivity="false">
-      <appender-ref ref="CONSOLE"/>
-      <appender-ref ref="Sentry"/>
-    </logger>
+      </encoder>
+    </appender>
   </springProfile>
 
-  <springProfile name="local">
-    <root level="info">
-      <appender-ref ref="CONSOLE"/>
-    </root>
-
-    <logger name="org.databiosphere.workspacedataservice" level="debug" additivity="false">
-      <appender-ref ref="CONSOLE"/>
-    </logger>
-
-    <logger name="org.springframework.web" level="debug" additivity="false">
-      <appender-ref ref="CONSOLE"/>
-    </logger>
+  <!-- in the control plane, log in JSON -->
+  <springProfile name="!local &amp; control-plane ">
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+      <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+        <level>${CONSOLE_LOG_THRESHOLD}</level>
+      </filter>
+      <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+      <charset>${CONSOLE_LOG_CHARSET}</charset>
+    </appender>
   </springProfile>
+
+  <!-- log everything at INFO level -->
+  <root level="info">
+    <appender-ref ref="CONSOLE"/>
+    <appender-ref ref="Sentry"/>
+  </root>
+
+  <!-- log WDS at DEBUG level -->
+  <logger name="org.databiosphere.workspacedataservice" level="debug" additivity="false">
+    <appender-ref ref="CONSOLE"/>
+    <appender-ref ref="Sentry"/>
+  </logger>
+
+  <!-- log WDS Sam integration at DEBUG level -->
+  <logger name="org.databiosphere.workspacedataservice.sam" level="debug" additivity="false">
+    <appender-ref ref="CONSOLE"/>
+    <appender-ref ref="Sentry"/>
+  </logger>
+
+  <!-- log org.springframework.web at DEBUG level -->
+  <logger name="org.springframework.web" level="debug" additivity="false">
+    <appender-ref ref="CONSOLE"/>
+    <appender-ref ref="Sentry"/>
+  </logger>
 
 </configuration>

--- a/service/src/main/resources/logback-spring.xml
+++ b/service/src/main/resources/logback-spring.xml
@@ -7,7 +7,6 @@
 
   <!-- import some Spring defaults -->
   <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
-  <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
 
   <!-- Quiet down logback during startup. If you are trying to change or debug logging setup,
            you may want to comment out this line during your development efforts. -->
@@ -21,8 +20,14 @@
     <minimumBreadcrumbLevel>INFO</minimumBreadcrumbLevel>
   </appender>
 
-  <!-- in the data plane, or when running locally, log in plaintext -->
-  <springProfile name="local | data-plane">
+  <!-- when running locally, use the Spring Boot default logging pattern. Note we also include
+         a logging.pattern.correlation override in application-local.yml. -->
+  <springProfile name="local">
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+  </springProfile>
+
+  <!-- in the data plane, log in plaintext (with no colors) -->
+  <springProfile name="!local &amp; data-plane">
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
       <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
         <level>${CONSOLE_LOG_THRESHOLD}</level>

--- a/service/src/main/resources/logback-spring.xml
+++ b/service/src/main/resources/logback-spring.xml
@@ -40,7 +40,7 @@
   </springProfile>
 
   <!-- in the control plane, log in JSON -->
-  <springProfile name="!local &amp; control-plane ">
+  <springProfile name="!local &amp; control-plane">
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
       <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
         <level>${CONSOLE_LOG_THRESHOLD}</level>

--- a/service/src/main/resources/logback-spring.xml
+++ b/service/src/main/resources/logback-spring.xml
@@ -44,26 +44,33 @@
     </appender>
   </springProfile>
 
-  <!-- log everything at INFO level -->
+  <!-- log everything at INFO level by default -->
   <root level="info">
     <appender-ref ref="CONSOLE"/>
     <appender-ref ref="Sentry"/>
   </root>
 
-  <!-- log WDS at DEBUG level -->
-  <logger name="org.databiosphere.workspacedataservice" level="debug" additivity="false">
+  <!-- WDS -->
+  <logger name="org.databiosphere.workspacedataservice" level="info" additivity="false">
     <appender-ref ref="CONSOLE"/>
     <appender-ref ref="Sentry"/>
   </logger>
 
-  <!-- log WDS Sam integration at DEBUG level -->
-  <logger name="org.databiosphere.workspacedataservice.sam" level="debug" additivity="false">
+  <!-- WDS Sam integration -->
+  <logger name="org.databiosphere.workspacedataservice.sam" level="info" additivity="false">
     <appender-ref ref="CONSOLE"/>
     <appender-ref ref="Sentry"/>
   </logger>
 
-  <!-- log org.springframework.web at DEBUG level -->
-  <logger name="org.springframework.web" level="debug" additivity="false">
+  <!-- DispatcherServlet logs request URLs and response codes at DEBUG level -->
+  <logger name="org.springframework.web.servlet.DispatcherServlet" level="debug"
+          additivity="false">
+    <appender-ref ref="CONSOLE"/>
+    <appender-ref ref="Sentry"/>
+  </logger>
+
+  <!-- log the remainder of org.springframework.web at INFO level -->
+  <logger name="org.springframework.web" level="info" additivity="false">
     <appender-ref ref="CONSOLE"/>
     <appender-ref ref="Sentry"/>
   </logger>


### PR DESCRIPTION
[AJ-1634](https://broadworkbench.atlassian.net/browse/AJ-1634)

Multiple logging-related changes in this PR:
1. Reduce logging volume from DEBUG to INFO most everywhere
2. Configure `DispatcherServlet` to continue to log at DEBUG so we get request URLs and response codes
3. Elevate a couple log messages to INFO from DEBUG so they're still visible
4. Reorganize `logback-spring.xml` to reduce duplication and nesting
5. When running with the `local` profile, re-enable the default Spring boot color-coded logs for developer goodness

NOT in this PR: filtering out /status/liveness and /status/readiness from the logs. This is somewhat involved, and I hope to tackle that in a follow-on PR. Is this worth doing?

`SPRING_PROFILES_ACTIVE=dev,control-plane gw bootRun`: 
<img width="1321" alt="dev,control-plane" src="https://github.com/DataBiosphere/terra-workspace-data-service/assets/6041577/cbc9e600-e8d8-453e-b272-f8e59d979166">

`SPRING_PROFILES_ACTIVE=dev,data-plane gw bootRun`:
<img width="1319" alt="dev,data-plane" src="https://github.com/DataBiosphere/terra-workspace-data-service/assets/6041577/6ed9904a-57d0-4790-91aa-be1b0a846fcc">

`SPRING_PROFILES_ACTIVE=local,control-plane gw bootRun`
and
`SPRING_PROFILES_ACTIVE=local,data-plane gw bootRun`:
<img width="1346" alt="local" src="https://github.com/DataBiosphere/terra-workspace-data-service/assets/6041577/d9f91acc-54bb-41d9-9bdd-f59a3490f112">


[AJ-1634]: https://broadworkbench.atlassian.net/browse/AJ-1634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ