### PR TITLE
[AJ-1793] Simplify JSON serialization in publish pacts workflow

### DIFF
--- a/.github/workflows/publish-pacts.yml
+++ b/.github/workflows/publish-pacts.yml
@@ -115,30 +115,18 @@ jobs:
       - name: Run consumer tests
         run: ./gradlew pactTests
 
-      - name: Locate all pact json files and output Base64-encoded pacts
+      - name: Locate pact files
         id: locate-pacts
         run: |
-          # Locate .json pact files in $pactOutputDir
-          pactPaths=($(find "${{ env.WDS_PACTS_OUTPUT_DIR }}" -type f -name "*.json"))
-
-          # Put the Base64-encoded pacts in JSON string
-          pactPathsJson="["
-          # Loop through $pactPaths and encode the corresponding pact
-          for path in "${pactPaths[@]}"; do
-            pactPathsJson="${pactPathsJson}\"$path\", "
-          done
-
-          pactPathsJson="${pactPathsJson%, }]"
-
-          echo "pact-paths=$pactPathsJson" >> $GITHUB_OUTPUT
+          pactPaths=$(find "$WDS_PACTS_OUTPUT_DIR" -type f -name "*.json" | jq -cnR "[inputs]")
+          echo "pact-paths=$pactPaths" >> $GITHUB_OUTPUT
 
       - name: Upload pact files to artifact
         id: upload-pacts
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.WDS_PACTS_ARTIFACT }}
-          path: |
-            ${{ env.WDS_PACTS_OUTPUT_DIR }}
+          path: ${{ env.WDS_PACTS_OUTPUT_DIR }}
           retention-days: 1
 
   publish-pacts-job:
@@ -153,8 +141,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ env.WDS_PACTS_ARTIFACT }}
-          path: |
-            ${{ env.WDS_PACTS_OUTPUT_DIR }}
+          path: ${{ env.WDS_PACTS_OUTPUT_DIR }}
 
       - name: Encode pact as non-breaking base64 string
         id: encode-pact


### PR DESCRIPTION
The `locate-pacts` step finds all Pact JSON files and outputs them as a JSON serialized.

This simplifies the JSON serialization by using `jq` instead of string concatenation to build JSON.

It also removes some labels/comments about base 64 encoding, since the `locate-pacts` step does not encode the Pact files.