### PR TITLE
[AJ-1687] Fix expected format for PubSub message

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/pubsub/JobStatusUpdate.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/pubsub/JobStatusUpdate.java
@@ -15,10 +15,10 @@ public record JobStatusUpdate(
   public static JobStatusUpdate createFromPubSubMessage(PubSubMessage message) {
     try {
       Map<String, String> attributes = message.attributes();
-      UUID jobId = UUID.fromString(attributes.get("import_id"));
-      StatusEnum newStatus = rawlsStatusToJobStatus(attributes.get("new_status"));
-      StatusEnum currentStatus = rawlsStatusToJobStatus(attributes.get("current_status"));
-      String errorMessage = attributes.get("error_message");
+      UUID jobId = UUID.fromString(attributes.get("importId"));
+      StatusEnum newStatus = rawlsStatusToJobStatus(attributes.get("newStatus"));
+      StatusEnum currentStatus = rawlsStatusToJobStatus(attributes.get("currentStatus"));
+      String errorMessage = attributes.get("errorMessage");
       return new JobStatusUpdate(jobId, currentStatus, newStatus, errorMessage);
     } catch (Exception e) {
       throw new ValidationException(

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/PubSubControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/PubSubControllerMockMvcTest.java
@@ -61,9 +61,9 @@ class PubSubControllerMockMvcTest extends MockMvcTestBase {
         new PubSubRequest(
             new PubSubMessage(
                 Map.of(
-                    "import_id", jobId.toString(),
-                    "current_status", "Upserting",
-                    "new_status", "Done"),
+                    "importId", jobId.toString(),
+                    "currentStatus", "Upserting",
+                    "newStatus", "Done"),
                 null,
                 "123456789",
                 "2024-03-20T10:00:00.000Z"),


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1687

One more fix for PubSub 🤞 

I adapted this code from import service, which uses snake case keys for pulling information out of the PubSub message attributes.
https://github.com/broadinstitute/import-service/blob/a818658d0850818804235c5dc7f239c0de95c8cf/app/status.py#L59-L65

But it turns out, the PubSub message attributes have camel case keys. I have no idea how/where it's getting translated in import service, but this should let CWDS handle status update messages.