### PR TITLE
[AJ-1635] Configure Dependabot to group minor and patch version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,9 @@ updates:
       day: "monday"
       time: "08:00"
       timezone: "America/New_York"
+    groups:
+      minor-and-patch-updates:
+        applies-to: "version-updates"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
A couple of times now, I've noticed @davidangb and @jladieu combine multiple Dependabot updates into one PR. Instead of doing that manually, we can have Dependabot do it for us.

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups