### PR TITLE
[AJ-1687] More logging for errors handling PubSub message

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/PubSubController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/PubSubController.java
@@ -1,5 +1,7 @@
 package org.databiosphere.workspacedataservice.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.databiosphere.workspacedataservice.annotations.DeploymentMode.ControlPlane;
 import org.databiosphere.workspacedataservice.pubsub.JobStatusUpdate;
 import org.databiosphere.workspacedataservice.pubsub.PubSubMessage;
@@ -19,9 +21,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class PubSubController {
   private static final Logger LOGGER = LoggerFactory.getLogger(PubSubController.class);
   private final JobService jobService;
+  private final ObjectMapper objectMapper;
 
-  public PubSubController(JobService jobService) {
+  public PubSubController(JobService jobService, ObjectMapper objectMapper) {
     this.jobService = jobService;
+    this.objectMapper = objectMapper;
   }
 
   @PostMapping("/pubsub/import-status")
@@ -41,7 +45,12 @@ public class PubSubController {
     } catch (ValidationException e) {
       // Return a successful status for invalid updates to prevent PubSub from retrying the request.
       // https://cloud.google.com/pubsub/docs/push#receive_push
-      LOGGER.error("Error processing status update: {}", e.getMessage());
+      try {
+        String jsonMessage = objectMapper.writeValueAsString(message);
+        LOGGER.error("Error processing status update: %s".formatted(jsonMessage), e);
+      } catch (JsonProcessingException jsonException) {
+        LOGGER.error("Error processing status update", e);
+      }
       return new ResponseEntity<>(HttpStatus.ACCEPTED);
     }
   }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/pubsub/JobStatusUpdate.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/pubsub/JobStatusUpdate.java
@@ -21,7 +21,8 @@ public record JobStatusUpdate(
       String errorMessage = attributes.get("error_message");
       return new JobStatusUpdate(jobId, currentStatus, newStatus, errorMessage);
     } catch (Exception e) {
-      throw new ValidationException("Unable to parse job status update from PubSub message: %s", e);
+      throw new ValidationException(
+          "Unable to parse job status update from PubSub message: %s".formatted(e.getMessage()), e);
     }
   }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/ValidationException.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/ValidationException.java
@@ -8,4 +8,8 @@ public class ValidationException extends RuntimeException {
   public ValidationException(String message) {
     super(message);
   }
+
+  public ValidationException(String message, Throwable cause) {
+    super(message, cause);
+  }
 }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1687

Trying to figure out why CWDS is failing to parse the PubSub message. This attempts to:
- Throw a ValidationException if the PubSub message can't be parsed. This will have the endpoint return a successful status code and avoid retrying the message.
- Log the message that couldn't be parsed.