### PR TITLE
AJ-1681 Remove extraneous 'needs' from GHA job

### DIFF
--- a/.github/workflows/publish-app-version.yml
+++ b/.github/workflows/publish-app-version.yml
@@ -73,7 +73,6 @@ jobs:
   # Deploy the new version of cWDS to the dev environment.
   cwds-set-version-in-dev:
     uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
-    needs: cwds-report-to-sherlock
     with:
       new-version: ${{ inputs.new-tag }}
       chart-name: 'cwds'


### PR DESCRIPTION
https://github.com/DataBiosphere/terra-workspace-data-service/pull/626 removed the `cwds-report-to-sherlock` job from [publish-app-version.yml](https://github.com/DataBiosphere/terra-workspace-data-service/pull/626/files#diff-1ac4fd7604e5ec940e6c79797149bd0b58599ff0d613e65f55bbb83a4e1b32fd) but forgot to remove `needs: cwds-report-to-sherlock` from the following job.

Reminder:

PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 
