### PR TITLE
AJ-1695: restore Postgres search path after clone/restore

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/BackupRestoreService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/BackupRestoreService.java
@@ -212,9 +212,10 @@ public class BackupRestoreService {
     } finally {
       // restore the original search path
       if (originalSearchPath != null) {
-        namedTemplate.update(
+        namedTemplate.queryForObject(
             "SELECT pg_catalog.set_config('search_path', :originalSearchPath, false);",
-            Map.of("originalSearchPath", originalSearchPath));
+            Map.of("originalSearchPath", originalSearchPath),
+            String.class);
       }
 
       // clean up


### PR DESCRIPTION
## Background

The default *[search path](https://www.postgresql.org/docs/current/ddl-schemas.html#DDL-SCHEMAS-PATH)* for Postgres db connections is `"$user", public`. This means that anytime we use _unqualified_ names in a SQL statement, Postgres will look for those objects in the `public` schema and in a schema named after the current user (which in our case doesn't exist).

When WDS creates a new table for a user, it issues a statement like:
```
create table "some-uuid"."mytable" (id text primary key, myfile file);
```
This creates two columns:
* a column named "id" of type "text", which is the primary key
* a column named "myfile" of type "file"

The "text" type is a built-in Postgres type. The "file" type is a custom WDS type, which is created in our first Liquibase changeset [here](https://github.com/DataBiosphere/terra-workspace-data-service/blob/379e303fe240e638d1824dc74cf34bba59ac0966/service/src/main/resources/liquibase/changesets/20230426_domains.yaml#L20-L22). This "file" type _exists in the "public" schema_.

In that SQL statement, notice that we create the "myfile" column as type "file", not as "public.file". This gets back to the *search path* - since the default search path includes "public", Postgres knows how to look in "public" for "file", and finds it. This is equivalent to specifying "public.file". 

## The Problem

WDS cloning starts with `pg_dump`-ing the source database. This generates a file of SQL statements which will reconstitute the data. In the clone, we then execute all those SQL statements. These include `create table` and (the equivalent of) `insert` statements.

But, the pg_dump statements also include:
```
SELECT pg_catalog.set_config('search_path', '', false);
```

This statement changes the Postgres search path, and _removes the public schema_ . Therefore, after performing the restore, the db connection no longer searches in "public" … which manifests as being unable to find the `file` datatype!!!

## The Solution in This PR

Before executing the pg_dump statements, query for and save a copy of the original search path.

After executing the pg_dump statements, restore the original search path.

## References

1. https://www.postgresql.org/message-id/ace62b19-f918-3579-3633-b9e19da8b9de%40aklaver.com
2. https://postgrespro.com/list/thread-id/2448092
3. https://www.postgresql.org/message-id/1331174.1661396866%40sss.pgh.pa.us