### PR TITLE
AJ-1695: reset Postgres search path to default after clone/restore

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/BackupRestoreService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/BackupRestoreService.java
@@ -227,7 +227,7 @@ public class BackupRestoreService {
   private void logSearchPath(String logPrefix) {
     try {
       String searchPath = namedTemplate.queryForObject("SHOW search_path;", Map.of(), String.class);
-      LOGGER.info("{}, the Postgres search path is: {}", logPrefix, searchPath);
+      LOGGER.info("{}, the Postgres search path is: [{}]", logPrefix, searchPath);
     } catch (Exception e) {
       // don't fail if there is a problem with logging
     }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/BackupRestoreServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/BackupRestoreServiceTest.java
@@ -1,12 +1,27 @@
 package org.databiosphere.workspacedataservice.service;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.dao.BackupRestoreDao;
+import org.databiosphere.workspacedataservice.service.model.exception.LaunchProcessException;
+import org.databiosphere.workspacedataservice.shared.model.RestoreResponse;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 
@@ -20,6 +35,9 @@ import org.springframework.test.context.TestPropertySource;
     })
 class BackupRestoreServiceTest extends TestBase {
   @Autowired private BackupRestoreService backupRestoreService;
+  @Autowired private NamedParameterJdbcTemplate namedTemplate;
+
+  @MockBean BackupRestoreDao<RestoreResponse> mockRestoreDao;
 
   @Test
   void CheckBackupCommandLine() {
@@ -43,5 +61,51 @@ class BackupRestoreServiceTest extends TestBase {
     assertThat(blobName)
         .containsPattern(
             "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}-[0-9]{4}-[0-9]{2}-[0-9]{2}_([0-9]+(-[0-9]+)+)\\.sql");
+  }
+
+  @Test
+  void postgresSearchPathResetToDefault() {
+    // ARRANGE
+    // make note of the Postgres search path, prior to doing anything else with restores
+    String beforeCloneSearchPath =
+        namedTemplate.queryForObject("SHOW search_path;", Map.of(), String.class);
+    assertNotNull(beforeCloneSearchPath);
+
+    // simulate the behavior of restoring a pg_dump:
+    UUID trackingId = UUID.randomUUID();
+
+    // pg_dumps contain the following `set_config` line, which changes the Postgres search path.
+    // manually execute it here, simulating what happens when we restore the pg_dump
+    namedTemplate.queryForObject(
+        "SELECT pg_catalog.set_config('search_path', '', false);", Map.of(), String.class);
+    // for the purposes of this test, since we've simulated the search path change, no need to do
+    // anything else. Throw an error from the RestoreDao, so we will exit out of `restoreAzureWDS`
+    // early.
+    // N.B. exiting early makes this test much faster, because it exits before we try to use Azure
+    // credentials to generate tokens.
+    doThrow(new LaunchProcessException("Unit test intentional error"))
+        .when(mockRestoreDao)
+        .createEntry(eq(trackingId), any());
+
+    // ACT
+    // Execute a restore. This restore will fail due to the mocking above; that's ok - this test
+    // only verifies that the restore code resets the Postgres search path (even on failure)
+    backupRestoreService.restoreAzureWDS(
+        "v0.2", "/file/name/is/irrelevant", trackingId, "token-is-irrelevant");
+
+    // ASSERT
+    // make note of the Postgres search path, after cloning
+    String afterCloneSearchPath =
+        namedTemplate.queryForObject("SHOW search_path;", Map.of(), String.class);
+    assertNotNull(afterCloneSearchPath);
+
+    // assert the postgres search path after restore is the same as before restore
+    assertEquals(searchPathToSet(beforeCloneSearchPath), searchPathToSet(afterCloneSearchPath));
+  }
+
+  // Postgres search path is a comma-delimited list; change it to a Set because we don't care
+  // about order or duplication of items within the search path
+  private Set<String> searchPathToSet(String searchPath) {
+    return Arrays.stream(searchPath.split(",")).map(String::trim).collect(Collectors.toSet());
   }
 }


### PR DESCRIPTION
## Background

The default *[search path](https://www.postgresql.org/docs/current/ddl-schemas.html#DDL-SCHEMAS-PATH)* for Postgres db connections is `"$user", public`. This means that anytime we use _unqualified_ names in a SQL statement, Postgres will look for those objects in the `public` schema and in a schema named after the current user (which in our case doesn't exist).

When WDS creates a new table for a user, it issues a statement like:
```
create table "some-uuid"."mytable" (id text primary key, myfile file);
```
This creates two columns:
* a column named "id" of type "text", which is the primary key
* a column named "myfile" of type "file"

The "text" type is a built-in Postgres type. The "file" type is a custom WDS type, which is created in our first Liquibase changeset [here](https://github.com/DataBiosphere/terra-workspace-data-service/blob/379e303fe240e638d1824dc74cf34bba59ac0966/service/src/main/resources/liquibase/changesets/20230426_domains.yaml#L20-L22). This "file" type _exists in the "public" schema_.

In that SQL statement, notice that we create the "myfile" column as type "file", not as "public.file". This gets back to the *search path* - since the default search path includes "public", Postgres knows how to look in "public" for "file", and finds it. This is equivalent to specifying "public.file". 

## The Problem

WDS cloning starts with `pg_dump`-ing the source database. This generates a file of SQL statements which will reconstitute the data. In the clone, we then execute all those SQL statements. These include `create table` and (the equivalent of) `insert` statements.

But, the pg_dump statements also include:
```
SELECT pg_catalog.set_config('search_path', '', false);
```

This statement changes the Postgres search path, and _removes the public schema_ . Therefore, after performing the restore, the db connection no longer searches in "public" … which manifests as being unable to find the `file` datatype!!!

## The Solution in This PR

After executing the pg_dump statements, restore the search path to the default value.

This PR supersedes #651.

I feel much better about telling Postgres to reset the search path to what _it_ thinks the default is via `SET search_path TO DEFAULT` (in this PR) than I do about the implementation in #651 which resets the search path to what _we_ think the default is.



## References

1. https://www.postgresql.org/message-id/ace62b19-f918-3579-3633-b9e19da8b9de%40aklaver.com
2. https://postgrespro.com/list/thread-id/2448092
3. https://www.postgresql.org/message-id/1331174.1661396866%40sss.pgh.pa.us