### PR TITLE
AJ-1671: set server.forward-headers-strategy for control plane

### DIFF
--- a/service/src/main/resources/application-control-plane.yml
+++ b/service/src/main/resources/application-control-plane.yml
@@ -26,3 +26,8 @@ sentry:
   releasename: "cWDS"
   env: ${TERRA_ENV:}
   deploymentMode: control-plane
+
+server:
+  # since we run behind a proxy in the control plane, we need to respect X-Forwarded-* headers
+  # for example, we need to use X-Forwarded-Host instead of Host for redirects
+  forward-headers-strategy: native


### PR DESCRIPTION
AJ-1671

In the control plane, we run behind an Apache proxy. This proxy sends an `X-Forwarded-Host` instead of the standard `Host` header (as most proxies do). This breaks our redirect for swagger.

Spring has support for `X-Forwarded-Host`, but it needs to be turned on. This PR turns it on. See https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#howto.webserver.use-behind-a-proxy-server for details.

Update: well, this doesn't do the job. Next step is to look at the Apache proxy in bees and understand which headers it is sending. In local tests, I can see that the change in this PR respects `X-Forwarded-Host` … does Apache actually send that?