### PR TITLE
AJ-1727 Measure outbound requests in `RestClientRetry`

### DIFF
--- a/service/src/test/java/org/databiosphere/workspacedataservice/leonardo/LeonardoDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/leonardo/LeonardoDaoTest.java
@@ -18,7 +18,6 @@ import org.broadinstitute.dsde.workbench.client.leonardo.model.AppType;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.AuditInfo;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.ListAppResponse;
 import org.databiosphere.workspacedataservice.common.TestBase;
-import org.databiosphere.workspacedataservice.retry.RestClientRetry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,7 +28,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 
 @DirtiesContext
-@SpringBootTest(classes = {LeonardoConfig.class, RestClientRetry.class})
+@SpringBootTest
 @TestPropertySource(
     properties = {"twds.instance.workspace-id=90e1b179-9f83-4a6f-a8c2-db083df4cd03"})
 class LeonardoDaoTest extends TestBase {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/pact/SamPactTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/pact/SamPactTest.java
@@ -12,6 +12,7 @@ import au.com.dius.pact.consumer.junit5.PactTestFor;
 import au.com.dius.pact.core.model.PactSpecVersion;
 import au.com.dius.pact.core.model.RequestResponsePact;
 import au.com.dius.pact.core.model.annotations.Pact;
+import io.micrometer.observation.tck.TestObservationRegistry;
 import java.util.Map;
 import org.broadinstitute.dsde.workbench.client.sam.model.SystemStatus;
 import org.databiosphere.workspacedataservice.retry.RestClientRetry;
@@ -261,12 +262,15 @@ class SamPactTest {
   }
 
   private SamDao getSamDao(MockServer mockServer) {
-    return new HttpSamDao(new HttpSamClientFactory(mockServer.getUrl()), new RestClientRetry());
+    return new HttpSamDao(
+        new HttpSamClientFactory(mockServer.getUrl()),
+        new RestClientRetry(TestObservationRegistry.create()));
   }
 
   private SamAuthorizationDaoFactory samAuthorizationDaoFactory(MockServer mockServer) {
     return new SamAuthorizationDaoFactory(
-        new HttpSamClientFactory(mockServer.getUrl()), new RestClientRetry());
+        new HttpSamClientFactory(mockServer.getUrl()),
+        new RestClientRetry(TestObservationRegistry.create()));
   }
 
   private WorkspaceId dummyWorkspaceId() {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/pact/WsmPactTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/pact/WsmPactTest.java
@@ -22,6 +22,7 @@ import bio.terra.workspace.model.CloningInstructionsEnum;
 import bio.terra.workspace.model.ResourceType;
 import bio.terra.workspace.model.StewardshipType;
 import com.google.common.collect.ImmutableMap;
+import io.micrometer.observation.tck.TestObservationRegistry;
 import java.util.Arrays;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
@@ -547,7 +548,8 @@ class WsmPactTest {
   private static WorkspaceManagerDao buildWsmDao(MockServer mockServer) {
     WorkspaceManagerClientFactory clientFactory =
         new HttpWorkspaceManagerClientFactory(mockServer.getUrl());
-    return new WorkspaceManagerDao(clientFactory, new RestClientRetry());
+    return new WorkspaceManagerDao(
+        clientFactory, new RestClientRetry(TestObservationRegistry.create()));
   }
 
   // headers

--- a/service/src/test/java/org/databiosphere/workspacedataservice/retry/RestClientRetryTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/retry/RestClientRetryTest.java
@@ -81,7 +81,7 @@ class RestClientRetryTest extends TestBase {
     int code = 401;
     Exception apiException =
         clazz.getDeclaredConstructor(int.class, String.class).newInstance(code, "");
-    RestCall<Boolean> RestCall =
+    RestCall<Boolean> restCall =
         () -> {
           throw apiException;
         };
@@ -91,8 +91,8 @@ class RestClientRetryTest extends TestBase {
         };
     assertThrows(
         AuthenticationException.class,
-        () -> restClientRetry.withRetryAndErrorHandling(RestCall, "AuthenticationException"),
-        "RestCall should throw AuthenticationException");
+        () -> restClientRetry.withRetryAndErrorHandling(restCall, "AuthenticationException"),
+        "restCall should throw AuthenticationException");
     assertThrows(
         AuthenticationException.class,
         () -> restClientRetry.withRetryAndErrorHandling(voidRestCall, "AuthenticationException"),
@@ -111,7 +111,7 @@ class RestClientRetryTest extends TestBase {
     int code = 403;
     Exception apiException =
         clazz.getDeclaredConstructor(int.class, String.class).newInstance(code, "");
-    RestCall<Boolean> RestCall =
+    RestCall<Boolean> restCall =
         () -> {
           throw apiException;
         };
@@ -121,8 +121,8 @@ class RestClientRetryTest extends TestBase {
         };
     assertThrows(
         AuthorizationException.class,
-        () -> restClientRetry.withRetryAndErrorHandling(RestCall, "AuthorizationException"),
-        "RestCall should throw AuthorizationException");
+        () -> restClientRetry.withRetryAndErrorHandling(restCall, "AuthorizationException"),
+        "restCall should throw AuthorizationException");
     assertThrows(
         AuthorizationException.class,
         () -> restClientRetry.withRetryAndErrorHandling(voidRestCall, "AuthorizationException"),
@@ -133,7 +133,7 @@ class RestClientRetryTest extends TestBase {
       "When REST target throws a NullPointerException, restClientRetry should throw RestException(500)")
   @Test
   void nullPointerException() {
-    RestCall<Boolean> RestCall =
+    RestCall<Boolean> restCall =
         () -> {
           throw new NullPointerException();
         };
@@ -141,7 +141,7 @@ class RestClientRetryTest extends TestBase {
         () -> {
           throw new NullPointerException();
         };
-    expectRestExceptionWithStatusCode(500, RestCall);
+    expectRestExceptionWithStatusCode(500, restCall);
     expectRestExceptionWithStatusCode(500, voidRestCall);
   }
 
@@ -149,7 +149,7 @@ class RestClientRetryTest extends TestBase {
       "When REST target throws a RuntimeException, restClientRetry should throw RestException(500)")
   @Test
   void runtimeException() {
-    RestCall<Boolean> RestCall =
+    RestCall<Boolean> restCall =
         () -> {
           throw new RuntimeException();
         };
@@ -157,7 +157,7 @@ class RestClientRetryTest extends TestBase {
         () -> {
           throw new RuntimeException();
         };
-    expectRestExceptionWithStatusCode(500, RestCall);
+    expectRestExceptionWithStatusCode(500, restCall);
     expectRestExceptionWithStatusCode(500, voidRestCall);
   }
 
@@ -173,7 +173,7 @@ class RestClientRetryTest extends TestBase {
           IllegalAccessException {
     Exception apiException =
         clazz.getDeclaredConstructor(int.class, String.class).newInstance(code, "");
-    RestCall<Boolean> RestCall =
+    RestCall<Boolean> restCall =
         () -> {
           throw apiException;
         };
@@ -181,7 +181,7 @@ class RestClientRetryTest extends TestBase {
         () -> {
           throw apiException;
         };
-    expectRestExceptionWithStatusCode(500, RestCall);
+    expectRestExceptionWithStatusCode(500, restCall);
     expectRestExceptionWithStatusCode(500, voidRestCall);
   }
 
@@ -198,7 +198,7 @@ class RestClientRetryTest extends TestBase {
     Exception apiException =
         clazz.getDeclaredConstructor(int.class, String.class).newInstance(code, "");
 
-    RestCall<Boolean> RestCall =
+    RestCall<Boolean> restCall =
         () -> {
           throw apiException;
         };
@@ -206,7 +206,7 @@ class RestClientRetryTest extends TestBase {
         () -> {
           throw apiException;
         };
-    expectRestExceptionWithStatusCode(code, RestCall);
+    expectRestExceptionWithStatusCode(code, restCall);
     expectRestExceptionWithStatusCode(code, voidRestCall);
   }
 
@@ -222,7 +222,7 @@ class RestClientRetryTest extends TestBase {
     Exception apiException =
         clazz.getDeclaredConstructor(int.class, String.class).newInstance(code, "");
 
-    RestCall<Boolean> RestCall =
+    RestCall<Boolean> restCall =
         () -> {
           counter.incrementAndGet();
           throw apiException;
@@ -231,10 +231,10 @@ class RestClientRetryTest extends TestBase {
     // this test doesn't care what exception is thrown; other tests verify that
     assertThrows(
         Exception.class,
-        () -> restClientRetry.withRetryAndErrorHandling(RestCall, "retryableExceptions"));
+        () -> restClientRetry.withRetryAndErrorHandling(restCall, "retryableExceptions"));
     // with current settings, will retry 5 times. Any retry means we'll have more than
     // one invocation.
-    assertTrue(counter.get() > 1, "RestCall should have retried");
+    assertTrue(counter.get() > 1, "restCall should have retried");
 
     // reset counter
     counter.set(0);
@@ -250,7 +250,7 @@ class RestClientRetryTest extends TestBase {
         () -> restClientRetry.withRetryAndErrorHandling(voidRestCall, "retryableExceptions"));
     // with current settings, will retry 5 times. Any retry means we'll have more than
     // one invocation.
-    assertTrue(counter.get() > 1, "VoidRestCall should have retried");
+    assertTrue(counter.get() > 1, "voidRestCall should have retried");
   }
 
   @CartesianTest(
@@ -267,7 +267,7 @@ class RestClientRetryTest extends TestBase {
     Exception apiException =
         clazz.getDeclaredConstructor(int.class, String.class).newInstance(code, "");
 
-    RestCall<Boolean> RestCall =
+    RestCall<Boolean> restCall =
         () -> {
           counter.incrementAndGet();
           throw apiException;
@@ -276,9 +276,9 @@ class RestClientRetryTest extends TestBase {
     // this test doesn't care what exception is thrown; other tests verify that
     assertThrows(
         Exception.class,
-        () -> restClientRetry.withRetryAndErrorHandling(RestCall, "retryableExceptions"));
+        () -> restClientRetry.withRetryAndErrorHandling(restCall, "retryableExceptions"));
     // this test does care how many times the RestCall was invoked
-    assertEquals(1, counter.get(), "RestCall should not have retried");
+    assertEquals(1, counter.get(), "restCall should not have retried");
 
     // reset counter
     counter.set(0);
@@ -293,20 +293,20 @@ class RestClientRetryTest extends TestBase {
         Exception.class,
         () -> restClientRetry.withRetryAndErrorHandling(voidRestCall, "retryableExceptions"));
     // this test does care how many times the RestCall was invoked
-    assertEquals(1, counter.get(), "VoidRestCall should not have retried");
+    assertEquals(1, counter.get(), "voidRestCall should not have retried");
   }
 
-  private void expectRestExceptionWithStatusCode(int expectedStatusCode, RestCall<?> RestCall) {
+  private void expectRestExceptionWithStatusCode(int expectedStatusCode, RestCall<?> restCall) {
     RestException actual =
         assertThrows(
             RestException.class,
-            () -> restClientRetry.withRetryAndErrorHandling(RestCall, "RestCall-unittest"),
-            "RestCall should throw RestException");
+            () -> restClientRetry.withRetryAndErrorHandling(restCall, "RestCall-unittest"),
+            "restCall should throw RestException");
 
     assertEquals(
         expectedStatusCode,
         actual.getStatusCode().value(),
-        "RestCall: Incorrect status code in RestException");
+        "restCall: Incorrect status code in RestException");
   }
 
   private void expectRestExceptionWithStatusCode(

--- a/service/src/test/java/org/databiosphere/workspacedataservice/workspacemanager/WorkspaceManagerDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/workspacemanager/WorkspaceManagerDaoTest.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.UUID;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.databiosphere.workspacedataservice.common.TestBase;
-import org.databiosphere.workspacedataservice.retry.RestClientRetry;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -38,7 +37,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles(profiles = "mock-sam")
-@SpringBootTest(classes = {WorkspaceManagerConfig.class, RestClientRetry.class})
+@SpringBootTest
 @DirtiesContext
 class WorkspaceManagerDaoTest extends TestBase {
 


### PR DESCRIPTION
[AJ-1727](https://broadworkbench.atlassian.net/browse/AJ-1727): Add `wds.outbound` observation

This will measure count & latency for outbound requests, using the `loggerHint` as a label.

[AJ-1727]: https://broadworkbench.atlassian.net/browse/AJ-1727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ