### PR TITLE
AJ-1669: Reuse `RecordSink` for full import.

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJob.java
@@ -34,6 +34,7 @@ import org.databiosphere.workspacedataservice.dataimport.ImportDetails;
 import org.databiosphere.workspacedataservice.dataimport.WsmSnapshotSupport;
 import org.databiosphere.workspacedataservice.jobexec.JobExecutionException;
 import org.databiosphere.workspacedataservice.jobexec.QuartzJob;
+import org.databiosphere.workspacedataservice.recordsink.RecordSink;
 import org.databiosphere.workspacedataservice.recordsink.RecordSinkFactory;
 import org.databiosphere.workspacedataservice.recordsource.RecordSource.ImportMode;
 import org.databiosphere.workspacedataservice.recordsource.RecordSourceFactory;
@@ -108,6 +109,9 @@ public class TdrManifestQuartzJob extends QuartzJob {
     UUID targetCollection = getJobDataUUID(jobDataMap, ARG_COLLECTION);
 
     // TDR import is interested in the collectionId (not the workspaceId)
+    // TODO(AJ-1589): make prefix assignment dynamic. However, of note: the prefix is currently
+    //   ignored for RecordSinkMode.WDS.  In this case, it might be worth adding support for
+    //   omitting the prefix as part of supporting the prefix assignment.
     ImportDetails importDetails = new ImportDetails(targetCollection, "tdr");
 
     // determine the workspace for the target collection
@@ -130,6 +134,7 @@ public class TdrManifestQuartzJob extends QuartzJob {
     // get all the parquet files from the manifests
 
     FileDownloadHelper fileDownloadHelper = getFilesForImport(tdrManifestImportTables);
+    RecordSink recordSink = recordSinkFactory.buildRecordSink(importDetails);
 
     // loop through the tables to be imported and upsert base attributes
     var result =
@@ -137,14 +142,11 @@ public class TdrManifestQuartzJob extends QuartzJob {
             tdrManifestImportTables,
             fileDownloadHelper.getFileMap(),
             ImportMode.BASE_ATTRIBUTES,
-            importDetails);
+            recordSink);
 
     // add relations to the existing base attributes
     importTables(
-        tdrManifestImportTables,
-        fileDownloadHelper.getFileMap(),
-        ImportMode.RELATIONS,
-        importDetails);
+        tdrManifestImportTables, fileDownloadHelper.getFileMap(), ImportMode.RELATIONS, recordSink);
 
     // activity logging for import status
     // no specific activity logging for relations since main import is a superset
@@ -168,16 +170,16 @@ public class TdrManifestQuartzJob extends QuartzJob {
    *
    * @param inputFile Parquet file to be imported.
    * @param table info about the table to be imported
+   * @param recordSink {@link RecordSink} that directs the records to their destination
    * @param importMode mode for this invocation
-   * @param importDetails contains collection into which to import and prefix
    * @return statistics on what was imported
    */
   @VisibleForTesting
   BatchWriteResult importTable(
       InputFile inputFile,
       TdrManifestImportTable table,
-      ImportMode importMode,
-      ImportDetails importDetails) {
+      RecordSink recordSink,
+      ImportMode importMode) {
     // upsert this parquet file's contents
     try (ParquetReader<GenericRecord> avroParquetReader =
         AvroParquetReader.<GenericRecord>builder(inputFile)
@@ -186,7 +188,7 @@ public class TdrManifestQuartzJob extends QuartzJob {
       logger.info("batch-writing records for file ...");
       return batchWriteService.batchWrite(
           recordSourceFactory.forTdrImport(avroParquetReader, table, importMode),
-          recordSinkFactory.buildRecordSink(importDetails),
+          recordSink,
           table.recordType(),
           table.primaryKey());
     } catch (Throwable t) {
@@ -199,14 +201,13 @@ public class TdrManifestQuartzJob extends QuartzJob {
    *
    * @param importTables tables to be imported
    * @param importMode mode for this invocation
-   * @param importDetails contains collection into which to import and prefix
+   * @param recordSink {@link RecordSink} that directs the records to their destination
    */
   private BatchWriteResult importTables(
       List<TdrManifestImportTable> importTables,
       Multimap<String, File> fileMap,
       ImportMode importMode,
-      ImportDetails importDetails) {
-
+      RecordSink recordSink) {
     var combinedResult = BatchWriteResult.empty();
     // loop through the tables that have data files.
     importTables.forEach(
@@ -225,7 +226,7 @@ public class TdrManifestQuartzJob extends QuartzJob {
 
                       // generate the HadoopInputFile
                       InputFile inputFile = HadoopInputFile.fromPath(hadoopFilePath, configuration);
-                      var result = importTable(inputFile, importTable, importMode, importDetails);
+                      var result = importTable(inputFile, importTable, recordSink, importMode);
                       combinedResult.merge(result);
                     } catch (IOException e) {
                       throw new TdrManifestImportException(e.getMessage(), e);

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobTest.java
@@ -32,6 +32,8 @@ import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.databiosphere.workspacedataservice.dataimport.FileDownloadHelper;
 import org.databiosphere.workspacedataservice.dataimport.ImportDetails;
 import org.databiosphere.workspacedataservice.dataimport.tdr.TdrManifestExemplarData.AzureSmall;
+import org.databiosphere.workspacedataservice.recordsink.RecordSink;
+import org.databiosphere.workspacedataservice.recordsink.RecordSinkFactory;
 import org.databiosphere.workspacedataservice.recordsource.RecordSource.ImportMode;
 import org.databiosphere.workspacedataservice.retry.RestClientRetry;
 import org.databiosphere.workspacedataservice.service.CollectionService;
@@ -65,6 +67,7 @@ class TdrManifestQuartzJobTest extends TestBase {
   @MockBean ActivityLogger activityLogger;
   @MockBean RecordService recordService;
   @MockBean RecordDao recordDao;
+  @Autowired RecordSinkFactory recordSinkFactory;
   @Autowired RestClientRetry restClientRetry;
   @Autowired ObjectMapper objectMapper;
   @Autowired TdrTestSupport testSupport;
@@ -193,12 +196,13 @@ class TdrManifestQuartzJobTest extends TestBase {
             new Path(malformedParquet.getURL().toString()), new Configuration());
 
     ImportDetails importDetails = new ImportDetails(workspaceId, "tdr");
+    RecordSink recordSink = recordSinkFactory.buildRecordSink(importDetails);
     // Make sure real errors on parsing parquets are not swallowed
     assertThrows(
         TdrManifestImportException.class,
         () ->
             tdrManifestQuartzJob.importTable(
-                malformedFile, table, ImportMode.BASE_ATTRIBUTES, importDetails));
+                malformedFile, table, recordSink, ImportMode.BASE_ATTRIBUTES));
   }
 
   @Test


### PR DESCRIPTION
For [AJ-1669](https://broadworkbench.atlassian.net/browse/AJ-1669): this makes an entire import job use the same `RecordSink` instance for all batches.  The goal here is to make the `RawlsRecordSink` capable of handling the entire import job with a single GCS file & pubsub, rather than triggering a new file & pubsub message for each batch.

In a subsequent change, the `RecordSink` will be given an additional method to finalize the import, which is what will be called at the very end of a batch to do all the post-processing.

[AJ-1669]: https://broadworkbench.atlassian.net/browse/AJ-1669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ