### PR TITLE
[AJ-1786] Generate Pacts for both WDS and CWDS

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -246,13 +246,29 @@ test {
     systemProperties['user.timezone'] = "UTC"
 }
 
-tasks.register("pactTests", Test) {
+tasks.register("wdsPactTests", Test) {
+    environment "CONSUMER_NAME", "wds"
     useJUnitPlatform {
         includeTags "pact-test"
     }
     testLogging {
         showStandardStreams = true
     }
+}
+
+tasks.register("cwdsPactTests", Test) {
+    environment "CONSUMER_NAME", "cwds"
+    useJUnitPlatform {
+        includeTags "pact-test"
+    }
+    testLogging {
+        showStandardStreams = true
+    }
+}
+
+tasks.register("pactTests") {
+    dependsOn "wdsPactTests"
+    dependsOn "cwdsPactTests"
 }
 
 testing {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/pact/SamPactTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/pact/SamPactTest.java
@@ -41,7 +41,7 @@ class SamPactTest {
     RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
   }
 
-  @Pact(consumer = "wds", provider = "sam")
+  @Pact(consumer = "${CONSUMER_NAME:wds}", provider = "sam")
   public RequestResponsePact statusApiPact(PactDslWithProvider builder) {
     return builder
         .given("Sam is ok")
@@ -54,7 +54,7 @@ class SamPactTest {
         .toPact();
   }
 
-  @Pact(consumer = "wds", provider = "sam")
+  @Pact(consumer = "${CONSUMER_NAME:wds}", provider = "sam")
   public RequestResponsePact downStatusApiPact(PactDslWithProvider builder) {
     return builder
         .given("Sam is not ok")
@@ -67,7 +67,7 @@ class SamPactTest {
         .toPact();
   }
 
-  @Pact(consumer = "wds", provider = "sam")
+  @Pact(consumer = "${CONSUMER_NAME:wds}", provider = "sam")
   public RequestResponsePact writeNoPermissionPact(PactDslWithProvider builder) {
     return builder
         .given("user does not have write permission", Map.of("dummyResourceId", dummyResourceId))
@@ -82,7 +82,7 @@ class SamPactTest {
         .toPact();
   }
 
-  @Pact(consumer = "wds", provider = "sam")
+  @Pact(consumer = "${CONSUMER_NAME:wds}", provider = "sam")
   public RequestResponsePact writePermissionPact(PactDslWithProvider builder) {
     return builder
         .given("user has write permission", Map.of("dummyResourceId", dummyResourceId))
@@ -97,7 +97,7 @@ class SamPactTest {
         .toPact();
   }
 
-  @Pact(consumer = "wds", provider = "sam")
+  @Pact(consumer = "${CONSUMER_NAME:wds}", provider = "sam")
   public RequestResponsePact readPermissionPact(PactDslWithProvider builder) {
     return builder
         .given("user has read permission", Map.of("dummyResourceId", dummyResourceId))
@@ -112,7 +112,7 @@ class SamPactTest {
         .toPact();
   }
 
-  @Pact(consumer = "wds", provider = "sam")
+  @Pact(consumer = "${CONSUMER_NAME:wds}", provider = "sam")
   public RequestResponsePact readNoPermissionPact(PactDslWithProvider builder) {
     return builder
         .given("user does not have read permission", Map.of("dummyResourceId", dummyResourceId))
@@ -127,7 +127,7 @@ class SamPactTest {
         .toPact();
   }
 
-  @Pact(consumer = "wds", provider = "sam")
+  @Pact(consumer = "${CONSUMER_NAME:wds}", provider = "sam")
   public RequestResponsePact userStatusPact(PactDslWithProvider builder) {
     var userResponseShape =
         new PactDslJsonBody()
@@ -147,7 +147,7 @@ class SamPactTest {
         .toPact();
   }
 
-  @Pact(consumer = "wds", provider = "sam")
+  @Pact(consumer = "${CONSUMER_NAME:wds}", provider = "sam")
   public RequestResponsePact noUserStatusPact(PactDslWithProvider builder) {
     return builder
         .given("user status info request without access token")
@@ -159,7 +159,7 @@ class SamPactTest {
         .toPact();
   }
 
-  @Pact(consumer = "wds", provider = "sam")
+  @Pact(consumer = "${CONSUMER_NAME:wds}", provider = "sam")
   public RequestResponsePact petTokenPact(PactDslWithProvider builder) {
     PactDslJsonRootValue responseBody = PactDslJsonRootValue.stringType("aToken");
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/pact/TdrPactTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/pact/TdrPactTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 class TdrPactTest {
   static final UUID dummySnapshotId = UUID.fromString("12345678-abc9-012d-3456-e7fab89cd01e");
 
-  @Pact(consumer = "wds")
+  @Pact(consumer = "${CONSUMER_NAME:wds}")
   public RequestResponsePact noSnapshotPact(PactDslWithProvider builder) {
     return builder
         .given("snapshot with given id doesn't exist", Map.of("id", dummySnapshotId.toString()))
@@ -43,7 +43,7 @@ class TdrPactTest {
         .toPact();
   }
 
-  @Pact(consumer = "wds")
+  @Pact(consumer = "${CONSUMER_NAME:wds}")
   public RequestResponsePact noAccessToSnapshotPact(PactDslWithProvider builder) {
     return builder
         .given(
@@ -58,7 +58,7 @@ class TdrPactTest {
         .toPact();
   }
 
-  @Pact(consumer = "wds")
+  @Pact(consumer = "${CONSUMER_NAME:wds}")
   public RequestResponsePact userHasAccessToSnapshotPact(PactDslWithProvider builder) {
     return builder
         .given(


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1786

Pacts are between services. Since the WDS repository now contains two services (WDS and CWDS), we want to publish Pacts for both of those.

Some Pacts are the same for WDS and CWDS. Both services have the same interactions with Sam and DataRepo. For those, we want to use one Pact consumer test to publish a Pact for both services.

To accomplish that, this replaces the hard coded `wds` consumer name with a consumer name from an environment variable. The Pact tests are run twice: once with the consumer name set to `wds` and once with it set to `cwds`. All of the resulting Pacts will be published to the Pact broker.