### PR TITLE
[AJ-1686] Enable GCP auto configuration only in the control plane

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/pubsub/PubSubConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/pubsub/PubSubConfig.java
@@ -12,24 +12,11 @@ public class PubSubConfig {
 
   // when Pub/Sub autoconfiguration is enabled, use the real ImportPubSub bean
   @Bean
-  @ConditionalOnProperty(
-      name = "spring.cloud.gcp.pubsub.enabled",
-      havingValue = "true",
-      matchIfMissing = true)
-  PubSub applicationDefaultCredentialsPubSub(
+  @ConditionalOnProperty(name = "spring.cloud.gcp.pubsub.enabled", havingValue = "true")
+  PubSub getPubSub(
       GcpProjectIdProvider projectIdProvider,
       PubSubTemplate pubSubTemplate,
       @Value("${spring.cloud.gcp.pubsub.topic}") String topic) {
     return new ImportPubSub(pubSubTemplate, topic, projectIdProvider.getProjectId());
-  }
-
-  // when Pub/Sub autoconfiguration is disabled, use a noop bean which has no other dependencies
-  @Bean
-  @ConditionalOnProperty(
-      name = "spring.cloud.gcp.pubsub.enabled",
-      havingValue = "false",
-      matchIfMissing = false)
-  PubSub noopPubSub() {
-    return new NoopPubSub();
   }
 }

--- a/service/src/main/resources/application-control-plane.yml
+++ b/service/src/main/resources/application-control-plane.yml
@@ -16,6 +16,8 @@ twds:
 spring:
   cloud:
     gcp:
+      core:
+        enabled: true
       project-id: ${SERVICE_GOOGLE_PROJECT}
       pubsub:
         topic: ${RAWLS_NOTIFY_TOPIC}

--- a/service/src/main/resources/application-test.yml
+++ b/service/src/main/resources/application-test.yml
@@ -1,0 +1,5 @@
+spring:
+  cloud:
+    gcp:
+      pubsub:
+        enabled: false

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -67,6 +67,8 @@ spring:
 
   cloud:
     gcp:
+      core:
+        enabled: false
       storage:
         enabled: false
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/annotations/AnnotatedApisTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/annotations/AnnotatedApisTest.java
@@ -24,19 +24,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.web.bind.annotation.RestController;
 
 @ActiveProfiles(
-    value = {"control-plane", "data-plane"},
+    value = {"control-plane", "data-plane", "test"},
     inheritProfiles = false)
 @DirtiesContext
 @SpringBootTest
-@TestPropertySource(
-    properties = {
-      // turn off pubsub autoconfiguration for tests
-      "spring.cloud.gcp.pubsub.enabled=false"
-    })
 class AnnotatedApisTest extends TestBase {
 
   // Since we're running with both control-plane and data-plane profiles simultaneously, Spring

--- a/service/src/test/java/org/databiosphere/workspacedataservice/common/TestBase.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/common/TestBase.java
@@ -23,14 +23,12 @@ import org.springframework.test.context.TestPropertySource;
  * which will automatically provide a hint if it detects a test failure due to a {@link
  * ConfigurationException}.
  */
-@ActiveProfiles({"data-plane"})
+@ActiveProfiles({"data-plane", "test"})
 @TestPropertySource(
     properties = {
       // data-plane mode requires a workspace-id to be set
       // example uuid from https://en.wikipedia.org/wiki/Universally_unique_identifier
       "twds.instance.workspace-id=123e4567-e89b-12d3-a456-426614174000",
-      // turn off pubsub autoconfiguration for tests
-      "spring.cloud.gcp.pubsub.enabled=false",
       // aggressive retry settings so unit tests don't run too long
       "rest.retry.maxAttempts=2",
       "rest.retry.backoff.delay=3",

--- a/service/src/test/java/org/databiosphere/workspacedataservice/config/TwdsPropertiesControlPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/config/TwdsPropertiesControlPlaneTest.java
@@ -14,14 +14,12 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest
-@ActiveProfiles("control-plane")
+@ActiveProfiles(profiles = {"control-plane", "test"})
 @TestPropertySource(
     properties = {
       // TODO(AJ-1656): control-plane should not require instance config in any form, this is a hold
       //   over from direct injection of @Value('twds.instance.workspace-id')
       "twds.instance.workspace-id=",
-      // turn off pubsub autoconfiguration for tests
-      "spring.cloud.gcp.pubsub.enabled=false"
     })
 @DirtiesContext
 class TwdsPropertiesControlPlaneTest {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/PubSubControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/PubSubControllerMockMvcTest.java
@@ -21,16 +21,10 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 
 @ActiveProfiles(
     inheritProfiles = false,
-    profiles = {"control-plane", "mock-sam"})
-@TestPropertySource(
-    properties = {
-      // turn off pubsub autoconfiguration for tests
-      "spring.cloud.gcp.pubsub.enabled=false"
-    })
+    profiles = {"control-plane", "mock-sam", "test"})
 class PubSubControllerMockMvcTest extends MockMvcTestBase {
   @MockBean private JobDao jobDao;
   @MockBean private CollectionDao collectionDao;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobControlPlaneE2ETest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobControlPlaneE2ETest.java
@@ -66,13 +66,11 @@ import org.springframework.util.StreamUtils;
  * parsing the PFB, and generating the JSON that gets stored in a bucket and communicated to Rawls
  * via pubsub.
  */
-@ActiveProfiles(profiles = {"mock-sam", "noop-scheduler-dao", "control-plane"})
+@ActiveProfiles(profiles = {"mock-sam", "noop-scheduler-dao", "control-plane", "test"})
 @DirtiesContext
 @SpringBootTest
 @TestPropertySource(
     properties = {
-      // turn off pubsub autoconfiguration for tests
-      "spring.cloud.gcp.pubsub.enabled=false",
       // Allow file imports to test with files from resources.
       "twds.data-import.allowed-schemes=file"
     })

--- a/service/src/test/java/org/databiosphere/workspacedataservice/pubsub/MockPubSub.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/pubsub/MockPubSub.java
@@ -6,7 +6,8 @@ import java.util.Map;
  * No-op class that replaces a real GCS-credential-enabled PubSub implementation. Use this to
  * satisfy {@link PubSub} dependencies in cases where are not running with a GCS service account.
  */
-public class NoopPubSub implements PubSub {
+public class MockPubSub implements PubSub {
+
   @Override
   public String publishSync(Map<String, String> message) {
     return null;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/pubsub/MockPubSubConfig.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/pubsub/MockPubSubConfig.java
@@ -1,0 +1,14 @@
+package org.databiosphere.workspacedataservice.pubsub;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class MockPubSubConfig {
+  @Bean
+  @Primary
+  PubSub getMockPubSub() {
+    return new MockPubSub();
+  }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/rawls/RawlsClientRetryTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/rawls/RawlsClientRetryTest.java
@@ -35,14 +35,14 @@ import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
 
 @DirtiesContext
-@ActiveProfiles(value = "control-plane", inheritProfiles = false)
+@ActiveProfiles(
+    value = {"control-plane", "test"},
+    inheritProfiles = false)
 @SpringBootTest
 @TestPropertySource(
     properties = {
       // URI parsing requires a valid hostname here, even if we don't contact this host
       "rawlsUrl=https://localhost/",
-      // turn off pubsub autoconfiguration for tests
-      "spring.cloud.gcp.pubsub.enabled=false",
       // allow 3 retry attempts, so we can better verify retries
       "rest.retry.maxAttempts=3",
       // with aggressive delay settings so unit tests don't run too long

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceControlPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceControlPlaneTest.java
@@ -26,7 +26,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 
 /**
  * Tests for permission behaviors in the control plane. See also {@link ImportServiceTest} for tests
@@ -34,14 +33,9 @@ import org.springframework.test.context.TestPropertySource;
  *
  * @see ImportServiceTest
  */
-@ActiveProfiles({"control-plane", "noop-scheduler-dao", "mock-sam"})
+@ActiveProfiles({"control-plane", "noop-scheduler-dao", "mock-sam", "test"})
 @DirtiesContext
 @SpringBootTest
-@TestPropertySource(
-    properties = {
-      // turn off pubsub autoconfiguration for tests
-      "spring.cloud.gcp.pubsub.enabled=false"
-    })
 class ImportServiceControlPlaneTest {
 
   @Autowired ImportService importService;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/JobServiceControlPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/JobServiceControlPlaneTest.java
@@ -38,16 +38,10 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 
-@ActiveProfiles(profiles = {"control-plane"})
+@ActiveProfiles(profiles = {"control-plane", "test"})
 @DirtiesContext
 @SpringBootTest
-@TestPropertySource(
-    properties = {
-      // turn off pubsub autoconfiguration for tests
-      "spring.cloud.gcp.pubsub.enabled=false"
-    })
 class JobServiceControlPlaneTest extends JobServiceBaseTest {
 
   @Autowired JobService jobService;


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1686

When WDS starts up, the Spring GCP framework looks for application default credentials, which it can't find because it's not running in GCP. This results in log noise from exceptions thrown at startup.

This disables auto configuration by default and enables it only on the control plane where CWDS is running in GCP.

https://googlecloudplatform.github.io/spring-cloud-gcp/5.1.0/reference/html/index.html#configuration