### PR TITLE
DC-839: Move references back to datarepo-client; Upgrade to latest

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -80,7 +80,7 @@ dependencies {
     implementation group: 'org.broadinstitute.dsde.workbench', name: 'sam-client_2.13', version: '0.1-752b4f3'
     implementation group: 'org.broadinstitute.dsde.workbench', name: 'leonardo-client_2.13', version: '1.3.6-22ee00b'
     implementation 'com.squareup.okhttp3:okhttp' // required by Sam client
-    implementation "bio.terra:datarepo-jakarta-client:1.570.0-SNAPSHOT"
+    implementation "bio.terra:datarepo-client:2.13.0-SNAPSHOT"
     implementation "bio.terra:workspace-manager-client:0.254.983-SNAPSHOT"
     implementation "bio.terra:java-pfb-library:0.29.0"
     implementation project(path: ':client')


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DC-839

With the [Spring Boot 3 Upgrade](https://github.com/DataBiosphere/jade-data-repo/pull/1581) for data repo, we're switching back to only publishing to one Jakarta backed client. This PR moves your references to the jakarta client back to the main data repo client and bumps to the latest version. This is an effort to alleviate any confusion around upgrading past the last supported datarepo-jakarta-client version.

____
Reminder:

PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 
