### PR TITLE
AJ-1586: send full bucketname + file in pubsub message

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSink.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSink.java
@@ -98,7 +98,7 @@ public class RawlsRecordSink implements RecordSink {
             .put("workspaceId", workspaceId.toString())
             .put("userEmail", user)
             .put("jobId", jobId.toString())
-            .put("upsertFile", upsertFile)
+            .put("upsertFile", storage.getBucketName() + "/" + upsertFile)
             .put("isUpsert", "true")
             .put("isCWDS", "true")
             .build();

--- a/service/src/main/java/org/databiosphere/workspacedataservice/storage/GcsStorage.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/storage/GcsStorage.java
@@ -51,7 +51,7 @@ public class GcsStorage {
 
   public String createGcsFile(InputStream contents, UUID jobId) throws IOException {
     // create the GCS Resource
-    var blobName = jobId.toString() + ".rawlsUpsert";
+    var blobName = jobId + ".rawlsUpsert";
     GoogleStorageResource gcsResource =
         new GoogleStorageResource(
             this.storage, String.format("gs://%s/%s", this.bucketName, blobName));
@@ -60,6 +60,10 @@ public class GcsStorage {
       contents.transferTo(os);
     }
     return gcsResource.getBlobName();
+  }
+
+  public String getBucketName() {
+    return bucketName;
   }
 
   @VisibleForTesting

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobControlPlaneE2ETest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobControlPlaneE2ETest.java
@@ -184,7 +184,7 @@ class PfbQuartzJobControlPlaneE2ETest {
         .put("workspaceId", collectionId.toString())
         .put("userEmail", MockSamUsersApi.MOCK_USER_EMAIL)
         .put("jobId", jobId.toString())
-        .put("upsertFile", blobNameFor(jobId))
+        .put("upsertFile", storage.getBucketName() + "/" + blobNameFor(jobId))
         .put("isUpsert", "true")
         .put("isCWDS", "true")
         .build();

--- a/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkTest.java
@@ -177,7 +177,7 @@ class RawlsRecordSinkTest extends TestBase {
             .put("workspaceId", WORKSPACE_ID.toString())
             .put("userEmail", USER_EMAIL)
             .put("jobId", JOB_ID.toString())
-            .put("upsertFile", JOB_ID + ".rawlsUpsert")
+            .put("upsertFile", storage.getBucketName() + "/" + JOB_ID + ".rawlsUpsert")
             .put("isUpsert", "true")
             .put("isCWDS", "true")
             .build();


### PR DESCRIPTION
In the pubsub message that cWDS sends to Rawls, we must include the bucket name as well as the file path.