### PR TITLE
AJ-1687: control-plane import jobs should stay running after they finish in quartz

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/config/DataImportProperties.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/config/DataImportProperties.java
@@ -2,6 +2,54 @@ package org.databiosphere.workspacedataservice.config;
 
 /** Properties that dictate how data import processes should behave. */
 public class DataImportProperties {
+  private RecordSinkMode batchWriteRecordSink;
+  private String projectId;
+  private String rawlsBucketName;
+  private boolean succeedOnCompletion;
+
+  /** Where to write records after import, options are defined by {@link RecordSinkMode} */
+  public RecordSinkMode getBatchWriteRecordSink() {
+    return batchWriteRecordSink;
+  }
+
+  void setBatchWriteRecordSink(String batchWriteRecordSink) {
+    this.batchWriteRecordSink = RecordSinkMode.fromValue(batchWriteRecordSink);
+  }
+
+  public String getProjectId() {
+    return projectId;
+  }
+
+  void setProjectId(String projectId) {
+    this.projectId = projectId;
+  }
+
+  public String getRawlsBucketName() {
+    return rawlsBucketName;
+  }
+
+  void setRawlsBucketName(String rawlsBucketName) {
+    this.rawlsBucketName = rawlsBucketName;
+  }
+
+  /**
+   * Should Quartz-based jobs transition to SUCCEEDED when they complete internally in WDS? In the
+   * control plane, where a logical "job" requires Rawls to receive and write data, the Quartz job
+   * will complete well before Rawls writes data, so we should not mark the job as completed. Rawls
+   * will send a message indicating when the logical job is complete.
+   *
+   * @see org.databiosphere.workspacedataservice.dataimport.pfb.PfbQuartzJob
+   * @see org.databiosphere.workspacedataservice.dataimport.tdr.TdrManifestQuartzJob
+   * @return the configured value
+   */
+  public boolean isSucceedOnCompletion() {
+    return succeedOnCompletion;
+  }
+
+  public void setSucceedOnCompletion(boolean succeedOnCompletion) {
+    this.succeedOnCompletion = succeedOnCompletion;
+  }
+
   /** Dictates the sink where BatchWriteService should write records after import. */
   public enum RecordSinkMode {
     WDS("wds"),
@@ -20,36 +68,5 @@ public class DataImportProperties {
       }
       throw new RuntimeException("Unknown RecordSinkMode value: %s".formatted(value));
     }
-  }
-
-  private RecordSinkMode batchWriteRecordSink;
-
-  /** Where to write records after import, options are defined by {@link RecordSinkMode} */
-  public RecordSinkMode getBatchWriteRecordSink() {
-    return batchWriteRecordSink;
-  }
-
-  void setBatchWriteRecordSink(String batchWriteRecordSink) {
-    this.batchWriteRecordSink = RecordSinkMode.fromValue(batchWriteRecordSink);
-  }
-
-  private String projectId;
-
-  public String getProjectId() {
-    return projectId;
-  }
-
-  void setProjectId(String projectId) {
-    this.projectId = projectId;
-  }
-
-  private String rawlsBucketName;
-
-  public String getRawlsBucketName() {
-    return rawlsBucketName;
-  }
-
-  void setRawlsBucketName(String rawlsBucketName) {
-    this.rawlsBucketName = rawlsBucketName;
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJob.java
@@ -21,6 +21,7 @@ import java.util.stream.StreamSupport;
 import org.apache.avro.file.DataFileStream;
 import org.apache.avro.generic.GenericRecord;
 import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
+import org.databiosphere.workspacedataservice.config.DataImportProperties;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.dataimport.ImportDetails;
 import org.databiosphere.workspacedataservice.dataimport.WsmSnapshotSupport;
@@ -73,8 +74,9 @@ public class PfbQuartzJob extends QuartzJob {
       CollectionService collectionService,
       ActivityLogger activityLogger,
       SamDao samDao,
-      ObservationRegistry observationRegistry) {
-    super(observationRegistry);
+      ObservationRegistry observationRegistry,
+      DataImportProperties dataImportProperties) {
+    super(observationRegistry, dataImportProperties);
     this.jobDao = jobDao;
     this.wsmDao = wsmDao;
     this.restClientRetry = restClientRetry;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJob.java
@@ -27,6 +27,7 @@ import org.apache.parquet.hadoop.ParquetReader;
 import org.apache.parquet.hadoop.util.HadoopInputFile;
 import org.apache.parquet.io.InputFile;
 import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
+import org.databiosphere.workspacedataservice.config.DataImportProperties;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.dataimport.FileDownloadHelper;
 import org.databiosphere.workspacedataservice.dataimport.ImportDetails;
@@ -77,8 +78,9 @@ public class TdrManifestQuartzJob extends QuartzJob {
       CollectionService collectionService,
       ActivityLogger activityLogger,
       ObjectMapper mapper,
-      ObservationRegistry observationRegistry) {
-    super(observationRegistry);
+      ObservationRegistry observationRegistry,
+      DataImportProperties dataImportProperties) {
+    super(observationRegistry, dataImportProperties);
     this.jobDao = jobDao;
     this.wsmDao = wsmDao;
     this.restClientRetry = restClientRetry;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/jobexec/QuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/jobexec/QuartzJob.java
@@ -8,6 +8,7 @@ import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
 import java.net.URL;
 import java.util.UUID;
+import org.databiosphere.workspacedataservice.config.DataImportProperties;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.quartz.Job;
 import org.quartz.JobDataMap;
@@ -33,9 +34,12 @@ import org.quartz.JobExecutionContext;
 public abstract class QuartzJob implements Job {
 
   private final ObservationRegistry observationRegistry;
+  private final DataImportProperties dataImportProperties;
 
-  protected QuartzJob(ObservationRegistry observationRegistry) {
+  protected QuartzJob(
+      ObservationRegistry observationRegistry, DataImportProperties dataImportProperties) {
     this.observationRegistry = observationRegistry;
+    this.dataImportProperties = dataImportProperties;
   }
 
   /** implementing classes are expected to be beans that inject a JobDao */
@@ -64,9 +68,12 @@ public abstract class QuartzJob implements Job {
       }
       // execute the specifics of this job
       executeInternal(jobId, context);
-      // if we reached here, mark this job as successful
-      getJobDao().succeeded(jobId);
-      observation.lowCardinalityKeyValue("outcome", StatusEnum.SUCCEEDED.getValue());
+
+      // if we reached here, and config says we should, mark this job as successful
+      if (dataImportProperties.isSucceedOnCompletion()) {
+        getJobDao().succeeded(jobId);
+        observation.lowCardinalityKeyValue("outcome", StatusEnum.SUCCEEDED.getValue());
+      }
     } catch (Exception e) {
       // on any otherwise-unhandled exception, mark the job as failed
       getJobDao().fail(jobId, e);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/jobexec/QuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/jobexec/QuartzJob.java
@@ -73,6 +73,9 @@ public abstract class QuartzJob implements Job {
       if (dataImportProperties.isSucceedOnCompletion()) {
         getJobDao().succeeded(jobId);
         observation.lowCardinalityKeyValue("outcome", StatusEnum.SUCCEEDED.getValue());
+      } else {
+        // ensure we give the observation an outcome, even though we left the job running
+        observation.lowCardinalityKeyValue("outcome", StatusEnum.RUNNING.getValue());
       }
     } catch (Exception e) {
       // on any otherwise-unhandled exception, mark the job as failed

--- a/service/src/main/resources/application-control-plane.yml
+++ b/service/src/main/resources/application-control-plane.yml
@@ -9,8 +9,10 @@ twds:
     enforce-collections-match-workspace-id: false
   data-import:
     batch-write-record-sink: "rawls"
+    succeed-on-completion: false
     project-id: ${SERVICE_GOOGLE_PROJECT}
     rawls-bucket-name: ${SERVICE_GOOGLE_BUCKET}
+
 
 spring:
   cloud:

--- a/service/src/main/resources/application-data-plane.yml
+++ b/service/src/main/resources/application-data-plane.yml
@@ -9,6 +9,7 @@ twds:
     enforce-collections-match-workspace-id: true
   data-import:
     batch-write-record-sink: "wds"
+    succeed-on-completion: true
 
 spring:
   cloud:

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbTestSupport.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbTestSupport.java
@@ -6,6 +6,7 @@ import io.micrometer.observation.ObservationRegistry;
 import java.io.IOException;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
+import org.databiosphere.workspacedataservice.config.DataImportProperties;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
 import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
@@ -38,6 +39,7 @@ class PfbTestSupport {
   @Autowired private ImportService importService;
   @Autowired private WorkspaceManagerDao wsmDao;
   @Autowired private SamDao samDao;
+  @Autowired DataImportProperties dataImportProperties;
 
   void executePfbImportQuartzJob(UUID collectionId, Resource pfbResource)
       throws IOException, JobExecutionException {
@@ -69,6 +71,7 @@ class PfbTestSupport {
         collectionService,
         activityLogger,
         samDao,
-        observationRegistry);
+        observationRegistry,
+        dataImportProperties);
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrTestSupport.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrTestSupport.java
@@ -5,6 +5,7 @@ import io.micrometer.observation.ObservationRegistry;
 import java.net.URL;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
+import org.databiosphere.workspacedataservice.config.DataImportProperties;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.recordsink.RecordSinkFactory;
 import org.databiosphere.workspacedataservice.recordsource.RecordSourceFactory;
@@ -29,6 +30,7 @@ class TdrTestSupport {
   @Autowired private ActivityLogger activityLogger;
   @Autowired private ObjectMapper objectMapper;
   @Autowired private ObservationRegistry observationRegistry;
+  @Autowired DataImportProperties dataImportProperties;
 
   /** Returns a TdrManifestQuartzJob that is capable of pulling parquet files from the classpath. */
   TdrManifestQuartzJob buildTdrManifestQuartzJob(UUID workspaceId) {
@@ -42,7 +44,8 @@ class TdrTestSupport {
         collectionService,
         activityLogger,
         objectMapper,
-        observationRegistry) {
+        observationRegistry,
+        dataImportProperties) {
       @Override
       protected URL parseUrl(String path) {
         if (path.startsWith("classpath:")) {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/jobexec/QuartzJobTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/jobexec/QuartzJobTest.java
@@ -11,6 +11,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.micrometer.core.instrument.LongTaskTimer;
@@ -27,6 +29,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.config.DataImportProperties;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
 import org.databiosphere.workspacedataservice.observability.TestObservationRegistryConfig;
@@ -35,6 +38,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.quartz.JobDataMap;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobKey;
@@ -52,6 +57,7 @@ import org.springframework.test.annotation.DirtiesContext;
 class QuartzJobTest extends TestBase {
 
   @MockBean JobDao jobDao;
+  @MockBean DataImportProperties dataImportProperties;
   @Autowired MeterRegistry meterRegistry;
   // overridden with a TestObservationRegistry
   @Autowired private ObservationRegistry observationRegistry;
@@ -72,6 +78,8 @@ class QuartzJobTest extends TestBase {
     when(jobDao.updateStatus(any(), any())).thenReturn(genericJobServerModel);
     when(jobDao.fail(any(), anyString()))
         .thenThrow(new RuntimeException("test failed via jobDao.fail()"));
+
+    when(dataImportProperties.isSucceedOnCompletion()).thenReturn(true);
   }
 
   /** clear all observations and metrics prior to each test */
@@ -93,7 +101,7 @@ class QuartzJobTest extends TestBase {
     private boolean shouldThrowError = false;
 
     public TestableQuartzJob(String expectedToken, ObservationRegistry registry) {
-      super(registry);
+      super(registry, dataImportProperties);
       this.expectedToken = expectedToken;
     }
 
@@ -228,6 +236,30 @@ class QuartzJobTest extends TestBase {
         .hasError()
         .thenError()
         .hasMessage("Forced job to fail");
+  }
+
+  @ParameterizedTest(
+      name = "Jobs should complete as success or stay running based on isSucceedOnCompletion ({0})")
+  @ValueSource(booleans = {true, false})
+  void jobCompletion(boolean isSucceedOnCompletion) throws org.quartz.JobExecutionException {
+    // override return values from the @BeforeAll
+    when(dataImportProperties.isSucceedOnCompletion()).thenReturn(isSucceedOnCompletion);
+
+    String randomToken = RandomStringUtils.randomAlphanumeric(10);
+    UUID jobUuid = UUID.randomUUID();
+    JobExecutionContext mockContext = setUpTestJob(randomToken, jobUuid.toString());
+
+    // this test requires a TestObservationRegistry
+    TestObservationRegistry testObservationRegistry =
+        assertInstanceOf(TestObservationRegistry.class, observationRegistry);
+
+    // execute the TestableQuartzJob, then confirm observation recorded failure
+    new TestableQuartzJob(randomToken, observationRegistry, /* shouldThrowError= */ false)
+        .execute(mockContext);
+
+    var wantedNumberOfInvocations = isSucceedOnCompletion ? 1 : 0;
+
+    verify(jobDao, times(wantedNumberOfInvocations)).succeeded(jobUuid);
   }
 
   // sets up a job and returns the job context

--- a/service/src/test/java/org/databiosphere/workspacedataservice/jobexec/QuartzJobTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/jobexec/QuartzJobTest.java
@@ -253,12 +253,15 @@ class QuartzJobTest extends TestBase {
     TestObservationRegistry testObservationRegistry =
         assertInstanceOf(TestObservationRegistry.class, observationRegistry);
 
-    // execute the TestableQuartzJob, then confirm observation recorded failure
+    // execute the TestableQuartzJob. This will move the job to SUCCESS when
+    // dataImportProperties.isSucceedOnCompletion() is true; else it will leave the job
+    // in RUNNING
     new TestableQuartzJob(randomToken, observationRegistry, /* shouldThrowError= */ false)
         .execute(mockContext);
 
+    // assert the job is marked as succeeded ONLY when dataImportProperties.isSucceedOnCompletion()
+    // is true
     var wantedNumberOfInvocations = isSucceedOnCompletion ? 1 : 0;
-
     verify(jobDao, times(wantedNumberOfInvocations)).succeeded(jobUuid);
   }
 


### PR DESCRIPTION
When Rawls checks cWDS for status of a given import job, cWDS reports it has succeeded, so Rawls won't write anything.  This PR leaves cWDS jobs in RUNNING so Rawls will see them as safe.

In this PR:
* adds a new `twds.data-import.succeed-on-completion` property, set to `true` in the data plane and `false` in the control plane
* pipes the property through the `DataImportProperties` config class
    * used IntelliJ to restructure/reformat the `DataImportProperties` class
* reads the `DataImportProperties.isSucceedOnCompletion()` inside `QuartzJob`, and only mark the job as `SUCCESS` when true

_NOT_ in this PR:
* awaiting/reading a pub/sub message from Rawls, so we can finally mark the job as succeeded. After this PR, jobs will seem to stay in running forever according to WDS, but at least we'll be writing data to the Rawls-powered data tables.