### PR TITLE
[AJ-1782] Group updates to artifact actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,3 +36,8 @@ updates:
       day: "monday"
       time: "08:00"
       timezone: "America/New_York"
+    groups:
+      artifact-actions:
+        patterns:
+          - "actions/upload-artifact"
+          - "actions/download-artifact"


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1782

Workflows using these actions failed when one was updated, but not the other. This configures Dependabot to update them as a group.