### PR TITLE
[AJ-1687] Update PubSub configuration for tests

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/pubsub/PubSubConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/pubsub/PubSubConfig.java
@@ -12,24 +12,11 @@ public class PubSubConfig {
 
   // when Pub/Sub autoconfiguration is enabled, use the real ImportPubSub bean
   @Bean
-  @ConditionalOnProperty(
-      name = "spring.cloud.gcp.pubsub.enabled",
-      havingValue = "true",
-      matchIfMissing = true)
-  PubSub applicationDefaultCredentialsPubSub(
+  @ConditionalOnProperty(name = "spring.cloud.gcp.pubsub.enabled", havingValue = "true")
+  PubSub getPubSub(
       GcpProjectIdProvider projectIdProvider,
       PubSubTemplate pubSubTemplate,
       @Value("${spring.cloud.gcp.pubsub.topic}") String topic) {
     return new ImportPubSub(pubSubTemplate, topic, projectIdProvider.getProjectId());
-  }
-
-  // when Pub/Sub autoconfiguration is disabled, use a noop bean which has no other dependencies
-  @Bean
-  @ConditionalOnProperty(
-      name = "spring.cloud.gcp.pubsub.enabled",
-      havingValue = "false",
-      matchIfMissing = false)
-  PubSub noopPubSub() {
-    return new NoopPubSub();
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/pubsub/MockPubSub.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/pubsub/MockPubSub.java
@@ -6,7 +6,8 @@ import java.util.Map;
  * No-op class that replaces a real GCS-credential-enabled PubSub implementation. Use this to
  * satisfy {@link PubSub} dependencies in cases where are not running with a GCS service account.
  */
-public class NoopPubSub implements PubSub {
+public class MockPubSub implements PubSub {
+
   @Override
   public String publishSync(Map<String, String> message) {
     return null;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/pubsub/MockPubSubConfig.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/pubsub/MockPubSubConfig.java
@@ -1,0 +1,14 @@
+package org.databiosphere.workspacedataservice.pubsub;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class MockPubSubConfig {
+  @Bean
+  @Primary
+  PubSub getMockPubSub() {
+    return new MockPubSub();
+  }
+}


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1687

Prefactoring for AJ-1687...

We currently use a stub `PubSub` in tests. To do this, several tests configure the `spring.cloud.gcp.pubsub.enabled` property to `false` and PubSub config swaps out the implementation of `PubSub` based on that property.

Since this is only done for tests, this moves the stub PubSub and the Configuration that creates it into the test package and renames it from `Noop` to `Mock`, which aligns with other similar things like `MockSamResourcesApi`, etc.