### PR TITLE
AJ-1700: Initial scaffolding for cWDS support of `RAWLSJSON`

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJob.java
@@ -62,7 +62,6 @@ public class PfbQuartzJob extends QuartzJob {
 
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
-  private final JobDao jobDao;
   private final BatchWriteService batchWriteService;
   private final CollectionService collectionService;
   private final ActivityLogger activityLogger;
@@ -82,8 +81,7 @@ public class PfbQuartzJob extends QuartzJob {
       ObservationRegistry observationRegistry,
       SnapshotSupportFactory snapshotSupportFactory,
       DataImportProperties dataImportProperties) {
-    super(observationRegistry, dataImportProperties);
-    this.jobDao = jobDao;
+    super(jobDao, observationRegistry, dataImportProperties);
     this.recordSourceFactory = recordSourceFactory;
     this.recordSinkFactory = recordSinkFactory;
     this.batchWriteService = batchWriteService;
@@ -91,11 +89,6 @@ public class PfbQuartzJob extends QuartzJob {
     this.activityLogger = activityLogger;
     this.samDao = samDao;
     this.snapshotSupportFactory = snapshotSupportFactory;
-  }
-
-  @Override
-  protected JobDao getJobDao() {
-    return this.jobDao;
   }
 
   @Override

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/rawlsjson/RawlsJsonQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/rawlsjson/RawlsJsonQuartzJob.java
@@ -1,0 +1,44 @@
+package org.databiosphere.workspacedataservice.dataimport.rawlsjson;
+
+import static org.databiosphere.workspacedataservice.generated.ImportRequestServerModel.TypeEnum.RAWLSJSON;
+import static org.databiosphere.workspacedataservice.shared.model.job.JobType.DATA_IMPORT;
+
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
+import java.util.UUID;
+import org.databiosphere.workspacedataservice.config.DataImportProperties;
+import org.databiosphere.workspacedataservice.dao.JobDao;
+import org.databiosphere.workspacedataservice.jobexec.QuartzJob;
+import org.quartz.JobExecutionContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RawlsJsonQuartzJob extends QuartzJob {
+  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private final JobDao jobDao;
+
+  public RawlsJsonQuartzJob(
+      DataImportProperties dataImportProperties,
+      ObservationRegistry observationRegistry,
+      JobDao jobDao) {
+    super(observationRegistry, dataImportProperties);
+    this.jobDao = jobDao;
+  }
+
+  @Override
+  protected JobDao getJobDao() {
+    return this.jobDao;
+  }
+
+  @Override
+  protected void annotateObservation(Observation observation) {
+    observation.lowCardinalityKeyValue("jobType", DATA_IMPORT.toString());
+    observation.lowCardinalityKeyValue("importType", RAWLSJSON.toString());
+  }
+
+  @Override
+  protected void executeInternal(UUID jobId, JobExecutionContext context) {
+    logger.atInfo().log(
+        "RawlsJsonQuartzJob.executeInternal: jobId={} - not yet implemented (no op)!", jobId);
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/rawlsjson/RawlsJsonQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/rawlsjson/RawlsJsonQuartzJob.java
@@ -15,19 +15,12 @@ import org.slf4j.LoggerFactory;
 
 public class RawlsJsonQuartzJob extends QuartzJob {
   private final Logger logger = LoggerFactory.getLogger(getClass());
-  private final JobDao jobDao;
 
   public RawlsJsonQuartzJob(
       DataImportProperties dataImportProperties,
       ObservationRegistry observationRegistry,
       JobDao jobDao) {
-    super(observationRegistry, dataImportProperties);
-    this.jobDao = jobDao;
-  }
-
-  @Override
-  protected JobDao getJobDao() {
-    return this.jobDao;
+    super(jobDao, observationRegistry, dataImportProperties);
   }
 
   @Override

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/rawlsjson/RawlsJsonSchedulable.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/rawlsjson/RawlsJsonSchedulable.java
@@ -1,0 +1,14 @@
+package org.databiosphere.workspacedataservice.dataimport.rawlsjson;
+
+import static org.databiosphere.workspacedataservice.generated.ImportRequestServerModel.TypeEnum.RAWLSJSON;
+
+import java.io.Serializable;
+import java.util.Map;
+import org.databiosphere.workspacedataservice.shared.model.Schedulable;
+
+public class RawlsJsonSchedulable extends Schedulable {
+  public RawlsJsonSchedulable(
+      String name, String description, Map<String, Serializable> arguments) {
+    super(RAWLSJSON.name(), name, RawlsJsonQuartzJob.class, description, arguments);
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/rawlsjson/package-info.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/rawlsjson/package-info.java
@@ -1,0 +1,6 @@
+@NonNullApi
+@NonNullFields
+package org.databiosphere.workspacedataservice.dataimport.rawlsjson;
+
+import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJob.java
@@ -68,7 +68,6 @@ import org.springframework.stereotype.Component;
 @Component
 public class TdrManifestQuartzJob extends QuartzJob {
 
-  private final JobDao jobDao;
   private final RecordSinkFactory recordSinkFactory;
   private final BatchWriteService batchWriteService;
   private final CollectionService collectionService;
@@ -93,8 +92,7 @@ public class TdrManifestQuartzJob extends QuartzJob {
       DataImportProperties dataImportProperties,
       SnapshotSupportFactory snapshotSupportFactory,
       SamDao samDao) {
-    super(observationRegistry, dataImportProperties);
-    this.jobDao = jobDao;
+    super(jobDao, observationRegistry, dataImportProperties);
     this.recordSinkFactory = recordSinkFactory;
     this.recordSourceFactory = recordSourceFactory;
     this.batchWriteService = batchWriteService;
@@ -104,11 +102,6 @@ public class TdrManifestQuartzJob extends QuartzJob {
     this.snapshotSupportFactory = snapshotSupportFactory;
     this.samDao = samDao;
     this.isTdrPermissionSyncingEnabled = dataImportProperties.isTdrPermissionSyncingEnabled();
-  }
-
-  @Override
-  protected JobDao getJobDao() {
-    return this.jobDao;
   }
 
   @Override

--- a/service/src/main/java/org/databiosphere/workspacedataservice/generated/ImportRequestServerModel.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/generated/ImportRequestServerModel.java
@@ -33,6 +33,8 @@ public class ImportRequestServerModel {
   public enum TypeEnum {
     PFB("PFB"),
     
+    RAWLSJSON("RAWLSJSON"),
+    
     TDRMANIFEST("TDRMANIFEST");
 
     private String value;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import org.apache.commons.lang3.NotImplementedException;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.dao.SchedulerDao;
 import org.databiosphere.workspacedataservice.dataimport.ImportJobInput;
@@ -156,9 +157,10 @@ public class ImportService {
       UUID jobId,
       Map<String, Serializable> arguments) {
     return switch (importType) {
+      case PFB -> new PfbSchedulable(jobId.toString(), "PFB import", arguments);
+      case RAWLSJSON -> throw new NotImplementedException("RAWLSJSON import not implemented");
       case TDRMANIFEST -> new TdrManifestSchedulable(
           jobId.toString(), "TDR manifest import", arguments);
-      case PFB -> new PfbSchedulable(jobId.toString(), "PFB import", arguments);
     };
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
@@ -10,12 +10,12 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-import org.apache.commons.lang3.NotImplementedException;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.dao.SchedulerDao;
 import org.databiosphere.workspacedataservice.dataimport.ImportJobInput;
 import org.databiosphere.workspacedataservice.dataimport.ImportSourceValidator;
 import org.databiosphere.workspacedataservice.dataimport.pfb.PfbSchedulable;
+import org.databiosphere.workspacedataservice.dataimport.rawlsjson.RawlsJsonSchedulable;
 import org.databiosphere.workspacedataservice.dataimport.tdr.TdrManifestSchedulable;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
 import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
@@ -158,7 +158,7 @@ public class ImportService {
       Map<String, Serializable> arguments) {
     return switch (importType) {
       case PFB -> new PfbSchedulable(jobId.toString(), "PFB import", arguments);
-      case RAWLSJSON -> throw new NotImplementedException("RAWLSJSON import not implemented");
+      case RAWLSJSON -> new RawlsJsonSchedulable(jobId.toString(), "RAWLSJSON import", arguments);
       case TDRMANIFEST -> new TdrManifestSchedulable(
           jobId.toString(), "TDR manifest import", arguments);
     };

--- a/service/src/main/resources/static/swagger/apis-v1.yaml
+++ b/service/src/main/resources/static/swagger/apis-v1.yaml
@@ -49,7 +49,7 @@ paths:
               properties:
                 type:
                   type: string
-                  enum: [ PFB, TDRMANIFEST ]
+                  enum: [ PFB, RAWLSJSON, TDRMANIFEST ]
                   description: format of file to import
                 url:
                   type: string

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/rawlsjson/RawlsJsonQuartzJobControlPlaneE2ETest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/rawlsjson/RawlsJsonQuartzJobControlPlaneE2ETest.java
@@ -1,0 +1,37 @@
+package org.databiosphere.workspacedataservice.dataimport.rawlsjson;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * Tests for RAWLSJSON import that execute "end-to-end" - which for this format is relatively
+ * simple, merely moving the import file from the given URI to an expected location without any
+ * reprocessing and communicating that the new location to Rawls via pubsub.
+ */
+@ActiveProfiles(profiles = {"mock-sam", "noop-scheduler-dao", "control-plane"})
+@DirtiesContext
+@SpringBootTest
+@TestPropertySource(
+    properties = {
+      // turn off pubsub autoconfiguration for tests
+      "spring.cloud.gcp.pubsub.enabled=false",
+      // Allow file imports to test with files from resources.
+      "twds.data-import.allowed-schemes=file",
+      // Rawls url must be valid, else context initialization (Spring startup) will fail
+      "rawlsUrl=https://localhost/",
+    })
+@AutoConfigureMockMvc
+class RawlsJsonQuartzJobControlPlaneE2ETest {
+  @Disabled("Not yet implemented")
+  @Test
+  void happyPath() {
+    fail("Not yet implemented!");
+  }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/rawlsjson/RawlsJsonQuartzJobTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/rawlsjson/RawlsJsonQuartzJobTest.java
@@ -1,0 +1,19 @@
+package org.databiosphere.workspacedataservice.dataimport.rawlsjson;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.databiosphere.workspacedataservice.common.TestBase;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("mock-sam")
+class RawlsJsonQuartzJobTest extends TestBase {
+  @Disabled("Not yet implemented")
+  @Test
+  void happyPath() {
+    fail("Not yet implemented!");
+  }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/rawlsjson/package-info.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/rawlsjson/package-info.java
@@ -1,0 +1,6 @@
+@NonNullApi
+@NonNullFields
+package org.databiosphere.workspacedataservice.dataimport.rawlsjson;
+
+import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceTest.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.EnumSource.Mode;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
@@ -99,8 +100,11 @@ class ImportServiceTest extends TestBase {
 
   // does createSchedulable properly store the jobId, job group, and job data map?
   @ParameterizedTest(name = "for import type {0}")
-  @EnumSource(ImportRequestServerModel.TypeEnum.class)
-  void createSchedulableValues(ImportRequestServerModel.TypeEnum importType) {
+  @EnumSource(
+      value = TypeEnum.class,
+      names = {"RAWLSJSON"},
+      mode = Mode.EXCLUDE)
+  void createSchedulableValues(TypeEnum importType) {
     UUID jobId = UUID.randomUUID();
     Map<String, Serializable> arguments = Map.of("foo", "bar", "twenty-three", 23);
 
@@ -135,8 +139,11 @@ class ImportServiceTest extends TestBase {
   // this is the happy path for importService.createImport; we should end up with a
   // job in QUEUED status
   @ParameterizedTest(name = "for import type {0}")
-  @EnumSource(ImportRequestServerModel.TypeEnum.class)
-  void persistsJobAsQueued(ImportRequestServerModel.TypeEnum importType) {
+  @EnumSource(
+      value = TypeEnum.class,
+      names = {"RAWLSJSON"},
+      mode = Mode.EXCLUDE)
+  void persistsJobAsQueued(TypeEnum importType) {
     // schedulerDao.schedule(), which returns void, returns successfully
     doNothing().when(schedulerDao).schedule(any(Schedulable.class));
     // create collection (in the MockCollectionDao)
@@ -157,8 +164,11 @@ class ImportServiceTest extends TestBase {
 
   // importService.createImport should make appropriate calls to the SchedulerDao
   @ParameterizedTest(name = "for import type {0}")
-  @EnumSource(ImportRequestServerModel.TypeEnum.class)
-  void addsJobToScheduler(ImportRequestServerModel.TypeEnum importType) {
+  @EnumSource(
+      value = TypeEnum.class,
+      names = {"RAWLSJSON"},
+      mode = Mode.EXCLUDE)
+  void addsJobToScheduler(TypeEnum importType) {
     // schedulerDao.schedule(), which returns void, returns successfully
     doNothing().when(schedulerDao).schedule(any(Schedulable.class));
     // create collection (in the MockCollectionDao)
@@ -188,8 +198,11 @@ class ImportServiceTest extends TestBase {
 
   // if we hit an error scheduling the job in Quartz, we should mark the job as being in ERROR
   @ParameterizedTest(name = "for import type {0}")
-  @EnumSource(ImportRequestServerModel.TypeEnum.class)
-  void failsJobIfSchedulingFails(ImportRequestServerModel.TypeEnum importType) {
+  @EnumSource(
+      value = TypeEnum.class,
+      names = {"RAWLSJSON"},
+      mode = Mode.EXCLUDE)
+  void failsJobIfSchedulingFails(TypeEnum importType) {
     // schedulerDao.schedule(), which returns void, returns successfully
     doThrow(new RuntimeException("unit test failme"))
         .when(schedulerDao)
@@ -211,9 +224,11 @@ class ImportServiceTest extends TestBase {
   }
 
   @ParameterizedTest(name = "for import type {0}")
-  @EnumSource(ImportRequestServerModel.TypeEnum.class)
-  void doesNotCreateJobWithoutPetToken(ImportRequestServerModel.TypeEnum importType)
-      throws ApiException {
+  @EnumSource(
+      value = TypeEnum.class,
+      names = {"RAWLSJSON"},
+      mode = Mode.EXCLUDE)
+  void doesNotCreateJobWithoutPetToken(TypeEnum importType) throws ApiException {
     given(mockSamClientFactory.getGoogleApi(any(BearerToken.class))).willReturn(mockSamGoogleApi);
     // Sam permission check will always return true
     given(mockSamGoogleApi.getArbitraryPetServiceAccountToken(any()))
@@ -235,8 +250,11 @@ class ImportServiceTest extends TestBase {
   }
 
   @ParameterizedTest(name = "for import type {0}, validates import source before creating job")
-  @EnumSource(ImportRequestServerModel.TypeEnum.class)
-  void doesNotCreateJobIfImportSourceValidationFails(ImportRequestServerModel.TypeEnum importType) {
+  @EnumSource(
+      value = TypeEnum.class,
+      names = {"RAWLSJSON"},
+      mode = Mode.EXCLUDE)
+  void doesNotCreateJobIfImportSourceValidationFails(TypeEnum importType) {
     // Arrange
     // schedulerDao.schedule(), which returns void, returns successfully
     doNothing().when(schedulerDao).schedule(any(Schedulable.class));


### PR DESCRIPTION
Some small no-op / skeletal implementations to lay the groundwork for the `RAWLSJSON` format, which will be used to support async TSV in cWDS.