### PR TITLE
[AJ-1687] Decouple CWDS project and Rawls notification topic

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/pubsub/ImportPubSub.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/pubsub/ImportPubSub.java
@@ -7,12 +7,11 @@ import java.util.concurrent.CompletableFuture;
 public class ImportPubSub implements PubSub {
 
   private final PubSubTemplate pubSubTemplate;
-  private final String fullTopicName;
+  private final String topic;
 
-  public ImportPubSub(PubSubTemplate pubSubTemplate, String topic, String project) {
+  public ImportPubSub(PubSubTemplate pubSubTemplate, String topic) {
     this.pubSubTemplate = pubSubTemplate;
-    /// projects/[project_name]/topics/[topic_name]
-    this.fullTopicName = "projects/" + project + "/topics/" + topic;
+    this.topic = topic;
   }
 
   // As noted in the PubSub superclass, this method encapsulates waiting for the pubsub library's
@@ -23,8 +22,7 @@ public class ImportPubSub implements PubSub {
   public String publishSync(Map<String, String> message) {
     // PubSubTemplate.publish returns a future
     // Rawls expects the actual data to be in the headers rather than the payload
-    CompletableFuture<String> publishFuture =
-        this.pubSubTemplate.publish(fullTopicName, "b''", message);
+    CompletableFuture<String> publishFuture = pubSubTemplate.publish(topic, "b''", message);
     // we must wait for the future to complete before returning, else we'll have spun off an
     // unwatched thread
     return publishFuture.join();

--- a/service/src/main/java/org/databiosphere/workspacedataservice/pubsub/ImportPubSub.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/pubsub/ImportPubSub.java
@@ -22,7 +22,7 @@ public class ImportPubSub implements PubSub {
   public String publishSync(Map<String, String> message) {
     // PubSubTemplate.publish returns a future
     // Rawls expects the actual data to be in the headers rather than the payload
-    CompletableFuture<String> publishFuture = pubSubTemplate.publish(topic, "b''", message);
+    CompletableFuture<String> publishFuture = pubSubTemplate.publish(topic, "", message);
     // we must wait for the future to complete before returning, else we'll have spun off an
     // unwatched thread
     return publishFuture.join();

--- a/service/src/main/java/org/databiosphere/workspacedataservice/pubsub/PubSubConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/pubsub/PubSubConfig.java
@@ -1,6 +1,5 @@
 package org.databiosphere.workspacedataservice.pubsub;
 
-import com.google.cloud.spring.core.GcpProjectIdProvider;
 import com.google.cloud.spring.pubsub.core.PubSubTemplate;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -17,10 +16,8 @@ public class PubSubConfig {
       havingValue = "true",
       matchIfMissing = true)
   PubSub applicationDefaultCredentialsPubSub(
-      GcpProjectIdProvider projectIdProvider,
-      PubSubTemplate pubSubTemplate,
-      @Value("${spring.cloud.gcp.pubsub.topic}") String topic) {
-    return new ImportPubSub(pubSubTemplate, topic, projectIdProvider.getProjectId());
+      PubSubTemplate pubSubTemplate, @Value("${spring.cloud.gcp.pubsub.topic}") String topic) {
+    return new ImportPubSub(pubSubTemplate, topic);
   }
 
   // when Pub/Sub autoconfiguration is disabled, use a noop bean which has no other dependencies


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1687

More tidying of PubSub config as part of AJ-1687...

This tweaks the configuration for the PubSub topic for CWDS to notify Rawls of an import.

Currently, ImportPubSub constructs a fully qualified topic name from CWDS's GCP project and the configured short topic name. However, this is unnecessarily complex.

It assumes that CWDS and the topic are in the same project. Because they are, we can use the short topic name instead of the fully qualified name. And if they were not, this change would allow us to configure CWDS using a fully qualified topic name.