### PR TITLE
AJ-1571: Make `workspace-id` non-positional.

### DIFF
--- a/smoke_test/README.md
+++ b/smoke_test/README.md
@@ -55,28 +55,33 @@ tests.
 
 next, run tests.
 
-syntax: python smoke_test.py {CWDS_HOST} {WORKSPACE_ID} $(gcloud auth print-access-token)
+syntax: python smoke_test.py {CWDS_HOST} $(gcloud auth print-access-token) --workspace-id {WORKSPACE_ID}
 
 example to run tests against dev:
 
-```python smoke_test.py cwds.dsde-dev.broadinstitute.org 1df7c7c1-ce85-4dc3-8539-4766896821bb $(gcloud auth print-access-token)```
+```python smoke_test.py cwds.dsde-dev.broadinstitute.org $(gcloud auth print-access-token) --workspace-id 1df7c7c1-ce85-4dc3-8539-4766896821bb```
 _(you can replace the provided workspace uuid with any real GCP workspace's uuid)_
 
 ### To run the orchestration integration tests:
 
-syntax: python smoke_test.py {CWDS_HOST} \
-  {WORKSPACE_ID} $(gcloud auth print-access-token) \
-  --orchestration-host {ORCHESTRATION_HOST} \
+syntax:
+```
+python smoke_test.py {CWDS_HOST} \
+  $(gcloud auth print-access-token) \
+  --workspace-id {WORKSPACE_ID} \
   --workspace-namespace {NAMESPACE} \
-  --workspace-name {NAME}
+  --workspace-name {NAME} \
+  --orchestration-host {ORCHESTRATION_HOST}
+```
 
 example to run tests against dev:
 ```
 python smoke_test.py https://cwds.dsde-dev.broadinstitute.org/ \
-	1df7c7c1-ce85-4dc3-8539-4766896821bb $(gcloud auth print-access-token) \
-	--orchestration-host https://firecloud-orchestration.dsde-dev.broadinstitute.org/ \
-	--workspace-namespace general-dev-billing-account \
-	--workspace-name cwds-smoketest-do-not-delete
+  $(gcloud auth print-access-token) \
+  --workspace-id 1df7c7c1-ce85-4dc3-8539-4766896821bb \
+  --workspace-namespace general-dev-billing-account \
+  --workspace-name cwds-smoketest-do-not-delete \
+  --orchestration-host https://firecloud-orchestration.dsde-dev.broadinstitute.org/
 ```
 
 ## Required and Optional Arguments
@@ -99,10 +104,10 @@ and this is the default if no protocol is specified:
 Optional - A `gcloud` access token. If present, `smoke_test.py` will execute all unauthenticated
 tests as well as all authenticated tests using the access token provided in this argument.
 
-### --orchestration-host
+### --workspace-id
 
-Optional - Can be just a domain or a domain and port, similar to CWDS_HOST, but should point to an
-orchestration backend. Omitting this will cause the orchestration tests to be skipped.
+Optional - A GCP workspace ID. If present along with a user-token, `smoke_test.py` will execute all
+authenticated tests in addition to unautheticated tests.
 
 ### --workspace-namespace
 
@@ -116,7 +121,12 @@ Optional - The name of the workspace to be used in the orchestration integration
 will cause the orchestration tests to be skipped. This should be the name of the workspace
 identified by the WORKSPACE_ID parameter.
 
-### Verbosity
+### --orchestration-host
+
+Optional - Can be just a domain or a domain and port, similar to CWDS_HOST, but should point to an
+orchestration backend. Omitting this will cause the orchestration tests to be skipped.
+
+### --verbosity
 
 Optional - You may control how much information is printed to `STDOUT` while running the smoke tests
 by passing a verbosity argument to `smoke_test.py`. For example to print more information about the

--- a/smoke_test/smoke_test.py
+++ b/smoke_test/smoke_test.py
@@ -89,15 +89,11 @@ if __name__ == "__main__":
   1: Minimal - (default) Prints number of tests executed plus a dot for each success and an F for each failure
   2: Verbose - Help string and its result will be printed for each test"""
   )
+  # Note: CWDS_HOST & user_token are positional for compatibility with:
+  # https://github.com/broadinstitute/terra-github-workflows/blob/main/.github/actions/run-smoke-tests/action.yaml
   parser.add_argument(
     "CWDS_HOST",
     help="domain with optional port number of the cWDS host you want to test"
-  )
-  parser.add_argument(
-    "workspace_id",
-    nargs='?',
-    default=None,
-    help="Optional; workspace id against which tests run. If this and user_token are present, enables additional tests."
   )
   parser.add_argument(
     "user_token",
@@ -106,9 +102,9 @@ if __name__ == "__main__":
     help="Optional; auth token for authenticated tests. If this and workspace_id are present, enables additional tests."
   )
   parser.add_argument(
-    "--orchestration-host",
+    "--workspace-id",
     default=None,
-    help="Optional; domain with optional port number of the orchestration host you want to test."
+    help="Optional; workspace id against which tests run. If this and user_token are present, enables additional tests."
   )
   parser.add_argument(
     "--workspace-namespace",
@@ -119,6 +115,11 @@ if __name__ == "__main__":
     "--workspace-name",
     default=None,
     help="Optional; workspace name against which orchestration tests run. Required for orchestration tests to run."
+  )
+  parser.add_argument(
+    "--orchestration-host",
+    default=None,
+    help="Optional; domain with optional port number of the orchestration host you want to test."
   )
 
   args = parser.parse_args()


### PR DESCRIPTION
Paired with: https://github.com/broadinstitute/terra-github-workflows/pull/186

This fixes a broken smoke-test that [failed](https://github.com/broadinstitute/terra-github-workflows/actions/runs/8637719883/job/23680564602) due to sensitivity to positional arguments.