### PR TITLE
AJ-1573: smoke tests add workspace_id CLI argument; use it in the job-listing test

### DIFF
--- a/smoke_test/README.md
+++ b/smoke_test/README.md
@@ -55,11 +55,12 @@ tests.
 
 next, run tests.
 
-syntax: python smoke_test.py {CWDS_HOST} $(gcloud auth print-access-token)
+syntax: python smoke_test.py {CWDS_HOST} {WORKSPACE_ID} $(gcloud auth print-access-token)
 
 example to run tests against dev:
 
-```python smoke_test.py cwds.dsde-dev.broadinstitute.org $(gcloud auth print-access-token)```
+```python smoke_test.py cwds.dsde-dev.broadinstitute.org 123e4567-e89b-12d3-a456-426614174000 $(gcloud auth print-access-token)```
+_(replace the example workspace uuid with a real workspace's uuid)_
 
 ## Required and Optional Arguments
 

--- a/smoke_test/smoke_test.py
+++ b/smoke_test/smoke_test.py
@@ -27,13 +27,14 @@ def gather_tests(is_authenticated: bool = False) -> TestSuite:
   suite.addTests(version_tests)
 
   if is_authenticated:
+    print("user_token and workspace_id both provided.  Running additional authenticated tests.")
     user_info_tests = unittest.defaultTestLoader.loadTestsFromTestCase(CwdsJobListingTests)
     resource_types_tests = unittest.defaultTestLoader.loadTestsFromTestCase(CwdsJobStatusTests)
 
     suite.addTests(user_info_tests)
     suite.addTests(resource_types_tests)
   else:
-    print("No User Token provided.  Skipping authenticated tests.")
+    print("user_token and/or workspace_id not provided.  Skipping authenticated tests.")
 
   return suite
 
@@ -43,9 +44,10 @@ def main(main_args):
     verify_user_token(main_args.user_token)
 
   CwdsSmokeTestCase.CWDS_HOST = main_args.CWDS_HOST
+  CwdsSmokeTestCase.WORKSPACE_ID = main_args.workspace_id
   CwdsSmokeTestCase.USER_TOKEN = main_args.user_token
 
-  test_suite = gather_tests(main_args.user_token)
+  test_suite = gather_tests(main_args.user_token and main_args.workspace_id)
 
   runner = unittest.TextTestRunner(verbosity=main_args.verbosity)
   result = runner.run(test_suite)
@@ -82,10 +84,16 @@ if __name__ == "__main__":
     help="domain with optional port number of the cWDS host you want to test"
   )
   parser.add_argument(
+    "workspace_id",
+    nargs='?',
+    default=None,
+    help="Optional; workspace id against which tests run. If this and user_token are present, enables additional tests."
+  )
+  parser.add_argument(
     "user_token",
     nargs='?',
     default=None,
-    help="Optional. If present, will test additional authenticated endpoints using the specified token"
+    help="Optional; auth token for authenticated tests. If this and workspace_id are present, enables additional tests."
   )
 
   args = parser.parse_args()

--- a/smoke_test/tests/authenticated/cwds_job_listing_tests.py
+++ b/smoke_test/tests/authenticated/cwds_job_listing_tests.py
@@ -1,3 +1,4 @@
+import json
 from urllib.parse import urljoin
 from uuid import uuid4
 
@@ -12,7 +13,9 @@ class CwdsJobListingTests(CwdsSmokeTestCase):
 
   def test_status_code_is_404(self):
     """Call the job-listing url; it should return 404 since we are specifying a random collection"""
-    response = CwdsSmokeTestCase.call_cwds(self.job_listing_url(uuid4()),
+    response = CwdsSmokeTestCase.call_cwds(self.job_listing_url(CwdsSmokeTestCase.WORKSPACE_ID),
                                            CwdsSmokeTestCase.USER_TOKEN)
-    self.assertEqual(response.status_code, 404,
-                     f"Job Listing HTTP Status is not 404: {response.text}")
+    self.assertEqual(response.status_code, 200,
+                     f"Job Listing HTTP Status is not 200: {response.text}")
+    job_list = json.loads(response.text)
+    self.assertIsInstance(job_list, list, "job listing was not an array")

--- a/smoke_test/tests/cwds_smoke_test_case.py
+++ b/smoke_test/tests/cwds_smoke_test_case.py
@@ -8,6 +8,7 @@ from urllib.parse import urljoin
 
 class CwdsSmokeTestCase(TestCase):
   CWDS_HOST = None
+  WORKSPACE_ID = None
   USER_TOKEN = None
 
   @staticmethod


### PR DESCRIPTION
* accept a workspace id on the command-line when running smoke tests
* use the workspace id in the job-listing test, so that test does something useful

In support of this, I have created a "cwds-smoketest-do-not-delete" workspace in the dev env to use for smoke tests. Before this rolls out to staging and prod I will create workspaces there too.