### PR TITLE
[AJ-1687] Add handler for PubSub messages from Rawls

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/PubSubController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/PubSubController.java
@@ -1,0 +1,48 @@
+package org.databiosphere.workspacedataservice.controller;
+
+import org.databiosphere.workspacedataservice.annotations.DeploymentMode.ControlPlane;
+import org.databiosphere.workspacedataservice.pubsub.JobStatusUpdate;
+import org.databiosphere.workspacedataservice.pubsub.PubSubMessage;
+import org.databiosphere.workspacedataservice.pubsub.PubSubRequest;
+import org.databiosphere.workspacedataservice.service.JobService;
+import org.databiosphere.workspacedataservice.service.model.exception.ValidationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@ControlPlane
+@RestController
+public class PubSubController {
+  private static final Logger LOGGER = LoggerFactory.getLogger(PubSubController.class);
+  private final JobService jobService;
+
+  public PubSubController(JobService jobService) {
+    this.jobService = jobService;
+  }
+
+  @PostMapping("/pubsub/import-status")
+  public ResponseEntity<String> receiveImportNotification(@RequestBody PubSubRequest request) {
+    PubSubMessage message = request.message();
+    LOGGER.info(
+        "Received PubSub message: {}, published {}", message.messageId(), message.publishTime());
+    try {
+      JobStatusUpdate update = JobStatusUpdate.createFromPubSubMessage(request.message());
+      LOGGER.info(
+          "Received status update for job {}: {} -> {}",
+          update.jobId(),
+          update.currentStatus(),
+          update.currentStatus());
+      jobService.processStatusUpdate(update);
+      return new ResponseEntity<>(HttpStatus.OK);
+    } catch (ValidationException e) {
+      // Return a successful status for invalid updates to prevent PubSub from retrying the request.
+      // https://cloud.google.com/pubsub/docs/push#receive_push
+      LOGGER.error("Error processing status update: {}", e.getMessage());
+      return new ResponseEntity<>(HttpStatus.ACCEPTED);
+    }
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/PubSubController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/PubSubController.java
@@ -35,7 +35,7 @@ public class PubSubController {
           "Received status update for job {}: {} -> {}",
           update.jobId(),
           update.currentStatus(),
-          update.currentStatus());
+          update.newStatus());
       jobService.processStatusUpdate(update);
       return new ResponseEntity<>(HttpStatus.OK);
     } catch (ValidationException e) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/pubsub/JobStatusUpdate.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/pubsub/JobStatusUpdate.java
@@ -1,0 +1,29 @@
+package org.databiosphere.workspacedataservice.pubsub;
+
+import java.util.Map;
+import java.util.UUID;
+import javax.annotation.Nullable;
+import org.databiosphere.workspacedataservice.generated.GenericJobServerModel.StatusEnum;
+
+public record JobStatusUpdate(
+    UUID jobId, StatusEnum currentStatus, StatusEnum newStatus, @Nullable String errorMessage) {
+  public static JobStatusUpdate createFromPubSubMessage(PubSubMessage message) {
+    Map<String, String> attributes = message.attributes();
+    UUID jobId = UUID.fromString(attributes.get("import_id"));
+    StatusEnum newStatus = rawlsStatusToJobStatus(attributes.get("new_status"));
+    StatusEnum currentStatus = rawlsStatusToJobStatus(attributes.get("current_status"));
+    String errorMessage = attributes.get("error_message");
+    return new JobStatusUpdate(jobId, currentStatus, newStatus, errorMessage);
+  }
+
+  private static StatusEnum rawlsStatusToJobStatus(String rawlsStatus) {
+    return switch (rawlsStatus) {
+      case "ReadyForUpsert" -> StatusEnum.RUNNING;
+      case "Upserting" -> StatusEnum.RUNNING;
+      case "Done" -> StatusEnum.SUCCEEDED;
+      case "Error" -> StatusEnum.ERROR;
+      default -> throw new RuntimeException(
+          "Unknown Rawls import status: %s".formatted(rawlsStatus));
+    };
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/pubsub/JobStatusUpdate.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/pubsub/JobStatusUpdate.java
@@ -7,6 +7,10 @@ import org.databiosphere.workspacedataservice.generated.GenericJobServerModel.St
 
 public record JobStatusUpdate(
     UUID jobId, StatusEnum currentStatus, StatusEnum newStatus, @Nullable String errorMessage) {
+  public JobStatusUpdate(UUID jobId, StatusEnum currentStatus, StatusEnum newStatus) {
+    this(jobId, currentStatus, newStatus, null);
+  }
+
   public static JobStatusUpdate createFromPubSubMessage(PubSubMessage message) {
     Map<String, String> attributes = message.attributes();
     UUID jobId = UUID.fromString(attributes.get("import_id"));

--- a/service/src/main/java/org/databiosphere/workspacedataservice/pubsub/JobStatusUpdate.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/pubsub/JobStatusUpdate.java
@@ -22,7 +22,7 @@ public record JobStatusUpdate(
       case "Upserting" -> StatusEnum.RUNNING;
       case "Done" -> StatusEnum.SUCCEEDED;
       case "Error" -> StatusEnum.ERROR;
-      default -> throw new RuntimeException(
+      default -> throw new IllegalArgumentException(
           "Unknown Rawls import status: %s".formatted(rawlsStatus));
     };
   }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/pubsub/PubSubMessage.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/pubsub/PubSubMessage.java
@@ -1,0 +1,10 @@
+package org.databiosphere.workspacedataservice.pubsub;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+
+public record PubSubMessage(
+    @JsonProperty("attributes") Map<String, String> attributes,
+    @JsonProperty("data") String data,
+    @JsonProperty("messageId") String messageId,
+    @JsonProperty("publishTime") String publishTime) {}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/pubsub/PubSubMessage.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/pubsub/PubSubMessage.java
@@ -1,10 +1,6 @@
 package org.databiosphere.workspacedataservice.pubsub;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Map;
 
 public record PubSubMessage(
-    @JsonProperty("attributes") Map<String, String> attributes,
-    @JsonProperty("data") String data,
-    @JsonProperty("messageId") String messageId,
-    @JsonProperty("publishTime") String publishTime) {}
+    Map<String, String> attributes, String data, String messageId, String publishTime) {}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/pubsub/PubSubRequest.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/pubsub/PubSubRequest.java
@@ -1,0 +1,8 @@
+package org.databiosphere.workspacedataservice.pubsub;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record PubSubRequest(
+    @JsonProperty("message") PubSubMessage message,
+    @JsonProperty("deliveryAttempt") Integer deliveryAttempt,
+    @JsonProperty("subscription") String subscription) {}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/pubsub/PubSubRequest.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/pubsub/PubSubRequest.java
@@ -1,8 +1,3 @@
 package org.databiosphere.workspacedataservice.pubsub;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
-public record PubSubRequest(
-    @JsonProperty("message") PubSubMessage message,
-    @JsonProperty("deliveryAttempt") Integer deliveryAttempt,
-    @JsonProperty("subscription") String subscription) {}
+public record PubSubRequest(PubSubMessage message, Integer deliveryAttempt, String subscription) {}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/JobService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/JobService.java
@@ -1,18 +1,28 @@
 package org.databiosphere.workspacedataservice.service;
 
+import static org.apache.commons.lang3.ObjectUtils.firstNonNull;
+
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
+import org.databiosphere.workspacedataservice.pubsub.JobStatusUpdate;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthenticationMaskableException;
 import org.databiosphere.workspacedataservice.service.model.exception.MissingObjectException;
+import org.databiosphere.workspacedataservice.service.model.exception.ValidationException;
 import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.stereotype.Service;
 
 @Service
 public class JobService {
+  private static final Set<GenericJobServerModel.StatusEnum> terminalJobStatuses =
+      Set.of(
+          GenericJobServerModel.StatusEnum.SUCCEEDED,
+          GenericJobServerModel.StatusEnum.ERROR,
+          GenericJobServerModel.StatusEnum.CANCELLED);
 
   JobDao jobDao;
   CollectionService collectionService;
@@ -43,5 +53,40 @@ public class JobService {
       throw new AuthenticationMaskableException("Collection");
     }
     return jobDao.getJobsForCollection(collectionId, statuses);
+  }
+
+  /**
+   * Process a job status update from Rawls received via PubSub. This method is only used in the
+   * control plane (it's exposed through the control plane only PubSubController).
+   */
+  public void processStatusUpdate(JobStatusUpdate update) {
+    try {
+      UUID jobId = update.jobId();
+      GenericJobServerModel job = getJob(jobId);
+      GenericJobServerModel.StatusEnum currentStatus = job.getStatus();
+      GenericJobServerModel.StatusEnum newStatus = update.newStatus();
+
+      // Ignore messages that don't change the job's status.
+      // Rawls and import service have more granular statuses than CWDS, so the initial update
+      // will be from "ReadyToUpsert" to "Upserting", which both translate to "RUNNING" in CWDS.
+      if (currentStatus.equals(newStatus)) {
+        return;
+      }
+
+      // Once a job has reached a terminal state, do not update its status again.
+      if (terminalJobStatuses.contains(currentStatus)) {
+        throw new ValidationException(
+            "Unable to update terminal status for job %s".formatted(jobId));
+      }
+
+      if (newStatus.equals(GenericJobServerModel.StatusEnum.ERROR)) {
+        jobDao.fail(jobId, firstNonNull(update.errorMessage(), "Unknown error"));
+      } else {
+        jobDao.updateStatus(jobId, newStatus);
+      }
+    } catch (MissingObjectException e) {
+      // Via PubSub, CWDS will receive status updates for both CWDS and import service jobs.
+      // If the job is not found in the database (because it's an import service job), ignore it.
+    }
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/JobService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/JobService.java
@@ -1,6 +1,6 @@
 package org.databiosphere.workspacedataservice.service;
 
-import static org.apache.commons.lang3.ObjectUtils.firstNonNull;
+import static java.util.Objects.requireNonNullElse;
 
 import java.util.List;
 import java.util.Optional;
@@ -78,7 +78,7 @@ public class JobService {
       }
 
       if (newStatus.equals(StatusEnum.ERROR)) {
-        jobDao.fail(jobId, firstNonNull(update.errorMessage(), "Unknown error"));
+        jobDao.fail(jobId, requireNonNullElse(update.errorMessage(), "Unknown error"));
       } else {
         jobDao.updateStatus(jobId, newStatus);
       }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/JobService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/JobService.java
@@ -77,10 +77,12 @@ public class JobService {
             "Unable to update terminal status for job %s".formatted(jobId));
       }
 
-      if (newStatus.equals(StatusEnum.ERROR)) {
-        jobDao.fail(jobId, requireNonNullElse(update.errorMessage(), "Unknown error"));
-      } else {
-        jobDao.updateStatus(jobId, newStatus);
+      switch (newStatus) {
+        case SUCCEEDED -> jobDao.succeeded(jobId);
+        case ERROR -> jobDao.fail(
+            jobId, requireNonNullElse(update.errorMessage(), "Unknown error"));
+        default -> throw new ValidationException(
+            "Unexpected status from Rawls for job %s: %s".formatted(jobId, newStatus));
       }
     } catch (MissingObjectException e) {
       // Via PubSub, CWDS will receive status updates for both CWDS and import service jobs.

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/JobService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/JobService.java
@@ -19,7 +19,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class JobService {
-  private static final Set<StatusEnum> terminalJobStatuses =
+  private static final Set<StatusEnum> TERMINAL_JOB_STATUSES =
       Set.of(StatusEnum.SUCCEEDED, StatusEnum.ERROR, StatusEnum.CANCELLED);
 
   JobDao jobDao;
@@ -72,7 +72,7 @@ public class JobService {
       }
 
       // Once a job has reached a terminal state, do not update its status again.
-      if (terminalJobStatuses.contains(currentStatus)) {
+      if (TERMINAL_JOB_STATUSES.contains(currentStatus)) {
         throw new ValidationException(
             "Unable to update terminal status for job %s".formatted(jobId));
       }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/JobService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/JobService.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
+import org.databiosphere.workspacedataservice.generated.GenericJobServerModel.StatusEnum;
 import org.databiosphere.workspacedataservice.pubsub.JobStatusUpdate;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthenticationMaskableException;
 import org.databiosphere.workspacedataservice.service.model.exception.MissingObjectException;
@@ -18,11 +19,8 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class JobService {
-  private static final Set<GenericJobServerModel.StatusEnum> terminalJobStatuses =
-      Set.of(
-          GenericJobServerModel.StatusEnum.SUCCEEDED,
-          GenericJobServerModel.StatusEnum.ERROR,
-          GenericJobServerModel.StatusEnum.CANCELLED);
+  private static final Set<StatusEnum> terminalJobStatuses =
+      Set.of(StatusEnum.SUCCEEDED, StatusEnum.ERROR, StatusEnum.CANCELLED);
 
   JobDao jobDao;
   CollectionService collectionService;
@@ -63,8 +61,8 @@ public class JobService {
     try {
       UUID jobId = update.jobId();
       GenericJobServerModel job = getJob(jobId);
-      GenericJobServerModel.StatusEnum currentStatus = job.getStatus();
-      GenericJobServerModel.StatusEnum newStatus = update.newStatus();
+      StatusEnum currentStatus = job.getStatus();
+      StatusEnum newStatus = update.newStatus();
 
       // Ignore messages that don't change the job's status.
       // Rawls and import service have more granular statuses than CWDS, so the initial update
@@ -79,7 +77,7 @@ public class JobService {
             "Unable to update terminal status for job %s".formatted(jobId));
       }
 
-      if (newStatus.equals(GenericJobServerModel.StatusEnum.ERROR)) {
+      if (newStatus.equals(StatusEnum.ERROR)) {
         jobDao.fail(jobId, firstNonNull(update.errorMessage(), "Unknown error"));
       } else {
         jobDao.updateStatus(jobId, newStatus);

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/PubSubControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/PubSubControllerMockMvcTest.java
@@ -1,0 +1,117 @@
+package org.databiosphere.workspacedataservice.controller;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.Map;
+import java.util.UUID;
+import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
+import org.databiosphere.workspacedataservice.dao.CollectionDao;
+import org.databiosphere.workspacedataservice.dao.JobDao;
+import org.databiosphere.workspacedataservice.dataimport.snapshotsupport.RawlsSnapshotSupportFactory;
+import org.databiosphere.workspacedataservice.dataimport.snapshotsupport.SnapshotSupportFactory;
+import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
+import org.databiosphere.workspacedataservice.pubsub.PubSub;
+import org.databiosphere.workspacedataservice.pubsub.PubSubMessage;
+import org.databiosphere.workspacedataservice.pubsub.PubSubRequest;
+import org.databiosphere.workspacedataservice.rawls.RawlsClient;
+import org.databiosphere.workspacedataservice.recordsink.RawlsRecordSinkFactory;
+import org.databiosphere.workspacedataservice.recordsink.RecordSinkFactory;
+import org.databiosphere.workspacedataservice.retry.RestClientRetry;
+import org.databiosphere.workspacedataservice.shared.model.CollectionId;
+import org.databiosphere.workspacedataservice.storage.GcsStorage;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+@ActiveProfiles(profiles = {"control-plane", "mock-sam"})
+@TestPropertySource(
+    properties = {
+      // turn off pubsub autoconfiguration for tests
+      "spring.cloud.gcp.pubsub.enabled=false"
+    })
+class PubSubControllerMockMvcTest extends MockMvcTestBase {
+  @MockBean private JobDao jobDao;
+  @MockBean private CollectionDao collectionDao;
+
+  // Since we're running with both control-plane and data-plane profiles simultaneously, Spring
+  // does not know what to do with beans which are satisfied by two different mutually exclusive
+  // implementations. In this @TestConfiguration, we explicitly specify @Primary beans for any
+  // conflicts.
+  @TestConfiguration
+  static class SpecifyConflictingBeans {
+    @Primary
+    @Bean("overrideRecordSinkFactory")
+    RecordSinkFactory overrideRecordSinkFactory(
+        ObjectMapper mapper, GcsStorage storage, PubSub pubSub) {
+      return new RawlsRecordSinkFactory(mapper, storage, pubSub);
+    }
+
+    @Primary
+    @Bean("overrideSnapshotSupportFactory")
+    SnapshotSupportFactory overrideSnapshotSupportFactory(
+        RestClientRetry restClientRetry, ActivityLogger activityLogger, RawlsClient rawlsClient) {
+      return new RawlsSnapshotSupportFactory(restClientRetry, activityLogger, rawlsClient);
+    }
+  }
+
+  @Test
+  void statusUpdateNotification() throws Exception {
+    // Arrange
+    UUID jobId = UUID.randomUUID();
+
+    // Job exists
+    CollectionId collectionId = CollectionId.of(UUID.randomUUID());
+    GenericJobServerModel expected =
+        new GenericJobServerModel(
+            jobId,
+            GenericJobServerModel.JobTypeEnum.DATA_IMPORT,
+            collectionId.id(),
+            GenericJobServerModel.StatusEnum.RUNNING,
+            // set created and updated to now, but in UTC because that's how Postgres stores it
+            OffsetDateTime.now(ZoneId.of("Z")),
+            OffsetDateTime.now(ZoneId.of("Z")));
+    when(jobDao.getJob(jobId)).thenReturn(expected);
+
+    // Collection does not exist, so virtual collection is used
+    when(collectionDao.getWorkspaceId(collectionId))
+        .thenThrow(new EmptyResultDataAccessException("unit test intentional error", 1));
+
+    PubSubRequest request =
+        new PubSubRequest(
+            new PubSubMessage(
+                Map.of(
+                    "import_id", jobId.toString(),
+                    "current_status", "Upserting",
+                    "new_status", "Done"),
+                null,
+                "123456789",
+                "2024-03-20T10:00:00.000Z"),
+            null,
+            "import-service-notify-test");
+
+    // Act/Assert
+    mockMvc
+        .perform(
+            post("/pubsub/import-status")
+                .content(toJson(request))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    // Assert
+    verify(jobDao, times(1)).updateStatus(jobId, GenericJobServerModel.StatusEnum.SUCCEEDED);
+  }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/PubSubControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/PubSubControllerMockMvcTest.java
@@ -6,37 +6,26 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.Map;
 import java.util.UUID;
-import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
 import org.databiosphere.workspacedataservice.dao.CollectionDao;
 import org.databiosphere.workspacedataservice.dao.JobDao;
-import org.databiosphere.workspacedataservice.dataimport.snapshotsupport.RawlsSnapshotSupportFactory;
-import org.databiosphere.workspacedataservice.dataimport.snapshotsupport.SnapshotSupportFactory;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
-import org.databiosphere.workspacedataservice.pubsub.PubSub;
 import org.databiosphere.workspacedataservice.pubsub.PubSubMessage;
 import org.databiosphere.workspacedataservice.pubsub.PubSubRequest;
-import org.databiosphere.workspacedataservice.rawls.RawlsClient;
-import org.databiosphere.workspacedataservice.recordsink.RawlsRecordSinkFactory;
-import org.databiosphere.workspacedataservice.recordsink.RecordSinkFactory;
-import org.databiosphere.workspacedataservice.retry.RestClientRetry;
 import org.databiosphere.workspacedataservice.shared.model.CollectionId;
-import org.databiosphere.workspacedataservice.storage.GcsStorage;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Primary;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 
-@ActiveProfiles(profiles = {"control-plane", "mock-sam"})
+@ActiveProfiles(
+    inheritProfiles = false,
+    profiles = {"control-plane", "mock-sam"})
 @TestPropertySource(
     properties = {
       // turn off pubsub autoconfiguration for tests
@@ -45,27 +34,6 @@ import org.springframework.test.context.TestPropertySource;
 class PubSubControllerMockMvcTest extends MockMvcTestBase {
   @MockBean private JobDao jobDao;
   @MockBean private CollectionDao collectionDao;
-
-  // Since we're running with both control-plane and data-plane profiles simultaneously, Spring
-  // does not know what to do with beans which are satisfied by two different mutually exclusive
-  // implementations. In this @TestConfiguration, we explicitly specify @Primary beans for any
-  // conflicts.
-  @TestConfiguration
-  static class SpecifyConflictingBeans {
-    @Primary
-    @Bean("overrideRecordSinkFactory")
-    RecordSinkFactory overrideRecordSinkFactory(
-        ObjectMapper mapper, GcsStorage storage, PubSub pubSub) {
-      return new RawlsRecordSinkFactory(mapper, storage, pubSub);
-    }
-
-    @Primary
-    @Bean("overrideSnapshotSupportFactory")
-    SnapshotSupportFactory overrideSnapshotSupportFactory(
-        RestClientRetry restClientRetry, ActivityLogger activityLogger, RawlsClient rawlsClient) {
-      return new RawlsSnapshotSupportFactory(restClientRetry, activityLogger, rawlsClient);
-    }
-  }
 
   @Test
   void statusUpdateNotification() throws Exception {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/PubSubControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/PubSubControllerMockMvcTest.java
@@ -112,6 +112,6 @@ class PubSubControllerMockMvcTest extends MockMvcTestBase {
         .andReturn();
 
     // Assert
-    verify(jobDao, times(1)).updateStatus(jobId, GenericJobServerModel.StatusEnum.SUCCEEDED);
+    verify(jobDao, times(1)).succeeded(jobId);
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/JobServiceControlPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/JobServiceControlPlaneTest.java
@@ -221,8 +221,7 @@ class JobServiceControlPlaneTest extends JobServiceBaseTest {
         new JobStatusUpdate(
             jobId,
             GenericJobServerModel.StatusEnum.RUNNING,
-            GenericJobServerModel.StatusEnum.SUCCEEDED,
-            null);
+            GenericJobServerModel.StatusEnum.SUCCEEDED);
 
     // Act
     jobService.processStatusUpdate(update);
@@ -259,8 +258,7 @@ class JobServiceControlPlaneTest extends JobServiceBaseTest {
         new JobStatusUpdate(
             jobId,
             GenericJobServerModel.StatusEnum.RUNNING,
-            GenericJobServerModel.StatusEnum.RUNNING,
-            null);
+            GenericJobServerModel.StatusEnum.RUNNING);
 
     // Act
     jobService.processStatusUpdate(update);
@@ -278,8 +276,7 @@ class JobServiceControlPlaneTest extends JobServiceBaseTest {
         new JobStatusUpdate(
             jobId,
             GenericJobServerModel.StatusEnum.SUCCEEDED,
-            GenericJobServerModel.StatusEnum.RUNNING,
-            null);
+            GenericJobServerModel.StatusEnum.RUNNING);
 
     // Act/Assert
     ValidationException e =
@@ -300,8 +297,7 @@ class JobServiceControlPlaneTest extends JobServiceBaseTest {
         new JobStatusUpdate(
             jobId,
             GenericJobServerModel.StatusEnum.RUNNING,
-            GenericJobServerModel.StatusEnum.SUCCEEDED,
-            null);
+            GenericJobServerModel.StatusEnum.SUCCEEDED);
 
     // Act
     jobService.processStatusUpdate(update);

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/JobServiceControlPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/JobServiceControlPlaneTest.java
@@ -228,7 +228,7 @@ class JobServiceControlPlaneTest extends JobServiceBaseTest {
     jobService.processStatusUpdate(update);
 
     // Assert
-    verify(jobDao, times(1)).updateStatus(jobId, GenericJobServerModel.StatusEnum.SUCCEEDED);
+    verify(jobDao, times(1)).succeeded(jobId);
   }
 
   @Test
@@ -266,7 +266,7 @@ class JobServiceControlPlaneTest extends JobServiceBaseTest {
     jobService.processStatusUpdate(update);
 
     // Assert
-    verify(jobDao, never()).updateStatus(eq(jobId), any());
+    verify(jobDao, never()).running(jobId);
   }
 
   @Test
@@ -287,7 +287,7 @@ class JobServiceControlPlaneTest extends JobServiceBaseTest {
 
     // Assert
     assertEquals("Unable to update terminal status for job %s".formatted(jobId), e.getMessage());
-    verify(jobDao, never()).updateStatus(eq(jobId), any());
+    verify(jobDao, never()).succeeded(jobId);
   }
 
   @Test
@@ -307,7 +307,7 @@ class JobServiceControlPlaneTest extends JobServiceBaseTest {
     jobService.processStatusUpdate(update);
 
     // Assert
-    verify(jobDao, never()).updateStatus(eq(jobId), any());
+    verify(jobDao, never()).succeeded(jobId);
   }
 
   private UUID setupProcessJobStatusUpdateTest(GenericJobServerModel.StatusEnum initialStatus) {


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1687

An import isn't complete until Rawls finishes importing the entities JSON file written by CWDS. Currently, when it is done, it notifies import service of the final job status via PubSub ([code](https://github.com/broadinstitute/rawls/blob/44f717ce2b7d076aebf577b64377c7c56e4e11f3/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala#L341-L344)). We want a similar set up for CWDS. This adds a handler for those PubSub messages.

See https://cloud.google.com/pubsub/docs/push#receive_push for the PubSub request format.

Adapted from import service: https://github.com/broadinstitute/import-service/blob/a818658d0850818804235c5dc7f239c0de95c8cf/app/status.py#L55-L106

Still to do here is authentication for the PubSub requests. PubSub will be configured to authenticate requests with CWDS' service account, but this PR does not include verification of that token. I wanted to see if the PubSub wiring works before dealing with that.