### PR TITLE
AJ-1695: (take 2) add public. qualifier to file/relation types

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/DataTypeMapping.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/DataTypeMapping.java
@@ -14,17 +14,17 @@ public enum DataTypeMapping {
   DATE(null, "date", false, "?"),
   DATE_TIME(null, "timestamp with time zone", false, "?"),
   STRING(null, "text", false, "?"),
-  RELATION(null, "relation", false, "?"),
+  RELATION(null, "public.relation", false, "?"),
   JSON(null, "jsonb", false, "?::jsonb"),
   NUMBER(null, "numeric", false, "?"),
-  FILE(null, "file", false, "?"),
+  FILE(null, "public.file", false, "?"),
   ARRAY_OF_NUMBER(Double[].class, "numeric[]", true, "?::numeric[]"),
   ARRAY_OF_DATE(String[].class, "date[]", true, "?::date[]"),
   ARRAY_OF_DATE_TIME(
       String[].class, "timestamp with time zone[]", true, "?::timestamp with time zone[]"),
   ARRAY_OF_STRING(String[].class, "text[]", true, "?"),
-  ARRAY_OF_RELATION(String[].class, "array_of_relation", true, "?"),
-  ARRAY_OF_FILE(String[].class, "array_of_file", true, "?"),
+  ARRAY_OF_RELATION(String[].class, "public.array_of_relation", true, "?"),
+  ARRAY_OF_FILE(String[].class, "public.array_of_file", true, "?"),
   ARRAY_OF_BOOLEAN(Boolean[].class, "boolean[]", true, "?"),
   ARRAY_OF_JSON(String[].class, "jsonb[]", true, "?::jsonb[]");
 
@@ -38,8 +38,7 @@ public enum DataTypeMapping {
 
   private static final Map<String, DataTypeMapping> MAPPING_BY_PG_TYPE = new HashMap<>();
 
-  private static record BaseTypeAndArrayTypePair(
-      DataTypeMapping baseType, DataTypeMapping arrayType) {}
+  private record BaseTypeAndArrayTypePair(DataTypeMapping baseType, DataTypeMapping arrayType) {}
 
   private static final ImmutableList<BaseTypeAndArrayTypePair> BASE_TYPE_AND_ARRAY_TYPE_PAIRS =
       ImmutableList.of(
@@ -52,10 +51,13 @@ public enum DataTypeMapping {
           new BaseTypeAndArrayTypePair(RELATION, ARRAY_OF_RELATION),
           new BaseTypeAndArrayTypePair(JSON, ARRAY_OF_JSON));
 
+  // when building the MAPPING_BY_PG_TYPE, strip the "public." qualifier from postgres types.
+  // we need that qualifier when generating SQL, but the qualifier will not be returned by
+  // postgres when describing columns.
   static {
     Arrays.stream(DataTypeMapping.values())
         .filter(v -> !EnumSet.of(EMPTY_ARRAY, NULL).contains(v))
-        .forEach(e -> MAPPING_BY_PG_TYPE.put(e.getPostgresType(), e));
+        .forEach(e -> MAPPING_BY_PG_TYPE.put(e.getPostgresType().replace("public.", ""), e));
   }
 
   DataTypeMapping(


### PR DESCRIPTION
## Background

The default *[search path](https://www.postgresql.org/docs/current/ddl-schemas.html#DDL-SCHEMAS-PATH)* for Postgres db connections is `"$user", public`. This means that anytime we use _unqualified_ names in a SQL statement, Postgres will look for those objects in the `public` schema and in a schema named after the current user (which in our case doesn't exist).

When WDS creates a new table for a user, it issues a statement like:
```
create table "some-uuid"."mytable" (id text primary key, myfile file);
```
This creates two columns:
* a column named "id" of type "text", which is the primary key
* a column named "myfile" of type "file"

The "text" type is a built-in Postgres type. The "file" type is a custom WDS type, which is created in our first Liquibase changeset [here](https://github.com/DataBiosphere/terra-workspace-data-service/blob/379e303fe240e638d1824dc74cf34bba59ac0966/service/src/main/resources/liquibase/changesets/20230426_domains.yaml#L20-L22). This "file" type _exists in the "public" schema_.

In that example SQL statement, notice that we create the "myfile" column as type "file", not as "public.file". This gets back to the *search path* - since the default search path includes "public", Postgres knows how to look in "public" for "file", and finds it. This is equivalent to specifying "public.file". 

## The Problem

WDS cloning starts with `pg_dump`-ing the source database. This generates a file of SQL statements which will reconstitute the data. In the clone, we then execute all those SQL statements. These include `create table` and (the equivalent of) `insert` statements.

But, the pg_dump statements also include:
```
SELECT pg_catalog.set_config('search_path', '', false);
```

This statement changes the Postgres search path, and _removes the public schema_ . Therefore, after performing the restore, the db connection no longer searches in "public" … which manifests as being unable to find the `file` datatype!!!

## The Solution in This PR

When issuing our SQL statements to create/alter tables and columns, always qualify the `file` (and `relation`, `array_of_file`, `array_of_relation`) datatype as `public.file`. This means that the Postgres search path is irrelevant.

## References

1. https://www.postgresql.org/message-id/ace62b19-f918-3579-3633-b9e19da8b9de%40aklaver.com
2. https://postgrespro.com/list/thread-id/2448092
3. https://www.postgresql.org/message-id/1331174.1661396866%40sss.pgh.pa.us