### PR TITLE
[AJ-1686] Enable GCP auto configuration only in the control plane

### DIFF
--- a/service/src/main/resources/application-control-plane.yml
+++ b/service/src/main/resources/application-control-plane.yml
@@ -16,6 +16,8 @@ twds:
 spring:
   cloud:
     gcp:
+      core:
+        enabled: true
       project-id: ${SERVICE_GOOGLE_PROJECT}
       pubsub:
         topic: ${RAWLS_NOTIFY_TOPIC}

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -67,6 +67,8 @@ spring:
 
   cloud:
     gcp:
+      core:
+        enabled: false
       storage:
         enabled: false
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1686

When WDS starts up, the Spring GCP framework looks for application default credentials, which it can't find because it's not running in GCP. This results in log noise from exceptions thrown at startup.

This disables auto configuration by default and enables it only on the control plane where CWDS is running in GCP.

https://googlecloudplatform.github.io/spring-cloud-gcp/5.1.0/reference/html/index.html#configuration

To test locally, make sure you don't have application default credentials set up: `gcloud auth application-default revoke`.