### PR TITLE
AJ-1628: TSV uploads detect datatypes across batches

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/DataTypeInferer.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/DataTypeInferer.java
@@ -60,7 +60,8 @@ public class DataTypeInferer {
     return result;
   }
 
-  Map<String, DataTypeMapping> inferTypes(List<Record> records) {
+  @VisibleForTesting
+  public Map<String, DataTypeMapping> inferTypes(List<Record> records) {
     Map<String, DataTypeMapping> result = new HashMap<>();
     for (Record rcd : records) {
       if (rcd.getAttributes() == null) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/DataTypeInferer.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/DataTypeInferer.java
@@ -60,7 +60,6 @@ public class DataTypeInferer {
     return result;
   }
 
-  @VisibleForTesting
   public Map<String, DataTypeMapping> inferTypes(List<Record> records) {
     Map<String, DataTypeMapping> result = new HashMap<>();
     for (Record rcd : records) {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
@@ -439,7 +439,7 @@ class FullStackRecordControllerTest extends TestBase {
 
   @Test
   @Transactional
-  void dataTypeMismatchShouldFailBatchWrite() throws Exception {
+  void dataTypeMismatchShouldNotFailBatchWrite() throws Exception {
     RecordType recordType = RecordType.valueOf("bw-test");
     List<Record> someRecords = createSomeRecords(recordType, 2);
     List<BatchOperation> operations =
@@ -454,7 +454,7 @@ class FullStackRecordControllerTest extends TestBase {
         .get(1)
         .getRecord()
         .getAttributes()
-        .putAttribute("attr2", "not a float, this should fail");
+        .putAttribute("attr2", "not a float, this should not fail");
     ResponseEntity<ErrorResponse> response =
         restTemplate.exchange(
             "/{instanceid}/batch/{v}/{type}",
@@ -464,15 +464,7 @@ class FullStackRecordControllerTest extends TestBase {
             instanceId,
             versionId,
             recordType);
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-    ErrorResponse err = response.getBody();
-    assertNotNull(err);
-    assertThat(err.getMessage())
-        .contains(
-            "Some of the records in your request don't have the proper data for the record type");
-    assertThat(response.getBody().getMessage())
-        .contains(
-            "is a STRING in the request but is defined as NUMBER in the record type definition for bw-test");
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
   }
 
   @Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/BatchWriteServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/BatchWriteServiceTest.java
@@ -6,23 +6,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 import bio.terra.pfb.PfbReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.TreeMap;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import org.apache.avro.file.DataFileStream;
 import org.apache.avro.generic.GenericRecord;
 import org.databiosphere.workspacedataservice.common.TestBase;
@@ -34,23 +25,17 @@ import org.databiosphere.workspacedataservice.recordsink.RecordSinkFactory;
 import org.databiosphere.workspacedataservice.recordsource.RecordSource;
 import org.databiosphere.workspacedataservice.recordsource.RecordSource.ImportMode;
 import org.databiosphere.workspacedataservice.recordsource.RecordSourceFactory;
-import org.databiosphere.workspacedataservice.recordsource.TsvRecordSource;
 import org.databiosphere.workspacedataservice.service.model.BatchWriteResult;
 import org.databiosphere.workspacedataservice.service.model.exception.BadStreamingWriteRequestException;
 import org.databiosphere.workspacedataservice.shared.model.CollectionId;
-import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.ArgumentMatchers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
-import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 
@@ -96,97 +81,6 @@ class BatchWriteServiceTest extends TestBase {
               () -> batchWriteService.batchWrite(recordSource, recordSink, THING_TYPE, RECORD_ID));
       String errorMessage = ex.getMessage();
       assertEquals("Duplicate field 'key'", errorMessage);
-    }
-  }
-
-  // when batchWriteTsvStream is called with a single specified RecordType, we should infer the
-  // table schema only once even if we insert multiple batches.
-  @Test
-  void schemaInferredOnceForOneRecordType() throws IOException {
-    // generate a TSV input with a header and 5 rows
-    StringBuilder tsvContent = new StringBuilder("id\tcol1\n");
-    for (int i = 0; i < 5; i++) {
-      tsvContent.append(i).append("\t").append(i).append("\n");
-    }
-    MockMultipartFile file =
-        new MockMultipartFile(
-            "records", "simple.tsv", MediaType.TEXT_PLAIN_VALUE, tsvContent.toString().getBytes());
-
-    // other params
-    RecordType recordType = RecordType.valueOf("myType");
-    String primaryKey = "id";
-
-    // call the BatchWriteService. Since this test specifies a batch size of 2, the 5 TSV rows will
-    // execute in 3 batches.
-    // Note that this call to batchWriteTsvStream specifies a non-null RecordType.
-    TsvRecordSource recordSource =
-        recordSourceFactory.forTsv(file.getInputStream(), recordType, Optional.of(primaryKey));
-    try (RecordSink recordSink = recordSinkFactory.buildRecordSink(CollectionId.of(COLLECTION))) {
-      batchWriteService.batchWrite(recordSource, recordSink, recordType, primaryKey);
-    }
-
-    // we should write three batches
-    verify(recordService, times(3))
-        .batchUpsert(eq(COLLECTION), eq(recordType), any(), any(), eq(primaryKey));
-
-    // but we should only have inferred the schema once
-    verify(inferer, times(1)).inferTypes(ArgumentMatchers.<List<Record>>any());
-  }
-
-  // when batchWritePfbStream is called and the input contains multiple record types, we should
-  // infer each type's table schema only once even if we insert multiple batches.
-  @Test
-  void schemaInferredOnceForEachRecordType() {
-    // create a stream with 5 "things", 10 "items", and 15 "widgets"
-    // use a TreeMap, so we can control the order in which the record types appear in the stream.
-    Map<String, Integer> counts = new TreeMap<>();
-    counts.put("thing", 5);
-    counts.put("item", 10);
-    counts.put("widget", 15);
-    try (DataFileStream<GenericRecord> pfbStream = PfbTestUtils.mockPfbStream(counts)) {
-
-      // call the BatchWriteService. Since this test specifies a batch size of 2, it will result
-      // in the following calls:
-      // * batchUpsertWithErrorCapture 3 times for "thing"
-      // * batchUpsertWithErrorCapture 6 times for "item"
-      //    - 1 call for batch #3 which will be (thing, item)
-      //    - 5 more calls for batches #4-7 which will be (item, item)
-      //    - 1 call for batch #8 which will be (item, widget)
-      // * batchUpsertWithErrorCapture 8 times for "widget"
-      //    - 1 call for batch #8 which will be (item, widget)
-      //    - 7 more calls for batches #9-15 which will be (widget, widget)
-      // * inferTypes once for each of "thing", "item", and "widget"
-      batchWritePfbStream(pfbStream, /* primaryKey= */ ID_FIELD, ImportMode.BASE_ATTRIBUTES);
-
-      // verify calls to batchUpsertWithErrorCapture
-      verify(recordService, times(3))
-          .batchUpsert(eq(COLLECTION), eq(RecordType.valueOf("thing")), any(), any(), eq(ID_FIELD));
-      verify(recordService, times(5))
-          .batchUpsert(eq(COLLECTION), eq(RecordType.valueOf("item")), any(), any(), eq(ID_FIELD));
-      verify(recordService, times(8))
-          .batchUpsert(
-              eq(COLLECTION), eq(RecordType.valueOf("widget")), any(), any(), eq(ID_FIELD));
-
-      // but we should only have inferred schemas three times - once for each record Type
-      @SuppressWarnings("unchecked")
-      ArgumentCaptor<List<Record>> argumentCaptor = ArgumentCaptor.forClass(List.class);
-      verify(inferer, times(3)).inferTypes(argumentCaptor.capture());
-
-      List<List<Record>> allArguments = argumentCaptor.getAllValues();
-      // collapse the record types from each call to inferTypes
-      Set<List<RecordType>> actualRecordTypes =
-          allArguments.stream()
-              .map(recList -> recList.stream().map(Record::getRecordType).distinct().toList())
-              .collect(Collectors.toSet());
-      // we expect the actual invocation to be:
-      Set<List<RecordType>> expected =
-          Set.of(
-              List.of(RecordType.valueOf("thing")),
-              List.of(RecordType.valueOf("item")),
-              List.of(RecordType.valueOf("widget")));
-      assertEquals(expected, actualRecordTypes);
-    } catch (IOException e) {
-      fail(e.getMessage());
     }
   }
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvBatchTypeDetectionTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvBatchTypeDetectionTest.java
@@ -1,0 +1,100 @@
+package org.databiosphere.workspacedataservice.tsv;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.UUID;
+import org.databiosphere.workspacedataservice.dao.CollectionDao;
+import org.databiosphere.workspacedataservice.dao.RecordDao;
+import org.databiosphere.workspacedataservice.recordsink.RecordSink;
+import org.databiosphere.workspacedataservice.recordsink.RecordSinkFactory;
+import org.databiosphere.workspacedataservice.recordsource.RecordSourceFactory;
+import org.databiosphere.workspacedataservice.recordsource.TsvRecordSource;
+import org.databiosphere.workspacedataservice.service.BatchWriteService;
+import org.databiosphere.workspacedataservice.service.DataTypeInferer;
+import org.databiosphere.workspacedataservice.service.RecordOrchestratorService;
+import org.databiosphere.workspacedataservice.service.RecordService;
+import org.databiosphere.workspacedataservice.service.model.AttributeSchema;
+import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
+import org.databiosphere.workspacedataservice.service.model.RecordTypeSchema;
+import org.databiosphere.workspacedataservice.shared.model.CollectionId;
+import org.databiosphere.workspacedataservice.shared.model.RecordType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+
+@DirtiesContext
+@SpringBootTest
+@TestPropertySource(properties = {"twds.write.batch.size=2"})
+public class TsvBatchTypeDetectionTest {
+
+  @Autowired private RecordSourceFactory recordSourceFactory;
+  @Autowired private RecordSinkFactory recordSinkFactory;
+  @Autowired private BatchWriteService batchWriteService;
+  @Autowired private RecordOrchestratorService recordOrchestratorService;
+  @Autowired private CollectionDao collectionDao;
+  @Autowired RecordDao recordDao;
+  @Autowired DataTypeInferer inferer;
+  @Autowired RecordService recordService;
+
+  private static final UUID COLLECTION = UUID.fromString("aaaabbbb-cccc-dddd-1111-222233334444");
+  private static final RecordType THING_TYPE = RecordType.valueOf("thing");
+
+  @BeforeEach
+  void setUp() {
+    if (!collectionDao.collectionSchemaExists(COLLECTION)) {
+      collectionDao.createSchema(COLLECTION);
+    }
+  }
+
+  @AfterEach
+  void tearDown() {
+    collectionDao.dropSchema(COLLECTION);
+  }
+
+  // when batchWriteTsvStream is called with a single specified RecordType, we should not fail if
+  // the first batch and a later batch have conflicting data types
+  @Test
+  void schemaSafeAcrossBatches() throws IOException {
+    // generate a TSV input with one column. The first batch of rows has numerics for this column,
+    // but the second batch has a string. This should not fail the import.
+    String tsvContent = """
+id\tmyColumn
+1\t1
+2\t2
+3\t"I'm a string!"
+""";
+    MockMultipartFile file =
+        new MockMultipartFile(
+            "records", "simple.tsv", MediaType.TEXT_PLAIN_VALUE, tsvContent.getBytes());
+
+    // other params
+    String primaryKey = "id";
+
+    // call the BatchWriteService. Since this test specifies a batch size of 2, the type detection
+    // in the first batch will determine that myColumn is a number. The second batch will encounter
+    // a string for that column.
+    TsvRecordSource recordSource =
+        recordSourceFactory.forTsv(file.getInputStream(), THING_TYPE, Optional.of(primaryKey));
+    // batchWrite will fail if we are not correctly re-detecting datatypes in later batches
+    // (note this is a try-with-resources; an exception from batchWrite() will still fail the test)
+    try (RecordSink recordSink = recordSinkFactory.buildRecordSink(CollectionId.of(COLLECTION))) {
+      batchWriteService.batchWrite(recordSource, recordSink, THING_TYPE, primaryKey);
+    }
+
+    // retrieve the final record schema
+    RecordTypeSchema actualRecordSchema =
+        recordOrchestratorService.describeRecordType(COLLECTION, "v0.2", THING_TYPE);
+    AttributeSchema actual = actualRecordSchema.getAttributeSchema("myColumn");
+
+    // "myColumn" should be a string, reflecting the change we saw in the second batch
+    assertEquals(DataTypeMapping.STRING.name(), actual.datatype());
+  }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvBatchTypeDetectionTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvBatchTypeDetectionTest.java
@@ -42,7 +42,7 @@ import org.springframework.test.context.TestPropertySource;
 @DirtiesContext
 @SpringBootTest
 @TestPropertySource(properties = {"twds.write.batch.size=2"})
-public class TsvBatchTypeDetectionTest extends TestBase {
+class TsvBatchTypeDetectionTest extends TestBase {
 
   @Autowired private RecordSourceFactory recordSourceFactory;
   @Autowired private RecordSinkFactory recordSinkFactory;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvBatchTypeDetectionTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvBatchTypeDetectionTest.java
@@ -74,8 +74,7 @@ public class TsvBatchTypeDetectionTest extends TestBase {
   void schemaSafeAcrossBatches() throws IOException {
     // generate a TSV input with one column. The first batch of rows has numerics for this column,
     // but the second batch has a string. This should not fail the import.
-    String tsvContent =
-        """
+    String tsvContent = """
 id\tmyColumn
 1\t1
 2\t2


### PR DESCRIPTION
## Before this PR
WDS would read the first _batch_ of records from a TSV upload (or other input!), infer a schema based on the contents of those records, and then use that schema for the remainder of the batches. The batch size is relatively large, at 5000 records, defined [here](https://github.com/DataBiosphere/terra-workspace-data-service/blob/d8212da81efe1e1934a9f84e73ba72f7668c6f1f/service/src/main/resources/application.yml#L126).

However, this means that if a record in any batch later than the first has a conflicting datatype, the upload will fail. For instance, if the first 5000 records have integers in a given column but the 5001st record has a string, we'll hit an error trying to insert a string into a number column.

## After this PR
We now infer schema on every batch. This trades performance for correctness - it's definitely more work inside the codebase, but it eliminates errors.

This PR adds one unit test in `TsvBatchTypeDetectionTest`, deletes two tests that are no longer needed, and updates another unit test for correctness.

