### PR TITLE
[AJ-1681] Skip publishing Docker image on Dependabot PRs

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -11,7 +11,8 @@ on:
       ACR_SP_USER:
         required: true
   pull_request:
-    branches: [ '**' ]
+    branches-ignore:
+      - 'dependabot/**'
   push:
     branches:
       - main


### PR DESCRIPTION
On Dependabot PRs, this workflow fails to login to ACR because the username and password are stored in secrets that are not accessible to Dependabot.