### PR TITLE
AJ-1669: Improve PFB E2E test coverage.

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkFactory.java
@@ -1,22 +1,16 @@
 package org.databiosphere.workspacedataservice.recordsink;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.function.Consumer;
 import org.databiosphere.workspacedataservice.annotations.DeploymentMode.ControlPlane;
 import org.databiosphere.workspacedataservice.dataimport.ImportDetails;
 import org.databiosphere.workspacedataservice.pubsub.PubSub;
-import org.databiosphere.workspacedataservice.recordsink.RawlsRecordSink.RawlsJsonConsumer;
 import org.databiosphere.workspacedataservice.storage.GcsStorage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /** RecordSinkFactory implementation for the control plane */
 @ControlPlane
 @Component
 public class RawlsRecordSinkFactory implements RecordSinkFactory {
-
-  private Consumer<String> jsonConsumer;
-
   private final ObjectMapper mapper;
 
   private final GcsStorage storage;
@@ -27,14 +21,6 @@ public class RawlsRecordSinkFactory implements RecordSinkFactory {
     this.mapper = mapper;
     this.storage = storage;
     this.pubSub = pubSub;
-    this.jsonConsumer = json -> {};
-  }
-
-  // jsonConsumer currently only used by tests, so it is optional. If/when this is used consistently
-  // at runtime, it should move to the constructor and no longer be optional
-  @Autowired(required = false)
-  public void setJsonConsumer(@RawlsJsonConsumer Consumer<String> jsonConsumer) {
-    this.jsonConsumer = jsonConsumer;
   }
 
   // TODO(AJ-1589): make prefix assignment dynamic. However, of note: the prefix is currently
@@ -45,6 +31,6 @@ public class RawlsRecordSinkFactory implements RecordSinkFactory {
   }
 
   private RecordSink rawlsRecordSink(ImportDetails importDetails) {
-    return new RawlsRecordSink(mapper, jsonConsumer, storage, pubSub, importDetails);
+    return new RawlsRecordSink(mapper, storage, pubSub, importDetails);
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobControlPlaneE2ETest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobControlPlaneE2ETest.java
@@ -1,6 +1,6 @@
 package org.databiosphere.workspacedataservice.dataimport.pfb;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.databiosphere.workspacedataservice.TestTags.SLOW;
 import static org.databiosphere.workspacedataservice.recordsink.RawlsModel.AttributeOperation;
 import static org.databiosphere.workspacedataservice.recordsink.RawlsModel.Entity;
@@ -11,6 +11,7 @@ import static org.databiosphere.workspacedataservice.recordsink.RawlsModel.Op.CR
 import static org.databiosphere.workspacedataservice.recordsink.RawlsModel.Op.REMOVE_ATTRIBUTE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import bio.terra.workspace.model.ResourceList;
@@ -18,47 +19,51 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
-import java.io.StringWriter;
+import java.io.InputStream;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
-import java.util.function.Consumer;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import org.databiosphere.workspacedataservice.pubsub.PubSub;
 import org.databiosphere.workspacedataservice.recordsink.RawlsModel.AddListMember;
 import org.databiosphere.workspacedataservice.recordsink.RawlsModel.AddUpdateAttribute;
 import org.databiosphere.workspacedataservice.recordsink.RawlsModel.CreateAttributeValueList;
 import org.databiosphere.workspacedataservice.recordsink.RawlsModel.RemoveAttribute;
-import org.databiosphere.workspacedataservice.recordsink.RawlsRecordSink.RawlsJsonConsumer;
+import org.databiosphere.workspacedataservice.sam.MockSamUsersApi;
 import org.databiosphere.workspacedataservice.service.CollectionService;
+import org.databiosphere.workspacedataservice.storage.GcsStorage;
 import org.databiosphere.workspacedataservice.workspacemanager.WorkspaceManagerDao;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.quartz.JobExecutionException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.core.io.Resource;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.util.StreamUtils;
 
 /**
  * Tests for PFB import that execute "end-to-end" - that is, they go through the whole process of
  * parsing the PFB, and generating the JSON that gets stored in a bucket and communicated to Rawls
  * via pubsub.
- *
- * <p>TODO(AJ-1669): Add coverage for bucket storage & pubsub
  */
 @ActiveProfiles(profiles = {"mock-sam", "noop-scheduler-dao", "control-plane"})
 @DirtiesContext
 @SpringBootTest
-@Import(PfbQuartzJobControlPlaneE2ETest.UseStringWriterForJsonConsumer.class)
 @TestPropertySource(
     properties = {
       // turn off pubsub autoconfiguration for tests
@@ -68,9 +73,12 @@ class PfbQuartzJobControlPlaneE2ETest {
   @Autowired ObjectMapper mapper;
   @Autowired CollectionService collectionService;
   @Autowired PfbTestSupport testSupport;
-  @Autowired StringWriter recordedJson; // emitted JSON will be captured in this StringWriter
-
+  @Autowired GcsStorage storage;
+  @SpyBean PubSub pubSub;
   @MockBean WorkspaceManagerDao wsmDao;
+
+  /** ArgumentCaptor for the message passed to {@link PubSub#publishSync(Map)}. */
+  @Captor private ArgumentCaptor<Map<String, String>> pubSubMessageCaptor;
 
   @Value("classpath:pfb/minimal-data.pfb")
   Resource minimalDataPfb;
@@ -86,40 +94,32 @@ class PfbQuartzJobControlPlaneE2ETest {
 
   private UUID collectionId;
 
-  /**
-   * Overrides the {@link RawlsJsonConsumer} bean to emit JSON into a StringWriter. This
-   * StringWriter is then autowired into the test, which can read its contents to verify the JSON
-   * emitted as a side effect of running the test jobs.
-   */
-  @TestConfiguration
-  static class UseStringWriterForJsonConsumer {
-    @Bean
-    public StringWriter recordedJson() {
-      return new StringWriter();
-    }
-
-    @Bean
-    @RawlsJsonConsumer
-    Consumer<String> jsonConsumer() {
-      return (json) -> recordedJson().append(json);
-    }
-  }
-
   @BeforeEach
-  void beforeEach() {
+  void setup() {
     collectionId = UUID.randomUUID();
-    recordedJson.getBuffer().setLength(0); // clear the buffer before each test
     // stub out WSM to report no snapshots already linked to this workspace
     when(wsmDao.enumerateDataRepoSnapshotReferences(any(), anyInt(), anyInt()))
         .thenReturn(new ResourceList());
+  }
+
+  @AfterEach
+  void teardown() {
+    storage.getBlobsInBucket().forEach(blob -> storage.deleteBlob(blob.getName()));
   }
 
   /* import test.avro, and validate the tables and row counts it imported. */
   @Test
   @Tag(SLOW)
   void pfbToRawlsEntity() throws JobExecutionException, IOException {
-    testSupport.executePfbImportQuartzJob(collectionId, minimalDataPfb);
-    var entities = assertRecordedEntitiesSerde(minimalDataExpectedJson);
+    // Arrange / Act
+    UUID jobId = testSupport.executePfbImportQuartzJob(collectionId, minimalDataPfb);
+
+    // Assert
+    assertPubSubMessage(expectedPubSubMessageFor(jobId));
+    assertSingleBlobWritten(blobNameFor(jobId));
+    InputStream writtenJson = storage.getBlobContents(blobNameFor(jobId));
+
+    var entities = assertRecordedEntitiesSerde(writtenJson, minimalDataExpectedJson);
     assertThat(entities.size()).isEqualTo(1);
     var entity = entities.get(0);
     assertThat(entity.name()).isEqualTo("HG01101_cram");
@@ -142,8 +142,15 @@ class PfbQuartzJobControlPlaneE2ETest {
   @Test
   @Tag(SLOW)
   void pfbToRawlsEntityWithArrays() throws JobExecutionException, IOException {
-    testSupport.executePfbImportQuartzJob(collectionId, dataWithArrayPfb);
-    var entities = assertRecordedEntitiesSerde(dataWithArrayExpectedJson);
+    // Arrange / Act
+    UUID jobId = testSupport.executePfbImportQuartzJob(collectionId, dataWithArrayPfb);
+
+    // Assert
+    assertPubSubMessage(expectedPubSubMessageFor(jobId));
+    assertSingleBlobWritten(blobNameFor(jobId));
+
+    InputStream writtenJson = storage.getBlobContents(blobNameFor(jobId));
+    var entities = assertRecordedEntitiesSerde(writtenJson, dataWithArrayExpectedJson);
 
     assertThat(entities.size()).isEqualTo(1);
     var entity = entities.get(0);
@@ -172,6 +179,34 @@ class PfbQuartzJobControlPlaneE2ETest {
     assertThat(actual).isEqualTo(expected);
   }
 
+  private ImmutableMap<String, String> expectedPubSubMessageFor(UUID jobId) {
+    return new ImmutableMap.Builder<String, String>()
+        .put("workspaceId", collectionId.toString())
+        .put("userEmail", MockSamUsersApi.MOCK_USER_EMAIL)
+        .put("jobId", jobId.toString())
+        .put("upsertFile", blobNameFor(jobId))
+        .put("isUpsert", "true")
+        .put("isCWDS", "true")
+        .build();
+  }
+
+  private static String blobNameFor(UUID jobId) {
+    return "%s.rawlsUpsert".formatted(jobId);
+  }
+
+  private void assertPubSubMessage(Map<String, String> expectedMessage) {
+    verify(pubSub).publishSync(pubSubMessageCaptor.capture());
+    assertThat(pubSubMessageCaptor.getValue()).isEqualTo(expectedMessage);
+  }
+
+  private void assertSingleBlobWritten(String expectedBlobName) {
+    var blobsWritten =
+        StreamSupport.stream(storage.getBlobsInBucket().spliterator(), /* parallel= */ false)
+            .toList();
+    assertThat(blobsWritten).hasSize(1);
+    assertThat(blobsWritten.get(0).getName()).isEqualTo(expectedBlobName);
+  }
+
   private void assertAttributeValue(Entity entity, String attributeName, Object expected) {
     assertThat(
             filteredOps(entity, ADD_UPDATE_ATTRIBUTE)
@@ -188,9 +223,10 @@ class PfbQuartzJobControlPlaneE2ETest {
   }
 
   // serde == serialize then deserialize; to test the full roundtrip to/from JSON
-  private List<Entity> assertRecordedEntitiesSerde(Resource expectedJsonResource) {
+  private List<Entity> assertRecordedEntitiesSerde(
+      InputStream jsonStream, Resource expectedJsonResource) {
     try {
-      String actualJson = recordedJson.toString();
+      String actualJson = StreamUtils.copyToString(jsonStream, StandardCharsets.UTF_8);
       String expectedJson = new String(expectedJsonResource.getInputStream().readAllBytes());
       assertJsonEquals(expectedJson, actualJson);
       return mapper.readValue(actualJson, new TypeReference<>() {});

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbTestSupport.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbTestSupport.java
@@ -41,7 +41,7 @@ class PfbTestSupport {
   @Autowired private SamDao samDao;
   @Autowired DataImportProperties dataImportProperties;
 
-  void executePfbImportQuartzJob(UUID collectionId, Resource pfbResource)
+  UUID executePfbImportQuartzJob(UUID collectionId, Resource pfbResource)
       throws IOException, JobExecutionException {
     ImportRequestServerModel importRequest =
         new ImportRequestServerModel(ImportRequestServerModel.TypeEnum.PFB, pfbResource.getURI());
@@ -54,6 +54,8 @@ class PfbTestSupport {
     JobExecutionContext mockContext = stubJobContext(jobId, pfbResource, collectionId);
 
     buildPfbQuartzJob(collectionId).execute(mockContext);
+
+    return jobId;
   }
 
   PfbQuartzJob buildPfbQuartzJob() {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/sam/MockSamUsersApi.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/sam/MockSamUsersApi.java
@@ -4,8 +4,11 @@ import org.broadinstitute.dsde.workbench.client.sam.api.UsersApi;
 import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo;
 
 public class MockSamUsersApi extends UsersApi {
+  public static final String MOCK_USER_SUBJECT_ID = "mock-user-subject-id";
+  public static final String MOCK_USER_EMAIL = "mock@user.email";
+
   @Override
   public UserStatusInfo getUserStatusInfo() {
-    return new UserStatusInfo().userSubjectId("mock-user-subject-id");
+    return new UserStatusInfo().userSubjectId(MOCK_USER_SUBJECT_ID).userEmail(MOCK_USER_EMAIL);
   }
 }


### PR DESCRIPTION
In prep for making changes for [AJ-1669](https://broadworkbench.atlassian.net/browse/AJ-1669), improve E2E test coverage for PFB imports in cWDS:

* Verify PubSub message publishing.
* Verify GCS text storage.
* Use the contents of the GCS text instead of the `jsonConsumer` to do all the existing verifications on JSON content.
* Get rid of `jsonConsumer` which existed only to verify the JSON and is no longe needed.

[AJ-1669]: https://broadworkbench.atlassian.net/browse/AJ-1669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ