### PR TITLE
[AJ-1782] Automatically tag Dependabot PRs with ticket

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     open-pull-requests-limit: 10
     reviewers:
       - "@DataBiosphere/analysisjourneys"
+    commit-message:
+      prefix: "[AJ-1782]"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1782

Automatically tag Dependabot PRs with the permanent Jira ticket for WDS dependency updates.