### PR TITLE
[AJ-1742] Use dedicated subscription for local CWDS

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ with `gcloud` or by setting the `GOOGLE_CLOUD_PROJECT` environment variable.
    # Topic for incoming notifications from Rawls
    # Since this topic is in a different GCP project, we need the fully qualified name
    export IMPORT_STATUS_UPDATES_TOPIC=projects/terra-importservice-dev/topics/import-service-notify-dev
+   # Create a subscription dedicated to your local CWDS
+   export IMPORT_STATUS_UPDATES_SUBSCRIPTION=cwds-import-status-updates-local-$(whoami)
    ```
 
    This will send imports the dev Rawls; you may want to use a dummy project/topic instead.

--- a/service/src/main/resources/application-control-plane.yml
+++ b/service/src/main/resources/application-control-plane.yml
@@ -13,10 +13,8 @@ twds:
     rawls-bucket-name: ${SERVICE_GOOGLE_BUCKET}
     # Name of PubSub topic for incoming import status notifications from Rawls.
     status-updates-topic: ${IMPORT_STATUS_UPDATES_TOPIC}
-    # In live environments, there should only be one subscription per project, so it can use
-    # a preset name. For BEEs, each BEE will have its own subscription, so the subscription
-    # name needs to be set to something unique to the BEE.
-    status-updates-subscription: ${IMPORT_STATUS_UPDATES_SUBSCRIPTION:cwds-import-status-updates}
+    # Name of PubSub subscription used to subscribe to the status-updates-topic.
+    status-updates-subscription: ${IMPORT_STATUS_UPDATES_SUBSCRIPTION}
 
 
 spring:


### PR DESCRIPTION
It occurred to me yesterday, we shouldn't have local CWDS' pulling messages from the same subscription as dev, since that could prevent dev from receiving messages for imports in the dev environment and updating its database accordingly.

It's probably also worthwhile to remove the default configuration for the subscription name to help avoid this, but that will require a change to terra-helmfile.