### PR TITLE
AJ-1743 Update bee-create

### DIFF
--- a/.github/actions/create-bee/action.yml
+++ b/.github/actions/create-bee/action.yml
@@ -24,5 +24,6 @@ runs:
           { 
           "bee-name": "${{ inputs.bee_name }}", 
           "bee-template-name": "rawls-e2e-azure-tests", 
-          "version-template": "dev" 
+          "version-template": "dev",
+          "default-versions-only": true
           }


### PR DESCRIPTION
Per [this slack thread](https://broadinstitute.slack.com/archives/C0DSD41QT/p1712771051205049), the `default-versions-only: true` parameter will be needed on bee-create workflows (since we don't use `custom-versions-json`)

Reminder:

PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 
