### PR TITLE
Add SERVICE_GOOGLE_BUCKET env variable to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ with `gcloud` or by setting the `GOOGLE_CLOUD_PROJECT` environment variable.
 
    This will send imports the dev Rawls; you may want to use a dummy project/topic instead.
 
+4. Configure the Google Cloud Storage bucket to write Rawls JSON to.
+   ```bash
+   export SERVICE_GOOGLE_BUCKET=cwds-batchupsert-dev
+   ```
+
 ##### SAM_URL
 
 WDS contacts Sam for permission checks. You will need to configure Sam's URL by setting an


### PR DESCRIPTION
CWDS needs to be configured with a bucket to write Rawls JSON to. Currently, this is not mentioned in the readme, making it more difficult to run CWDS locally.