### PR TITLE
AJ-1669: Add `finalizeBatchWrite` to `RecordSink`

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJob.java
@@ -145,8 +145,12 @@ public class TdrManifestQuartzJob extends QuartzJob {
             recordSink);
 
     // add relations to the existing base attributes
-    importTables(
-        tdrManifestImportTables, fileDownloadHelper.getFileMap(), ImportMode.RELATIONS, recordSink);
+    result.merge(
+        importTables(
+            tdrManifestImportTables,
+            fileDownloadHelper.getFileMap(),
+            ImportMode.RELATIONS,
+            recordSink));
 
     // activity logging for import status
     // no specific activity logging for relations since main import is a superset
@@ -160,6 +164,10 @@ public class TdrManifestQuartzJob extends QuartzJob {
                             .record()
                             .withRecordType(entry.getKey())
                             .ofQuantity(entry.getValue())));
+
+    // Commit results, publish to downstream systems, etc.
+    recordSink.finalizeBatchWrite(result);
+
     // delete temp files after everything else is completed
     // Any failed deletions will be removed if/when pod restarts
     fileDownloadHelper.deleteFileDirectory();

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSink.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSink.java
@@ -21,6 +21,7 @@ import org.databiosphere.workspacedataservice.recordsink.RawlsModel.AttributeOpe
 import org.databiosphere.workspacedataservice.recordsink.RawlsModel.CreateAttributeValueList;
 import org.databiosphere.workspacedataservice.recordsink.RawlsModel.Entity;
 import org.databiosphere.workspacedataservice.recordsink.RawlsModel.RemoveAttribute;
+import org.databiosphere.workspacedataservice.service.model.BatchWriteResult;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
 import org.databiosphere.workspacedataservice.service.model.exception.BatchWriteException;
 import org.databiosphere.workspacedataservice.shared.model.Record;
@@ -82,6 +83,13 @@ public class RawlsRecordSink implements RecordSink {
   @Override
   public void deleteBatch(RecordType recordType, List<Record> records) throws BatchWriteException {
     throw new UnsupportedOperationException("RawlsRecordSink does not support deleteBatch");
+  }
+
+  @Override
+  public void finalizeBatchWrite(BatchWriteResult result) {
+    // currently a no-op
+    // TODO(AJ-1669): do pubsub here, maybe do GCS cleanup here (assuming a file was reused
+    //   throughout)
   }
 
   private void publishToPubSub(UUID workspaceId, String user, UUID jobId, String upsertFile) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RecordSink.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RecordSink.java
@@ -3,6 +3,7 @@ package org.databiosphere.workspacedataservice.recordsink;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import org.databiosphere.workspacedataservice.service.model.BatchWriteResult;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
 import org.databiosphere.workspacedataservice.service.model.exception.BatchWriteException;
 import org.databiosphere.workspacedataservice.shared.model.Record;
@@ -31,4 +32,10 @@ public interface RecordSink {
   /** Delete the given batch of records. */
   void deleteBatch(RecordType recordType, List<Record> records)
       throws BatchWriteException, IOException;
+
+  /**
+   * Callback invoked at the end of a series of batches operations with the result. Implementers can
+   * commit changes, clean up resources, publish results, etc.
+   */
+  void finalizeBatchWrite(BatchWriteResult result);
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/WdsRecordSink.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/WdsRecordSink.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.databiosphere.workspacedataservice.service.DataTypeInferer;
 import org.databiosphere.workspacedataservice.service.RecordService;
+import org.databiosphere.workspacedataservice.service.model.BatchWriteResult;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
 import org.databiosphere.workspacedataservice.service.model.exception.BatchWriteException;
 import org.databiosphere.workspacedataservice.shared.model.Record;
@@ -70,5 +71,10 @@ public class WdsRecordSink implements RecordSink {
   @Override
   public void deleteBatch(RecordType recordType, List<Record> records) throws BatchWriteException {
     recordDao.batchDelete(collectionId, recordType, records);
+  }
+
+  @Override
+  public void finalizeBatchWrite(BatchWriteResult result) {
+    // no-op
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/BatchWriteServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/BatchWriteServiceTest.java
@@ -32,6 +32,7 @@ import org.databiosphere.workspacedataservice.dataimport.ImportDetails;
 import org.databiosphere.workspacedataservice.dataimport.pfb.PfbTestUtils;
 import org.databiosphere.workspacedataservice.recordsink.RecordSink;
 import org.databiosphere.workspacedataservice.recordsink.RecordSinkFactory;
+import org.databiosphere.workspacedataservice.recordsource.RecordSource;
 import org.databiosphere.workspacedataservice.recordsource.RecordSource.ImportMode;
 import org.databiosphere.workspacedataservice.recordsource.RecordSourceFactory;
 import org.databiosphere.workspacedataservice.recordsource.TsvRecordSource;
@@ -82,20 +83,18 @@ class BatchWriteServiceTest extends TestBase {
   }
 
   @Test
-  void testRejectsDuplicateKeys() {
+  void testRejectsDuplicateKeys() throws IOException {
     String streamContents =
         "[{\"operation\": \"upsert\", \"record\": {\"id\": \"1\", \"type\": \"thing\", \"attributes\": {\"key\": \"value1\", \"key\": \"value2\"}}}]";
     InputStream is = new ByteArrayInputStream(streamContents.getBytes());
 
+    RecordSource recordSource = recordSourceFactory.forJson(is);
+    RecordSink recordSink =
+        recordSinkFactory.buildRecordSink(new ImportDetails(COLLECTION, "json"));
     Exception ex =
         assertThrows(
             BadStreamingWriteRequestException.class,
-            () ->
-                batchWriteService.batchWrite(
-                    recordSourceFactory.forJson(is),
-                    recordSinkFactory.buildRecordSink(new ImportDetails(COLLECTION, "json")),
-                    THING_TYPE,
-                    RECORD_ID));
+            () -> batchWriteService.batchWrite(recordSource, recordSink, THING_TYPE, RECORD_ID));
 
     String errorMessage = ex.getMessage();
     assertEquals("Duplicate field 'key'", errorMessage);
@@ -125,7 +124,9 @@ class BatchWriteServiceTest extends TestBase {
         recordSourceFactory.forTsv(file.getInputStream(), recordType, Optional.of(primaryKey));
     RecordSink recordSink =
         recordSinkFactory.buildRecordSink(new ImportDetails(COLLECTION, /* prefix= */ "tsv"));
-    batchWriteService.batchWrite(recordSource, recordSink, recordType, primaryKey);
+    BatchWriteResult result =
+        batchWriteService.batchWrite(recordSource, recordSink, recordType, primaryKey);
+    recordSink.finalizeBatchWrite(result);
 
     // we should write three batches
     verify(recordService, times(3))
@@ -264,10 +265,15 @@ class BatchWriteServiceTest extends TestBase {
 
   private BatchWriteResult batchWritePfbStream(
       DataFileStream<GenericRecord> pfbStream, String primaryKey, ImportMode importMode) {
-    return batchWriteService.batchWrite(
-        recordSourceFactory.forPfb(pfbStream, importMode),
-        recordSinkFactory.buildRecordSink(new ImportDetails(COLLECTION, /* prefix= */ "pfb")),
-        /* recordType= */ null,
-        primaryKey);
+    RecordSink recordSink =
+        recordSinkFactory.buildRecordSink(new ImportDetails(COLLECTION, /* prefix= */ "pfb"));
+    var result =
+        batchWriteService.batchWrite(
+            recordSourceFactory.forPfb(pfbStream, importMode),
+            recordSink,
+            /* recordType= */ null,
+            primaryKey);
+    recordSink.finalizeBatchWrite(result);
+    return result;
   }
 }


### PR DESCRIPTION
For [AJ-1669](https://broadworkbench.atlassian.net/browse/AJ-1669): this provides a callback hook that can be used to perform any necessary steps _after_ all batches are complete.  Its intended use is to allow `RawlsRecordSink` to finish writing to the underlying GCS Storage, and send a pubsub message downstream just once after all batches are complete.

Right now it is basically a no-op, but it could be used at this point to consolidate the activity logging logic, for example.

[AJ-1669]: https://broadworkbench.atlassian.net/browse/AJ-1669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ