### PR TITLE
AJ-1716: delete non-empty temp dir

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/FileDownloadHelper.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/FileDownloadHelper.java
@@ -55,7 +55,7 @@ public class FileDownloadHelper {
 
   public void deleteFileDirectory() {
     try {
-      Files.delete(tempFileDir);
+      FileUtils.deleteDirectory(tempFileDir.toFile());
     } catch (IOException e) {
       logger.error("Error deleting temporary files: {}", e.getMessage());
     }


### PR DESCRIPTION
Discovered during AJ-1716; does not resolve that ticket.

We never cleaned up the temp directories we created while importing TDR snapshots.

The previous code's javadoc says:
> If the file is a directory then the directory must be empty.

So, I'm switching the code from using `java.nio.file.Files` to `org.apache.commons.io.FileUtils`, which knows how to delete a non-empty directory.