### PR TITLE
[AJ-1705] Specify cloning instructions and purpose when linking snapshots through Rawls

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/rawls/NamedDataRepoSnapshot.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/rawls/NamedDataRepoSnapshot.java
@@ -1,5 +1,7 @@
 package org.databiosphere.workspacedataservice.rawls;
 
+import bio.terra.workspace.model.CloningInstructionsEnum;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -8,12 +10,24 @@ import java.util.UUID;
  * @param name name for this reference
  * @param description description for this reference
  * @param snapshotId the UUID of the snapshot to reference
+ * @param cloningInstructions cloning semantics for this snapshot
+ * @param properties key-value pairs to associate with the snapshot
  */
-public record NamedDataRepoSnapshot(String name, String description, UUID snapshotId) {
+public record NamedDataRepoSnapshot(
+    String name,
+    String description,
+    UUID snapshotId,
+    CloningInstructionsEnum cloningInstructions,
+    Map<String, String> properties) {
 
   public static NamedDataRepoSnapshot forSnapshotId(UUID snapshotId) {
     String referenceName = "%s-policy".formatted(snapshotId);
     String referenceDescription = "created at %s".formatted(System.currentTimeMillis());
-    return new NamedDataRepoSnapshot(referenceName, referenceDescription, snapshotId);
+    return new NamedDataRepoSnapshot(
+        referenceName,
+        referenceDescription,
+        snapshotId,
+        CloningInstructionsEnum.REFERENCE,
+        Map.of("purpose", "policy"));
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/rawls/RawlsClient.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/rawls/RawlsClient.java
@@ -30,8 +30,6 @@ public class RawlsClient {
     }
   }
 
-  // TODO: (AJ-1705) Add cloning instructions COPY_REFERENCE and a purpose=policy
-  //     key-value pair to the reference’s properties
   public void createSnapshotReference(UUID workspaceId, UUID snapshotId) {
     try {
       NamedDataRepoSnapshot namedDataRepoSnapshot = NamedDataRepoSnapshot.forSnapshotId(snapshotId);

--- a/service/src/test/java/org/databiosphere/workspacedataservice/rawls/RawlsClientTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/rawls/RawlsClientTest.java
@@ -58,7 +58,6 @@ class RawlsClientTest {
     rawlsClient.createSnapshotReference(workspaceId.id(), snapshotId);
 
     // ASSERT
-    // verify it retried three times, until it got the success
     verify(mockRawlsApi)
         .createDataRepoSnapshotByWorkspaceId(
             eq(workspaceId.id()), namedDataRepoSnapshotCaptor.capture());

--- a/service/src/test/java/org/databiosphere/workspacedataservice/rawls/RawlsClientTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/rawls/RawlsClientTest.java
@@ -1,0 +1,75 @@
+package org.databiosphere.workspacedataservice.rawls;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import bio.terra.workspace.model.CloningInstructionsEnum;
+import java.util.UUID;
+import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.stubbing.Answer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+@DirtiesContext
+@ActiveProfiles(value = "control-plane", inheritProfiles = false)
+@SpringBootTest
+@TestPropertySource(
+    properties = {
+      // URI parsing requires a valid hostname here, even if we don't contact this host
+      "rawlsUrl=https://localhost/",
+      // turn off pubsub autoconfiguration for tests
+      "spring.cloud.gcp.pubsub.enabled=false",
+      // allow 3 retry attempts, so we can better verify retries
+      "rest.retry.maxAttempts=3",
+      // with aggressive delay settings so unit tests don't run too long
+      "rest.retry.backoff.delay=3",
+    })
+public class RawlsClientTest {
+  @MockBean RawlsApi mockRawlsApi;
+
+  @Autowired RawlsClient rawlsClient;
+
+  @BeforeEach
+  void beforeEach() {
+    reset(mockRawlsApi);
+  }
+
+  @Captor ArgumentCaptor<NamedDataRepoSnapshot> namedDataRepoSnapshotCaptor;
+
+  @Test
+  void linkSnapshot() {
+    // ARRANGE
+    WorkspaceId workspaceId = WorkspaceId.of(UUID.randomUUID());
+    UUID snapshotId = UUID.randomUUID();
+
+    when(mockRawlsApi.createDataRepoSnapshotByWorkspaceId(eq(workspaceId.id()), any()))
+        .thenAnswer((Answer<?>) invocation -> null);
+
+    // ACT
+    rawlsClient.createSnapshotReference(workspaceId.id(), snapshotId);
+
+    // ASSERT
+    // verify it retried three times, until it got the success
+    verify(mockRawlsApi)
+        .createDataRepoSnapshotByWorkspaceId(
+            eq(workspaceId.id()), namedDataRepoSnapshotCaptor.capture());
+    NamedDataRepoSnapshot snapshotReference = namedDataRepoSnapshotCaptor.getValue();
+    assertEquals(snapshotId, snapshotReference.snapshotId());
+    assertEquals("%s-policy".formatted(snapshotId), snapshotReference.name());
+    assertEquals(CloningInstructionsEnum.REFERENCE, snapshotReference.cloningInstructions());
+    assertThat(snapshotReference.properties()).containsEntry("purpose", "policy");
+  }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/rawls/RawlsClientTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/rawls/RawlsClientTest.java
@@ -24,7 +24,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 
 @DirtiesContext
-@ActiveProfiles(value = "control-plane", inheritProfiles = false)
+@ActiveProfiles(value = "control-plane")
 @SpringBootTest
 @TestPropertySource(
     properties = {
@@ -32,10 +32,6 @@ import org.springframework.test.context.TestPropertySource;
       "rawlsUrl=https://localhost/",
       // turn off pubsub autoconfiguration for tests
       "spring.cloud.gcp.pubsub.enabled=false",
-      // allow 3 retry attempts, so we can better verify retries
-      "rest.retry.maxAttempts=3",
-      // with aggressive delay settings so unit tests don't run too long
-      "rest.retry.backoff.delay=3",
     })
 class RawlsClientTest {
   @MockBean RawlsApi mockRawlsApi;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/rawls/RawlsClientTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/rawls/RawlsClientTest.java
@@ -37,7 +37,7 @@ import org.springframework.test.context.TestPropertySource;
       // with aggressive delay settings so unit tests don't run too long
       "rest.retry.backoff.delay=3",
     })
-public class RawlsClientTest {
+class RawlsClientTest {
   @MockBean RawlsApi mockRawlsApi;
 
   @Autowired RawlsClient rawlsClient;


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1705

Part 1 of [AJ-1705](https://broadworkbench.atlassian.net/browse/AJ-1705)...

When we link snapshots via WSM, we specify "REFERENCE" for cloning instructions and "policy" for purpose.
https://github.com/DataBiosphere/terra-workspace-data-service/blob/be53253095d079e52b12b7631663404485e8c861/service/src/main/java/org/databiosphere/workspacedataservice/workspacemanager/WorkspaceManagerDao.java#L41-L77

This passes those same arguments when linking snapshots via Rawls.

Support for these options was added to Rawls in https://github.com/broadinstitute/rawls/pull/2790.

[AJ-1705]: https://broadworkbench.atlassian.net/browse/AJ-1705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ