### PR TITLE
AJ-1776: use real commit SHA for tagging PR builds

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -43,6 +43,7 @@ jobs:
           echo "github.ref: ${{ github.ref }}"
           echo "github.ref_name: ${{ github.ref_name }}"
           echo "github.sha: ${{ github.sha }}"
+          echo "github.event.pull_request.head.sha: ${{ github.event.pull_request.head.sha }}"
 
       - name: Set commit short hash
         id: setHash

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -44,6 +44,7 @@ jobs:
           echo "github.ref_name: ${{ github.ref_name }}"
           echo "github.sha: ${{ github.sha }}"
           echo "github.event.pull_request.head.sha: ${{ github.event.pull_request.head.sha }}"
+          echo "github.event.pull_request.head: ${{ toJSON(github.event.pull_request.head) }}"
 
       - name: Set commit short hash
         id: setHash

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -35,6 +35,15 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
+      - name: Short hash experiments
+        id: shortHashExperiments
+        run: |
+          echo "github.base_ref: ${{ github.base_ref }}"
+          echo "github.head_ref: ${{ github.head_ref }}"
+          echo "github.ref: ${{ github.ref }}"
+          echo "github.ref_name: ${{ github.ref_name }}"
+          echo "github.sha: ${{ github.sha }}"
+
       - name: Set commit short hash
         id: setHash
         run: |

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -38,6 +38,11 @@ jobs:
       - name: Short hash experiments
         id: shortHashExperiments
         run: |
+          # full sha for PRs
+
+          git_short_sha=$(echo ${{ github.event.pull_request.head.sha || github.sha}} | cut -c1-7)
+          echo "git_short_sha: ${{ git_short_sha }}"
+
           echo "github.base_ref: ${{ github.base_ref }}"
           echo "github.head_ref: ${{ github.head_ref }}"
           echo "github.ref: ${{ github.ref }}"

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -35,26 +35,12 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
-      - name: Short hash experiments
-        id: shortHashExperiments
-        run: |
-          # full sha for PRs
-
-          git_short_sha=$(echo ${{ github.event.pull_request.head.sha || github.sha}} | cut -c1-7)
-          echo "git_short_sha: $git_short_sha"
-
-          echo "github.base_ref: ${{ github.base_ref }}"
-          echo "github.head_ref: ${{ github.head_ref }}"
-          echo "github.ref: ${{ github.ref }}"
-          echo "github.ref_name: ${{ github.ref_name }}"
-          echo "github.sha: ${{ github.sha }}"
-          echo "github.event.pull_request.head.sha: ${{ github.event.pull_request.head.sha }}"
-          echo "github.event.pull_request.head: ${{ toJSON(github.event.pull_request.head) }}"
-
       - name: Set commit short hash
         id: setHash
+        # github.event.pull_request.head.sha is the latest commit for a pull request
+        # github.sha is the latest commit for a merge to main (but is the merge commit on PRs)
         run: |
-          git_short_sha=$(git rev-parse --short HEAD)
+          git_short_sha=$(echo ${{ github.event.pull_request.head.sha || github.sha }} | cut -c1-7)
           echo $git_short_sha
           echo "git_short_sha=${git_short_sha}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set commit short hash
         id: setHash
         # github.event.pull_request.head.sha is the latest commit for a pull request
-        # github.sha is the latest commit for a merge to main (but is the merge commit on PRs)
+        # github.sha is the latest commit for a push to main (but is the merge commit on PRs)
         run: |
           git_short_sha=$(echo ${{ github.event.pull_request.head.sha || github.sha }} | cut -c1-7)
           echo $git_short_sha

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -41,7 +41,7 @@ jobs:
           # full sha for PRs
 
           git_short_sha=$(echo ${{ github.event.pull_request.head.sha || github.sha}} | cut -c1-7)
-          echo "git_short_sha: ${{ git_short_sha }}"
+          echo "git_short_sha: $git_short_sha"
 
           echo "github.base_ref: ${{ github.base_ref }}"
           echo "github.head_ref: ${{ github.head_ref }}"


### PR DESCRIPTION
When publishing docker images / reporting to Sherlock on PRs, use the SHA from the latest PR commit instead of the SHA or the merge commit. This makes it much easier to correlate image tags/Sherlock versions with your PR.

Check out the actions that ran on this PR, especially `report-to-sherlock`, and compare to the list of commits in this PR.