### PR TITLE
AJ-1681 remove alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ export SPRING_PROFILES_ACTIVE=local,data-plane
 
 Other profiles that are available are:
 
-- alpha
 - staging
 - dev
 - prod

--- a/scripts/render-config.sh
+++ b/scripts/render-config.sh
@@ -1,6 +1,6 @@
 # Simple script for pulling local vault credentials. All arguments are optional.
 # Usage is: ./scripts/render-config.sh [wds env] [vault env] [vaulttoken]
-# wds env options are: local, dev, alpha, perf, staging, prod
+# wds env options are: local, dev, perf, staging, prod
 # vault env options are: local, docker
 # vaulttoken: put your vault token here
 
@@ -11,7 +11,7 @@ VAULT_TOKEN=${3:-$(cat "$HOME"/.vault-token)}
 VAULT_ADDR="https://clotho.broadinstitute.org:8200"
 WDS_VAULT_PATH="secret/dsde/$WDS_ENV/workspacedata"
 
-case $VAULT_ENV in 
+case $VAULT_ENV in
     local | docker) ;;
     *)
         echo "Invalid input: Vault env must be docker or local.\n" \

--- a/service/src/main/java/org/databiosphere/workspacedataservice/SentryInitializer.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/SentryInitializer.java
@@ -44,7 +44,7 @@ public class SentryInitializer {
   private static final String DEFAULT_ENV = "unknown";
   // Environments we want to monitor on sentry - don't send errors from local, bees, or Github
   // actions
-  private static final List<String> environments = List.of("prod", "alpha", "staging", "dev");
+  private static final List<String> environments = List.of("prod", "staging", "dev");
 
   @Bean
   public SmartInitializingSingleton initialize() {

--- a/service/src/main/resources/application-alpha.yml
+++ b/service/src/main/resources/application-alpha.yml
@@ -1,4 +1,0 @@
-samurl: https://sam.dsde-alpha.broadinstitute.org/
-datarepourl: https://data.alpha.broadinstitute.org/
-workspacemanagerurl: https://workspace.dsde-alpha.broadinstitute.org/
-leoUrl: https://leonardo.dsde-alpha.broadinstitute.org/

--- a/service/src/test/java/org/databiosphere/workspacedataservice/SentryInitializerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/SentryInitializerTest.java
@@ -15,7 +15,6 @@ class SentryInitializerTest {
     return Stream.of(
         Arguments.of("https://sam.dsde-prod.broadinstitute.org", "prod"),
         Arguments.of("https://sam.dsde-staging.broadinstitute.org", "staging"),
-        Arguments.of("https://sam.dsde-alpha.broadinstitute.org", "alpha"),
         Arguments.of("https://sam.dsde-dev.broadinstitute.org", "dev"),
         Arguments.of("https://sam.bee-fancy-generated-name.bee.envs-terra.bio", "unknown"),
         Arguments.of("UNDEFINED", "unknown"),


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1681
The alpha environment has been/is being removed; we don't need config for it anymore.

Reminder:

PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 
