### PR TITLE
[AJ-1639] Configure Dependabot to update java-pfb

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,8 @@
 version: 2
+registries:
+  broad-artifactory:
+    type: maven-repository
+    url: https://broadinstitute.jfrog.io/artifactory/libs-release
 updates:
   - package-ecosystem: "gradle"
     directory: "/"
@@ -21,3 +25,23 @@ updates:
         update-types:
           - "minor"
           - "patch"
+  - package-ecosystem: "gradle"
+    registries:
+      - "broad-artifactory"
+    directory: "/"
+    labels:
+      - "dependencies"
+      - "gradle"
+    reviewers:
+      - "@DataBiosphere/analysisjourneys"
+    commit-message:
+      prefix: "[AJ-1782]"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "America/New_York"
+    groups:
+      java-pfb:
+        patterns:
+          - "bio.terra:java-pfb-library"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,9 +27,6 @@ updates:
         update-types:
           - "minor"
           - "patch"
-      java-pfb:
-        patterns:
-          - "bio.terra:java-pfb-library"
   - package-ecosystem: "github-actions"
     directory: "/"
     labels:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ registries:
     url: https://broadinstitute.jfrog.io/artifactory/libs-release
 updates:
   - package-ecosystem: "gradle"
+    registries:
+      - "broad-artifactory"
     directory: "/"
     labels:
       - "dependencies"
@@ -25,23 +27,6 @@ updates:
         update-types:
           - "minor"
           - "patch"
-  - package-ecosystem: "gradle"
-    registries:
-      - "broad-artifactory"
-    directory: "/"
-    labels:
-      - "dependencies"
-      - "gradle"
-    reviewers:
-      - "@DataBiosphere/analysisjourneys"
-    commit-message:
-      prefix: "[AJ-1782]"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "08:00"
-      timezone: "America/New_York"
-    groups:
       java-pfb:
         patterns:
           - "bio.terra:java-pfb-library"


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1639

Experimenting to see if we can have Dependabot update java-pfb in WDS.

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/guidance-for-the-configuration-of-private-registries-for-dependabot