### PR TITLE
AJ-1671: Tomcat should use relative redirects

### DIFF
--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -118,6 +118,8 @@ server:
   error:
     include-stacktrace: never
     include-message: always
+  tomcat:
+    use-relative-redirects: true
 
 twds:
   write.batch.size: 5000

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -119,6 +119,7 @@ server:
     include-stacktrace: never
     include-message: always
   tomcat:
+    # relative redirects fix issues redirecting to swagger-ui in BEEs
     use-relative-redirects: true
 
 twds:


### PR DESCRIPTION
AJ-1671

The redirect from `/` to `/swagger/swagger-ui.html` was not working in BEEs; cWDS got confused about to where it should redirect because of proxies in BEEs.

This PR tells Tomcat to use relative urls when issuing redirects, which fixes the issue. I tested by running locally and by deploying this PR to my BEE: https://cwds.davidan-cool-bee-name.bee.envs-terra.bio/
