### PR TITLE
AJ-1669: Write and publish only once.

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJob.java
@@ -9,6 +9,7 @@ import static org.databiosphere.workspacedataservice.shared.model.Schedulable.AR
 
 import bio.terra.pfb.PfbReader;
 import io.micrometer.observation.ObservationRegistry;
+import java.io.IOException;
 import java.net.URL;
 import java.util.Objects;
 import java.util.Set;
@@ -128,19 +129,23 @@ public class PfbQuartzJob extends QuartzJob {
     linkSnapshots(snapshotIds, workspaceId);
 
     // Import all the tables and rows inside the PFB.
-    RecordSink recordSink = recordSinkFactory.buildRecordSink(importDetails);
+    try (RecordSink recordSink = recordSinkFactory.buildRecordSink(importDetails)) {
+      // This is HTTP connection #2 to the PFB.
+      logger.info("Importing tables and rows from this PFB...");
+      BatchWriteResult result =
+          withPfbStream(url, stream -> importTables(stream, recordSink, BASE_ATTRIBUTES));
 
-    // This is HTTP connection #2 to the PFB.
-    logger.info("Importing tables and rows from this PFB...");
-    BatchWriteResult result =
-        withPfbStream(url, stream -> importTables(stream, recordSink, BASE_ATTRIBUTES));
+      // This is HTTP connection #3 to the PFB.
+      logger.info("Updating tables and rows from this PFB with relations...");
+      // TODO: merging batch results may have unexpected behavior until BatchWriteResult can
+      //   group its merged results under import mode; most notably, relations will be double
+      //   counted
+      result.merge(withPfbStream(url, stream -> importTables(stream, recordSink, RELATIONS)));
+    } catch (IOException e) {
+      // TODO: better error handling than this?
+      throw new RuntimeException(e);
+    }
 
-    // This is HTTP connection #3 to the PFB.
-    logger.info("Updating tables and rows from this PFB with relations...");
-    result.merge(withPfbStream(url, stream -> importTables(stream, recordSink, RELATIONS)));
-
-    // Commit results, publish to downstream systems, etc.
-    recordSink.finalizeBatchWrite(result);
     // TODO(AJ-1453): save the result of importTables and persist them to the job
   }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJob.java
@@ -9,7 +9,6 @@ import static org.databiosphere.workspacedataservice.shared.model.Schedulable.AR
 
 import bio.terra.pfb.PfbReader;
 import io.micrometer.observation.ObservationRegistry;
-import java.io.IOException;
 import java.net.URL;
 import java.util.Objects;
 import java.util.Set;
@@ -37,6 +36,8 @@ import org.databiosphere.workspacedataservice.sam.SamDao;
 import org.databiosphere.workspacedataservice.service.BatchWriteService;
 import org.databiosphere.workspacedataservice.service.CollectionService;
 import org.databiosphere.workspacedataservice.service.model.BatchWriteResult;
+import org.databiosphere.workspacedataservice.service.model.exception.DataImportException;
+import org.databiosphere.workspacedataservice.service.model.exception.PfbImportException;
 import org.databiosphere.workspacedataservice.service.model.exception.PfbParsingException;
 import org.databiosphere.workspacedataservice.shared.model.BearerToken;
 import org.databiosphere.workspacedataservice.shared.model.CollectionId;
@@ -141,9 +142,8 @@ public class PfbQuartzJob extends QuartzJob {
       //   group its merged results under import mode; most notably, relations will be double
       //   counted
       result.merge(withPfbStream(url, stream -> importTables(stream, recordSink, RELATIONS)));
-    } catch (IOException e) {
-      // TODO: better error handling than this?
-      throw new RuntimeException(e);
+    } catch (DataImportException e) {
+      throw new PfbImportException(e.getMessage(), e);
     }
 
     // TODO(AJ-1453): save the result of importTables and persist them to the job

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJob.java
@@ -44,6 +44,7 @@ import org.databiosphere.workspacedataservice.service.BatchWriteService;
 import org.databiosphere.workspacedataservice.service.CollectionService;
 import org.databiosphere.workspacedataservice.service.model.BatchWriteResult;
 import org.databiosphere.workspacedataservice.service.model.TdrManifestImportTable;
+import org.databiosphere.workspacedataservice.service.model.exception.DataImportException;
 import org.databiosphere.workspacedataservice.service.model.exception.TdrManifestImportException;
 import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
@@ -161,9 +162,8 @@ public class TdrManifestQuartzJob extends QuartzJob {
                               .record()
                               .withRecordType(entry.getKey())
                               .ofQuantity(entry.getValue())));
-    } catch (IOException e) {
-      // TODO: better exception handling?
-      throw new RuntimeException(e);
+    } catch (DataImportException e) {
+      throw new TdrManifestImportException(e.getMessage(), e);
     }
 
     // delete temp files after everything else is completed

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJob.java
@@ -132,39 +132,39 @@ public class TdrManifestQuartzJob extends QuartzJob {
     // get all the parquet files from the manifests
 
     FileDownloadHelper fileDownloadHelper = getFilesForImport(tdrManifestImportTables);
-    RecordSink recordSink = recordSinkFactory.buildRecordSink(importDetails);
+    try (RecordSink recordSink = recordSinkFactory.buildRecordSink(importDetails)) {
+      // loop through the tables to be imported and upsert base attributes
+      var result =
+          importTables(
+              tdrManifestImportTables,
+              fileDownloadHelper.getFileMap(),
+              ImportMode.BASE_ATTRIBUTES,
+              recordSink);
 
-    // loop through the tables to be imported and upsert base attributes
-    var result =
-        importTables(
-            tdrManifestImportTables,
-            fileDownloadHelper.getFileMap(),
-            ImportMode.BASE_ATTRIBUTES,
-            recordSink);
+      // add relations to the existing base attributes
+      result.merge(
+          importTables(
+              tdrManifestImportTables,
+              fileDownloadHelper.getFileMap(),
+              ImportMode.RELATIONS,
+              recordSink));
 
-    // add relations to the existing base attributes
-    result.merge(
-        importTables(
-            tdrManifestImportTables,
-            fileDownloadHelper.getFileMap(),
-            ImportMode.RELATIONS,
-            recordSink));
-
-    // activity logging for import status
-    // no specific activity logging for relations since main import is a superset
-    result
-        .entrySet()
-        .forEach(
-            entry ->
-                activityLogger.saveEventForCurrentUser(
-                    user ->
-                        user.upserted()
-                            .record()
-                            .withRecordType(entry.getKey())
-                            .ofQuantity(entry.getValue())));
-
-    // Commit results, publish to downstream systems, etc.
-    recordSink.finalizeBatchWrite(result);
+      // activity logging for import status
+      // no specific activity logging for relations since main import is a superset
+      result
+          .entrySet()
+          .forEach(
+              entry ->
+                  activityLogger.saveEventForCurrentUser(
+                      user ->
+                          user.upserted()
+                              .record()
+                              .withRecordType(entry.getKey())
+                              .ofQuantity(entry.getValue())));
+    } catch (IOException e) {
+      // TODO: better exception handling?
+      throw new RuntimeException(e);
+    }
 
     // delete temp files after everything else is completed
     // Any failed deletions will be removed if/when pod restarts

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSink.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSink.java
@@ -39,12 +39,26 @@ public class RawlsRecordSink implements RecordSink {
   private final ImportDetails importDetails;
 
   RawlsRecordSink(
-      ObjectMapper mapper, GcsStorage storage, PubSub pubSub, ImportDetails importDetails) {
-    this.attributePrefixer = new RawlsAttributePrefixer(importDetails.prefixStrategy());
+      RawlsAttributePrefixer attributePrefixer,
+      ObjectMapper mapper,
+      GcsStorage storage,
+      PubSub pubSub,
+      ImportDetails importDetails) {
+    this.attributePrefixer = attributePrefixer;
     this.mapper = mapper;
     this.storage = storage;
     this.pubSub = pubSub;
     this.importDetails = importDetails;
+  }
+
+  public static RawlsRecordSink create(
+      ObjectMapper mapper, GcsStorage storage, PubSub pubSub, ImportDetails importDetails) {
+    return new RawlsRecordSink(
+        new RawlsAttributePrefixer(importDetails.prefixStrategy()),
+        mapper,
+        storage,
+        pubSub,
+        importDetails);
   }
 
   @Override

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSink.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSink.java
@@ -2,12 +2,14 @@ package org.databiosphere.workspacedataservice.recordsink;
 
 import static java.util.Objects.requireNonNull;
 
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableList;
+import com.google.cloud.spring.storage.GoogleStorageResource;
+import com.google.cloud.storage.Blob;
 import com.google.common.collect.ImmutableMap;
 import com.google.mu.util.stream.BiStream;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -22,9 +24,11 @@ import org.databiosphere.workspacedataservice.recordsink.RawlsModel.CreateAttrib
 import org.databiosphere.workspacedataservice.recordsink.RawlsModel.Entity;
 import org.databiosphere.workspacedataservice.recordsink.RawlsModel.RemoveAttribute;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
+import org.databiosphere.workspacedataservice.service.model.exception.DataImportException;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 import org.databiosphere.workspacedataservice.storage.GcsStorage;
+import org.springframework.util.function.ThrowingConsumer;
 
 /**
  * {@link RecordSink} implementation that produces Rawls-compatible JSON using {@link RawlsModel}
@@ -32,32 +36,47 @@ import org.databiosphere.workspacedataservice.storage.GcsStorage;
  */
 public class RawlsRecordSink implements RecordSink {
   private final RawlsAttributePrefixer attributePrefixer;
-  private final ObjectMapper mapper;
-  private final GcsStorage storage;
   private final PubSub pubSub;
   private final ImportDetails importDetails;
 
+  private final JsonWriter jsonWriter;
+  private final Blob blob;
+
   RawlsRecordSink(
       RawlsAttributePrefixer attributePrefixer,
-      ObjectMapper mapper,
-      GcsStorage storage,
+      JsonWriter jsonWriter,
       PubSub pubSub,
-      ImportDetails importDetails) {
+      ImportDetails importDetails,
+      Blob blob) {
     this.attributePrefixer = attributePrefixer;
-    this.mapper = mapper;
-    this.storage = storage;
+    this.jsonWriter = jsonWriter;
+
+    // TODO: These three instance variables are used exclusively for pubsub concerns; if we can
+    //   factor the pubsub responsibility out somehow, RawlsRecordSink can be a lot more focused.
     this.pubSub = pubSub;
     this.importDetails = importDetails;
+    this.blob = blob;
   }
 
+  /**
+   * Creates a {@link RawlsRecordSink} that writes a stream of JSON entities to the given {@link
+   * GcsStorage}.
+   *
+   * @param mapper used to generate the stream of JSON entities
+   * @param storage where the JSON stream will be written
+   * @param pubSub to notify upon JSON stream completion
+   * @param importDetails to use for generating the message to send to PubSub
+   */
   public static RawlsRecordSink create(
       ObjectMapper mapper, GcsStorage storage, PubSub pubSub, ImportDetails importDetails) {
+    String blobName = getBlobName(requireNonNull(importDetails.jobId()));
+    Blob blob = storage.createBlob(blobName);
     return new RawlsRecordSink(
         new RawlsAttributePrefixer(importDetails.prefixStrategy()),
-        mapper,
-        storage,
+        JsonWriter.create(storage.getOutputStream(blob), mapper),
         pubSub,
-        importDetails);
+        importDetails,
+        blob);
   }
 
   @Override
@@ -76,20 +95,8 @@ public class RawlsRecordSink implements RecordSink {
       Map<String, DataTypeMapping> schema, // ignored
       List<Record> records,
       String primaryKey // ignored
-      ) throws IOException {
-    ImmutableList.Builder<Entity> entities = ImmutableList.builder();
-    records.stream().map(this::toEntity).forEach(entities::add);
-
-    String upsertFileName =
-        storage.createGcsFile(
-            new ByteArrayInputStream(mapper.writeValueAsBytes(entities.build())),
-            requireNonNull(importDetails.jobId()));
-
-    publishToPubSub(
-        importDetails.collectionId(),
-        requireNonNull(importDetails.userEmail()),
-        importDetails.jobId(),
-        upsertFileName);
+      ) {
+    records.stream().map(this::toEntity).forEach(jsonWriter::writeEntity);
   }
 
   @Override
@@ -99,22 +106,8 @@ public class RawlsRecordSink implements RecordSink {
 
   @Override
   public void close() {
-    // currently a no-op
-    // TODO(AJ-1669): do pubsub here, maybe do GCS cleanup here (assuming a file was reused
-    //   throughout)
-  }
-
-  private void publishToPubSub(UUID workspaceId, String user, UUID jobId, String upsertFile) {
-    Map<String, String> message =
-        new ImmutableMap.Builder<String, String>()
-            .put("workspaceId", workspaceId.toString())
-            .put("userEmail", user)
-            .put("jobId", jobId.toString())
-            .put("upsertFile", storage.getBucketName() + "/" + upsertFile)
-            .put("isUpsert", "true")
-            .put("isCWDS", "true")
-            .build();
-    pubSub.publishSync(message);
+    jsonWriter.close();
+    publishToPubSub(importDetails);
   }
 
   private Entity toEntity(Record record) {
@@ -139,5 +132,97 @@ public class RawlsRecordSink implements RecordSink {
     }
 
     return Stream.of(new AddUpdateAttribute(name, attributeValue));
+  }
+
+  static String getBlobName(UUID jobId) {
+    return "%s.rawlsUpsert".formatted(jobId.toString());
+  }
+
+  private void publishToPubSub(ImportDetails importDetails) {
+    UUID jobId = requireNonNull(importDetails.jobId());
+    UUID workspaceId = importDetails.collectionId();
+    String user = requireNonNull(importDetails.userEmail());
+    Map<String, String> message =
+        new ImmutableMap.Builder<String, String>()
+            .put("workspaceId", workspaceId.toString())
+            .put("userEmail", user)
+            .put("jobId", jobId.toString())
+            .put("upsertFile", blob.getBucket() + "/" + blob.getName())
+            .put("isUpsert", "true")
+            .put("isCWDS", "true")
+            .build();
+    pubSub.publishSync(message);
+  }
+
+  /**
+   * {@link JsonWriter} is responsible for writing JSON to a {@link GoogleStorageResource} and is
+   * intended to encapsulate the logic to get an {@link OutputStream} set up to do that and ensure
+   * the array of entities generated is properly initialized and terminated with "[" tokens.
+   */
+  private static class JsonWriter implements AutoCloseable {
+    private final JsonGenerator jsonGenerator;
+
+    // TODO: consider using a simple state machine here [enum INITIALIZED, WRITING, CLOSED] to
+    //  ensure the array stream is only started and closed once
+    private boolean streamStarted = false;
+
+    private JsonWriter(JsonGenerator jsonGenerator) {
+      this.jsonGenerator = jsonGenerator;
+    }
+
+    /**
+     * Initialize a new {@link JsonWriter} to write to the given {@link GoogleStorageResource} using
+     * the provided {@link ObjectMapper}.
+     */
+    private static JsonWriter create(OutputStream outputStream, ObjectMapper objectMapper) {
+      try {
+        return new JsonWriter(objectMapper.getFactory().createGenerator(outputStream));
+      } catch (IOException e) {
+        throw new JsonWriteException("Failed to create", e);
+      }
+    }
+
+    /** Write a single entity to the JSON array in Google storage. */
+    private void writeEntity(Entity entity) {
+      if (!streamStarted) {
+        writeJson(JsonGenerator::writeStartArray); // write a "[" to begin the array of entities
+        streamStarted = true;
+      }
+
+      writeJson(generator -> generator.writePOJO(entity));
+    }
+
+    /** Terminate the JSON array and close the underlying {@link JsonGenerator}. */
+    @Override
+    public void close() {
+      if (streamStarted) {
+        writeJson(JsonGenerator::writeEndArray); // write a "]" to end the array of entities
+      }
+      try {
+        jsonGenerator.close();
+      } catch (IOException e) {
+        throw new JsonWriteException("Failed to close", e);
+      }
+    }
+
+    private void writeJson(ThrowingConsumer<JsonGenerator> jsonGeneratorConsumer) {
+      jsonGeneratorConsumer.accept(jsonGenerator);
+      try {
+        jsonGenerator.flush();
+      } catch (IOException e) {
+        throw new JsonWriteException("Failed to flush", e);
+      }
+    }
+  }
+
+  /**
+   * This unchecked exception wraps the {@link IOException} that can occur at various stages while
+   * establishing a stream and writing JSON to Google Storage. It extends {@link
+   * DataImportException} so callers don't need to handle it explicitly.
+   */
+  public static class JsonWriteException extends DataImportException {
+    public JsonWriteException(String message, IOException cause) {
+      super(message, cause);
+    }
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSink.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSink.java
@@ -21,7 +21,6 @@ import org.databiosphere.workspacedataservice.recordsink.RawlsModel.AttributeOpe
 import org.databiosphere.workspacedataservice.recordsink.RawlsModel.CreateAttributeValueList;
 import org.databiosphere.workspacedataservice.recordsink.RawlsModel.Entity;
 import org.databiosphere.workspacedataservice.recordsink.RawlsModel.RemoveAttribute;
-import org.databiosphere.workspacedataservice.service.model.BatchWriteResult;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
@@ -99,7 +98,7 @@ public class RawlsRecordSink implements RecordSink {
   }
 
   @Override
-  public void finalizeBatchWrite(BatchWriteResult result) {
+  public void close() {
     // currently a no-op
     // TODO(AJ-1669): do pubsub here, maybe do GCS cleanup here (assuming a file was reused
     //   throughout)

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSink.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSink.java
@@ -23,7 +23,6 @@ import org.databiosphere.workspacedataservice.recordsink.RawlsModel.Entity;
 import org.databiosphere.workspacedataservice.recordsink.RawlsModel.RemoveAttribute;
 import org.databiosphere.workspacedataservice.service.model.BatchWriteResult;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
-import org.databiosphere.workspacedataservice.service.model.exception.BatchWriteException;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 import org.databiosphere.workspacedataservice.storage.GcsStorage;
@@ -64,7 +63,7 @@ public class RawlsRecordSink implements RecordSink {
       Map<String, DataTypeMapping> schema, // ignored
       List<Record> records,
       String primaryKey // ignored
-      ) throws BatchWriteException, IOException {
+      ) throws IOException {
     ImmutableList.Builder<Entity> entities = ImmutableList.builder();
     records.stream().map(this::toEntity).forEach(entities::add);
 
@@ -81,7 +80,7 @@ public class RawlsRecordSink implements RecordSink {
   }
 
   @Override
-  public void deleteBatch(RecordType recordType, List<Record> records) throws BatchWriteException {
+  public void deleteBatch(RecordType recordType, List<Record> records) {
     throw new UnsupportedOperationException("RawlsRecordSink does not support deleteBatch");
   }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkFactory.java
@@ -31,6 +31,6 @@ public class RawlsRecordSinkFactory implements RecordSinkFactory {
   }
 
   private RecordSink rawlsRecordSink(ImportDetails importDetails) {
-    return new RawlsRecordSink(mapper, storage, pubSub, importDetails);
+    return RawlsRecordSink.create(mapper, storage, pubSub, importDetails);
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RecordSink.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RecordSink.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.Map;
 import org.databiosphere.workspacedataservice.service.model.BatchWriteResult;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
-import org.databiosphere.workspacedataservice.service.model.exception.BatchWriteException;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 
@@ -27,11 +26,10 @@ public interface RecordSink {
       Map<String, DataTypeMapping> schema,
       List<Record> records,
       String primaryKey)
-      throws BatchWriteException, IOException;
+      throws IOException;
 
   /** Delete the given batch of records. */
-  void deleteBatch(RecordType recordType, List<Record> records)
-      throws BatchWriteException, IOException;
+  void deleteBatch(RecordType recordType, List<Record> records) throws IOException;
 
   /**
    * Callback invoked at the end of a series of batches operations with the result. Implementers can

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RecordSink.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RecordSink.java
@@ -1,10 +1,9 @@
 package org.databiosphere.workspacedataservice.recordsink;
 
-import java.io.Closeable;
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
+import org.databiosphere.workspacedataservice.service.model.exception.DataImportException;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 
@@ -12,28 +11,43 @@ import org.databiosphere.workspacedataservice.shared.model.RecordType;
  * Implementations of this interface are responsible for modifying the schema and writing/deleting
  * batches of records.
  */
-public interface RecordSink extends Closeable {
-  /** Create or modify the schema for a record type and write the records. */
+public interface RecordSink extends AutoCloseable {
+  /**
+   * Create or modify the schema for a record type and write the records.
+   *
+   * @throws DataImportException if an error occurs creating or modifying types
+   */
   Map<String, DataTypeMapping> createOrModifyRecordType(
       RecordType recordType,
       Map<String, DataTypeMapping> schema,
       List<Record> records,
-      String recordTypePrimaryKey);
+      String recordTypePrimaryKey)
+      throws DataImportException;
 
-  /** Upsert the given batch of records. */
+  /**
+   * Upsert the given batch of records.
+   *
+   * @throws DataImportException if an error occurs while upserting the records
+   */
   void upsertBatch(
       RecordType recordType,
       Map<String, DataTypeMapping> schema,
       List<Record> records,
       String primaryKey)
-      throws IOException;
+      throws DataImportException;
 
-  /** Delete the given batch of records. */
-  void deleteBatch(RecordType recordType, List<Record> records) throws IOException;
+  /**
+   * Delete the given batch of records.
+   *
+   * @throws DataImportException if an error occurs while deleting the records
+   */
+  void deleteBatch(RecordType recordType, List<Record> records) throws DataImportException;
 
   /**
    * Callback invoked at the end of a series of batches operations with the result. Implementers can
    * commit changes, clean up resources, publish results, etc.
+   *
+   * @throws DataImportException if an error occurs while closing the sink
    */
-  void close() throws IOException;
+  void close() throws DataImportException;
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RecordSink.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RecordSink.java
@@ -1,9 +1,9 @@
 package org.databiosphere.workspacedataservice.recordsink;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import org.databiosphere.workspacedataservice.service.model.BatchWriteResult;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
@@ -12,7 +12,7 @@ import org.databiosphere.workspacedataservice.shared.model.RecordType;
  * Implementations of this interface are responsible for modifying the schema and writing/deleting
  * batches of records.
  */
-public interface RecordSink {
+public interface RecordSink extends Closeable {
   /** Create or modify the schema for a record type and write the records. */
   Map<String, DataTypeMapping> createOrModifyRecordType(
       RecordType recordType,
@@ -35,5 +35,5 @@ public interface RecordSink {
    * Callback invoked at the end of a series of batches operations with the result. Implementers can
    * commit changes, clean up resources, publish results, etc.
    */
-  void finalizeBatchWrite(BatchWriteResult result);
+  void close() throws IOException;
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/WdsRecordSink.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/WdsRecordSink.java
@@ -8,7 +8,6 @@ import org.databiosphere.workspacedataservice.service.DataTypeInferer;
 import org.databiosphere.workspacedataservice.service.RecordService;
 import org.databiosphere.workspacedataservice.service.model.BatchWriteResult;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
-import org.databiosphere.workspacedataservice.service.model.exception.BatchWriteException;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 
@@ -63,13 +62,12 @@ public class WdsRecordSink implements RecordSink {
       RecordType recordType,
       Map<String, DataTypeMapping> schema,
       List<Record> records,
-      String primaryKey)
-      throws BatchWriteException {
+      String primaryKey) {
     recordService.batchUpsert(collectionId, recordType, records, schema, primaryKey);
   }
 
   @Override
-  public void deleteBatch(RecordType recordType, List<Record> records) throws BatchWriteException {
+  public void deleteBatch(RecordType recordType, List<Record> records) {
     recordDao.batchDelete(collectionId, recordType, records);
   }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/WdsRecordSink.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/WdsRecordSink.java
@@ -6,7 +6,6 @@ import java.util.UUID;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.databiosphere.workspacedataservice.service.DataTypeInferer;
 import org.databiosphere.workspacedataservice.service.RecordService;
-import org.databiosphere.workspacedataservice.service.model.BatchWriteResult;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
@@ -72,7 +71,7 @@ public class WdsRecordSink implements RecordSink {
   }
 
   @Override
-  public void finalizeBatchWrite(BatchWriteResult result) {
+  public void close() {
     // no-op
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
@@ -30,6 +30,7 @@ import org.databiosphere.workspacedataservice.service.model.Relation;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthorizationException;
 import org.databiosphere.workspacedataservice.service.model.exception.BadStreamingWriteRequestException;
 import org.databiosphere.workspacedataservice.service.model.exception.ConflictException;
+import org.databiosphere.workspacedataservice.service.model.exception.DataImportException;
 import org.databiosphere.workspacedataservice.service.model.exception.MissingObjectException;
 import org.databiosphere.workspacedataservice.service.model.exception.ValidationException;
 import org.databiosphere.workspacedataservice.shared.model.CollectionId;
@@ -133,7 +134,7 @@ public class RecordOrchestratorService { // TODO give me a better name
       RecordType recordType,
       Optional<String> primaryKey,
       MultipartFile records)
-      throws IOException {
+      throws IOException, DataImportException {
     validateAndPermissions(collectionId, version);
     if (recordDao.recordTypeExists(collectionId, recordType)) {
       primaryKey =
@@ -157,9 +158,6 @@ public class RecordOrchestratorService { // TODO give me a better name
       activityLogger.saveEventForCurrentUser(
           user -> user.upserted().record().withRecordType(recordType).ofQuantity(qty));
       return qty;
-    } catch (IOException e) {
-      // TODO: better exception handling?
-      throw new RuntimeException(e);
     }
   }
 
@@ -380,7 +378,8 @@ public class RecordOrchestratorService { // TODO give me a better name
       String version,
       RecordType recordType,
       Optional<String> primaryKey,
-      InputStream is) {
+      InputStream is)
+      throws DataImportException {
     validateAndPermissions(collectionId, version);
     if (recordDao.recordTypeExists(collectionId, recordType)) {
       recordService.validatePrimaryKey(collectionId, recordType, primaryKey);
@@ -402,9 +401,6 @@ public class RecordOrchestratorService { // TODO give me a better name
       activityLogger.saveEventForCurrentUser(
           user -> user.modified().record().withRecordType(recordType).ofQuantity(qty));
       return qty;
-    } catch (IOException e) {
-      // TODO: better exception handling?
-      throw new RuntimeException(e);
     }
   }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordService.java
@@ -24,12 +24,12 @@ import org.databiosphere.workspacedataservice.service.model.Relation;
 import org.databiosphere.workspacedataservice.service.model.RelationCollection;
 import org.databiosphere.workspacedataservice.service.model.RelationValue;
 import org.databiosphere.workspacedataservice.service.model.ReservedNames;
-import org.databiosphere.workspacedataservice.service.model.exception.BatchWriteException;
 import org.databiosphere.workspacedataservice.service.model.exception.ConflictingPrimaryKeysException;
 import org.databiosphere.workspacedataservice.service.model.exception.InvalidNameException;
 import org.databiosphere.workspacedataservice.service.model.exception.InvalidRelationException;
 import org.databiosphere.workspacedataservice.service.model.exception.MissingObjectException;
 import org.databiosphere.workspacedataservice.service.model.exception.NewPrimaryKeyException;
+import org.databiosphere.workspacedataservice.service.model.exception.TypeMismatchException;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
 import org.databiosphere.workspacedataservice.shared.model.RecordRequest;
@@ -143,7 +143,7 @@ public class RecordService {
         recordTypeSchemaWithoutId.remove(primaryKey);
         List<String> rowErrors = checkEachRow(records, recordTypeSchemaWithoutId);
         if (!rowErrors.isEmpty()) {
-          throw new BatchWriteException(rowErrors);
+          throw new TypeMismatchException(rowErrors);
         }
       }
       throw e;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/TypeMismatchException.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/TypeMismatchException.java
@@ -5,9 +5,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 @ResponseStatus(code = HttpStatus.BAD_REQUEST)
-public class BatchWriteException extends IllegalArgumentException {
+public class TypeMismatchException extends IllegalArgumentException {
 
-  public BatchWriteException(List<String> errorInfo) {
+  public TypeMismatchException(List<String> errorInfo) {
     super(
         "Some of the records in your request don't have the proper data for the record type. "
             + "This is likely not an exhaustive list so please look for records with similar problems in your request: "

--- a/service/src/main/java/org/databiosphere/workspacedataservice/storage/GcsStorage.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/storage/GcsStorage.java
@@ -17,29 +17,26 @@ public class GcsStorage {
 
   private final String bucketName;
 
-  // projectId in GCP (string) is similar to subscriptionId in Azure (UUID)
-  private final String projectId;
-
   // Generates an instance of the storage class using the credentials the current process is running
   // under
-  public GcsStorage(DataImportProperties properties) throws IOException {
+  public static GcsStorage create(DataImportProperties properties) throws IOException {
     GoogleCredentials credentials = GoogleCredentials.getApplicationDefault();
-    this.bucketName = properties.getRawlsBucketName();
-    this.projectId = properties.getProjectId();
-    StorageOptions storageOptions =
+    String projectId = properties.getProjectId();
+
+    return new GcsStorage(
         StorageOptions.newBuilder()
-            .setProjectId(this.projectId)
+            .setProjectId(projectId)
             .setCredentials(credentials)
-            .build();
-    this.storage = storageOptions.getService();
+            .build()
+            .getService(),
+        properties.getRawlsBucketName());
   }
 
   // primarily here for tests, but also allows this class to be used with values other than
   // the ones provided in the config, if needed
-  public GcsStorage(Storage storage, String bucketName, String projectId) {
+  public GcsStorage(Storage storage, String bucketName) {
     this.storage = storage;
     this.bucketName = bucketName;
-    this.projectId = projectId;
   }
 
   public InputStream getBlobContents(String blobName) throws IOException {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/storage/GcsStorage.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/storage/GcsStorage.java
@@ -1,6 +1,10 @@
 package org.databiosphere.workspacedataservice.storage;
 
+import static java.util.Objects.requireNonNull;
+
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.BaseWriteChannel;
+import com.google.cloud.WriteChannel;
 import com.google.cloud.spring.storage.GoogleStorageResource;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.Storage;
@@ -9,54 +13,75 @@ import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.UUID;
+import java.nio.channels.Channels;
 import org.databiosphere.workspacedataservice.config.DataImportProperties;
+import org.springframework.util.unit.DataSize;
 
 public class GcsStorage {
   private final Storage storage;
-
   private final String bucketName;
+  private final DataSize blobWriterChunkSize;
+
+  private static final DataSize MIN_CHUNK_SIZE = DataSize.ofKilobytes(256);
+
+  /** Based on default defined in {@link BaseWriteChannel} */
+  private static final DataSize DEFAULT_CHUNK_SIZE =
+      DataSize.ofBytes(MIN_CHUNK_SIZE.toBytes() * 60);
 
   // Generates an instance of the storage class using the credentials the current process is running
   // under
   public static GcsStorage create(DataImportProperties properties) throws IOException {
-    GoogleCredentials credentials = GoogleCredentials.getApplicationDefault();
-    String projectId = properties.getProjectId();
-
     return new GcsStorage(
         StorageOptions.newBuilder()
-            .setProjectId(projectId)
-            .setCredentials(credentials)
+            // projectId in GCP (string) is similar to subscriptionId in Azure (UUID)
+            .setProjectId(requireNonNull(properties.getProjectId()))
+            .setCredentials(GoogleCredentials.getApplicationDefault())
             .build()
             .getService(),
-        properties.getRawlsBucketName());
+        requireNonNull(properties.getRawlsBucketName()));
   }
 
   // primarily here for tests, but also allows this class to be used with values other than
   // the ones provided in the config, if needed
-  public GcsStorage(Storage storage, String bucketName) {
+  GcsStorage(Storage storage, String bucketName, DataSize blobWriterChunkSize) {
     this.storage = storage;
     this.bucketName = bucketName;
+    this.blobWriterChunkSize = blobWriterChunkSize;
+  }
+
+  GcsStorage(Storage storage, String bucketName) {
+    this(storage, bucketName, DEFAULT_CHUNK_SIZE);
   }
 
   public InputStream getBlobContents(String blobName) throws IOException {
-    GoogleStorageResource gcsResource =
-        new GoogleStorageResource(
-            this.storage, String.format("gs://%s/%s", this.bucketName, blobName));
-    return gcsResource.getInputStream();
+    return getGcsResource(blobName).getInputStream();
   }
 
-  public String createGcsFile(InputStream contents, UUID jobId) throws IOException {
-    // create the GCS Resource
-    var blobName = jobId + ".rawlsUpsert";
-    GoogleStorageResource gcsResource =
-        new GoogleStorageResource(
-            this.storage, String.format("gs://%s/%s", this.bucketName, blobName));
-    // write the data to the resource
-    try (OutputStream os = gcsResource.getOutputStream()) {
-      contents.transferTo(os);
-    }
-    return gcsResource.getBlobName();
+  /**
+   * Creates and returns an {@link OutputStream} to write to the given {@link Blob}.
+   *
+   * @return an {@link OutputStream} to write to the given {@link Blob}
+   */
+  public OutputStream getOutputStream(Blob blob) {
+    return createOutputStream(blob);
+  }
+
+  /**
+   * Creates a {@link Blob} with the given name in the configured bucket.
+   *
+   * @return an {@link OutputStream} to write to the newly created Blob
+   */
+  public OutputStream getOutputStream(String name) {
+    return getOutputStream(createBlob(name));
+  }
+
+  /**
+   * Creates a {@link Blob} with the given name in the configured bucket.
+   *
+   * @return the newly created Blob
+   */
+  public Blob createBlob(String name) {
+    return getGcsResource(name).createBlob();
   }
 
   public String getBucketName() {
@@ -71,5 +96,16 @@ public class GcsStorage {
   @VisibleForTesting
   public void deleteBlob(String blobName) {
     storage.delete(this.bucketName, blobName);
+  }
+
+  private GoogleStorageResource getGcsResource(String blobName) {
+    return new GoogleStorageResource(
+        this.storage, String.format("gs://%s/%s", this.bucketName, blobName));
+  }
+
+  private OutputStream createOutputStream(Blob blob) {
+    WriteChannel writeChannel = blob.writer();
+    writeChannel.setChunkSize((int) blobWriterChunkSize.toBytes());
+    return Channels.newOutputStream(writeChannel);
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/storage/GcsStorageConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/storage/GcsStorageConfig.java
@@ -11,6 +11,6 @@ import org.springframework.context.annotation.Configuration;
 public class GcsStorageConfig {
   @Bean
   public GcsStorage gcsStorage(DataImportProperties properties) throws IOException {
-    return new GcsStorage(properties);
+    return GcsStorage.create(properties);
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkPrefixingTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkPrefixingTest.java
@@ -148,7 +148,7 @@ class RawlsRecordSinkPrefixingTest extends TestBase {
   private List<Entity> doUpsert(Record record, PrefixStrategy prefixStrategy) {
     String USER_EMAIL = "userEmail";
     RecordSink recordSink =
-        new RawlsRecordSink(
+        RawlsRecordSink.create(
             mapper,
             storage,
             pubSub,

--- a/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkPrefixingTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkPrefixingTest.java
@@ -168,8 +168,6 @@ class RawlsRecordSinkPrefixingTest extends TestBase {
           recordList,
           /* primaryKey= */ "name" // currently ignored
           );
-    } catch (IOException e) {
-      throw new RuntimeException(e);
     }
 
     // Assert

--- a/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkTest.java
@@ -68,7 +68,7 @@ class RawlsRecordSinkTest extends TestBase {
   @BeforeEach
   void setUp() {
     recordSink =
-        new RawlsRecordSink(
+        RawlsRecordSink.create(
             mapper,
             storage,
             pubSub,

--- a/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkTest.java
@@ -196,8 +196,6 @@ class RawlsRecordSinkTest extends TestBase {
           recordList,
           /* primaryKey= */ "name" // currently ignored
           );
-    } catch (IOException e) {
-      throw new RuntimeException(e);
     }
 
     // Assert

--- a/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkTest.java
@@ -38,7 +38,6 @@ import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 import org.databiosphere.workspacedataservice.storage.GcsStorage;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -55,7 +54,6 @@ import org.springframework.util.StreamUtils;
 class RawlsRecordSinkTest extends TestBase {
   @Autowired private ObjectMapper mapper;
   @MockBean private PubSub pubSub;
-  private RecordSink recordSink;
 
   @Qualifier("mockGcsStorage")
   @Autowired
@@ -64,16 +62,6 @@ class RawlsRecordSinkTest extends TestBase {
   private final UUID WORKSPACE_ID = UUID.randomUUID();
   private final UUID JOB_ID = UUID.randomUUID();
   private final String USER_EMAIL = "userEmail";
-
-  @BeforeEach
-  void setUp() {
-    recordSink =
-        RawlsRecordSink.create(
-            mapper,
-            storage,
-            pubSub,
-            new ImportDetails(JOB_ID, USER_EMAIL, WORKSPACE_ID, PrefixStrategy.NONE));
-  }
 
   @Test
   void translatesEntityFields() {
@@ -158,14 +146,16 @@ class RawlsRecordSinkTest extends TestBase {
   }
 
   @Test
-  void batchDeleteNotSupported() {
+  void batchDeleteNotSupported() throws IOException {
     RecordType ignoredRecordType = RecordType.valueOf("widget");
     List<Record> ignoredEmptyRecords = List.of();
-    var thrown =
-        assertThrows(
-            UnsupportedOperationException.class,
-            () -> recordSink.deleteBatch(ignoredRecordType, ignoredEmptyRecords));
-    assertThat(thrown).hasMessageContaining("does not support deleteBatch");
+    try (RecordSink recordSink = newRecordSink()) {
+      var thrown =
+          assertThrows(
+              UnsupportedOperationException.class,
+              () -> recordSink.deleteBatch(ignoredRecordType, ignoredEmptyRecords));
+      assertThat(thrown).hasMessageContaining("does not support deleteBatch");
+    }
   }
 
   @Test
@@ -197,14 +187,21 @@ class RawlsRecordSinkTest extends TestBase {
     var recordList = concat(Stream.of(record), stream(additionalRecords)).toList();
     var recordType = recordList.stream().map(Record::getRecordType).collect(onlyElement());
     var blobName = "";
-    try {
+
+    // Act
+    try (RecordSink recordSink = newRecordSink()) {
       recordSink.upsertBatch(
           recordType,
           /* schema= */ Map.of(), // currently ignored
           recordList,
           /* primaryKey= */ "name" // currently ignored
           );
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
 
+    // Assert
+    try {
       // look for the blob that was created in a bucket with the appropriate json
       var blobs = storage.getBlobsInBucket();
       // confirm there is only 1
@@ -224,6 +221,14 @@ class RawlsRecordSinkTest extends TestBase {
         storage.deleteBlob(blobName);
       }
     }
+  }
+
+  private RawlsRecordSink newRecordSink() {
+    return RawlsRecordSink.create(
+        mapper,
+        storage,
+        pubSub,
+        new ImportDetails(JOB_ID, USER_EMAIL, WORKSPACE_ID, PrefixStrategy.NONE));
   }
 
   // assert that the given collection has exactly one item, then return it

--- a/service/src/test/java/org/databiosphere/workspacedataservice/storage/GcsStorageConfig.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/storage/GcsStorageConfig.java
@@ -9,13 +9,11 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @SpringBootTest
 public class GcsStorageConfig {
-  private String bucketName = "test-bucket";
-
-  private String projectId = "test-projectId";
+  private static final String BUCKET_NAME = "test-bucket";
 
   @Bean
   public GcsStorage mockGcsStorage() {
     Storage mockStorage = LocalStorageHelper.getOptions().getService();
-    return new GcsStorage(mockStorage, bucketName, projectId);
+    return new GcsStorage(mockStorage, BUCKET_NAME);
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/storage/GcsStorageConfig.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/storage/GcsStorageConfig.java
@@ -5,6 +5,7 @@ import com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.util.unit.DataSize;
 
 @Configuration
 @SpringBootTest
@@ -14,6 +15,9 @@ public class GcsStorageConfig {
   @Bean
   public GcsStorage mockGcsStorage() {
     Storage mockStorage = LocalStorageHelper.getOptions().getService();
-    return new GcsStorage(mockStorage, BUCKET_NAME);
+    // this is a hack to work around FakeStorageRpc, which fails when chunk size exceeded due
+    // to not being able to handle Content-Range header with an unspecified size
+    DataSize batchWriteChunkSize = DataSize.ofMegabytes(64);
+    return new GcsStorage(mockStorage, BUCKET_NAME, batchWriteChunkSize);
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/storage/GcsStorageTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/storage/GcsStorageTest.java
@@ -1,12 +1,18 @@
 package org.databiosphere.workspacedataservice.storage;
 
+import static com.google.common.collect.MoreCollectors.onlyElement;
+import static java.nio.charset.Charset.defaultCharset;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.assertj.core.util.Streams.stream;
+import static org.springframework.util.StreamUtils.copyToString;
 
-import java.io.ByteArrayInputStream;
+import com.google.cloud.storage.Blob;
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.Charset;
-import java.util.UUID;
+import java.io.OutputStream;
+import org.databiosphere.workspacedataservice.common.TestBase;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -14,34 +20,134 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.stereotype.Component;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.util.StreamUtils;
 
 @Component
 @DirtiesContext
 @SpringBootTest
-@ActiveProfiles("control-plane")
-@TestPropertySource(
-    properties = {
-      // turn off pubsub autoconfiguration for tests
-      "spring.cloud.gcp.pubsub.enabled=false"
-    })
-class GcsStorageTest {
-
+// inheritProfiles = false to make sure data-plane is not active from TestBase
+@ActiveProfiles(value = "control-plane", inheritProfiles = false)
+class GcsStorageTest extends TestBase {
   @Qualifier("mockGcsStorage")
   @Autowired
   private GcsStorage storage;
 
-  @Test
-  void testCreateandGetBlobSimple() throws IOException {
-    String initialString = "text";
-    UUID jobId = UUID.randomUUID();
-    InputStream targetStream = new ByteArrayInputStream(initialString.getBytes());
-    String newBlobName = storage.createGcsFile(targetStream, jobId);
-    assertThat(newBlobName).isNotNull();
+  @AfterEach
+  void cleanup() {
+    storage.getBlobsInBucket().forEach(Blob::delete);
+  }
 
-    String contents =
-        StreamUtils.copyToString(storage.getBlobContents(newBlobName), Charset.defaultCharset());
-    assertThat(contents).isEqualTo(initialString);
+  @Test
+  void createAndGetBlobSimple() throws IOException {
+    // Arrange
+    String initialString = "text";
+
+    // Act
+    try (OutputStream outputStream = storage.getOutputStream("testBlobName")) {
+      outputStream.write(initialString.getBytes());
+    }
+
+    // Act / Assert
+    assertThat(getContentsAsString("testBlobName")).isEqualTo(initialString);
+  }
+
+  @Test
+  void createAndGetBlobEmpty() throws IOException {
+    // Act
+    storage.createBlob("emptyBlob");
+
+    // Act / Assert
+    var onlyBlob = assertSingleBlob();
+    assertThat(onlyBlob.getName()).isEqualTo("emptyBlob");
+    assertThat(getContentsAsString("emptyBlob")).isEmpty();
+  }
+
+  @Test
+  void getBlobContentsMissing() {
+    // Act / Assert
+    assertThatExceptionOfType(IOException.class)
+        .isThrownBy(() -> storage.getBlobContents("missingBlob"));
+  }
+
+  @Test
+  void getBlobsInBucketEmpty() throws IOException {
+    // Act / Assert
+    assertThat(storage.getBlobsInBucket()).isEmpty();
+  }
+
+  @Test
+  void getBlobsInBucketSingle() throws IOException {
+    // Act
+    try (OutputStream outputStream = storage.getOutputStream("testBlobName")) {
+      outputStream.write("text".getBytes());
+    }
+
+    // Act / Assert
+    Blob onlyBlob = assertSingleBlob();
+
+    assertThat(onlyBlob.asBlobInfo())
+        .hasFieldOrPropertyWithValue("bucket", storage.getBucketName())
+        .hasFieldOrPropertyWithValue("name", "testBlobName");
+  }
+
+  @Test
+  void getBlobsInBucketMultiple() throws IOException {
+    // Act
+    try (OutputStream outputStream = storage.getOutputStream("testBlobName1")) {
+      outputStream.write("text".getBytes());
+    }
+
+    try (OutputStream outputStream = storage.getOutputStream("testBlobName2")) {
+      outputStream.write("text".getBytes());
+    }
+
+    storage.createBlob("testBlobName3");
+
+    // Act / Assert
+    Iterable<Blob> blobsInBucket = storage.getBlobsInBucket();
+    assertThat(blobsInBucket).hasSize(3);
+    assertThat(stream(blobsInBucket).map(Blob::getName))
+        .containsExactlyInAnyOrder("testBlobName1", "testBlobName2", "testBlobName3");
+  }
+
+  @Test
+  void deleteBlob() throws IOException {
+    // Arrange
+    storage.createBlob("testBlobName");
+
+    // Act
+    storage.deleteBlob("testBlobName");
+
+    // Act / Assert
+    assertThat(storage.getBlobsInBucket()).isEmpty();
+  }
+
+  @Test
+  void deleteBlobWithContent() throws IOException {
+    // Arrange
+    storage.createBlob("testBlobName");
+    try (OutputStream outputStream = storage.getOutputStream("testBlobName")) {
+      outputStream.write("text".getBytes());
+    }
+
+    // Act
+    storage.deleteBlob("testBlobName");
+
+    // Act / Assert
+    assertThat(storage.getBlobsInBucket()).isEmpty();
+  }
+
+  @Test
+  void deleteBlobMissing() {
+    // Act / Assert
+    assertThatNoException().isThrownBy(() -> storage.deleteBlob("missingBlob"));
+  }
+
+  private String getContentsAsString(String blobName) throws IOException {
+    return copyToString(storage.getBlobContents(blobName), defaultCharset());
+  }
+
+  private Blob assertSingleBlob() {
+    assertThat(storage.getBlobsInBucket()).hasSize(1);
+    return stream(storage.getBlobsInBucket()).collect(onlyElement());
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/storage/GcsStorageTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/storage/GcsStorageTest.java
@@ -45,20 +45,22 @@ class GcsStorageTest extends TestBase {
     try (OutputStream outputStream = storage.getOutputStream("testBlobName")) {
       outputStream.write(initialString.getBytes());
     }
+    String actualContent = getContentsAsString("testBlobName");
 
-    // Act / Assert
-    assertThat(getContentsAsString("testBlobName")).isEqualTo(initialString);
+    // Assert
+    assertThat(actualContent).isEqualTo(initialString);
   }
 
   @Test
   void createAndGetBlobEmpty() throws IOException {
     // Act
     storage.createBlob("emptyBlob");
+    String actualContent = getContentsAsString("emptyBlob");
 
-    // Act / Assert
+    // Assert
     var onlyBlob = assertSingleBlob();
     assertThat(onlyBlob.getName()).isEqualTo("emptyBlob");
-    assertThat(getContentsAsString("emptyBlob")).isEmpty();
+    assertThat(actualContent).isEmpty();
   }
 
   @Test
@@ -76,7 +78,7 @@ class GcsStorageTest extends TestBase {
 
   @Test
   void getBlobsInBucketSingle() throws IOException {
-    // Act
+    // Arrange
     try (OutputStream outputStream = storage.getOutputStream("testBlobName")) {
       outputStream.write("text".getBytes());
     }
@@ -84,6 +86,7 @@ class GcsStorageTest extends TestBase {
     // Act / Assert
     Blob onlyBlob = assertSingleBlob();
 
+    // Assert
     assertThat(onlyBlob.asBlobInfo())
         .hasFieldOrPropertyWithValue("bucket", storage.getBucketName())
         .hasFieldOrPropertyWithValue("name", "testBlobName");
@@ -91,7 +94,7 @@ class GcsStorageTest extends TestBase {
 
   @Test
   void getBlobsInBucketMultiple() throws IOException {
-    // Act
+    // Arrange
     try (OutputStream outputStream = storage.getOutputStream("testBlobName1")) {
       outputStream.write("text".getBytes());
     }
@@ -102,8 +105,10 @@ class GcsStorageTest extends TestBase {
 
     storage.createBlob("testBlobName3");
 
-    // Act / Assert
+    // Act
     Iterable<Blob> blobsInBucket = storage.getBlobsInBucket();
+
+    // Assert
     assertThat(blobsInBucket).hasSize(3);
     assertThat(stream(blobsInBucket).map(Blob::getName))
         .containsExactlyInAnyOrder("testBlobName1", "testBlobName2", "testBlobName3");
@@ -117,7 +122,7 @@ class GcsStorageTest extends TestBase {
     // Act
     storage.deleteBlob("testBlobName");
 
-    // Act / Assert
+    // Assert
     assertThat(storage.getBlobsInBucket()).isEmpty();
   }
 
@@ -132,7 +137,7 @@ class GcsStorageTest extends TestBase {
     // Act
     storage.deleteBlob("testBlobName");
 
-    // Act / Assert
+    // Assert
     assertThat(storage.getBlobsInBucket()).isEmpty();
   }
 
@@ -147,7 +152,8 @@ class GcsStorageTest extends TestBase {
   }
 
   private Blob assertSingleBlob() {
-    assertThat(storage.getBlobsInBucket()).hasSize(1);
-    return stream(storage.getBlobsInBucket()).collect(onlyElement());
+    Iterable<Blob> blobsInBucket = storage.getBlobsInBucket();
+    assertThat(blobsInBucket).hasSize(1);
+    return stream(blobsInBucket).collect(onlyElement());
   }
 }


### PR DESCRIPTION
For [AJ-1669](https://broadworkbench.atlassian.net/browse/AJ-1669): Rather than writing a Blob for every batch and every record type, record all writes for a whole batch into one Blob and send a single Pubsub message.
 
The PR currently contains 4 commits.  3 prefactoring & 1 actual change.

The prefactorings are done up front to ease review and reduce the footprint of the final actual change.

Each commit has a description to explain intent and is intended to be easier to review than the whole, so I recommend taking a look at each separately.

[AJ-1669]: https://broadworkbench.atlassian.net/browse/AJ-1669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ