### PR TITLE
[AJ-1708] Skip publish Docker workflow on Dependabot PRs

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -11,8 +11,6 @@ on:
       ACR_SP_USER:
         required: true
   pull_request:
-    branches-ignore:
-      - 'dependabot/**'
   push:
     branches:
       - main
@@ -25,6 +23,7 @@ env:
 
 jobs:
   publish-docker-job:
+    if: github.actor != 'dependabot[bot]'
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -116,6 +115,7 @@ jobs:
   # Report the new version of cWDS to Sherlock.
   # This enables Sherlock to gather metrics and generate changelogs for deployments.
   cwds-report-to-sherlock:
+    if: github.actor != 'dependabot[bot]'
     needs: publish-docker-job
     uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
     with:


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1708

This workflow is still running and failing on Dependabot PRs. For example: #679.
https://github.com/DataBiosphere/terra-workspace-data-service/actions/runs/8420039149/job/23053921543?pr=679

#658 failed to disable this workflow because the `branches-ignore` filter operates on the branch that the PR is targeting (`main` for Dependabot PRs), not the source branch.

`github.actor` is the documented way to identify a Dependabot PR.
https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#responding-to-events
