### PR TITLE
AJ-1726 Add measurement to `processStatusUpdate`

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/QuartzSchedulerDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/QuartzSchedulerDao.java
@@ -3,7 +3,6 @@ package org.databiosphere.workspacedataservice.dao;
 import static org.quartz.TriggerBuilder.newTrigger;
 
 import org.databiosphere.workspacedataservice.shared.model.Schedulable;
-import org.quartz.JobBuilder;
 import org.quartz.JobDetail;
 import org.quartz.JobKey;
 import org.quartz.Scheduler;
@@ -23,17 +22,8 @@ public class QuartzSchedulerDao implements SchedulerDao {
   }
 
   public void schedule(Schedulable schedulable) {
-    JobKey jobKey = new JobKey(schedulable.getId(), schedulable.getGroup());
-
-    JobDetail jobDetail =
-        JobBuilder.newJob()
-            .ofType(schedulable.getImplementation())
-            .withIdentity(jobKey)
-            .setJobData(schedulable.getArgumentsAsJobDataMap())
-            .storeDurably(false) // delete from the quartz table after the job finishes
-            .withDescription(schedulable.getDescription())
-            .build();
-
+    JobDetail jobDetail = schedulable.getJobDetail();
+    JobKey jobKey = jobDetail.getKey();
     // tell Quartz to run the job: run only once, start immediately
     Trigger trigger = newTrigger().forJob(jobKey).startNow().build();
     try {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/jobexec/QuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/jobexec/QuartzJob.java
@@ -14,6 +14,7 @@ import org.databiosphere.workspacedataservice.service.MDCServletRequestListener;
 import org.quartz.Job;
 import org.quartz.JobDataMap;
 import org.quartz.JobExecutionContext;
+import org.quartz.JobKey;
 import org.slf4j.MDC;
 
 /**
@@ -50,7 +51,8 @@ public abstract class QuartzJob implements Job {
   @Override
   public void execute(JobExecutionContext context) throws org.quartz.JobExecutionException {
     // retrieve jobId
-    UUID jobId = UUID.fromString(context.getJobDetail().getKey().getName());
+    JobKey jobKey = context.getJobDetail().getKey();
+    UUID jobId = UUID.fromString(jobKey.getName());
 
     // (try to) set the MDC request id based on the originating thread
     propagateMdc(context);
@@ -58,7 +60,7 @@ public abstract class QuartzJob implements Job {
     Observation observation =
         Observation.start("wds.job.execute", observationRegistry)
             .contextualName("job-execution")
-            .lowCardinalityKeyValue("jobType", getClass().getSimpleName())
+            .lowCardinalityKeyValue("jobType", jobKey.getGroup())
             .highCardinalityKeyValue("jobId", jobId.toString());
     try {
       // mark this job as running

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
@@ -4,6 +4,7 @@ import static org.databiosphere.workspacedataservice.shared.model.Schedulable.AR
 import static org.databiosphere.workspacedataservice.shared.model.Schedulable.ARG_TOKEN;
 import static org.databiosphere.workspacedataservice.shared.model.Schedulable.ARG_URL;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
@@ -137,14 +138,15 @@ public class ImportService {
     }
   }
 
-  protected Schedulable createSchedulable(
+  @VisibleForTesting
+  public static Schedulable createSchedulable(
       ImportRequestServerModel.TypeEnum importType,
       UUID jobId,
       Map<String, Serializable> arguments) {
     return switch (importType) {
       case TDRMANIFEST -> new TdrManifestSchedulable(
           jobId.toString(), "TDR manifest import", arguments);
-      case PFB -> new PfbSchedulable(jobId.toString(), "TODO: PFB import", arguments);
+      case PFB -> new PfbSchedulable(jobId.toString(), "PFB import", arguments);
     };
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/JobService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/JobService.java
@@ -116,6 +116,8 @@ public class JobService {
             "Unexpected status from Rawls for job %s: %s".formatted(jobId, newStatus));
       }
     } catch (Exception e) {
+      // catchall for any exceptions that occur during the status update (including those explicitly
+      // thrown in the try block); in all such cases, mark the observation as having an error
       observation.error(e);
       if (e instanceof EmptyResultDataAccessException) {
         throw new MissingObjectException("Job");

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/Schedulable.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/Schedulable.java
@@ -1,9 +1,13 @@
 package org.databiosphere.workspacedataservice.shared.model;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.Serializable;
 import java.util.Map;
 import org.quartz.Job;
+import org.quartz.JobBuilder;
 import org.quartz.JobDataMap;
+import org.quartz.JobDetail;
+import org.quartz.JobKey;
 
 public class Schedulable {
 
@@ -36,29 +40,38 @@ public class Schedulable {
     this.arguments = arguments;
   }
 
+  @VisibleForTesting
   public String getGroup() {
     return group;
   }
 
+  @VisibleForTesting
   public String getId() {
     return id;
   }
 
+  @VisibleForTesting
   public String getDescription() {
     return description;
   }
 
+  @VisibleForTesting
   public Class<? extends Job> getImplementation() {
     return implementation;
   }
 
+  @VisibleForTesting
   public Map<String, Serializable> getArguments() {
     return arguments;
   }
 
-  public JobDataMap getArgumentsAsJobDataMap() {
-    JobDataMap jobDataMap = new JobDataMap();
-    jobDataMap.putAll(arguments);
-    return jobDataMap;
+  public JobDetail getJobDetail() {
+    return JobBuilder.newJob()
+        .ofType(getImplementation())
+        .withIdentity(new JobKey(id, group))
+        .setJobData(new JobDataMap(arguments))
+        .storeDurably(false) // delete from the quartz table after the job finishes
+        .withDescription(getDescription())
+        .build();
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobControlPlaneE2ETest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobControlPlaneE2ETest.java
@@ -299,7 +299,7 @@ class PfbQuartzJobControlPlaneE2ETest {
     // Arrange / Act
     ImmutableMap<String, String> successTags =
         new ImmutableMap.Builder<String, String>()
-            .put("jobType", "PfbQuartzJob")
+            .put("jobType", "PFB")
             .put("outcome", "RUNNING")
             .put("error", "none")
             .build();
@@ -316,8 +316,7 @@ class PfbQuartzJobControlPlaneE2ETest {
     assertMetric(metrics, "wds_job_execute_active_seconds_max", "0.0");
 
     // (counter) we should have counted one job.execute event regardless of outcome
-    assertMetric(
-        metrics, "wds_job_execute_job_running_total", "1.0", Map.of("jobType", "PfbQuartzJob"));
+    assertMetric(metrics, "wds_job_execute_job_running_total", "1.0", Map.of("jobType", "PFB"));
 
     // (counter) of job.execute events
     assertMetric(metrics, "wds_job_execute_seconds_count", "1.0", successTags);
@@ -335,7 +334,7 @@ class PfbQuartzJobControlPlaneE2ETest {
     // Arrange / Act
     ImmutableMap<String, String> failureTags =
         new ImmutableMap.Builder<String, String>()
-            .put("jobType", "PfbQuartzJob")
+            .put("jobType", "PFB")
             .put("outcome", "ERROR")
             .put("error", "RuntimeException")
             .build();
@@ -353,8 +352,7 @@ class PfbQuartzJobControlPlaneE2ETest {
     assertMetric(metrics, "wds_job_execute_active_seconds_max", "0.0");
 
     // (counter) we should have counted one job.execute event regardless of outcome
-    assertMetric(
-        metrics, "wds_job_execute_job_running_total", "1.0", Map.of("jobType", "PfbQuartzJob"));
+    assertMetric(metrics, "wds_job_execute_job_running_total", "1.0", Map.of("jobType", "PFB"));
 
     // (counter) of job.execute events
     assertMetric(metrics, "wds_job_execute_seconds_count", "1.0", failureTags);

--- a/service/src/test/java/org/databiosphere/workspacedataservice/jobexec/QuartzJobTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/jobexec/QuartzJobTest.java
@@ -144,7 +144,7 @@ class QuartzJobTest extends TestBase {
         .hasObservationWithNameEqualTo("wds.job.execute")
         .that()
         .hasHighCardinalityKeyValue("jobId", jobUuid)
-        .hasLowCardinalityKeyValue("jobType", "jobGroup")
+        .hasLowCardinalityKeyValue("jobType", "testJobType")
         .hasLowCardinalityKeyValue("outcome", StatusEnum.SUCCEEDED.getValue())
         .hasBeenStarted()
         .hasBeenStopped();
@@ -209,7 +209,7 @@ class QuartzJobTest extends TestBase {
         .hasObservationWithNameEqualTo("wds.job.execute")
         .that()
         .hasHighCardinalityKeyValue("jobId", jobUuid)
-        .hasLowCardinalityKeyValue("jobType", "jobGroup")
+        .hasLowCardinalityKeyValue("jobType", "testJobType")
         .hasLowCardinalityKeyValue("outcome", StatusEnum.ERROR.getValue())
         .hasBeenStarted()
         .hasBeenStopped()
@@ -247,7 +247,7 @@ class QuartzJobTest extends TestBase {
     when(mockContext.getMergedJobDataMap())
         .thenReturn(new JobDataMap(Map.of(ARG_TOKEN, randomToken)));
     JobDetailImpl jobDetail = new JobDetailImpl();
-    jobDetail.setKey(new JobKey(jobUuid, "jobGroup"));
+    jobDetail.setKey(new JobKey(jobUuid, "testJobType"));
     when(mockContext.getJobDetail()).thenReturn(jobDetail);
     return mockContext;
   }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/jobexec/QuartzJobTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/jobexec/QuartzJobTest.java
@@ -144,7 +144,7 @@ class QuartzJobTest extends TestBase {
         .hasObservationWithNameEqualTo("wds.job.execute")
         .that()
         .hasHighCardinalityKeyValue("jobId", jobUuid)
-        .hasLowCardinalityKeyValue("jobType", "TestableQuartzJob")
+        .hasLowCardinalityKeyValue("jobType", "jobGroup")
         .hasLowCardinalityKeyValue("outcome", StatusEnum.SUCCEEDED.getValue())
         .hasBeenStarted()
         .hasBeenStopped();
@@ -209,7 +209,7 @@ class QuartzJobTest extends TestBase {
         .hasObservationWithNameEqualTo("wds.job.execute")
         .that()
         .hasHighCardinalityKeyValue("jobId", jobUuid)
-        .hasLowCardinalityKeyValue("jobType", "TestableQuartzJob")
+        .hasLowCardinalityKeyValue("jobType", "jobGroup")
         .hasLowCardinalityKeyValue("outcome", StatusEnum.ERROR.getValue())
         .hasBeenStarted()
         .hasBeenStopped()
@@ -243,12 +243,11 @@ class QuartzJobTest extends TestBase {
 
   // sets up a job and returns the job context
   private JobExecutionContext setUpTestJob(String randomToken, String jobUuid) {
-    // String jobUuid = UUID.randomUUID().toString();
     JobExecutionContext mockContext = mock(JobExecutionContext.class);
     when(mockContext.getMergedJobDataMap())
         .thenReturn(new JobDataMap(Map.of(ARG_TOKEN, randomToken)));
     JobDetailImpl jobDetail = new JobDetailImpl();
-    jobDetail.setKey(new JobKey(jobUuid, "bar"));
+    jobDetail.setKey(new JobKey(jobUuid, "jobGroup"));
     when(mockContext.getJobDetail()).thenReturn(jobDetail);
     return mockContext;
   }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceTest.java
@@ -1,5 +1,6 @@
 package org.databiosphere.workspacedataservice.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.databiosphere.workspacedataservice.generated.ImportRequestServerModel.TypeEnum;
 import static org.databiosphere.workspacedataservice.shared.model.Schedulable.ARG_COLLECTION;
 import static org.databiosphere.workspacedataservice.shared.model.Schedulable.ARG_TOKEN;
@@ -103,7 +104,7 @@ class ImportServiceTest extends TestBase {
     UUID jobId = UUID.randomUUID();
     Map<String, Serializable> arguments = Map.of("foo", "bar", "twenty-three", 23);
 
-    Schedulable actual = importService.createSchedulable(importType, jobId, arguments);
+    Schedulable actual = ImportService.createSchedulable(importType, jobId, arguments);
 
     JobDataMap expectedJobDataMap = new JobDataMap();
     expectedJobDataMap.put("foo", "bar");
@@ -111,7 +112,8 @@ class ImportServiceTest extends TestBase {
 
     assertEquals(jobId.toString(), actual.getId());
     assertEquals(importType.name(), actual.getGroup());
-    assertEquals(expectedJobDataMap, actual.getArgumentsAsJobDataMap());
+
+    assertThat(actual.getJobDetail().getJobDataMap()).isEqualTo(expectedJobDataMap);
   }
 
   private static Stream<Arguments> provideImplementationClasses() {
@@ -126,7 +128,7 @@ class ImportServiceTest extends TestBase {
   void createSchedulableImplementationClasses(
       TypeEnum importType, Class<? extends Job> expectedClass) {
     UUID jobId = UUID.randomUUID();
-    Schedulable actual = importService.createSchedulable(importType, jobId, Map.of());
+    Schedulable actual = ImportService.createSchedulable(importType, jobId, Map.of());
     assertEquals(expectedClass, actual.getImplementation());
   }
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/JobServiceControlPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/JobServiceControlPlaneTest.java
@@ -50,7 +50,7 @@ import org.springframework.test.context.TestPropertySource;
       // Rawls url must be valid, else context initialization (Spring startup) will fail
       "rawlsUrl=https://localhost/"
     })
-class JobServiceControlPlaneTest extends JobServiceBaseTest {
+class JobServiceControlPlaneTest extends JobServiceTestBase {
 
   @Autowired JobService jobService;
   @MockBean JobDao jobDao;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/JobServiceDataPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/JobServiceDataPlaneTest.java
@@ -36,7 +36,7 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles(profiles = {"data-plane"})
 @DirtiesContext
 @SpringBootTest(properties = {"twds.instance.workspace-id=f01dab1e-0000-1111-2222-000011112222"})
-class JobServiceDataPlaneTest extends JobServiceBaseTest {
+class JobServiceDataPlaneTest extends JobServiceTestBase {
 
   @Autowired JobService jobService;
   @Autowired @SingleTenant WorkspaceId workspaceId;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/JobServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/JobServiceTest.java
@@ -39,10 +39,15 @@ import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles(
     profiles = {
-      "data-plane", // need _a_ profile even if this test only contains tests for common behavior
+      "control-plane", // need _a_ profile even if this test only contains tests for common behavior
     })
 @DirtiesContext
-@SpringBootTest(properties = {"twds.instance.workspace-id=f01dab1e-0000-1111-2222-000011112222"})
+@SpringBootTest(
+    properties = {
+      "spring.cloud.gcp.pubsub.enabled=false",
+      // Rawls url must be valid, else context initialization (Spring startup) will fail
+      "rawlsUrl=https://localhost/"
+    })
 @WithTestObservationRegistry
 class JobServiceTest extends JobServiceTestBase {
   @Autowired JobService jobService;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/JobServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/JobServiceTest.java
@@ -1,0 +1,134 @@
+package org.databiosphere.workspacedataservice.service;
+
+import static java.util.UUID.randomUUID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.UUID;
+import org.databiosphere.workspacedataservice.dao.JobDao;
+import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
+import org.databiosphere.workspacedataservice.generated.GenericJobServerModel.JobTypeEnum;
+import org.databiosphere.workspacedataservice.generated.GenericJobServerModel.StatusEnum;
+import org.databiosphere.workspacedataservice.pubsub.JobStatusUpdate;
+import org.databiosphere.workspacedataservice.service.model.exception.MissingObjectException;
+import org.databiosphere.workspacedataservice.service.model.exception.ValidationException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles(
+    profiles = {
+      "data-plane", // need _a_ profile even if this test only contains tests for common behavior
+    })
+@DirtiesContext
+@SpringBootTest(properties = {"twds.instance.workspace-id=f01dab1e-0000-1111-2222-000011112222"})
+public class JobServiceTest extends JobServiceTestBase {
+  @Autowired JobService jobService;
+  @MockBean JobDao jobDao;
+
+  @Test
+  void processJobStatusUpdateSuccess() {
+    // Arrange
+    UUID jobId = setupProcessJobStatusUpdateTest();
+
+    JobStatusUpdate update = new JobStatusUpdate(jobId, StatusEnum.RUNNING, StatusEnum.SUCCEEDED);
+
+    // Act
+    jobService.processStatusUpdate(update);
+
+    // Assert
+    verify(jobDao, times(1)).succeeded(jobId);
+  }
+
+  @Test
+  void processJobStatusUpdateError() {
+    // Arrange
+    UUID jobId = setupProcessJobStatusUpdateTest();
+
+    JobStatusUpdate update =
+        new JobStatusUpdate(jobId, StatusEnum.RUNNING, StatusEnum.ERROR, "Something went wrong");
+
+    // Act
+    jobService.processStatusUpdate(update);
+
+    // Assert
+    verify(jobDao, times(1)).fail(jobId, "Something went wrong");
+  }
+
+  @Test
+  void processJobStatusUpdateNoop() {
+    // Arrange
+    UUID jobId = setupProcessJobStatusUpdateTest();
+
+    JobStatusUpdate update = new JobStatusUpdate(jobId, StatusEnum.RUNNING, StatusEnum.RUNNING);
+
+    // Act
+    jobService.processStatusUpdate(update);
+
+    // Assert
+    verify(jobDao, never()).running(jobId);
+  }
+
+  @Test
+  void processJobStatusUpdateForTerminalJob() {
+    // Arrange
+    UUID jobId = setupProcessJobStatusUpdateTest(StatusEnum.SUCCEEDED);
+
+    JobStatusUpdate update = new JobStatusUpdate(jobId, StatusEnum.SUCCEEDED, StatusEnum.RUNNING);
+
+    // Act/Assert
+    ValidationException e =
+        assertThrows(ValidationException.class, () -> jobService.processStatusUpdate(update));
+
+    // Assert
+    assertEquals("Unable to update terminal status for job %s".formatted(jobId), e.getMessage());
+    verify(jobDao, never()).succeeded(jobId);
+  }
+
+  @Test
+  void processJobStatusUpdateForNonExistentJob() {
+    // Arrange
+    UUID jobId = randomUUID();
+    when(jobDao.getJob(jobId))
+        .thenThrow(new EmptyResultDataAccessException("unit test intentional error", 1));
+
+    JobStatusUpdate update = new JobStatusUpdate(jobId, StatusEnum.RUNNING, StatusEnum.SUCCEEDED);
+
+    // Act/Assert
+    assertThrows(MissingObjectException.class, () -> jobService.processStatusUpdate(update));
+
+    // Assert
+    verify(jobDao, never()).succeeded(jobId);
+  }
+
+  private UUID setupProcessJobStatusUpdateTest(StatusEnum initialStatus) {
+    UUID jobId = randomUUID();
+    // Job exists
+    GenericJobServerModel expectedJob =
+        new GenericJobServerModel(
+            jobId,
+            JobTypeEnum.DATA_IMPORT,
+            randomUUID(),
+            initialStatus,
+            // set created and updated to now, but in UTC because that's how Postgres stores it
+            OffsetDateTime.now(ZoneId.of("Z")),
+            OffsetDateTime.now(ZoneId.of("Z")));
+    when(jobDao.getJob(jobId)).thenReturn(expectedJob);
+
+    return jobId;
+  }
+
+  private UUID setupProcessJobStatusUpdateTest() {
+    return setupProcessJobStatusUpdateTest(StatusEnum.RUNNING);
+  }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/JobServiceTestBase.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/JobServiceTestBase.java
@@ -10,7 +10,7 @@ import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel.StatusEnum;
 import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 
-public abstract class JobServiceBaseTest {
+public abstract class JobServiceTestBase {
 
   List<String> allStatuses = Arrays.stream(StatusEnum.values()).map(StatusEnum::toString).toList();
 


### PR DESCRIPTION
For [AJ-1726](https://broadworkbench.atlassian.net/browse/AJ-1726):  Add measurement to `processStatusUpdate`.

Commits have been intentionally broken apart for easier review if needed.

Introduces two new measures:
- `wds.job.update` is the time it takes to update a job in the database
- `wds.job.elapsed` is the time elapsed since the job was created

Also changes the `jobType` label values of the existing `wds.job.execute` measurement to use the value from `JobKey` so that all the `wds.job` metrics are keyed the same way.



[AJ-1726]: https://broadworkbench.atlassian.net/browse/AJ-1726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ