### PR TITLE
[AJ-1588] Validate URLs for file imports

### DIFF
--- a/.github/workflows/release-python-client.yml
+++ b/.github/workflows/release-python-client.yml
@@ -69,7 +69,7 @@ jobs:
           PGPASSWORD: postgres
         run: psql -h 127.0.0.1 -U postgres -f ./local-dev/local-postgres-init.sql
 
-      - name: Mock Sam via command-line docker run
+      - name: Mock APIs via command-line docker run
         run: |
           docker run -v ${{ github.workspace }}/service/src/test/resources/nginx.conf:/etc/nginx/nginx.conf:ro -v ${{ github.workspace }}/service/src/test/resources:/usr/share/nginx/html -p 9889:80 -d nginx:1.23.3
 
@@ -90,6 +90,7 @@ jobs:
           export WORKSPACE_ID=123e4567-e89b-12d3-a456-426614174000
           export SPRING_PROFILES_ACTIVE=data-plane
           ./gradlew --build-cache build -x test
+          # Allow http imports from localhost to test with files from resources served by the mock API server
           ./gradlew bootRun --args='--twds.data-import.allowed-hosts=localhost --twds.data-import.allowed-schemes=http' &
           count=20
           until $(curl --output /dev/null --silent --head --fail http://localhost:8080/status); do

--- a/.github/workflows/release-python-client.yml
+++ b/.github/workflows/release-python-client.yml
@@ -90,7 +90,7 @@ jobs:
           export WORKSPACE_ID=123e4567-e89b-12d3-a456-426614174000
           export SPRING_PROFILES_ACTIVE=data-plane
           ./gradlew --build-cache build -x test
-          ./gradlew bootRun &
+          ./gradlew bootRun --args='--twds.data-import.allowed-hosts=localhost --twds.data-import.allowed-schemes=http' &
           count=20
           until $(curl --output /dev/null --silent --head --fail http://localhost:8080/status); do
             printf '.'

--- a/service/src/main/java/org/databiosphere/workspacedataservice/config/DataImportProperties.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/config/DataImportProperties.java
@@ -24,6 +24,7 @@ public class DataImportProperties {
           new AllowedImportSource("*.s3.amazonaws.com") // virtual host style legacy global endpoint
           );
   private Set<AllowedImportSource> allowedImportSources = Collections.emptySet();
+  private boolean fileImportsAllowed = false;
 
   /** Where to write records after import, options are defined by {@link RecordSinkMode} */
   public RecordSinkMode getBatchWriteRecordSink() {
@@ -83,6 +84,15 @@ public class DataImportProperties {
             : Arrays.stream(allowedImportSources)
                 .map(AllowedImportSource::new)
                 .collect(Collectors.toSet());
+  }
+
+  /** Whether files may be imported from file: URLs. This should only be enabled for tests. */
+  public boolean fileImportsAllowed() {
+    return fileImportsAllowed;
+  }
+
+  public void setAllowFileImports(boolean allowFileImports) {
+    this.fileImportsAllowed = allowFileImports;
   }
 
   /** Dictates the sink where BatchWriteService should write records after import. */

--- a/service/src/main/java/org/databiosphere/workspacedataservice/config/DataImportProperties.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/config/DataImportProperties.java
@@ -24,7 +24,7 @@ public class DataImportProperties {
           new AllowedHost("*.s3.amazonaws.com") // virtual host style legacy global endpoint
           );
   private Set<AllowedHost> allowedHosts = Collections.emptySet();
-  private boolean fileImportsAllowed = false;
+  private Set<String> allowedSchemes = Set.of("https");
 
   /** Where to write records after import, options are defined by {@link RecordSinkMode} */
   public RecordSinkMode getBatchWriteRecordSink() {
@@ -84,13 +84,15 @@ public class DataImportProperties {
             : Arrays.stream(allowedHosts).map(AllowedHost::new).collect(Collectors.toSet());
   }
 
-  /** Whether files may be imported from file: URLs. This should only be enabled for tests. */
-  public boolean fileImportsAllowed() {
-    return fileImportsAllowed;
+  public Set<String> getAllowedSchemes() {
+    return allowedSchemes;
   }
 
-  public void setAllowFileImports(boolean allowFileImports) {
-    this.fileImportsAllowed = allowFileImports;
+  public void setAllowedSchemes(@Nullable String[] allowedSchemes) {
+    this.allowedSchemes =
+        allowedSchemes == null
+            ? Collections.emptySet()
+            : Arrays.stream(allowedSchemes).collect(Collectors.toSet());
   }
 
   /** Dictates the sink where BatchWriteService should write records after import. */

--- a/service/src/main/java/org/databiosphere/workspacedataservice/config/DataImportProperties.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/config/DataImportProperties.java
@@ -113,8 +113,8 @@ public class DataImportProperties {
     }
   }
 
-  public class AllowedHost {
-    private String pattern;
+  public static class AllowedHost {
+    private final String pattern;
 
     public AllowedHost(String hostPattern) {
       this.pattern = hostPattern;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/config/DataImportProperties.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/config/DataImportProperties.java
@@ -7,7 +7,6 @@ import com.google.common.collect.Sets;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import org.springframework.lang.Nullable;
 
 /** Properties that dictate how data import processes should behave. */
 public class DataImportProperties {
@@ -79,20 +78,16 @@ public class DataImportProperties {
     return Sets.union(defaultAllowedHosts, allowedHosts);
   }
 
-  public void setAllowedHosts(@Nullable String[] allowedHosts) {
-    this.allowedHosts =
-        allowedHosts == null
-            ? emptySet()
-            : stream(allowedHosts).map(Pattern::compile).collect(Collectors.toSet());
+  public void setAllowedHosts(String[] allowedHosts) {
+    this.allowedHosts = stream(allowedHosts).map(Pattern::compile).collect(Collectors.toSet());
   }
 
   public Set<String> getAllowedSchemes() {
     return allowedSchemes;
   }
 
-  public void setAllowedSchemes(@Nullable String[] allowedSchemes) {
-    this.allowedSchemes =
-        allowedSchemes == null ? emptySet() : stream(allowedSchemes).collect(Collectors.toSet());
+  public void setAllowedSchemes(String[] allowedSchemes) {
+    this.allowedSchemes = stream(allowedSchemes).collect(Collectors.toSet());
   }
 
   /** Dictates the sink where BatchWriteService should write records after import. */

--- a/service/src/main/java/org/databiosphere/workspacedataservice/config/DataImportProperties.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/config/DataImportProperties.java
@@ -10,7 +10,7 @@ import java.util.stream.Collectors;
 
 /** Properties that dictate how data import processes should behave. */
 public class DataImportProperties {
-  private static final Set<Pattern> defaultAllowedHosts =
+  private static final Set<Pattern> DEFAULT_ALLOWED_HOSTS =
       Set.of(
           Pattern.compile("storage\\.googleapis\\.com"),
           Pattern.compile(".*\\.core\\.windows\\.net"),
@@ -75,7 +75,7 @@ public class DataImportProperties {
    * always allowed sources (GCS buckets, Azure storage containers, and S3 buckets).
    */
   public Set<Pattern> getAllowedHosts() {
-    return Sets.union(defaultAllowedHosts, allowedHosts);
+    return Sets.union(DEFAULT_ALLOWED_HOSTS, allowedHosts);
   }
 
   public void setAllowedHosts(String[] allowedHosts) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/config/DataImportProperties.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/config/DataImportProperties.java
@@ -1,13 +1,12 @@
 package org.databiosphere.workspacedataservice.config;
 
-import static org.apache.commons.lang3.StringUtils.isBlank;
-
 import com.google.common.collect.Sets;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.springframework.lang.Nullable;
 
 /** Properties that dictate how data import processes should behave. */
 public class DataImportProperties {
@@ -77,11 +76,11 @@ public class DataImportProperties {
     return Sets.union(defaultAllowedImportSources, allowedImportSources);
   }
 
-  public void setAllowedImportSources(String allowedImportSources) {
+  public void setAllowedImportSources(@Nullable String[] allowedImportSources) {
     this.allowedImportSources =
-        isBlank(allowedImportSources)
+        allowedImportSources == null
             ? Collections.emptySet()
-            : Arrays.stream(allowedImportSources.split(","))
+            : Arrays.stream(allowedImportSources)
                 .map(AllowedImportSource::new)
                 .collect(Collectors.toSet());
   }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/config/DataImportProperties.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/config/DataImportProperties.java
@@ -1,11 +1,30 @@
 package org.databiosphere.workspacedataservice.config;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+import com.google.common.collect.Sets;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 /** Properties that dictate how data import processes should behave. */
 public class DataImportProperties {
   private RecordSinkMode batchWriteRecordSink;
   private String projectId;
   private String rawlsBucketName;
   private boolean succeedOnCompletion;
+  private final Set<AllowedImportSource> defaultAllowedImportSources =
+      Set.of(
+          new AllowedImportSource("storage.googleapis.com"),
+          new AllowedImportSource("*.core.windows.net"),
+          // S3 allows multiple URL formats
+          // https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html
+          new AllowedImportSource("s3.amazonaws.com"), // path style legacy global endpoint
+          new AllowedImportSource("*.s3.amazonaws.com") // virtual host style legacy global endpoint
+          );
+  private Set<AllowedImportSource> allowedImportSources = Collections.emptySet();
 
   /** Where to write records after import, options are defined by {@link RecordSinkMode} */
   public RecordSinkMode getBatchWriteRecordSink() {
@@ -50,6 +69,23 @@ public class DataImportProperties {
     this.succeedOnCompletion = succeedOnCompletion;
   }
 
+  /**
+   * Accepted sources for imported files. This includes configured sources as well as default /
+   * always allowed sources (GCS buckets, Azure storage containers, and S3 buckets).
+   */
+  public Set<AllowedImportSource> getAllowedImportSources() {
+    return Sets.union(defaultAllowedImportSources, allowedImportSources);
+  }
+
+  public void setAllowedImportSources(String allowedImportSources) {
+    this.allowedImportSources =
+        isBlank(allowedImportSources)
+            ? Collections.emptySet()
+            : Arrays.stream(allowedImportSources.split(","))
+                .map(AllowedImportSource::new)
+                .collect(Collectors.toSet());
+  }
+
   /** Dictates the sink where BatchWriteService should write records after import. */
   public enum RecordSinkMode {
     WDS("wds"),
@@ -67,6 +103,22 @@ public class DataImportProperties {
         }
       }
       throw new RuntimeException("Unknown RecordSinkMode value: %s".formatted(value));
+    }
+  }
+
+  public class AllowedImportSource {
+    private String hostPattern;
+
+    public AllowedImportSource(String hostPattern) {
+      this.hostPattern = hostPattern;
+    }
+
+    public boolean matchesUrl(URI url) {
+      if (hostPattern.startsWith("*")) {
+        return url.getHost().endsWith(hostPattern.substring(1));
+      } else {
+        return url.getHost().equals(hostPattern);
+      }
     }
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/config/DataImportProperties.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/config/DataImportProperties.java
@@ -14,16 +14,16 @@ public class DataImportProperties {
   private String projectId;
   private String rawlsBucketName;
   private boolean succeedOnCompletion;
-  private final Set<AllowedImportSource> defaultAllowedImportSources =
+  private final Set<AllowedHost> defaultAllowedHosts =
       Set.of(
-          new AllowedImportSource("storage.googleapis.com"),
-          new AllowedImportSource("*.core.windows.net"),
+          new AllowedHost("storage.googleapis.com"),
+          new AllowedHost("*.core.windows.net"),
           // S3 allows multiple URL formats
           // https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html
-          new AllowedImportSource("s3.amazonaws.com"), // path style legacy global endpoint
-          new AllowedImportSource("*.s3.amazonaws.com") // virtual host style legacy global endpoint
+          new AllowedHost("s3.amazonaws.com"), // path style legacy global endpoint
+          new AllowedHost("*.s3.amazonaws.com") // virtual host style legacy global endpoint
           );
-  private Set<AllowedImportSource> allowedImportSources = Collections.emptySet();
+  private Set<AllowedHost> allowedHosts = Collections.emptySet();
   private boolean fileImportsAllowed = false;
 
   /** Where to write records after import, options are defined by {@link RecordSinkMode} */
@@ -73,17 +73,15 @@ public class DataImportProperties {
    * Accepted sources for imported files. This includes configured sources as well as default /
    * always allowed sources (GCS buckets, Azure storage containers, and S3 buckets).
    */
-  public Set<AllowedImportSource> getAllowedImportSources() {
-    return Sets.union(defaultAllowedImportSources, allowedImportSources);
+  public Set<AllowedHost> getAllowedHosts() {
+    return Sets.union(defaultAllowedHosts, allowedHosts);
   }
 
-  public void setAllowedImportSources(@Nullable String[] allowedImportSources) {
-    this.allowedImportSources =
-        allowedImportSources == null
+  public void setAllowedHosts(@Nullable String[] allowedHosts) {
+    this.allowedHosts =
+        allowedHosts == null
             ? Collections.emptySet()
-            : Arrays.stream(allowedImportSources)
-                .map(AllowedImportSource::new)
-                .collect(Collectors.toSet());
+            : Arrays.stream(allowedHosts).map(AllowedHost::new).collect(Collectors.toSet());
   }
 
   /** Whether files may be imported from file: URLs. This should only be enabled for tests. */
@@ -115,18 +113,18 @@ public class DataImportProperties {
     }
   }
 
-  public class AllowedImportSource {
-    private String hostPattern;
+  public class AllowedHost {
+    private String pattern;
 
-    public AllowedImportSource(String hostPattern) {
-      this.hostPattern = hostPattern;
+    public AllowedHost(String hostPattern) {
+      this.pattern = hostPattern;
     }
 
     public boolean matchesUrl(URI url) {
-      if (hostPattern.startsWith("*")) {
-        return url.getHost().endsWith(hostPattern.substring(1));
+      if (pattern.startsWith("*")) {
+        return url.getHost().endsWith(pattern.substring(1));
       } else {
-        return url.getHost().equals(hostPattern);
+        return url.getHost().equals(pattern);
       }
     }
   }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportSourceValidator.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportSourceValidator.java
@@ -26,7 +26,7 @@ public class ImportSourceValidator {
     boolean isFileUrl = importUrl.getScheme().equals("file");
     if (!isFileUrl
         && dataImportProperties.getAllowedHosts().stream()
-            .noneMatch(allowedHost -> allowedHost.matchesUrl(importUrl))) {
+            .noneMatch(allowedHost -> allowedHost.matcher(importUrl.getHost()).matches())) {
       throw new ValidationException(
           "Files may not be imported from %s.".formatted(importUrl.getHost()));
     }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportSourceValidator.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportSourceValidator.java
@@ -4,7 +4,6 @@ import java.net.URI;
 import java.util.Set;
 import java.util.regex.Pattern;
 import org.databiosphere.workspacedataservice.config.DataImportProperties;
-import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
 import org.databiosphere.workspacedataservice.service.model.exception.ValidationException;
 import org.springframework.stereotype.Component;
 
@@ -18,9 +17,7 @@ public class ImportSourceValidator {
     this.allowedHosts = dataImportProperties.getAllowedHosts();
   }
 
-  public void validateImportRequest(ImportRequestServerModel importRequest) {
-    URI importUrl = importRequest.getUrl();
-
+  public void validateImport(URI importUrl) {
     if (!allowedSchemes.contains(importUrl.getScheme())) {
       throw new ValidationException(
           "Files may not be imported from %s URLs.".formatted(importUrl.getScheme()));

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportSourceValidator.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportSourceValidator.java
@@ -1,6 +1,8 @@
 package org.databiosphere.workspacedataservice.dataimport;
 
 import java.net.URI;
+import java.util.Set;
+import java.util.regex.Pattern;
 import org.databiosphere.workspacedataservice.config.DataImportProperties;
 import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
 import org.databiosphere.workspacedataservice.service.model.exception.ValidationException;
@@ -8,16 +10,18 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class ImportSourceValidator {
-  private final DataImportProperties dataImportProperties;
+  private final Set<String> allowedSchemes;
+  private final Set<Pattern> allowedHosts;
 
   public ImportSourceValidator(DataImportProperties dataImportProperties) {
-    this.dataImportProperties = dataImportProperties;
+    this.allowedSchemes = dataImportProperties.getAllowedSchemes();
+    this.allowedHosts = dataImportProperties.getAllowedHosts();
   }
 
   public void validateImportRequest(ImportRequestServerModel importRequest) {
     URI importUrl = importRequest.getUrl();
 
-    if (!dataImportProperties.getAllowedSchemes().contains(importUrl.getScheme())) {
+    if (!allowedSchemes.contains(importUrl.getScheme())) {
       throw new ValidationException(
           "Files may not be imported from %s URLs.".formatted(importUrl.getScheme()));
     }
@@ -25,7 +29,7 @@ public class ImportSourceValidator {
     // File URLs don't have a host to validate.
     boolean isFileUrl = importUrl.getScheme().equals("file");
     if (!isFileUrl
-        && dataImportProperties.getAllowedHosts().stream()
+        && allowedHosts.stream()
             .noneMatch(allowedHost -> allowedHost.matcher(importUrl.getHost()).matches())) {
       throw new ValidationException(
           "Files may not be imported from %s.".formatted(importUrl.getHost()));

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportSourceValidator.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportSourceValidator.java
@@ -1,0 +1,34 @@
+package org.databiosphere.workspacedataservice.dataimport;
+
+import java.net.URI;
+import org.databiosphere.workspacedataservice.config.DataImportProperties;
+import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
+import org.databiosphere.workspacedataservice.service.model.exception.ValidationException;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ImportSourceValidator {
+  private final DataImportProperties dataImportProperties;
+
+  public ImportSourceValidator(DataImportProperties dataImportProperties) {
+    this.dataImportProperties = dataImportProperties;
+  }
+
+  public void validateImportRequest(ImportRequestServerModel importRequest) {
+    URI importUrl = importRequest.getUrl();
+
+    if (!dataImportProperties.getAllowedSchemes().contains(importUrl.getScheme())) {
+      throw new ValidationException(
+          "Files may not be imported from %s URLs.".formatted(importUrl.getScheme()));
+    }
+
+    // File URLs don't have a host to validate.
+    boolean isFileUrl = importUrl.getScheme().equals("file");
+    if (!isFileUrl
+        && dataImportProperties.getAllowedHosts().stream()
+            .noneMatch(allowedHost -> allowedHost.matchesUrl(importUrl))) {
+      throw new ValidationException(
+          "Files may not be imported from %s.".formatted(importUrl.getHost()));
+    }
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
@@ -69,7 +69,7 @@ public class ImportService {
       throw new AuthenticationMaskableException("Collection");
     }
 
-    importSourceValidator.validateImportRequest(importRequest);
+    importSourceValidator.validateImport(importRequest.getUrl());
 
     // get a token to execute the job
     String petToken = samDao.getPetToken();

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
@@ -161,8 +161,8 @@ public class ImportService {
 
     boolean isHttpsUrl = importUrl.getScheme().equals("https");
     if (isHttpsUrl
-        && dataImportProperties.getAllowedImportSources().stream()
-            .noneMatch(allowedImportSource -> allowedImportSource.matchesUrl(importUrl))) {
+        && dataImportProperties.getAllowedHosts().stream()
+            .noneMatch(allowedHost -> allowedHost.matchesUrl(importUrl))) {
       throw new ValidationException(
           "Files may not be imported from %s.".formatted(importUrl.getHost()));
     }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
@@ -4,13 +4,11 @@ import static org.databiosphere.workspacedataservice.shared.model.Schedulable.AR
 import static org.databiosphere.workspacedataservice.shared.model.Schedulable.ARG_TOKEN;
 import static org.databiosphere.workspacedataservice.shared.model.Schedulable.ARG_URL;
 
-import com.google.common.collect.Sets;
 import java.io.Serializable;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.config.DataImportProperties;
 import org.databiosphere.workspacedataservice.dao.JobDao;
@@ -150,17 +148,14 @@ public class ImportService {
   private void validateImportRequest(ImportRequestServerModel importRequest) {
     URI importUrl = importRequest.getUrl();
 
-    Set<String> allowedSchemes = Set.of("https");
-    if (dataImportProperties.fileImportsAllowed()) {
-      allowedSchemes = Sets.union(allowedSchemes, Set.of("file"));
-    }
-    if (!allowedSchemes.contains(importUrl.getScheme())) {
+    if (!dataImportProperties.getAllowedSchemes().contains(importUrl.getScheme())) {
       throw new ValidationException(
           "Files may not be imported from %s URLs.".formatted(importUrl.getScheme()));
     }
 
-    boolean isHttpsUrl = importUrl.getScheme().equals("https");
-    if (isHttpsUrl
+    // File URLs don't have a host to validate.
+    boolean isFileUrl = importUrl.getScheme().equals("file");
+    if (!isFileUrl
         && dataImportProperties.getAllowedHosts().stream()
             .noneMatch(allowedHost -> allowedHost.matchesUrl(importUrl))) {
       throw new ValidationException(

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/ImportControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/ImportControllerMockMvcTest.java
@@ -28,7 +28,8 @@ class ImportControllerMockMvcTest extends MockMvcTestBase {
     collectionDao.createSchema(instanceId);
     ImportRequestServerModel importRequest =
         new ImportRequestServerModel(
-            ImportRequestServerModel.TypeEnum.PFB, new URI("https://terra.bio"));
+            ImportRequestServerModel.TypeEnum.PFB,
+            new URI("https://teststorageaccount.blob.core.windows.net/testcontainer/file"));
 
     // calling the API should result in 201 Created
     MvcResult mvcResult =

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/ImportSourceValidatorTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/ImportSourceValidatorTest.java
@@ -18,7 +18,7 @@ public class ImportSourceValidatorTest {
 
   @ParameterizedTest(name = "for import type {0}, should require HTTPS URLs")
   @EnumSource(ImportRequestServerModel.TypeEnum.class)
-  void testRequiresHttpsImportUrls(ImportRequestServerModel.TypeEnum importType) {
+  void requiresHttpsImportUrls(ImportRequestServerModel.TypeEnum importType) {
     // Arrange
     URI importUri =
         URI.create("http://teststorageaccount.blob.core.windows.net/testcontainer/file");
@@ -34,7 +34,7 @@ public class ImportSourceValidatorTest {
 
   @ParameterizedTest(name = "for import type {0}, should accept files from configured sources")
   @EnumSource(ImportRequestServerModel.TypeEnum.class)
-  void testAllowsImportsFromConfiguredSources(ImportRequestServerModel.TypeEnum importType) {
+  void allowsImportsFromConfiguredSources(ImportRequestServerModel.TypeEnum importType) {
     // Arrange
     URI importUri = URI.create("https://files.terra.bio/file");
     ImportRequestServerModel importRequest = new ImportRequestServerModel(importType, importUri);
@@ -45,7 +45,7 @@ public class ImportSourceValidatorTest {
 
   @ParameterizedTest(name = "for import type {0}, should reject files from other sources")
   @EnumSource(ImportRequestServerModel.TypeEnum.class)
-  void testRejectsImportsFromOtherSources(ImportRequestServerModel.TypeEnum importType) {
+  void rejectsImportsFromOtherSources(ImportRequestServerModel.TypeEnum importType) {
     // Arrange
     URI importUri = URI.create("https://example.com/file");
     ImportRequestServerModel importRequest = new ImportRequestServerModel(importType, importUri);

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/ImportSourceValidatorTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/ImportSourceValidatorTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.net.URI;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
 import org.databiosphere.workspacedataservice.service.model.exception.ValidationException;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -13,7 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest(properties = {"twds.data-import.allowed-hosts=.*\\.terra\\.bio"})
-public class ImportSourceValidatorTest {
+public class ImportSourceValidatorTest extends TestBase {
   @Autowired ImportSourceValidator importSourceValidator;
 
   @ParameterizedTest(name = "for import type {0}, should require HTTPS URLs")

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/ImportSourceValidatorTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/ImportSourceValidatorTest.java
@@ -8,6 +8,8 @@ import java.net.URI;
 import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.service.model.exception.ValidationException;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -26,6 +28,25 @@ class ImportSourceValidatorTest extends TestBase {
         assertThrows(
             ValidationException.class, () -> importSourceValidator.validateImport(importUri));
     assertEquals("Files may not be imported from http URLs.", err.getMessage());
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        // Azure
+        "https://teststorageaccount.blob.core.windows.net/testcontainer/file",
+        // GCP
+        "https://storage.googleapis.com/testbucket/file",
+        // AWS
+        "https://s3.amazonaws.com/testbucket/file",
+        "https://testbucket.s3.amazonaws.com/file"
+      })
+  void allowsImportsFromCloudStorage(String cloudStorageUrl) {
+    // Arrange
+    URI importUri = URI.create(cloudStorageUrl);
+
+    // Act/Assert
+    assertDoesNotThrow(() -> importSourceValidator.validateImport(importUri));
   }
 
   @Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/ImportSourceValidatorTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/ImportSourceValidatorTest.java
@@ -6,10 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.net.URI;
 import org.databiosphere.workspacedataservice.common.TestBase;
-import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
 import org.databiosphere.workspacedataservice.service.model.exception.ValidationException;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -17,45 +15,37 @@ import org.springframework.boot.test.context.SpringBootTest;
 public class ImportSourceValidatorTest extends TestBase {
   @Autowired ImportSourceValidator importSourceValidator;
 
-  @ParameterizedTest(name = "for import type {0}, should require HTTPS URLs")
-  @EnumSource(ImportRequestServerModel.TypeEnum.class)
-  void requiresHttpsImportUrls(ImportRequestServerModel.TypeEnum importType) {
+  @Test
+  void requiresHttpsImportUrls() {
     // Arrange
     URI importUri =
         URI.create("http://teststorageaccount.blob.core.windows.net/testcontainer/file");
-    ImportRequestServerModel importRequest = new ImportRequestServerModel(importType, importUri);
 
     // Act/Assert
     ValidationException err =
         assertThrows(
-            ValidationException.class,
-            () -> importSourceValidator.validateImportRequest(importRequest));
+            ValidationException.class, () -> importSourceValidator.validateImport(importUri));
     assertEquals("Files may not be imported from http URLs.", err.getMessage());
   }
 
-  @ParameterizedTest(name = "for import type {0}, should accept files from configured sources")
-  @EnumSource(ImportRequestServerModel.TypeEnum.class)
-  void allowsImportsFromConfiguredSources(ImportRequestServerModel.TypeEnum importType) {
+  @Test
+  void allowsImportsFromConfiguredSources() {
     // Arrange
     URI importUri = URI.create("https://files.terra.bio/file");
-    ImportRequestServerModel importRequest = new ImportRequestServerModel(importType, importUri);
 
     // Act/Assert
-    assertDoesNotThrow(() -> importSourceValidator.validateImportRequest(importRequest));
+    assertDoesNotThrow(() -> importSourceValidator.validateImport(importUri));
   }
 
-  @ParameterizedTest(name = "for import type {0}, should reject files from other sources")
-  @EnumSource(ImportRequestServerModel.TypeEnum.class)
-  void rejectsImportsFromOtherSources(ImportRequestServerModel.TypeEnum importType) {
+  @Test
+  void rejectsImportsFromOtherSources() {
     // Arrange
     URI importUri = URI.create("https://example.com/file");
-    ImportRequestServerModel importRequest = new ImportRequestServerModel(importType, importUri);
 
     // Act/Assert
     ValidationException err =
         assertThrows(
-            ValidationException.class,
-            () -> importSourceValidator.validateImportRequest(importRequest));
+            ValidationException.class, () -> importSourceValidator.validateImport(importUri));
     assertEquals("Files may not be imported from example.com.", err.getMessage());
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/ImportSourceValidatorTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/ImportSourceValidatorTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest(properties = {"twds.data-import.allowed-hosts=*.terra.bio"})
+@SpringBootTest(properties = {"twds.data-import.allowed-hosts=.*\\.terra\\.bio"})
 public class ImportSourceValidatorTest {
   @Autowired ImportSourceValidator importSourceValidator;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/ImportSourceValidatorTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/ImportSourceValidatorTest.java
@@ -12,7 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest(properties = {"twds.data-import.allowed-hosts=.*\\.terra\\.bio"})
-public class ImportSourceValidatorTest extends TestBase {
+class ImportSourceValidatorTest extends TestBase {
   @Autowired ImportSourceValidator importSourceValidator;
 
   @Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/ImportSourceValidatorTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/ImportSourceValidatorTest.java
@@ -1,0 +1,60 @@
+package org.databiosphere.workspacedataservice.dataimport;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.net.URI;
+import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
+import org.databiosphere.workspacedataservice.service.model.exception.ValidationException;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(properties = {"twds.data-import.allowed-hosts=*.terra.bio"})
+public class ImportSourceValidatorTest {
+  @Autowired ImportSourceValidator importSourceValidator;
+
+  @ParameterizedTest(name = "for import type {0}, should require HTTPS URLs")
+  @EnumSource(ImportRequestServerModel.TypeEnum.class)
+  void testRequiresHttpsImportUrls(ImportRequestServerModel.TypeEnum importType) {
+    // Arrange
+    URI importUri =
+        URI.create("http://teststorageaccount.blob.core.windows.net/testcontainer/file");
+    ImportRequestServerModel importRequest = new ImportRequestServerModel(importType, importUri);
+
+    // Act/Assert
+    ValidationException err =
+        assertThrows(
+            ValidationException.class,
+            () -> importSourceValidator.validateImportRequest(importRequest));
+    assertEquals("Files may not be imported from http URLs.", err.getMessage());
+  }
+
+  @ParameterizedTest(name = "for import type {0}, should accept files from configured sources")
+  @EnumSource(ImportRequestServerModel.TypeEnum.class)
+  void testAllowsImportsFromConfiguredSources(ImportRequestServerModel.TypeEnum importType) {
+    // Arrange
+    URI importUri = URI.create("https://files.terra.bio/file");
+    ImportRequestServerModel importRequest = new ImportRequestServerModel(importType, importUri);
+
+    // Act/Assert
+    assertDoesNotThrow(() -> importSourceValidator.validateImportRequest(importRequest));
+  }
+
+  @ParameterizedTest(name = "for import type {0}, should reject files from other sources")
+  @EnumSource(ImportRequestServerModel.TypeEnum.class)
+  void testRejectsImportsFromOtherSources(ImportRequestServerModel.TypeEnum importType) {
+    // Arrange
+    URI importUri = URI.create("https://example.com/file");
+    ImportRequestServerModel importRequest = new ImportRequestServerModel(importType, importUri);
+
+    // Act/Assert
+    ValidationException err =
+        assertThrows(
+            ValidationException.class,
+            () -> importSourceValidator.validateImportRequest(importRequest));
+    assertEquals("Files may not be imported from example.com.", err.getMessage());
+  }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobControlPlaneE2ETest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobControlPlaneE2ETest.java
@@ -67,7 +67,8 @@ import org.springframework.util.StreamUtils;
 @TestPropertySource(
     properties = {
       // turn off pubsub autoconfiguration for tests
-      "spring.cloud.gcp.pubsub.enabled=false"
+      "spring.cloud.gcp.pubsub.enabled=false",
+      "twds.data-import.allow-file-imports=true"
     })
 class PfbQuartzJobControlPlaneE2ETest {
   @Autowired ObjectMapper mapper;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobControlPlaneE2ETest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobControlPlaneE2ETest.java
@@ -68,7 +68,7 @@ import org.springframework.util.StreamUtils;
     properties = {
       // turn off pubsub autoconfiguration for tests
       "spring.cloud.gcp.pubsub.enabled=false",
-      "twds.data-import.allow-file-imports=true"
+      "twds.data-import.allowed-schemes=file"
     })
 class PfbQuartzJobControlPlaneE2ETest {
   @Autowired ObjectMapper mapper;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobControlPlaneE2ETest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobControlPlaneE2ETest.java
@@ -68,6 +68,7 @@ import org.springframework.util.StreamUtils;
     properties = {
       // turn off pubsub autoconfiguration for tests
       "spring.cloud.gcp.pubsub.enabled=false",
+      // Allow file imports to test with files from resources.
       "twds.data-import.allowed-schemes=file"
     })
 class PfbQuartzJobControlPlaneE2ETest {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobDataPlaneE2ETest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobDataPlaneE2ETest.java
@@ -48,7 +48,11 @@ import org.springframework.test.context.ActiveProfiles;
  */
 @ActiveProfiles(profiles = {"mock-sam", "noop-scheduler-dao", "data-plane"})
 @DirtiesContext
-@SpringBootTest(properties = {"twds.data-import.allowed-schemes=file"})
+@SpringBootTest(
+    properties = {
+      // Allow file imports to test with files from resources.
+      "twds.data-import.allowed-schemes=file"
+    })
 class PfbQuartzJobDataPlaneE2ETest {
   @Autowired @SingleTenant WorkspaceId workspaceId;
   @Autowired RecordOrchestratorService recordOrchestratorService;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobDataPlaneE2ETest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobDataPlaneE2ETest.java
@@ -48,7 +48,7 @@ import org.springframework.test.context.ActiveProfiles;
  */
 @ActiveProfiles(profiles = {"mock-sam", "noop-scheduler-dao", "data-plane"})
 @DirtiesContext
-@SpringBootTest
+@SpringBootTest(properties = {"twds.data-import.allow-file-imports=true"})
 class PfbQuartzJobDataPlaneE2ETest {
   @Autowired @SingleTenant WorkspaceId workspaceId;
   @Autowired RecordOrchestratorService recordOrchestratorService;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobDataPlaneE2ETest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobDataPlaneE2ETest.java
@@ -48,7 +48,7 @@ import org.springframework.test.context.ActiveProfiles;
  */
 @ActiveProfiles(profiles = {"mock-sam", "noop-scheduler-dao", "data-plane"})
 @DirtiesContext
-@SpringBootTest(properties = {"twds.data-import.allow-file-imports=true"})
+@SpringBootTest(properties = {"twds.data-import.allowed-schemes=file"})
 class PfbQuartzJobDataPlaneE2ETest {
   @Autowired @SingleTenant WorkspaceId workspaceId;
   @Autowired RecordOrchestratorService recordOrchestratorService;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobE2ETest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobE2ETest.java
@@ -53,7 +53,7 @@ import org.springframework.test.context.ActiveProfiles;
  */
 @ActiveProfiles(profiles = {"mock-sam", "noop-scheduler-dao"})
 @DirtiesContext
-@SpringBootTest
+@SpringBootTest(properties = {"twds.data-import.allowed-schemes=file"})
 @AutoConfigureMockMvc
 class TdrManifestQuartzJobE2ETest extends TestBase {
   @Autowired private RecordOrchestratorService recordOrchestratorService;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobE2ETest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobE2ETest.java
@@ -53,7 +53,11 @@ import org.springframework.test.context.ActiveProfiles;
  */
 @ActiveProfiles(profiles = {"mock-sam", "noop-scheduler-dao"})
 @DirtiesContext
-@SpringBootTest(properties = {"twds.data-import.allowed-schemes=file"})
+@SpringBootTest(
+    properties = {
+      // Allow file imports to test with files from resources.
+      "twds.data-import.allowed-schemes=file"
+    })
 @AutoConfigureMockMvc
 class TdrManifestQuartzJobE2ETest extends TestBase {
   @Autowired private RecordOrchestratorService recordOrchestratorService;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceControlPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceControlPlaneTest.java
@@ -49,7 +49,8 @@ class ImportServiceControlPlaneTest {
   @MockBean SamAuthorizationDaoFactory samAuthorizationDaoFactory;
 
   private final SamAuthorizationDao samAuthorizationDao = spy(MockSamAuthorizationDao.allowAll());
-  private final URI importUri = URI.create("http://does/not/matter");
+  private final URI importUri =
+      URI.create("https://teststorageaccount.blob.core.windows.net/testcontainer/file");
   private final ImportRequestServerModel importRequest =
       new ImportRequestServerModel(PFB, importUri);
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceDataPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceDataPlaneTest.java
@@ -48,7 +48,8 @@ class ImportServiceDataPlaneTest {
   @MockBean SamAuthorizationDaoFactory samAuthorizationDaoFactory;
   private final SamAuthorizationDao samAuthorizationDao = spy(MockSamAuthorizationDao.allowAll());
 
-  private final URI importUri = URI.create("http://does/not/matter");
+  private final URI importUri =
+      URI.create("https://teststorageaccount.blob.core.windows.net/testcontainer/file");
   private final ImportRequestServerModel importRequest =
       new ImportRequestServerModel(PFB, importUri);
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceTest.java
@@ -57,7 +57,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles(profiles = {"mock-sam", "mock-collection-dao"})
 @DirtiesContext
-@SpringBootTest(properties = {"twds.data-import.allowed-import-sources=*.terra.bio"})
+@SpringBootTest(properties = {"twds.data-import.allowed-hosts=*.terra.bio"})
 class ImportServiceTest extends TestBase {
 
   @Autowired ImportService importService;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceTest.java
@@ -249,7 +249,7 @@ class ImportServiceTest extends TestBase {
         assertThrows(
             ValidationException.class,
             () -> importService.createImport(defaultCollectionId().id(), importRequest));
-    assertEquals("File URL must be an HTTPS URL.", err.getMessage());
+    assertEquals("Files may not be imported from http URLs.", err.getMessage());
 
     // No import job should be created.
     verify(jobDao, never()).createJob(any());


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1588

Per security requirements, we can't import from arbitrary URLs. This restricts import URLs to HTTPS URLs pointing to files in GCS buckets, Azure blob storage containers, or S3 buckets. Additional allowed import services can be configured.

One complication is that some import tests use a file URL for a local resource. I added another configuration option (to be used only in tests) to allow different URL schemes (file for some unit tests and http for client tests).