### PR TITLE
[AJ-1786] Change consumer Pacticipant name to cwds for Rawls Pact

### DIFF
--- a/.github/workflows/publish-pacts.yml
+++ b/.github/workflows/publish-pacts.yml
@@ -178,21 +178,24 @@ jobs:
             "repo-branch": "${{ needs.init-github-context.outputs.repo-branch }}",
             "release-tag": "${{ needs.regulated-tag-job.outputs.new-tag }}"
           }'
-      
+
   can-i-deploy: # The can-i-deploy job will run as a result of a PR. It reports the pact verification statuses on all deployed environments.
     runs-on: ubuntu-latest
     needs: [ run-consumer-contract-tests, regulated-tag-job ]
+    strategy:
+      matrix:
+        pacticipant-name: ["wds", "cwds"]
     steps:
       - name: Dispatch to terra-github-workflows
         uses: broadinstitute/workflow-dispatch@v4.0.0
         with:
-          run-name: "${{ env.CAN_I_DEPLOY_RUN_NAME }}"
+          run-name: "${{ env.CAN_I_DEPLOY_RUN_NAME }}-${{ matrix.pacticipant-name }}"
           workflow: .github/workflows/can-i-deploy.yaml
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
           inputs: '{
-            "run-name": "${{ env.CAN_I_DEPLOY_RUN_NAME }}",
-            "pacticipant": "wds",
+            "run-name": "${{ env.CAN_I_DEPLOY_RUN_NAME }}-${{ matrix.pacticipant-name }}",
+            "pacticipant": "${{ matrix.pacticipant-name }}",
             "version": "${{ needs.regulated-tag-job.outputs.new-tag }}"
           }'

--- a/service/src/test/java/org/databiosphere/workspacedataservice/pact/RawlsPactTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/pact/RawlsPactTest.java
@@ -49,7 +49,7 @@ class RawlsPactTest {
   private static final String WORKSPACE_UUID = "facade00-0000-4000-a000-000000000000";
   private static final String RESOURCE_UUID = "5ca1ab1e-0000-4000-a000-000000000000";
 
-  @Pact(consumer = "wds", provider = "rawls")
+  @Pact(consumer = "cwds", provider = "rawls")
   RequestResponsePact enumerateSnapshotsPact(PactDslWithProvider builder) {
     return builder
         .given("one snapshot in the given workspace", Map.of("workspaceId", WORKSPACE_UUID))
@@ -119,7 +119,7 @@ class RawlsPactTest {
         .build();
   }
 
-  @Pact(consumer = "wds", provider = "rawls")
+  @Pact(consumer = "cwds", provider = "rawls")
   RequestResponsePact createSnapshotPact(PactDslWithProvider builder) {
 
     var snapshotRequest =


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1786

First step in creating separate Pacticipants for WDS and CWDS.

The Pact with Rawls is only applicable to CWDS, WDS talks directly to WSM. This changes the consumer to "cwds" for the Rawls Pact.

With the new "cwds" Pacticipant, we also need to run `can-i-deploy` for CWDS. This changes the `publish-pacts.yml` workflow to run `can-i-deploy` for each Pacticipant.