### PR TITLE
AJ-1743 fix WSM pact

### DIFF
--- a/service/src/test/java/org/databiosphere/workspacedataservice/pact/WsmPactTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/pact/WsmPactTest.java
@@ -180,8 +180,8 @@ class WsmPactTest {
                         /* minSize= */ 1,
                         /* maxSize= */ 3,
                         p -> {
-                          p.stringValue("key", WorkspaceManagerDao.PROP_PURPOSE);
-                          p.stringValue("value", WorkspaceManagerDao.PURPOSE_POLICY);
+                          p.stringValue(
+                              WorkspaceManagerDao.PROP_PURPOSE, WorkspaceManagerDao.PURPOSE_POLICY);
                         });
                   });
             })
@@ -384,8 +384,9 @@ class WsmPactTest {
                                       /* minSize= */ 1,
                                       /* maxSize= */ 3,
                                       p -> {
-                                        p.stringValue("key", WorkspaceManagerDao.PROP_PURPOSE);
-                                        p.stringValue("value", WorkspaceManagerDao.PURPOSE_POLICY);
+                                        p.stringValue(
+                                            WorkspaceManagerDao.PROP_PURPOSE,
+                                            WorkspaceManagerDao.PURPOSE_POLICY);
                                       });
                                 });
                             resource.object(

--- a/service/src/test/java/org/databiosphere/workspacedataservice/pact/WsmPactTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/pact/WsmPactTest.java
@@ -178,7 +178,7 @@ class WsmPactTest {
                     metadata.minMaxArrayLike(
                         "properties",
                         /* minSize= */ 1,
-                        /* maxSize= */ 3,
+                        /* maxSize= */ 1,
                         p -> {
                           p.stringValue(
                               WorkspaceManagerDao.PROP_PURPOSE, WorkspaceManagerDao.PURPOSE_POLICY);
@@ -382,7 +382,7 @@ class WsmPactTest {
                                   metadata.minMaxArrayLike(
                                       "properties",
                                       /* minSize= */ 1,
-                                      /* maxSize= */ 3,
+                                      /* maxSize= */ 1,
                                       p -> {
                                         p.stringValue(
                                             WorkspaceManagerDao.PROP_PURPOSE,

--- a/service/src/test/java/org/databiosphere/workspacedataservice/pact/WsmPactTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/pact/WsmPactTest.java
@@ -175,13 +175,14 @@ class WsmPactTest {
                         "cloningInstructions", CloningInstructionsEnum.REFERENCE.toString());
                     metadata.datetime("name", nameFormatString);
                     // expect exactly one property, declaring the snapshot as being for policy only
-                    metadata.minMaxArrayLike(
+                    metadata.array(
                         "properties",
-                        /* minSize= */ 1,
-                        /* maxSize= */ 1,
-                        p -> {
-                          p.stringValue(
-                              WorkspaceManagerDao.PROP_PURPOSE, WorkspaceManagerDao.PURPOSE_POLICY);
+                        a -> {
+                          a.object(
+                              p -> {
+                                p.stringValue("key", WorkspaceManagerDao.PROP_PURPOSE);
+                                p.stringValue("value", WorkspaceManagerDao.PURPOSE_POLICY);
+                              });
                         });
                   });
             })

--- a/service/src/test/java/org/databiosphere/workspacedataservice/pact/WsmPactTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/pact/WsmPactTest.java
@@ -384,9 +384,8 @@ class WsmPactTest {
                                       /* minSize= */ 1,
                                       /* maxSize= */ 1,
                                       p -> {
-                                        p.stringValue(
-                                            WorkspaceManagerDao.PROP_PURPOSE,
-                                            WorkspaceManagerDao.PURPOSE_POLICY);
+                                        p.stringValue("key", WorkspaceManagerDao.PROP_PURPOSE);
+                                        p.stringValue("value", WorkspaceManagerDao.PURPOSE_POLICY);
                                       });
                                 });
                             resource.object(

--- a/service/src/test/java/org/databiosphere/workspacedataservice/pact/WsmPactTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/pact/WsmPactTest.java
@@ -178,7 +178,7 @@ class WsmPactTest {
                     metadata.minMaxArrayLike(
                         "properties",
                         /* minSize= */ 1,
-                        /* maxSize= */ 1,
+                        /* maxSize= */ 3,
                         p -> {
                           p.stringValue("key", WorkspaceManagerDao.PROP_PURPOSE);
                           p.stringValue("value", WorkspaceManagerDao.PURPOSE_POLICY);
@@ -382,7 +382,7 @@ class WsmPactTest {
                                   metadata.minMaxArrayLike(
                                       "properties",
                                       /* minSize= */ 1,
-                                      /* maxSize= */ 1,
+                                      /* maxSize= */ 3,
                                       p -> {
                                         p.stringValue("key", WorkspaceManagerDao.PROP_PURPOSE);
                                         p.stringValue("value", WorkspaceManagerDao.PURPOSE_POLICY);


### PR DESCRIPTION
The pact between WSM and WDS is [failing](https://pact-broker.dsp-eng-tools.broadinstitute.org/hal-browser/browser.html#/pacts/provider/workspacemanager/consumer/wds/pact-version/2cebab3d7090679e5aa97b996cfc47f0db59e748/verification-results/10305).  I see the message "Expected [{\"key\":\"key\",\"value\":\"purpose\"}, {\"key\":\"value\",\"value\":\"policy\"}] to have maximum 1", Attempting to fix that.

Reminder:

#### Releasing WDS ####
PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag-and-publish.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 

#### Keeping Docs Up To Date ####
If you make changes to the github actions or workflows, particularly when they are run or which other workflows they call, please update [the GHA wiki page](https://github.com/DataBiosphere/terra-workspace-data-service/wiki/GHA-structure-in-WDS) to stay up to date.
