### PR TITLE
AJ-1680: use RestClient and Spring-generated api proxy

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/rawls/BearerAuthRequestInitializer.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/rawls/BearerAuthRequestInitializer.java
@@ -1,0 +1,31 @@
+package org.databiosphere.workspacedataservice.rawls;
+
+import java.util.Objects;
+import org.databiosphere.workspacedataservice.sam.TokenContextUtil;
+import org.databiosphere.workspacedataservice.shared.model.BearerToken;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.client.ClientHttpRequest;
+import org.springframework.http.client.ClientHttpRequestInitializer;
+
+/**
+ * RequestInitializer for use in RestClient implementations: look for a bearer auth token via
+ * TokenContextUtil, and add that token - if found - to the outbound RestClient headers.
+ */
+public class BearerAuthRequestInitializer implements ClientHttpRequestInitializer {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(BearerAuthRequestInitializer.class);
+
+  @Override
+  public void initialize(@NotNull ClientHttpRequest request) {
+    BearerToken token = TokenContextUtil.getToken();
+
+    if (token.nonEmpty()) {
+      LOGGER.debug("setting access token for request");
+      request.getHeaders().setBearerAuth(Objects.requireNonNull(token.getValue()));
+    } else {
+      LOGGER.warn("No access token found for request.");
+    }
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/rawls/RawlsApi.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/rawls/RawlsApi.java
@@ -1,0 +1,38 @@
+package org.databiosphere.workspacedataservice.rawls;
+
+import bio.terra.workspace.model.DataRepoSnapshotResource;
+import java.util.UUID;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.service.annotation.GetExchange;
+import org.springframework.web.service.annotation.PostExchange;
+
+/**
+ * Rawls API signatures. Use these to create http proxies for outbound requests via e.g. RestClient.
+ */
+public interface RawlsApi {
+
+  /**
+   * List snapshot references in a workspace.
+   *
+   * @param workspaceId target workspace
+   * @param offset pagination offset
+   * @param limit pagination limit
+   * @return list of snapshot references in this workspace.
+   */
+  @GetExchange("/api/workspaces/{workspaceId}/snapshots/v2")
+  SnapshotListResponse enumerateDataRepoSnapshotByWorkspaceId(
+      @PathVariable UUID workspaceId, @RequestParam int offset, @RequestParam int limit);
+
+  /**
+   * Create a new snapshot reference in a workspace
+   *
+   * @param workspaceId target workspace
+   * @param namedDataRepoSnapshot the snapshot reference to create
+   * @return the created snapshot reference
+   */
+  @PostExchange("/api/workspaces/{workspaceId}/snapshots/v2")
+  DataRepoSnapshotResource createDataRepoSnapshotByWorkspaceId(
+      @PathVariable UUID workspaceId, @RequestBody NamedDataRepoSnapshot namedDataRepoSnapshot);
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/rawls/RawlsClient.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/rawls/RawlsClient.java
@@ -5,16 +5,12 @@ import static org.databiosphere.workspacedataservice.retry.RestClientRetry.RestC
 import bio.terra.workspace.model.DataRepoSnapshotResource;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.retry.RestClientRetry;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.web.client.RestClientResponseException;
 
 /** Client to make REST calls to Rawls */
 public class RawlsClient {
   private final RawlsApi rawlsApi;
   private final RestClientRetry restClientRetry;
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(RawlsClient.class);
 
   public RawlsClient(RawlsApi rawlsApi, RestClientRetry restClientRetry) {
     this.rawlsApi = rawlsApi;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/rawls/RawlsClient.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/rawls/RawlsClient.java
@@ -3,102 +3,50 @@ package org.databiosphere.workspacedataservice.rawls;
 import static org.databiosphere.workspacedataservice.retry.RestClientRetry.RestCall;
 
 import bio.terra.workspace.model.DataRepoSnapshotResource;
-import java.net.URI;
-import java.util.Objects;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.retry.RestClientRetry;
-import org.databiosphere.workspacedataservice.sam.TokenContextUtil;
-import org.databiosphere.workspacedataservice.shared.model.BearerToken;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestClientResponseException;
-import org.springframework.web.client.RestTemplate;
-import org.springframework.web.util.UriComponentsBuilder;
 
 /** Client to make REST calls to Rawls */
 public class RawlsClient {
-
-  private final String rawlsUrl;
-  // TODO: consider using RestClient instead of RestTemplate
-  private final RestTemplate restTemplate;
+  private final RawlsApi rawlsApi;
   private final RestClientRetry restClientRetry;
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RawlsClient.class);
 
-  public RawlsClient(String rawlsUrl, RestTemplate restTemplate, RestClientRetry restClientRetry) {
-    this.rawlsUrl = rawlsUrl;
-    this.restTemplate = restTemplate;
+  public RawlsClient(RawlsApi rawlsApi, RestClientRetry restClientRetry) {
+    this.rawlsApi = rawlsApi;
     this.restClientRetry = restClientRetry;
   }
 
   public SnapshotListResponse enumerateDataRepoSnapshotReferences(
       UUID workspaceId, int offset, int limit) {
     try {
-      URI targetUri =
-          UriComponentsBuilder.fromHttpUrl(rawlsUrl)
-              .pathSegment("api", "workspaces", workspaceId.toString(), "snapshots", "v2")
-              .queryParam("offset", offset)
-              .queryParam("limit", limit)
-              .build()
-              .toUri();
+      RestCall<SnapshotListResponse> restCall =
+          () -> rawlsApi.enumerateDataRepoSnapshotByWorkspaceId(workspaceId, offset, limit);
 
-      HttpEntity<?> requestEntity = new HttpEntity<>(getAuthedHeaders());
-
-      RestCall<ResponseEntity<SnapshotListResponse>> restCall =
-          () ->
-              restTemplate.exchange(
-                  targetUri, HttpMethod.GET, requestEntity, SnapshotListResponse.class);
-
-      ResponseEntity<SnapshotListResponse> response =
-          restClientRetry.withRetryAndErrorHandling(
-              restCall, "Rawls.enumerateDataRepoSnapshotReferences");
-
-      return response.getBody();
+      return restClientRetry.withRetryAndErrorHandling(
+          restCall, "Rawls.enumerateDataRepoSnapshotReferences");
     } catch (RestClientResponseException restException) {
       throw new RawlsException(restException);
     }
   }
 
   // TODO: (AJ-1705) Add cloning instructions COPY_REFERENCE and a purpose=policy
-  // key-value pair to the reference’s properties
+  //     key-value pair to the reference’s properties
   public void createSnapshotReference(UUID workspaceId, UUID snapshotId) {
     try {
-      URI targetUri =
-          UriComponentsBuilder.fromHttpUrl(rawlsUrl)
-              .pathSegment("api", "workspaces", workspaceId.toString(), "snapshots", "v2")
-              .build()
-              .toUri();
+      NamedDataRepoSnapshot namedDataRepoSnapshot = NamedDataRepoSnapshot.forSnapshotId(snapshotId);
 
-      HttpEntity<NamedDataRepoSnapshot> requestEntity =
-          new HttpEntity<>(NamedDataRepoSnapshot.forSnapshotId(snapshotId), getAuthedHeaders());
-
-      RestCall<ResponseEntity<DataRepoSnapshotResource>> restCall =
-          () ->
-              restTemplate.exchange(
-                  targetUri, HttpMethod.POST, requestEntity, DataRepoSnapshotResource.class);
+      RestCall<DataRepoSnapshotResource> restCall =
+          () -> rawlsApi.createDataRepoSnapshotByWorkspaceId(workspaceId, namedDataRepoSnapshot);
 
       // note we do not return the DataRepoSnapshotResource from this method
       restClientRetry.withRetryAndErrorHandling(restCall, "Rawls.createSnapshotReference");
     } catch (RestClientResponseException restException) {
       throw new RawlsException(restException);
     }
-  }
-
-  // Get the user's token from the context and attach it to headers
-  private HttpHeaders getAuthedHeaders() {
-    HttpHeaders headers = new HttpHeaders();
-    BearerToken token = TokenContextUtil.getToken();
-
-    if (token.nonEmpty()) {
-      LOGGER.debug("setting access token for rawls request");
-      headers.setBearerAuth(Objects.requireNonNull(token.getValue()));
-    } else {
-      LOGGER.warn("No access token found for rawls request.");
-    }
-    return headers;
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/rawls/RawlsClientConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/rawls/RawlsClientConfig.java
@@ -3,6 +3,8 @@ package org.databiosphere.workspacedataservice.rawls;
 import static org.databiosphere.workspacedataservice.annotations.DeploymentMode.*;
 
 import io.micrometer.observation.ObservationRegistry;
+import java.net.MalformedURLException;
+import java.net.URL;
 import org.databiosphere.workspacedataservice.retry.RestClientRetry;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -38,7 +40,13 @@ public class RawlsClientConfig {
   // current observationRegistry for Prometheus metrics
   @Bean
   @ControlPlane
-  public RestClient rawlsRestClient(ObservationRegistry observationRegistry) {
+  public RestClient rawlsRestClient(ObservationRegistry observationRegistry)
+      throws MalformedURLException {
+
+    // validate the Rawls url is well-formed.
+    // this will throw and prevent Spring startup if the Rawls url is invalid.
+    new URL(rawlsUrl);
+
     return RestClient.builder()
         .observationRegistry(observationRegistry)
         .baseUrl(rawlsUrl)

--- a/service/src/main/java/org/databiosphere/workspacedataservice/rawls/RawlsClientConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/rawls/RawlsClientConfig.java
@@ -2,12 +2,14 @@ package org.databiosphere.workspacedataservice.rawls;
 
 import static org.databiosphere.workspacedataservice.annotations.DeploymentMode.*;
 
+import io.micrometer.observation.ObservationRegistry;
 import org.databiosphere.workspacedataservice.retry.RestClientRetry;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.support.RestClientAdapter;
+import org.springframework.web.service.invoker.HttpServiceProxyFactory;
 
 @Configuration
 @ControlPlane
@@ -18,13 +20,29 @@ public class RawlsClientConfig {
 
   @Bean
   @ControlPlane
-  public RawlsClient rawlsClient(RestTemplate restTemplate, RestClientRetry restClientRetry) {
-    return new RawlsClient(rawlsUrl, restTemplate, restClientRetry);
+  public RawlsClient rawlsClient(RawlsApi rawlsApi, RestClientRetry restClientRetry) {
+    return new RawlsClient(rawlsApi, restClientRetry);
   }
 
+  // RestClient-enabled proxy for the Rawls API
   @Bean
   @ControlPlane
-  public RestTemplate restTemplate(RestTemplateBuilder builder) {
-    return builder.build();
+  public RawlsApi rawlsApi(RestClient restClient) {
+    HttpServiceProxyFactory httpServiceProxyFactory =
+        HttpServiceProxyFactory.builderFor(RestClientAdapter.create(restClient)).build();
+
+    return httpServiceProxyFactory.createClient(RawlsApi.class);
+  }
+
+  // fluent RestClient, initialized with Rawls' base url, auth from TokenContextUtil, and the
+  // current observationRegistry for Prometheus metrics
+  @Bean
+  @ControlPlane
+  public RestClient rawlsRestClient(ObservationRegistry observationRegistry) {
+    return RestClient.builder()
+        .observationRegistry(observationRegistry)
+        .baseUrl(rawlsUrl)
+        .requestInitializer(new BearerAuthRequestInitializer())
+        .build();
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/common/TestBase.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/common/TestBase.java
@@ -34,6 +34,8 @@ import org.springframework.test.context.TestPropertySource;
       // aggressive retry settings so unit tests don't run too long
       "rest.retry.maxAttempts=2",
       "rest.retry.backoff.delay=3",
+      // Rawls url must be valid, else context initialization (Spring startup) will fail
+      "rawlsUrl=https://localhost/"
     })
 @ExtendWith(ConfigurationExceptionDetector.class)
 public abstract class TestBase {}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/config/TwdsPropertiesControlPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/config/TwdsPropertiesControlPlaneTest.java
@@ -21,7 +21,9 @@ import org.springframework.test.context.TestPropertySource;
       //   over from direct injection of @Value('twds.instance.workspace-id')
       "twds.instance.workspace-id=",
       // turn off pubsub autoconfiguration for tests
-      "spring.cloud.gcp.pubsub.enabled=false"
+      "spring.cloud.gcp.pubsub.enabled=false",
+      // Rawls url must be valid, else context initialization (Spring startup) will fail
+      "rawlsUrl=https://localhost/"
     })
 @DirtiesContext
 class TwdsPropertiesControlPlaneTest {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobControlPlaneE2ETest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobControlPlaneE2ETest.java
@@ -74,7 +74,9 @@ import org.springframework.util.StreamUtils;
       // turn off pubsub autoconfiguration for tests
       "spring.cloud.gcp.pubsub.enabled=false",
       // Allow file imports to test with files from resources.
-      "twds.data-import.allowed-schemes=file"
+      "twds.data-import.allowed-schemes=file",
+      // Rawls url must be valid, else context initialization (Spring startup) will fail
+      "rawlsUrl=https://localhost/"
     })
 class PfbQuartzJobControlPlaneE2ETest {
   @Autowired ObjectMapper mapper;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/rawls/RawlsClientRetryTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/rawls/RawlsClientRetryTest.java
@@ -1,7 +1,6 @@
 package org.databiosphere.workspacedataservice.rawls;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.reset;
@@ -9,11 +8,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import bio.terra.workspace.model.DataRepoSnapshotResource;
 import com.google.api.client.http.HttpStatusCodes;
-import java.net.URI;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,16 +19,12 @@ import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatusCode;
-import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.web.client.HttpServerErrorException;
-import org.springframework.web.client.RestTemplate;
 
 @DirtiesContext
 @ActiveProfiles(value = "control-plane", inheritProfiles = false)
@@ -49,15 +41,15 @@ import org.springframework.web.client.RestTemplate;
       "rest.retry.backoff.delay=3",
     })
 class RawlsClientRetryTest {
-  // create mock for RestTemplate
-  @MockBean RestTemplate mockRestTemplate;
+  // create mock for RawlsApi
+  @MockBean RawlsApi mockRawlsApi;
 
   @Autowired RawlsClient rawlsClient;
 
   @BeforeEach
   void beforeEach() {
-    // reset mockRestTemplate
-    reset(mockRestTemplate);
+    // reset mockRawlsApi
+    reset(mockRawlsApi);
   }
 
   // define a 502 error, thrown by mocks below
@@ -75,15 +67,10 @@ class RawlsClientRetryTest {
     WorkspaceId workspaceId = WorkspaceId.of(UUID.randomUUID());
 
     // define the successful REST response payload
-    ResponseEntity<SnapshotListResponse> successResponse =
-        ResponseEntity.of(Optional.of(new SnapshotListResponse(List.of())));
-
-    // argument matcher for the rest template target url
-    var uriMatcher = new UriMatcher("/api/workspaces/%s/snapshots/v2".formatted(workspaceId));
+    SnapshotListResponse successResponse = new SnapshotListResponse(List.of());
 
     // RestTemplate will throw 502 on the first and second attempts, but succeed on the third
-    when(mockRestTemplate.exchange(
-            argThat(uriMatcher), eq(HttpMethod.GET), any(), eq(SnapshotListResponse.class)))
+    when(mockRawlsApi.enumerateDataRepoSnapshotByWorkspaceId(workspaceId.id(), 0, 5))
         .thenThrow(badGateway)
         .thenThrow(badGateway)
         .thenReturn(successResponse);
@@ -95,8 +82,7 @@ class RawlsClientRetryTest {
 
     // ASSERT
     // verify it retried three times, until it got the success
-    verify(mockRestTemplate, times(3))
-        .exchange(argThat(uriMatcher), eq(HttpMethod.GET), any(), eq(SnapshotListResponse.class));
+    verify(mockRawlsApi, times(3)).enumerateDataRepoSnapshotByWorkspaceId(workspaceId.id(), 0, 5);
 
     assertThat(snapshotListResponse.gcpDataRepoSnapshots()).isEmpty();
   }
@@ -107,17 +93,12 @@ class RawlsClientRetryTest {
     WorkspaceId workspaceId = WorkspaceId.of(UUID.randomUUID());
     UUID snapshotId = UUID.randomUUID();
 
-    // argument matcher for the rest template target url
-    var uriMatcher = new UriMatcher("/api/workspaces/%s/snapshots/v2".formatted(workspaceId));
     // argument matcher for the post payload
     var payloadMatcher = new NamedDataRepoSnapshotHttpEntityMatcher(snapshotId);
 
     // RestTemplate will throw 502 on the first and second attempts, but succeed on the third
-    when(mockRestTemplate.exchange(
-            argThat(uriMatcher),
-            eq(HttpMethod.POST),
-            argThat(payloadMatcher),
-            eq(DataRepoSnapshotResource.class)))
+    when(mockRawlsApi.createDataRepoSnapshotByWorkspaceId(
+            eq(workspaceId.id()), argThat(payloadMatcher)))
         .thenThrow(badGateway)
         .thenThrow(badGateway)
         .thenAnswer((Answer<?>) invocation -> null);
@@ -128,32 +109,16 @@ class RawlsClientRetryTest {
 
     // ASSERT
     // verify it retried three times, until it got the success
-    verify(mockRestTemplate, times(3))
-        .exchange(
-            argThat(uriMatcher),
-            eq(HttpMethod.POST),
-            argThat(payloadMatcher),
-            eq(DataRepoSnapshotResource.class));
+    verify(mockRawlsApi, times(3))
+        .createDataRepoSnapshotByWorkspaceId(eq(workspaceId.id()), argThat(payloadMatcher));
   }
 
-  // custom ArgumentMatcher - does a given URI contain the supplied substring?
-  static class UriMatcher implements ArgumentMatcher<URI> {
-    private final String substring;
-
-    UriMatcher(String substring) {
-      this.substring = substring;
-    }
-
-    @Override
-    public boolean matches(URI argument) {
-      return argument.toString().contains(substring);
-    }
-  }
-
-  // custom ArgumentMatcher - does a given NamedDataRepoSnapshot inside a HttpEntity
+  // custom ArgumentMatcher - does a given NamedDataRepoSnapshot
   // contain the supplied snapshotId?
+  // we need this because RawlsClient.createSnapshotReference adds a timestamp to each
+  // reference it creates, and those are hard to predict
   static class NamedDataRepoSnapshotHttpEntityMatcher
-      implements ArgumentMatcher<HttpEntity<NamedDataRepoSnapshot>> {
+      implements ArgumentMatcher<NamedDataRepoSnapshot> {
     private final UUID snapshotId;
 
     NamedDataRepoSnapshotHttpEntityMatcher(UUID snapshotId) {
@@ -161,9 +126,9 @@ class RawlsClientRetryTest {
     }
 
     @Override
-    public boolean matches(HttpEntity<NamedDataRepoSnapshot> argument) {
+    public boolean matches(NamedDataRepoSnapshot argument) {
 
-      return snapshotId.equals(argument.getBody().snapshotId());
+      return snapshotId.equals(argument.snapshotId());
     }
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceControlPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceControlPlaneTest.java
@@ -40,7 +40,9 @@ import org.springframework.test.context.TestPropertySource;
 @TestPropertySource(
     properties = {
       // turn off pubsub autoconfiguration for tests
-      "spring.cloud.gcp.pubsub.enabled=false"
+      "spring.cloud.gcp.pubsub.enabled=false",
+      // Rawls url must be valid, else context initialization (Spring startup) will fail
+      "rawlsUrl=https://localhost/"
     })
 class ImportServiceControlPlaneTest {
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/JobServiceControlPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/JobServiceControlPlaneTest.java
@@ -46,7 +46,9 @@ import org.springframework.test.context.TestPropertySource;
 @TestPropertySource(
     properties = {
       // turn off pubsub autoconfiguration for tests
-      "spring.cloud.gcp.pubsub.enabled=false"
+      "spring.cloud.gcp.pubsub.enabled=false",
+      // Rawls url must be valid, else context initialization (Spring startup) will fail
+      "rawlsUrl=https://localhost/"
     })
 class JobServiceControlPlaneTest extends JobServiceBaseTest {
 
@@ -319,7 +321,6 @@ class JobServiceControlPlaneTest extends JobServiceBaseTest {
             // set created and updated to now, but in UTC because that's how Postgres stores it
             OffsetDateTime.now(ZoneId.of("Z")),
             OffsetDateTime.now(ZoneId.of("Z")));
-    ;
     when(jobDao.getJob(jobId)).thenReturn(expectedJob);
     // Collection does not exist, so virtual collection is used
     when(collectionDao.getWorkspaceId(collectionId))


### PR DESCRIPTION
This PR changes the WDS-to-Rawls connection from using `RestTemplate` to a declarative proxy powered by `RestClient` and adds Prometheus observability.

`RestClient` is a modern and fluent replacement for `RestTemplate`; see https://spring.io/blog/2023/07/13/new-in-spring-6-1-restclient and https://docs.spring.io/spring-framework/reference/integration/rest-clients.html.

`RestClient` supports observability via Prometheus; see https://docs.spring.io/spring-framework/reference/integration/observability.html#observability.http-client.restclient. (`RestTemplate` supports it too).

Additionally, this PR changes our WDS-to-Rawls connection from imperative method invocations on `RestClient`/`RestTemplate` to a declarative HTTP interface; see https://docs.spring.io/spring-framework/reference/integration/rest-clients.html#rest-http-interface and https://www.baeldung.com/spring-6-http-interface. At a high level, this means we:
* define the API signatures we want to call, in `RawlsApi`
* define the `RestClient` we want to use when calling APIs, in `RawlsClientConfig`
* ask Spring to auto-generate an implementation for calling those APIs with that RestClient
* use the auto-generated bean to do the actual work



