### PR TITLE
AJ-1726: Streamline metric testing

### DIFF
--- a/service/src/test/java/org/databiosphere/workspacedataservice/annotations/WithTestObservationRegistry.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/annotations/WithTestObservationRegistry.java
@@ -1,0 +1,13 @@
+package org.databiosphere.workspacedataservice.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.databiosphere.workspacedataservice.observability.TestObservationRegistryConfig;
+import org.springframework.context.annotation.Import;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Import(TestObservationRegistryConfig.class)
+public @interface WithTestObservationRegistry {}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/annotations/WithTestObservationRegistry.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/annotations/WithTestObservationRegistry.java
@@ -1,13 +1,26 @@
 package org.databiosphere.workspacedataservice.annotations;
 
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistry;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.databiosphere.workspacedataservice.common.TestObservationRegistrySetupExtension;
 import org.databiosphere.workspacedataservice.observability.TestObservationRegistryConfig;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.context.annotation.Import;
 
+/**
+ * Tests can use this annotation to override the {@link ObservationRegistry} bean with a {@link
+ * TestObservationRegistry} that can be autowired by the test to gain access to convenience
+ * assertions for observations.
+ *
+ * <p>It also automatically adds an {@link @AfterEach} extension to clear all metrics and
+ * observations after each test.
+ */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Import(TestObservationRegistryConfig.class)
+@ExtendWith(TestObservationRegistrySetupExtension.class)
 public @interface WithTestObservationRegistry {}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/common/TestObservationRegistrySetupExtension.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/common/TestObservationRegistrySetupExtension.java
@@ -1,0 +1,21 @@
+package org.databiosphere.workspacedataservice.common;
+
+import static org.springframework.test.context.junit.jupiter.SpringExtension.getApplicationContext;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.observation.tck.TestObservationRegistry;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/** Extension to reset all Observation and Meter registries after each test. */
+public class TestObservationRegistrySetupExtension implements AfterEachCallback {
+
+  /** Reset all Observation and Meter registries after each test. */
+  @Override
+  public void afterEach(ExtensionContext context) {
+    getApplicationContext(context).getBean(TestObservationRegistry.class).clear();
+    getApplicationContext(context).getBean(MeterRegistry.class).clear();
+    Metrics.globalRegistry.clear();
+  }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobControlPlaneE2ETest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobControlPlaneE2ETest.java
@@ -27,9 +27,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.google.mu.util.stream.BiStream;
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Metrics;
-import io.micrometer.observation.tck.TestObservationRegistry;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -104,8 +101,6 @@ class PfbQuartzJobControlPlaneE2ETest {
   @Autowired CollectionService collectionService;
   @Autowired PfbTestSupport testSupport;
   @Autowired MockMvc mockMvc;
-  @Autowired MeterRegistry meterRegistry;
-  @Autowired TestObservationRegistry observationRegistry;
 
   @Autowired
   @Qualifier("mockGcsStorage")
@@ -147,9 +142,6 @@ class PfbQuartzJobControlPlaneE2ETest {
   @AfterEach
   void teardown() {
     storage.getBlobsInBucket().forEach(blob -> storage.deleteBlob(blob.getName()));
-    meterRegistry.clear();
-    Metrics.globalRegistry.clear();
-    observationRegistry.clear();
   }
 
   /* import test.avro, and validate the tables and row counts it imported. */

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobControlPlaneE2ETest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobControlPlaneE2ETest.java
@@ -41,7 +41,7 @@ import java.util.UUID;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
-import org.databiosphere.workspacedataservice.observability.TestObservationRegistryConfig;
+import org.databiosphere.workspacedataservice.annotations.WithTestObservationRegistry;
 import org.databiosphere.workspacedataservice.pubsub.PubSub;
 import org.databiosphere.workspacedataservice.rawls.RawlsClient;
 import org.databiosphere.workspacedataservice.rawls.SnapshotListResponse;
@@ -71,7 +71,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
-import org.springframework.context.annotation.Import;
 import org.springframework.core.io.Resource;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
@@ -98,7 +97,7 @@ import org.springframework.util.StreamUtils;
       "rawlsUrl=https://localhost/",
       "management.prometheus.metrics.export.enabled=true"
     })
-@Import(TestObservationRegistryConfig.class)
+@WithTestObservationRegistry
 @AutoConfigureMockMvc
 class PfbQuartzJobControlPlaneE2ETest {
   @Autowired ObjectMapper mapper;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobControlPlaneE2ETest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobControlPlaneE2ETest.java
@@ -19,7 +19,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -30,7 +29,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.mu.util.stream.BiStream;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
-import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.tck.TestObservationRegistry;
 import java.io.IOException;
 import java.io.InputStream;
@@ -108,8 +106,7 @@ class PfbQuartzJobControlPlaneE2ETest {
   @Autowired PfbTestSupport testSupport;
   @Autowired MockMvc mockMvc;
   @Autowired MeterRegistry meterRegistry;
-  // overridden with a TestObservationRegistry
-  @Autowired ObservationRegistry observationRegistry;
+  @Autowired TestObservationRegistry observationRegistry;
 
   @Autowired
   @Qualifier("mockGcsStorage")
@@ -153,7 +150,7 @@ class PfbQuartzJobControlPlaneE2ETest {
     storage.getBlobsInBucket().forEach(blob -> storage.deleteBlob(blob.getName()));
     meterRegistry.clear();
     Metrics.globalRegistry.clear();
-    ((TestObservationRegistry) observationRegistry).clear();
+    observationRegistry.clear();
   }
 
   /* import test.avro, and validate the tables and row counts it imported. */

--- a/service/src/test/java/org/databiosphere/workspacedataservice/jobexec/QuartzJobTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/jobexec/QuartzJobTest.java
@@ -17,7 +17,6 @@ import static org.mockito.Mockito.when;
 
 import io.micrometer.core.instrument.LongTaskTimer;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.tck.TestObservationRegistry;
@@ -34,9 +33,9 @@ import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
 import org.databiosphere.workspacedataservice.sam.TokenContextUtil;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.quartz.JobDataMap;
@@ -50,7 +49,7 @@ import org.springframework.test.annotation.DirtiesContext;
 
 @SpringBootTest
 @DirtiesContext
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestInstance(Lifecycle.PER_CLASS)
 @WithTestObservationRegistry
 class QuartzJobTest extends TestBase {
 
@@ -77,14 +76,6 @@ class QuartzJobTest extends TestBase {
         .thenThrow(new RuntimeException("test failed via jobDao.fail()"));
 
     when(dataImportProperties.isSucceedOnCompletion()).thenReturn(true);
-  }
-
-  /** clear all observations and metrics prior to each test */
-  @BeforeEach
-  void beforeEach() {
-    meterRegistry.clear();
-    Metrics.globalRegistry.clear();
-    observationRegistry.clear();
   }
 
   /**

--- a/service/src/test/java/org/databiosphere/workspacedataservice/jobexec/QuartzJobTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/jobexec/QuartzJobTest.java
@@ -27,11 +27,11 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.databiosphere.workspacedataservice.annotations.WithTestObservationRegistry;
 import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.config.DataImportProperties;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
-import org.databiosphere.workspacedataservice.observability.TestObservationRegistryConfig;
 import org.databiosphere.workspacedataservice.sam.TokenContextUtil;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -46,13 +46,12 @@ import org.quartz.impl.JobDetailImpl;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 
 @SpringBootTest
 @DirtiesContext
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@Import(TestObservationRegistryConfig.class)
+@WithTestObservationRegistry
 class QuartzJobTest extends TestBase {
 
   @MockBean JobDao jobDao;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/observability/TestObservationRegistryConfig.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/observability/TestObservationRegistryConfig.java
@@ -1,6 +1,5 @@
 package org.databiosphere.workspacedataservice.observability;
 
-import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.tck.TestObservationRegistry;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -16,7 +15,7 @@ import org.springframework.context.annotation.Bean;
 @TestConfiguration
 public class TestObservationRegistryConfig {
   @Bean
-  ObservationRegistry testObservationRegistry() {
+  TestObservationRegistry testObservationRegistry() {
     return TestObservationRegistry.create();
   }
 }


### PR DESCRIPTION
In prep for introducing additional metrics in for [AJ-1726](https://broadworkbench.atlassian.net/browse/AJ-1726): Adds a `@WithTestObservationRegistry` to DRY up a bunch of the boilerplate involved with doing metric testing.

Specifically:
- Tests can directly `@Autowire TestObservationRegistry` instead of having to cast it.
- Tests don't need to manage teardown of the various meter and observation registries.

[AJ-1726]: https://broadworkbench.atlassian.net/browse/AJ-1726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ