### PR TITLE
AJ-1708: Spring Boot to 3.2.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
 plugins {
-    id 'org.springframework.boot' version '3.2.3' apply false
+    id 'org.springframework.boot' version '3.2.4' apply false
     id 'io.spring.dependency-management' version '1.1.4' apply false
     id 'com.google.cloud.tools.jib' version '3.2.1' apply false
     id "org.sonarqube" version "4.4.1.3373" apply false


### PR DESCRIPTION
https://spring.io/blog/2024/03/21/spring-boot-3-2-4-available-now

I checked all our overridden dependencies, in `constraints` and `dependencyManagement` blocks, and none of them can be removed.