### PR TITLE
AJ-1669: Fix warnings near `BatchWriteService`

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -22,6 +22,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.lang.Nullable;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -108,7 +109,7 @@ public class RecordController {
       @PathVariable("instanceid") UUID instanceId,
       @PathVariable("recordType") RecordType recordType,
       @PathVariable("version") String version,
-      @RequestBody(required = false) SearchRequest searchRequest) {
+      @Nullable @RequestBody(required = false) SearchRequest searchRequest) {
     return recordOrchestratorService.queryForRecords(
         instanceId, recordType, version, searchRequest);
   }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -69,6 +69,7 @@ import org.springframework.jdbc.core.BatchPreparedStatementSetter;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Repository;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -251,7 +252,7 @@ public class RecordDao {
       int pageSize,
       int offset,
       String sortDirection,
-      String sortAttribute,
+      @Nullable String sortAttribute,
       UUID collectionId) {
     LOGGER.info("queryForRecords: {}", recordType.getName());
     return namedTemplate

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -252,7 +252,7 @@ public class RecordDao {
       int pageSize,
       int offset,
       String sortDirection,
-      @Nullable String sortAttribute,
+      @Nullable String sortAttribute, // this comes from SearchRequest, which might not be provided
       UUID collectionId) {
     LOGGER.info("queryForRecords: {}", recordType.getName());
     return namedTemplate

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/WsmSnapshotSupport.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/WsmSnapshotSupport.java
@@ -191,6 +191,7 @@ public class WsmSnapshotSupport {
                 tableModel -> identifyPrimaryKey(tableModel.getPrimaryKey())));
   }
 
+  // snapshotKeys comes from generated code which doesn't guarantee null safety
   String identifyPrimaryKey(@Nullable List<String> snapshotKeys) {
     if (snapshotKeys != null && snapshotKeys.size() == 1) {
       return snapshotKeys.get(0);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/WsmSnapshotSupport.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/WsmSnapshotSupport.java
@@ -27,6 +27,7 @@ import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.databiosphere.workspacedataservice.workspacemanager.WorkspaceManagerDao;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.lang.Nullable;
 
 public class WsmSnapshotSupport {
 
@@ -122,6 +123,7 @@ public class WsmSnapshotSupport {
    * @param resourceDescription the WSM object in which to find a snapshotId
    * @return the snapshotId if found, else null
    */
+  @Nullable
   protected UUID safeGetSnapshotId(ResourceDescription resourceDescription) {
     ResourceAttributesUnion resourceAttributes = resourceDescription.getResourceAttributes();
     if (resourceAttributes != null) {
@@ -189,7 +191,7 @@ public class WsmSnapshotSupport {
                 tableModel -> identifyPrimaryKey(tableModel.getPrimaryKey())));
   }
 
-  String identifyPrimaryKey(List<String> snapshotKeys) {
+  String identifyPrimaryKey(@Nullable List<String> snapshotKeys) {
     if (snapshotKeys != null && snapshotKeys.size() == 1) {
       return snapshotKeys.get(0);
     }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJob.java
@@ -43,6 +43,7 @@ import org.quartz.JobDataMap;
 import org.quartz.JobExecutionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 
 /** Shell/starting point for PFB import via Quartz. */
@@ -177,18 +178,16 @@ public class PfbQuartzJob extends QuartzJob {
             /* recordType= */ null, // record type is determined later
             /* primaryKey= */ ID_FIELD); // PFBs currently only use ID_FIELD as primary key
 
-    if (result != null) {
-      result
-          .entrySet()
-          .forEach(
-              entry -> {
-                RecordType recordType = entry.getKey();
-                int quantity = entry.getValue();
-                activityLogger.saveEventForCurrentUser(
-                    user ->
-                        user.upserted().record().withRecordType(recordType).ofQuantity(quantity));
-              });
-    }
+    result
+        .entrySet()
+        .forEach(
+            entry -> {
+              RecordType recordType = entry.getKey();
+              int quantity = entry.getValue();
+              activityLogger.saveEventForCurrentUser(
+                  user -> user.upserted().record().withRecordType(recordType).ofQuantity(quantity));
+            });
+
     return result;
   }
 
@@ -231,6 +230,7 @@ public class PfbQuartzJob extends QuartzJob {
     wsmSnapshotSupport.linkSnapshots(snapshotIds);
   }
 
+  @Nullable
   private UUID maybeUuid(String input) {
     try {
       return UUID.fromString(input);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJob.java
@@ -149,14 +149,13 @@ public class TdrManifestQuartzJob extends QuartzJob {
     result
         .entrySet()
         .forEach(
-            entry -> {
-              activityLogger.saveEventForCurrentUser(
-                  user ->
-                      user.upserted()
-                          .record()
-                          .withRecordType(entry.getKey())
-                          .ofQuantity(entry.getValue()));
-            });
+            entry ->
+                activityLogger.saveEventForCurrentUser(
+                    user ->
+                        user.upserted()
+                            .record()
+                            .withRecordType(entry.getKey())
+                            .ofQuantity(entry.getValue())));
     // delete temp files after everything else is completed
     // Any failed deletions will be removed if/when pod restarts
     fileDownloadHelper.deleteFileDirectory();
@@ -225,9 +224,7 @@ public class TdrManifestQuartzJob extends QuartzJob {
                       // generate the HadoopInputFile
                       InputFile inputFile = HadoopInputFile.fromPath(hadoopFilePath, configuration);
                       var result = importTable(inputFile, importTable, importMode, importDetails);
-                      if (result != null) {
-                        combinedResult.merge(result);
-                      }
+                      combinedResult.merge(result);
                     } catch (IOException e) {
                       throw new TdrManifestImportException(e.getMessage(), e);
                     }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/BatchWriteService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/BatchWriteService.java
@@ -47,7 +47,10 @@ public class BatchWriteService {
    */
   @WriteTransaction
   public BatchWriteResult batchWrite(
-      RecordSource recordSource, RecordSink recordSink, RecordType recordType, String primaryKey) {
+      RecordSource recordSource,
+      RecordSink recordSink,
+      @Nullable RecordType recordType,
+      String primaryKey) {
     try (recordSource) {
       return consumeWriteStream(recordSource, recordSink, recordType, primaryKey);
     } catch (IOException e) {
@@ -121,7 +124,8 @@ public class BatchWriteService {
     return result;
   }
 
-  private static void assertRecordTypesMatch(RecordType recordType, Set<RecordType> recordTypes) {
+  private static void assertRecordTypesMatch(
+      @Nullable RecordType recordType, Set<RecordType> recordTypes) {
     if (recordType != null && !Set.of(recordType).equals(recordTypes)) {
       throw new BadStreamingWriteRequestException(
           "Record Type was specified as argument to BatchWriteService, "

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
@@ -183,6 +183,7 @@ public class RecordOrchestratorService { // TODO give me a better name
       UUID collectionId,
       RecordType recordType,
       String version,
+      // SearchRequest isn't required in the controller, so it can be null here
       @Nullable SearchRequest searchRequest) {
     validateVersion(version);
     collectionService.validateCollection(collectionId);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
@@ -43,6 +43,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
@@ -179,7 +180,10 @@ public class RecordOrchestratorService { // TODO give me a better name
 
   @ReadTransaction
   public RecordQueryResponse queryForRecords(
-      UUID collectionId, RecordType recordType, String version, SearchRequest searchRequest) {
+      UUID collectionId,
+      RecordType recordType,
+      String version,
+      @Nullable SearchRequest searchRequest) {
     validateVersion(version);
     collectionService.validateCollection(collectionId);
     checkRecordTypeExists(collectionId, recordType);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/SearchRequest.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/SearchRequest.java
@@ -1,11 +1,13 @@
 package org.databiosphere.workspacedataservice.shared.model;
 
+import org.springframework.lang.Nullable;
+
 public class SearchRequest {
 
   private int limit = 10;
   private int offset = 0;
   private SortDirection sort = SortDirection.ASC;
-  private String sortAttribute = null;
+  @Nullable private String sortAttribute = null;
 
   public SearchRequest(int limit, int offset, SortDirection sort) {
     this.limit = limit;
@@ -46,6 +48,7 @@ public class SearchRequest {
     this.sort = sort;
   }
 
+  @Nullable
   public String getSortAttribute() {
     return sortAttribute;
   }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/WdsSnapshotSupportTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/WdsSnapshotSupportTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import bio.terra.datarepo.model.TableModel;
-import bio.terra.workspace.client.ApiException;
 import bio.terra.workspace.model.DataRepoSnapshotAttributes;
 import bio.terra.workspace.model.ResourceAttributesUnion;
 import bio.terra.workspace.model.ResourceDescription;
@@ -46,7 +45,7 @@ class WsmSnapshotSupportTest extends TestBase {
 
   @ParameterizedTest(name = "paginates through results when WSM has {0} references")
   @ValueSource(ints = {0, 1, 49, 50, 51, 99, 100, 101, 456})
-  void paginateExistingSnapshots(int wsmCount) throws ApiException {
+  void paginateExistingSnapshots(int wsmCount) {
     int testPageSize = 50; // page size to use during this test
 
     List<ResourceDescription> mockResources = new ArrayList<>();

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobControlPlaneE2ETest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobControlPlaneE2ETest.java
@@ -50,8 +50,10 @@ import org.springframework.test.context.TestPropertySource;
 
 /**
  * Tests for PFB import that execute "end-to-end" - that is, they go through the whole process of
- * parsing the PFB, and generating the JSON that (will eventually be) stored in a bucket (AJ-1585)
- * and communicated to Rawls via pubsub (AJ-1586).
+ * parsing the PFB, and generating the JSON that gets stored in a bucket and communicated to Rawls
+ * via pubsub.
+ *
+ * <p>TODO(AJ-1669): Add coverage for bucket storage & pubsub
  */
 @ActiveProfiles(profiles = {"mock-sam", "noop-scheduler-dao", "control-plane"})
 @DirtiesContext

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobDataPlaneE2ETest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobDataPlaneE2ETest.java
@@ -16,14 +16,17 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import org.databiosphere.workspacedataservice.annotations.SingleTenant;
 import org.databiosphere.workspacedataservice.service.CollectionService;
 import org.databiosphere.workspacedataservice.service.RecordOrchestratorService;
 import org.databiosphere.workspacedataservice.service.RelationUtils;
 import org.databiosphere.workspacedataservice.service.model.AttributeSchema;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
 import org.databiosphere.workspacedataservice.service.model.RecordTypeSchema;
+import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.databiosphere.workspacedataservice.shared.model.RecordResponse;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
+import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.databiosphere.workspacedataservice.workspacemanager.WorkspaceManagerDao;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,6 +50,7 @@ import org.springframework.test.context.ActiveProfiles;
 @DirtiesContext
 @SpringBootTest
 class PfbQuartzJobDataPlaneE2ETest {
+  @Autowired @SingleTenant WorkspaceId workspaceId;
   @Autowired RecordOrchestratorService recordOrchestratorService;
   @Autowired CollectionService collectionService;
   @Autowired PfbTestSupport testSupport;
@@ -73,7 +77,7 @@ class PfbQuartzJobDataPlaneE2ETest {
   @BeforeEach
   void beforeEach() {
     collectionId = UUID.randomUUID();
-    collectionService.createCollection(collectionId, "v0.2");
+    collectionService.createCollection(workspaceId, CollectionId.of(collectionId), "v0.2");
     // stub out WSM to report no snapshots already linked to this workspace
     when(wsmDao.enumerateDataRepoSnapshotReferences(any(), anyInt(), anyInt()))
         .thenReturn(new ResourceList());

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrTestSupport.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrTestSupport.java
@@ -1,5 +1,7 @@
 package org.databiosphere.workspacedataservice.dataimport.tdr;
 
+import static java.util.Objects.requireNonNull;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micrometer.observation.ObservationRegistry;
 import java.net.URL;
@@ -46,7 +48,8 @@ class TdrTestSupport {
       @Override
       protected URL parseUrl(String path) {
         if (path.startsWith("classpath:")) {
-          return getClass().getClassLoader().getResource(path.substring("classpath:".length()));
+          return requireNonNull(
+              getClass().getClassLoader().getResource(path.substring("classpath:".length())));
         }
         return super.parseUrl(path);
       }


### PR DESCRIPTION
This is cleanup in prep for making changes to `BatchWriteService` and `RecordSink` to only write one file out to storage at the end of an entire batch for [AJ-1669](https://broadworkbench.atlassian.net/browse/AJ-1669).

Eliminates most compiler warnings about nullability, as well as other minor syntax issues in these classes and all their adjacent collaborators.

The process I took to end up with this scope is as follows:
1) I started at `RawlsRecordSink` and `BatchWriteService` and fixed warnings there.
2) Nullability problems can be fixed locally but need to be traced upward/downward to ensure they are fixed at the root, so I searched backward for references to these two classes and fixed warnings in those files.
3) I opportunistically fixed other easy warnings in touched files, but left a few behind which would be annoying, harm readability, or were too much of a detour to fix correctly.
4) Go back to step 1 and recurse until all referencing classes are fixed.

Got lucky here with this process as the tree of dependents wasn't that broad, but admittedly this process could turn into a fanout nightmare for other more central dependencies.

Lessons learned: 
* It's much easier & safer to mark something as `@Nullable` to essentially accept the status quo and defer until later than it is to deal with deeply making something `@NonNull`.
* Marking code as `@Nullable` is a way of signaling future developers and the IDE to exercise caution, and so should be used liberally where needed to push the safety checks outward.  It's also a breadcrumb for future improvement (most `@Nullable` markings indicate an opportunity for improvement).
* Making something satisfy `@NonNull` provides benefits to surrounding code but requires care and should be done with intention.
* Can't trust nullability of all surrounding code, like our model classes, which are _not_ annotated as null-safe and don't give the compiler any hints to that effect.

[AJ-1669]: https://broadworkbench.atlassian.net/browse/AJ-1669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ