### PR TITLE
[AJ-1709] Configure project ID for PubSub

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/config/DataImportProperties.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/config/DataImportProperties.java
@@ -20,7 +20,6 @@ public class DataImportProperties {
           Pattern.compile(".*\\.s3\\.amazonaws\\.com") // virtual host style legacy global endpoint
           );
   private RecordSinkMode batchWriteRecordSink;
-  private String projectId;
   private String rawlsBucketName;
   private boolean succeedOnCompletion;
 
@@ -34,14 +33,6 @@ public class DataImportProperties {
 
   void setBatchWriteRecordSink(String batchWriteRecordSink) {
     this.batchWriteRecordSink = RecordSinkMode.fromValue(batchWriteRecordSink);
-  }
-
-  public String getProjectId() {
-    return projectId;
-  }
-
-  void setProjectId(String projectId) {
-    this.projectId = projectId;
   }
 
   public String getRawlsBucketName() {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/pubsub/PubSubConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/pubsub/PubSubConfig.java
@@ -1,5 +1,6 @@
 package org.databiosphere.workspacedataservice.pubsub;
 
+import com.google.cloud.spring.core.GcpProjectIdProvider;
 import com.google.cloud.spring.pubsub.core.PubSubTemplate;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -16,10 +17,10 @@ public class PubSubConfig {
       havingValue = "true",
       matchIfMissing = true)
   PubSub applicationDefaultCredentialsPubSub(
+      GcpProjectIdProvider projectIdProvider,
       PubSubTemplate pubSubTemplate,
-      @Value("${spring.cloud.gcp.pubsub.topic}") String topic,
-      @Value("${twds.data-import.project-id}") String project) {
-    return new ImportPubSub(pubSubTemplate, topic, project);
+      @Value("${spring.cloud.gcp.pubsub.topic}") String topic) {
+    return new ImportPubSub(pubSubTemplate, topic, projectIdProvider.getProjectId());
   }
 
   // when Pub/Sub autoconfiguration is disabled, use a noop bean which has no other dependencies

--- a/service/src/main/java/org/databiosphere/workspacedataservice/storage/GcsStorage.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/storage/GcsStorage.java
@@ -30,11 +30,12 @@ public class GcsStorage {
 
   // Generates an instance of the storage class using the credentials the current process is running
   // under
-  public static GcsStorage create(DataImportProperties properties) throws IOException {
+  public static GcsStorage create(String projectId, DataImportProperties properties)
+      throws IOException {
     return new GcsStorage(
         StorageOptions.newBuilder()
             // projectId in GCP (string) is similar to subscriptionId in Azure (UUID)
-            .setProjectId(requireNonNull(properties.getProjectId()))
+            .setProjectId(requireNonNull(projectId))
             .setCredentials(GoogleCredentials.getApplicationDefault())
             .build()
             .getService(),

--- a/service/src/main/java/org/databiosphere/workspacedataservice/storage/GcsStorageConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/storage/GcsStorageConfig.java
@@ -1,5 +1,6 @@
 package org.databiosphere.workspacedataservice.storage;
 
+import com.google.cloud.spring.core.GcpProjectIdProvider;
 import java.io.IOException;
 import org.databiosphere.workspacedataservice.annotations.DeploymentMode.ControlPlane;
 import org.databiosphere.workspacedataservice.config.DataImportProperties;
@@ -10,7 +11,8 @@ import org.springframework.context.annotation.Configuration;
 @ControlPlane
 public class GcsStorageConfig {
   @Bean
-  public GcsStorage gcsStorage(DataImportProperties properties) throws IOException {
-    return GcsStorage.create(properties);
+  public GcsStorage gcsStorage(
+      GcpProjectIdProvider projectIdProvider, DataImportProperties properties) throws IOException {
+    return GcsStorage.create(projectIdProvider.getProjectId(), properties);
   }
 }

--- a/service/src/main/resources/application-control-plane.yml
+++ b/service/src/main/resources/application-control-plane.yml
@@ -10,15 +10,14 @@ twds:
   data-import:
     batch-write-record-sink: "rawls"
     succeed-on-completion: false
-    project-id: ${SERVICE_GOOGLE_PROJECT}
     rawls-bucket-name: ${SERVICE_GOOGLE_BUCKET}
 
 
 spring:
   cloud:
     gcp:
+      project-id: ${SERVICE_GOOGLE_PROJECT}
       pubsub:
-        project-id: ${SERVICE_GOOGLE_PROJECT}
         topic: ${RAWLS_NOTIFY_TOPIC}
         enabled: true
 

--- a/service/src/main/resources/application-control-plane.yml
+++ b/service/src/main/resources/application-control-plane.yml
@@ -18,6 +18,7 @@ spring:
   cloud:
     gcp:
       pubsub:
+        project-id: ${SERVICE_GOOGLE_PROJECT}
         topic: ${RAWLS_NOTIFY_TOPIC}
         enabled: true
 


### PR DESCRIPTION
In office hours today, we discovered that the GCP PubSub library has its own project ID configuration and WDS fails to start if that configuration is not provided.

```
org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'pfbQuartzJob' defined in file [/Users/nwatts/workspace/terra-workspace-data-service/service/build/classes/java/main/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJob.class]: Unsatisfied dependency expressed through constructor parameter 4: Error creating bean with name 'rawlsRecordSinkFactory' defined in file [/Users/nwatts/workspace/terra-workspace-data-service/service/build/classes/java/main/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkFactory.class]: Unsatisfied dependency expressed through constructor parameter 2: Error creating bean with name 'applicationDefaultCredentialsPubSub' defined in class path resource [org/databiosphere/workspacedataservice/pubsub/PubSubConfig.class]: Unsatisfied dependency expressed through method 'applicationDefaultCredentialsPubSub' parameter 0: Error creating bean with name 'pubSubTemplate' defined in class path resource [com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfiguration.class]: Unsatisfied dependency expressed through method 'pubSubTemplate' parameter 0: Error creating bean with name 'pubSubPublisherTemplate' defined in class path resource [com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfiguration.class]: Unsatisfied dependency expressed through method 'pubSubPublisherTemplate' parameter 0: Error creating bean with name 'defaultPublisherFactory' defined in class path resource [com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfiguration.class]: Failed to instantiate [com.google.cloud.spring.pubsub.support.PublisherFactory]: Factory method 'defaultPublisherFactory' threw exception with message: The project ID can't be null or empty.
```

Our development instructions didn't explicitly cover this, but it worked for some developers because they had a default project set via `gcloud config`. Similarly, this works in the dev environment because it can get a project ID from the environment.


Setting `spring.cloud.gcp.pubsub.project-id` based on the `SERVICE_GOOGLE_PROJECT` environment variable (in https://github.com/DataBiosphere/terra-workspace-data-service/pull/659/commits/728a54ecfe80d52012a3df2c7491e01d445f55a3) made things work, but then we have the same project ID configured in two different places (one for Spring GCP config and one for our own TWDS data import config).

This changes everything to use Spring Cloud GCP's `GcpProjectIdProvider`. Spring Cloud GCP looks for configuration in several places, but this also sets `spring.cloud.gcp.pubsub.project-id` based on the `SERVICE_GOOGLE_PROJECT` environment variable so that our existing environment variable still works.
https://googlecloudplatform.github.io/spring-cloud-gcp/reference/html/index.html#project-id

We could also simplify by removing the `project-id` config and using `GOOGLE_CLOUD_PROJECT` instead of `SERVICE_GOOGLE_PROJECT` in development.