### PR TITLE
AJ-1716: TDR snapshot import to cWDS fails

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/config/TwdsProperties.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/config/TwdsProperties.java
@@ -1,13 +1,13 @@
 package org.databiosphere.workspacedataservice.config;
 
 import java.util.Optional;
-import javax.annotation.Nullable;
 import org.databiosphere.workspacedataservice.annotations.SingleTenant;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.lang.Nullable;
 
 /** Top-level ConfigurationProperties class representing the "twds" hierarchy of properties. */
 @Configuration

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresJobDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresJobDao.java
@@ -12,6 +12,7 @@ import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import javax.annotation.Nullable;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
 import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.databiosphere.workspacedataservice.shared.model.job.Job;
@@ -129,6 +130,7 @@ public class PostgresJobDao implements JobDao {
    */
   @Override
   public GenericJobServerModel fail(UUID jobId, String errorMessage) {
+    logger.error("Job {} failed: {}", jobId, errorMessage);
     return update(jobId, StatusEnum.ERROR, errorMessage, null);
   }
 
@@ -154,11 +156,15 @@ public class PostgresJobDao implements JobDao {
    */
   @Override
   public GenericJobServerModel fail(UUID jobId, String errorMessage, Exception e) {
+    logger.error("Job {} failed: {}", jobId, errorMessage, e);
     return update(jobId, StatusEnum.ERROR, errorMessage, e.getStackTrace());
   }
 
   private GenericJobServerModel update(
-      UUID jobId, StatusEnum status, String errorMessage, StackTraceElement[] stackTrace) {
+      UUID jobId,
+      StatusEnum status,
+      @Nullable String errorMessage,
+      @Nullable StackTraceElement[] stackTrace) {
 
     // start our sql statement and map of params
     StringBuilder sb = new StringBuilder("update sys_wds.job set status = :status");

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresJobDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresJobDao.java
@@ -12,7 +12,6 @@ import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import javax.annotation.Nullable;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
 import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.databiosphere.workspacedataservice.shared.model.job.Job;
@@ -23,6 +22,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Repository;
 
 /** Read/write jobs via the sys_wds.job Postgres table */

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/FileDownloadHelper.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/FileDownloadHelper.java
@@ -58,7 +58,8 @@ public class FileDownloadHelper {
       // TODO: this will throw DirectoryNotEmptyException; we need to delete individual files first
       Files.delete(tempFileDir);
     } catch (IOException e) {
-      logger.error("Error deleting temporary files: {} {}", e.getClass().getName(), e.getMessage());
+      logger.error(
+          "Error deleting temporary files: {} {}", e.getClass().getName(), e.getMessage(), e);
     }
   }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/FileDownloadHelper.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/FileDownloadHelper.java
@@ -55,9 +55,10 @@ public class FileDownloadHelper {
 
   public void deleteFileDirectory() {
     try {
+      // TODO: this will throw DirectoryNotEmptyException; we need to delete individual files first
       Files.delete(tempFileDir);
     } catch (IOException e) {
-      logger.error("Error deleting temporary files: {}", e.getMessage());
+      logger.error("Error deleting temporary files: {} {}", e.getClass().getName(), e.getMessage());
     }
   }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportDetails.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportDetails.java
@@ -1,31 +1,32 @@
 package org.databiosphere.workspacedataservice.dataimport;
 
-import jakarta.annotation.Nullable;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.recordsink.RawlsAttributePrefixer.PrefixStrategy;
 
 public record ImportDetails(
-    @Nullable UUID jobId,
-    @Nullable String userEmail,
-    UUID collectionId,
-    PrefixStrategy prefixStrategy) {
+    UUID jobId, String userEmail, UUID collectionId, PrefixStrategy prefixStrategy) {
+
+  private static final String DEFAULT_EMAIL = "unknown";
+  private static final UUID DEFAULT_JOB_ID =
+      UUID.fromString("00000000-0000-0000-0000-000000000000");
 
   /**
-   * Convenience constructor that sets jobId and userEmail to null
+   * Convenience constructor that sets jobId and userEmail to defaults
    *
    * @param collectionId target collection
    * @param prefixStrategy strategy for potentially renaming attributes
    */
   public ImportDetails(UUID collectionId, PrefixStrategy prefixStrategy) {
-    this(null, null, collectionId, prefixStrategy);
+    this(DEFAULT_JOB_ID, DEFAULT_EMAIL, collectionId, prefixStrategy);
   }
 
   /**
-   * Convenience constructor that sets jobId and userEmail to null, and sets prefixStrategy to NONE
+   * Convenience constructor that sets jobId and userEmail to defaults, and sets prefixStrategy to
+   * NONE
    *
    * @param collectionId target collection
    */
   public ImportDetails(UUID collectionId) {
-    this(null, null, collectionId, PrefixStrategy.NONE);
+    this(collectionId, PrefixStrategy.NONE);
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportDetails.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportDetails.java
@@ -1,12 +1,16 @@
 package org.databiosphere.workspacedataservice.dataimport;
 
 import java.util.UUID;
+import java.util.function.Supplier;
 import org.databiosphere.workspacedataservice.recordsink.RawlsAttributePrefixer.PrefixStrategy;
 
 public record ImportDetails(
-    UUID jobId, String userEmail, UUID collectionId, PrefixStrategy prefixStrategy) {
+    UUID jobId,
+    Supplier<String> userEmailSupplier,
+    UUID collectionId,
+    PrefixStrategy prefixStrategy) {
 
-  private static final String DEFAULT_EMAIL = "unknown";
+  private static final Supplier<String> DEFAULT_EMAIL = () -> "unknown";
   private static final UUID DEFAULT_JOB_ID =
       UUID.fromString("00000000-0000-0000-0000-000000000000");
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportDetails.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportDetails.java
@@ -23,4 +23,22 @@ public record ImportDetails(
   public ImportDetails(UUID collectionId) {
     this(DEFAULT_JOB_ID, DEFAULT_EMAIL_SUPPLIER, collectionId, PrefixStrategy.NONE);
   }
+
+  /**
+   * Override to ensure we never serialize the userEmailSupplier, which can contain an auth token.
+   *
+   * @return serialized String
+   */
+  @Override
+  public String toString() {
+    return "ImportDetails{"
+        + "jobId="
+        + jobId
+        + ", userEmailSupplier=Supplier<String>"
+        + ", collectionId="
+        + collectionId
+        + ", prefixStrategy="
+        + prefixStrategy
+        + '}';
+  }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportDetails.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportDetails.java
@@ -10,27 +10,17 @@ public record ImportDetails(
     UUID collectionId,
     PrefixStrategy prefixStrategy) {
 
-  private static final Supplier<String> DEFAULT_EMAIL = () -> "unknown";
+  private static final Supplier<String> DEFAULT_EMAIL_SUPPLIER = () -> "unknown";
   private static final UUID DEFAULT_JOB_ID =
       UUID.fromString("00000000-0000-0000-0000-000000000000");
 
   /**
-   * Convenience constructor that sets jobId and userEmail to defaults
-   *
-   * @param collectionId target collection
-   * @param prefixStrategy strategy for potentially renaming attributes
-   */
-  public ImportDetails(UUID collectionId, PrefixStrategy prefixStrategy) {
-    this(DEFAULT_JOB_ID, DEFAULT_EMAIL, collectionId, prefixStrategy);
-  }
-
-  /**
    * Convenience constructor that sets jobId and userEmail to defaults, and sets prefixStrategy to
-   * NONE
+   * NONE. Used by TSV and JSON APIs, which are not async and thus do not have job ids
    *
    * @param collectionId target collection
    */
   public ImportDetails(UUID collectionId) {
-    this(collectionId, PrefixStrategy.NONE);
+    this(DEFAULT_JOB_ID, DEFAULT_EMAIL_SUPPLIER, collectionId, PrefixStrategy.NONE);
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportDetails.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportDetails.java
@@ -3,16 +3,13 @@ package org.databiosphere.workspacedataservice.dataimport;
 import java.util.UUID;
 import java.util.function.Supplier;
 import org.databiosphere.workspacedataservice.recordsink.RawlsAttributePrefixer.PrefixStrategy;
+import org.springframework.lang.Nullable;
 
 public record ImportDetails(
-    UUID jobId,
-    Supplier<String> userEmailSupplier,
+    @Nullable UUID jobId,
+    @Nullable Supplier<String> userEmailSupplier,
     UUID collectionId,
     PrefixStrategy prefixStrategy) {
-
-  private static final Supplier<String> DEFAULT_EMAIL_SUPPLIER = () -> "unknown";
-  private static final UUID DEFAULT_JOB_ID =
-      UUID.fromString("00000000-0000-0000-0000-000000000000");
 
   /**
    * Convenience constructor that sets jobId and userEmail to defaults, and sets prefixStrategy to
@@ -21,7 +18,7 @@ public record ImportDetails(
    * @param collectionId target collection
    */
   public ImportDetails(UUID collectionId) {
-    this(DEFAULT_JOB_ID, DEFAULT_EMAIL_SUPPLIER, collectionId, PrefixStrategy.NONE);
+    this(null, null, collectionId, PrefixStrategy.NONE);
   }
 
   /**

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJob.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.UUID;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -103,10 +104,10 @@ public class PfbQuartzJob extends QuartzJob {
     // Collect details needed for import
     UUID targetCollection = getJobDataUUID(jobDataMap, ARG_COLLECTION);
     String authToken = getJobDataString(jobDataMap, ARG_TOKEN);
-    String userEmail = samDao.getUserEmail(BearerToken.of(authToken));
+    Supplier<String> userEmailSupplier = () -> samDao.getUserEmail(BearerToken.of(authToken));
 
     ImportDetails importDetails =
-        new ImportDetails(jobId, userEmail, targetCollection, PrefixStrategy.PFB);
+        new ImportDetails(jobId, userEmailSupplier, targetCollection, PrefixStrategy.PFB);
 
     // Import all the tables and rows inside the PFB.
     //

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJob.java
@@ -48,7 +48,6 @@ import org.databiosphere.workspacedataservice.service.BatchWriteService;
 import org.databiosphere.workspacedataservice.service.CollectionService;
 import org.databiosphere.workspacedataservice.service.model.BatchWriteResult;
 import org.databiosphere.workspacedataservice.service.model.TdrManifestImportTable;
-import org.databiosphere.workspacedataservice.service.model.exception.DataImportException;
 import org.databiosphere.workspacedataservice.service.model.exception.TdrManifestImportException;
 import org.databiosphere.workspacedataservice.shared.model.BearerToken;
 import org.databiosphere.workspacedataservice.shared.model.CollectionId;
@@ -169,10 +168,7 @@ public class TdrManifestQuartzJob extends QuartzJob {
                               .record()
                               .withRecordType(entry.getKey())
                               .ofQuantity(entry.getValue())));
-    } catch (DataImportException e) {
-      throw new TdrManifestImportException(e.getMessage(), e);
     } catch (Exception e) {
-      logger.error("Unexpected error in TdrManifestQuartzJob: " + e.getMessage(), e);
       throw new TdrManifestImportException(e.getMessage(), e);
     } finally {
       // delete temp files after everything else is completed

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJob.java
@@ -2,6 +2,7 @@ package org.databiosphere.workspacedataservice.dataimport.tdr;
 
 import static org.apache.parquet.avro.AvroReadSupport.READ_INT96_AS_FIXED;
 import static org.databiosphere.workspacedataservice.shared.model.Schedulable.ARG_COLLECTION;
+import static org.databiosphere.workspacedataservice.shared.model.Schedulable.ARG_TOKEN;
 import static org.databiosphere.workspacedataservice.shared.model.Schedulable.ARG_URL;
 
 import bio.terra.datarepo.model.RelationshipModel;
@@ -41,12 +42,14 @@ import org.databiosphere.workspacedataservice.recordsink.RecordSink;
 import org.databiosphere.workspacedataservice.recordsink.RecordSinkFactory;
 import org.databiosphere.workspacedataservice.recordsource.RecordSource.ImportMode;
 import org.databiosphere.workspacedataservice.recordsource.RecordSourceFactory;
+import org.databiosphere.workspacedataservice.sam.SamDao;
 import org.databiosphere.workspacedataservice.service.BatchWriteService;
 import org.databiosphere.workspacedataservice.service.CollectionService;
 import org.databiosphere.workspacedataservice.service.model.BatchWriteResult;
 import org.databiosphere.workspacedataservice.service.model.TdrManifestImportTable;
 import org.databiosphere.workspacedataservice.service.model.exception.DataImportException;
 import org.databiosphere.workspacedataservice.service.model.exception.TdrManifestImportException;
+import org.databiosphere.workspacedataservice.shared.model.BearerToken;
 import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
@@ -67,6 +70,7 @@ public class TdrManifestQuartzJob extends QuartzJob {
   private final ObjectMapper mapper;
   private final RecordSourceFactory recordSourceFactory;
   private final SnapshotSupportFactory snapshotSupportFactory;
+  private final SamDao samDao;
 
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
@@ -80,7 +84,8 @@ public class TdrManifestQuartzJob extends QuartzJob {
       ObjectMapper mapper,
       ObservationRegistry observationRegistry,
       DataImportProperties dataImportProperties,
-      SnapshotSupportFactory snapshotSupportFactory) {
+      SnapshotSupportFactory snapshotSupportFactory,
+      SamDao samDao) {
     super(observationRegistry, dataImportProperties);
     this.jobDao = jobDao;
     this.recordSinkFactory = recordSinkFactory;
@@ -90,6 +95,7 @@ public class TdrManifestQuartzJob extends QuartzJob {
     this.activityLogger = activityLogger;
     this.mapper = mapper;
     this.snapshotSupportFactory = snapshotSupportFactory;
+    this.samDao = samDao;
   }
 
   @Override
@@ -106,9 +112,12 @@ public class TdrManifestQuartzJob extends QuartzJob {
 
     // Collect details needed for import
     UUID targetCollection = getJobDataUUID(jobDataMap, ARG_COLLECTION);
+    String authToken = getJobDataString(jobDataMap, ARG_TOKEN);
+    String userEmail = samDao.getUserEmail(BearerToken.of(authToken));
 
     // TDR import is interested in the collectionId (not the workspaceId)
-    ImportDetails importDetails = new ImportDetails(targetCollection, PrefixStrategy.TDR);
+    ImportDetails importDetails =
+        new ImportDetails(jobId, userEmail, targetCollection, PrefixStrategy.TDR);
 
     // determine the workspace for the target collection
     WorkspaceId workspaceId = collectionService.getWorkspaceId(CollectionId.of(targetCollection));
@@ -160,6 +169,9 @@ public class TdrManifestQuartzJob extends QuartzJob {
                               .withRecordType(entry.getKey())
                               .ofQuantity(entry.getValue())));
     } catch (DataImportException e) {
+      throw new TdrManifestImportException(e.getMessage(), e);
+    } catch (Exception e) {
+      logger.error("Unexpected error in TdrManifestQuartzJob: " + e.getMessage(), e);
       throw new TdrManifestImportException(e.getMessage(), e);
     }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/pubsub/JobStatusUpdate.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/pubsub/JobStatusUpdate.java
@@ -2,9 +2,9 @@ package org.databiosphere.workspacedataservice.pubsub;
 
 import java.util.Map;
 import java.util.UUID;
-import javax.annotation.Nullable;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel.StatusEnum;
 import org.databiosphere.workspacedataservice.service.model.exception.ValidationException;
+import org.springframework.lang.Nullable;
 
 public record JobStatusUpdate(
     UUID jobId, StatusEnum currentStatus, StatusEnum newStatus, @Nullable String errorMessage) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSink.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSink.java
@@ -1,5 +1,7 @@
 package org.databiosphere.workspacedataservice.recordsink;
 
+import static java.util.Objects.requireNonNull;
+
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.cloud.spring.storage.GoogleStorageResource;
@@ -71,7 +73,7 @@ public class RawlsRecordSink implements RecordSink {
    */
   public static RawlsRecordSink create(
       ObjectMapper mapper, GcsStorage storage, PubSub pubSub, ImportDetails importDetails) {
-    String blobName = getBlobName(importDetails.jobId());
+    String blobName = getBlobName(requireNonNull(importDetails.jobId()));
     Blob blob = storage.createBlob(blobName);
     return new RawlsRecordSink(
         new RawlsAttributePrefixer(importDetails.prefixStrategy()),
@@ -141,9 +143,13 @@ public class RawlsRecordSink implements RecordSink {
   }
 
   private void publishToPubSub(ImportDetails importDetails) {
-    UUID jobId = importDetails.jobId();
+    UUID jobId = requireNonNull(importDetails.jobId());
     UUID workspaceId = importDetails.collectionId();
-    String user = importDetails.userEmailSupplier().get();
+    String user =
+        requireNonNull(
+                importDetails.userEmailSupplier(),
+                "Expected ImportDetails.userEmailSupplier to be non-null for async imports")
+            .get();
     Map<String, String> message =
         new ImmutableMap.Builder<String, String>()
             .put("workspaceId", workspaceId.toString())

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSink.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSink.java
@@ -1,6 +1,5 @@
 package org.databiosphere.workspacedataservice.recordsink;
 
-import static java.util.Objects.requireNonNull;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -73,7 +72,7 @@ public class RawlsRecordSink implements RecordSink {
    */
   public static RawlsRecordSink create(
       ObjectMapper mapper, GcsStorage storage, PubSub pubSub, ImportDetails importDetails) {
-    String blobName = getBlobName(requireNonNull(importDetails.jobId()));
+    String blobName = getBlobName(importDetails.jobId());
     Blob blob = storage.createBlob(blobName);
     return new RawlsRecordSink(
         new RawlsAttributePrefixer(importDetails.prefixStrategy()),
@@ -143,7 +142,7 @@ public class RawlsRecordSink implements RecordSink {
   }
 
   private void publishToPubSub(ImportDetails importDetails) {
-    UUID jobId = requireNonNull(importDetails.jobId());
+    UUID jobId = importDetails.jobId();
     UUID workspaceId = importDetails.collectionId();
     String user = importDetails.userEmailSupplier().get();
     Map<String, String> message =

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSink.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSink.java
@@ -1,6 +1,5 @@
 package org.databiosphere.workspacedataservice.recordsink;
 
-
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.cloud.spring.storage.GoogleStorageResource;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkFactory.java
@@ -1,5 +1,7 @@
 package org.databiosphere.workspacedataservice.recordsink;
 
+import static java.util.Objects.requireNonNull;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.databiosphere.workspacedataservice.annotations.DeploymentMode.ControlPlane;
 import org.databiosphere.workspacedataservice.dataimport.ImportDetails;
@@ -31,6 +33,11 @@ public class RawlsRecordSinkFactory implements RecordSinkFactory {
   }
 
   private RecordSink rawlsRecordSink(ImportDetails importDetails) {
+    requireNonNull(
+        importDetails.jobId(), "RawlsRecordSink requires ImportDetails.jobId to be non-null");
+    requireNonNull(
+        importDetails.userEmailSupplier(),
+        "RawlsRecordSink requires ImportDetails.userEmailSupplier to be non-null");
     return RawlsRecordSink.create(mapper, storage, pubSub, importDetails);
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobControlPlaneE2ETest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobControlPlaneE2ETest.java
@@ -240,12 +240,13 @@ class PfbQuartzJobControlPlaneE2ETest {
   @Tag(SLOW)
   void pubSubRequestsUserEmail() throws JobExecutionException, IOException {
     // Arrange / Act
-    UUID jobId = testSupport.executePfbImportQuartzJob(collectionId, minimalDataPfb);
+    testSupport.executePfbImportQuartzJob(collectionId, minimalDataPfb);
 
     // importing a PFB requires publishing to pubsub. As part of generating the pubsub message,
     // we query Sam for the user's email. Verify we made that call correctly.
-    // the "expectedToken" is the value from PfbTestUtils.stubJobContext().
-    verify(samDao, times(1)).getUserEmail(BearerToken.of("expectedToken"));
+    // the PfbTestUtils.BEARER_TOKEN is expected here because the job context was created from
+    // PfbTestUtils.stubJobContext().
+    verify(samDao, times(1)).getUserEmail(BearerToken.of(PfbTestUtils.BEARER_TOKEN));
   }
 
   private ImmutableMap<String, String> expectedPubSubMessageFor(UUID jobId) {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbTestUtils.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbTestUtils.java
@@ -57,6 +57,8 @@ public class PfbTestUtils {
               new Schema.Field("object", OBJECT_SCHEMA),
               new Schema.Field("relations", RELATION_ARRAY_SCHEMA)));
 
+  public static final String BEARER_TOKEN = "expectedToken";
+
   /**
    * Create a GenericRecord with the given id and name and an empty set of object attributes
    *
@@ -156,7 +158,7 @@ public class PfbTestUtils {
             new JobDataMap(
                 Map.of(
                     ARG_TOKEN,
-                    "expectedToken",
+                    BEARER_TOKEN,
                     ARG_URL,
                     resource.getURL().toString(),
                     ARG_COLLECTION,

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobTest.java
@@ -56,9 +56,11 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.core.io.Resource;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
 
 @DirtiesContext
 @SpringBootTest
+@ActiveProfiles("mock-sam")
 class TdrManifestQuartzJobTest extends TestBase {
 
   @MockBean JobDao jobDao;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrTestSupport.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrTestSupport.java
@@ -12,6 +12,7 @@ import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.dataimport.snapshotsupport.SnapshotSupportFactory;
 import org.databiosphere.workspacedataservice.recordsink.RecordSinkFactory;
 import org.databiosphere.workspacedataservice.recordsource.RecordSourceFactory;
+import org.databiosphere.workspacedataservice.sam.SamDao;
 import org.databiosphere.workspacedataservice.service.BatchWriteService;
 import org.databiosphere.workspacedataservice.service.CollectionService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,6 +23,7 @@ import org.springframework.stereotype.Component;
 @Component
 class TdrTestSupport {
   @Autowired private JobDao jobDao;
+  @Autowired private SamDao samDao;
   @Autowired private RecordSourceFactory recordSourceFactory;
   @Autowired private RecordSinkFactory recordSinkFactory;
   @Autowired private BatchWriteService batchWriteService;
@@ -44,7 +46,8 @@ class TdrTestSupport {
         objectMapper,
         observationRegistry,
         dataImportProperties,
-        snapshotSupportFactory) {
+        snapshotSupportFactory,
+        samDao) {
       @Override
       protected URL parseUrl(String path) {
         if (path.startsWith("classpath:")) {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkFactoryTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkFactoryTest.java
@@ -1,0 +1,60 @@
+package org.databiosphere.workspacedataservice.recordsink;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.UUID;
+import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.dataimport.ImportDetails;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+
+@DirtiesContext
+@SpringBootTest
+@ActiveProfiles(value = "control-plane", inheritProfiles = false)
+class RawlsRecordSinkFactoryTest extends TestBase {
+
+  @Autowired RecordSinkFactory recordSinkFactory;
+
+  @Test
+  void throwOnNullJobId() {
+    ImportDetails importDetails =
+        new ImportDetails(
+            null, () -> "email", UUID.randomUUID(), RawlsAttributePrefixer.PrefixStrategy.NONE);
+
+    Exception e =
+        assertThrows(
+            NullPointerException.class, () -> recordSinkFactory.buildRecordSink(importDetails));
+
+    assertThat(e.getMessage()).contains("ImportDetails.jobId");
+  }
+
+  @Test
+  void throwOnNullUserEmailSupplier() {
+    ImportDetails importDetails =
+        new ImportDetails(
+            UUID.randomUUID(), null, UUID.randomUUID(), RawlsAttributePrefixer.PrefixStrategy.NONE);
+
+    Exception e =
+        assertThrows(
+            NullPointerException.class, () -> recordSinkFactory.buildRecordSink(importDetails));
+
+    assertThat(e.getMessage()).contains("ImportDetails.userEmailSupplier");
+  }
+
+  @Test
+  void doNotThrowOnNonNull() {
+    ImportDetails importDetails =
+        new ImportDetails(
+            UUID.randomUUID(),
+            () -> "email",
+            UUID.randomUUID(),
+            RawlsAttributePrefixer.PrefixStrategy.NONE);
+
+    assertDoesNotThrow(() -> recordSinkFactory.buildRecordSink(importDetails));
+  }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkPrefixingTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkPrefixingTest.java
@@ -14,6 +14,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.Supplier;
 import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.dataimport.ImportDetails;
 import org.databiosphere.workspacedataservice.pubsub.PubSub;
@@ -146,7 +147,7 @@ class RawlsRecordSinkPrefixingTest extends TestBase {
   }
 
   private List<Entity> doUpsert(Record record, PrefixStrategy prefixStrategy) {
-    String USER_EMAIL = "userEmail";
+    Supplier<String> USER_EMAIL = () -> "userEmail";
     var recordList = List.of(record);
     var recordType = recordList.stream().map(Record::getRecordType).collect(onlyElement());
     var blobName = "";

--- a/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkTest.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.databiosphere.workspacedataservice.common.TestBase;
@@ -61,7 +62,7 @@ class RawlsRecordSinkTest extends TestBase {
 
   private final UUID WORKSPACE_ID = UUID.randomUUID();
   private final UUID JOB_ID = UUID.randomUUID();
-  private final String USER_EMAIL = "userEmail";
+  private final Supplier<String> USER_EMAIL = () -> "userEmail";
 
   @Test
   void translatesEntityFields() {
@@ -165,7 +166,7 @@ class RawlsRecordSinkTest extends TestBase {
     Map<String, String> expectedMessage =
         new ImmutableMap.Builder<String, String>()
             .put("workspaceId", WORKSPACE_ID.toString())
-            .put("userEmail", USER_EMAIL)
+            .put("userEmail", USER_EMAIL.get())
             .put("jobId", JOB_ID.toString())
             .put("upsertFile", storage.getBucketName() + "/" + JOB_ID + ".rawlsUpsert")
             .put("isUpsert", "true")

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/BatchWriteServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/BatchWriteServiceTest.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.UUID;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.apache.avro.file.DataFileStream;
 import org.apache.avro.generic.GenericRecord;
@@ -264,8 +265,11 @@ class BatchWriteServiceTest extends TestBase {
   private BatchWriteResult batchWritePfbStream(
       DataFileStream<GenericRecord> pfbStream, String primaryKey, ImportMode importMode)
       throws IOException {
+    UUID jobId = UUID.randomUUID();
+    Supplier<String> emailSupplier = () -> "testEmail";
     try (RecordSink recordSink =
-        recordSinkFactory.buildRecordSink(new ImportDetails(COLLECTION, PrefixStrategy.PFB))) {
+        recordSinkFactory.buildRecordSink(
+            new ImportDetails(jobId, emailSupplier, COLLECTION, PrefixStrategy.PFB))) {
       return batchWriteService.batchWrite(
           recordSourceFactory.forPfb(pfbStream, importMode),
           recordSink,


### PR DESCRIPTION
[AJ-1716](https://broadworkbench.atlassian.net/browse/AJ-1716) Snapshot imports fail in the control plane with no logged error

The root cause is that the TDR import job set `ImportDetails.jobId` to `null`, but `RawlsRecordSink` required the jobId to be non-null.

Along the way to fixing that, I also:
* added logging into the `JobDao.fail()` methods to ensure we log job errors
* changed how we retrieve the end user's email address, so we never request it in the data plane and don't request it until we absolutely need it in the control plane; added unit tests for this
* tweaked constructors of `ImportDetails` to make it less easy to insert bad data
* cleaned up some IntelliJ warnings


[AJ-1716]: https://broadworkbench.atlassian.net/browse/AJ-1716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ