### PR TITLE
AJ-1670: MDC requestId for Quartz jobs

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
@@ -25,6 +25,7 @@ import org.databiosphere.workspacedataservice.shared.model.job.JobResult;
 import org.databiosphere.workspacedataservice.shared.model.job.JobType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -87,6 +88,16 @@ public class ImportService {
       arguments.put(ARG_TOKEN, petToken);
       arguments.put(ARG_URL, importRequest.getUrl().toString());
       arguments.put(ARG_COLLECTION, collectionId.toString());
+      // try to put the MDC id into the job context; don't fail if this errors out
+      try {
+        arguments.put(
+            MDCServletRequestListener.MDC_KEY, MDC.get(MDCServletRequestListener.MDC_KEY));
+      } catch (Exception e) {
+        logger.warn(
+            "Could not add MDC requestId to job map for job {}: {}",
+            createdJob.getJobId(),
+            e.getMessage());
+      }
 
       // create the executable job to be scheduled
       Schedulable schedulable =

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
@@ -92,7 +92,7 @@ public class ImportService {
 
       // if we can find an MDC id, add it to the job context
       safeGetMdcId(createdJob.getJobId())
-          .map(requestId -> arguments.put(MDCServletRequestListener.MDC_KEY, requestId));
+          .ifPresent(requestId -> arguments.put(MDCServletRequestListener.MDC_KEY, requestId));
 
       // create the executable job to be scheduled
       Schedulable schedulable =

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
@@ -7,6 +7,7 @@ import static org.databiosphere.workspacedataservice.shared.model.Schedulable.AR
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.dao.SchedulerDao;
@@ -88,16 +89,10 @@ public class ImportService {
       arguments.put(ARG_TOKEN, petToken);
       arguments.put(ARG_URL, importRequest.getUrl().toString());
       arguments.put(ARG_COLLECTION, collectionId.toString());
-      // try to put the MDC id into the job context; don't fail if this errors out
-      try {
-        arguments.put(
-            MDCServletRequestListener.MDC_KEY, MDC.get(MDCServletRequestListener.MDC_KEY));
-      } catch (Exception e) {
-        logger.warn(
-            "Could not add MDC requestId to job map for job {}: {}",
-            createdJob.getJobId(),
-            e.getMessage());
-      }
+
+      // if we can find an MDC id, add it to the job context
+      safeGetMdcId(createdJob.getJobId())
+          .map(requestId -> arguments.put(MDCServletRequestListener.MDC_KEY, requestId));
 
       // create the executable job to be scheduled
       Schedulable schedulable =
@@ -118,6 +113,17 @@ public class ImportService {
 
     // return the queued job
     return createdJob;
+  }
+
+  // attempt to get the requestId from MDC. We expect this to always succeed, but if it doesn't,
+  // don't fail the import job. We only need the requestId for logging/correlation.
+  private Optional<String> safeGetMdcId(UUID jobId) {
+    try {
+      return Optional.of(MDC.get(MDCServletRequestListener.MDC_KEY));
+    } catch (Exception e) {
+      logger.warn("Could not add MDC requestId to job map for job {}: {}", jobId, e.getMessage());
+      return Optional.empty();
+    }
   }
 
   protected Schedulable createSchedulable(

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/MDCServletRequestListener.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/MDCServletRequestListener.java
@@ -25,7 +25,7 @@ import org.springframework.stereotype.Component;
 public class MDCServletRequestListener implements ServletRequestListener {
 
   // where the unique request id is stored in the MDC context
-  static final String MDC_KEY = "requestId";
+  public static final String MDC_KEY = "requestId";
   // the response header containing the unique request id
   public static final String RESPONSE_HEADER = "x-b3-traceid";
   // the list of request headers, in order, we will search for an incoming unique request id


### PR DESCRIPTION
Persist the MDC requestId into Quartz job context. Within the Quartz job, retrieve the id from context and put it into the new thread's MDC.

This screenshot of local logs shows the same requestId across threads. In the highlighted rectangle, the first column is the thread name and the second is the request id:
![Screenshot 2024-03-08 at 5 04 27 PM](https://github.com/DataBiosphere/terra-workspace-data-service/assets/6041577/dda7b153-8bb5-47ff-bfa6-a233769e3c7f)

compare to a screenshot from before this PR:
![Screenshot 2024-03-03 at 8 32 55 AM](https://github.com/DataBiosphere/terra-workspace-data-service/assets/6041577/ad409fec-0c93-4607-bac2-7e64708da80a)
