### PR TITLE
[AJ-1692] Auto approve Dependabot PRs

### DIFF
--- a/.github/workflows/auto-approve-dependabot-prs.yml
+++ b/.github/workflows/auto-approve-dependabot-prs.yml
@@ -1,0 +1,21 @@
+name: Dependabot auto-approve
+on: pull_request
+
+permissions:
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Approve a PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1692

Have Dependabot auto approve its PRs so that only one human is needed to meet the two thumbs requirement.

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#approve-a-pull-request