### PR TITLE
[AJ-1741] Move Rawls notification topic to WDS config

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/config/DataImportProperties.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/config/DataImportProperties.java
@@ -26,6 +26,7 @@ public class DataImportProperties {
 
   private Set<Pattern> allowedHosts = emptySet();
   private Set<String> allowedSchemes = Set.of("https");
+  private String rawlsNotificationsTopic;
   private String statusUpdatesTopic;
   private String statusUpdatesSubscription;
 
@@ -96,6 +97,14 @@ public class DataImportProperties {
 
   public void setAllowedSchemes(String[] allowedSchemes) {
     this.allowedSchemes = stream(allowedSchemes).collect(Collectors.toSet());
+  }
+
+  public String getRawlsNotificationsTopic() {
+    return rawlsNotificationsTopic;
+  }
+
+  public void setRawlsNotificationsTopic(String rawlsNotificationsTopic) {
+    this.rawlsNotificationsTopic = rawlsNotificationsTopic;
   }
 
   public String getStatusUpdatesTopic() {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/pubsub/PubSubConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/pubsub/PubSubConfig.java
@@ -10,7 +10,6 @@ import com.google.pubsub.v1.Subscription;
 import org.databiosphere.workspacedataservice.config.DataImportProperties;
 import org.databiosphere.workspacedataservice.service.PubSubService;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -29,9 +28,8 @@ public class PubSubConfig {
   }
 
   @Bean
-  PubSub getPubSub(
-      PubSubTemplate pubSubTemplate, @Value("${spring.cloud.gcp.pubsub.topic}") String topic) {
-    return new ImportPubSub(pubSubTemplate, topic);
+  PubSub getPubSub(PubSubTemplate pubSubTemplate, DataImportProperties dataImportProperties) {
+    return new ImportPubSub(pubSubTemplate, dataImportProperties.getRawlsNotificationsTopic());
   }
 
   @Bean

--- a/service/src/main/resources/application-control-plane.yml
+++ b/service/src/main/resources/application-control-plane.yml
@@ -12,6 +12,8 @@ twds:
     succeed-on-completion: false
     rawls-bucket-name: ${SERVICE_GOOGLE_BUCKET}
     enable-tdr-permission-sync: true
+    # Name of PubSub topic to notify Rawls of JSON files ready for import.
+    rawls-notifications-topic: ${RAWLS_NOTIFY_TOPIC}
     # Name of PubSub topic for incoming import status notifications from Rawls.
     status-updates-topic: ${IMPORT_STATUS_UPDATES_TOPIC}
     # In live environments, there should only be one subscription per project, so it can use
@@ -25,7 +27,6 @@ spring:
       core:
         enabled: true
       pubsub:
-        topic: ${RAWLS_NOTIFY_TOPIC}
         enabled: true
 
 sentry:


### PR DESCRIPTION
Currently, the configuration for the PubSub topic used to notify Rawls of available imports is mixed in with the Spring Cloud GCP configuration.

Since this configuration is WDS-specific, it should be in the WDS configuration. This also removes the `@Value` in `PubSubConfig` and accesses the value through `DataImportProperties`.