### PR TITLE
[AJ-1800] Fix run name for attach-billing-project-to-landing-zone retry

### DIFF
--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -78,7 +78,7 @@ jobs:
         if: steps.FirstAttemptLandingZone.outcome == 'failure'
         uses: ./.github/actions/landing-zone-attach
         with:
-          run_name: "${{ env.ATTACH_BP_TO_LZ_RUN_NAME }}-retry"
+          run_name: "${{ env.ATTACH_BP_TO_LZ_RUN_NAME }}"
           bee_name: ${{ env.BEE_NAME }}
           token: '${{ env.TOKEN }}'
           project_name: ${{ needs.params-gen.outputs.project-name }}


### PR DESCRIPTION
`attach-billing-project-to-landing-zone` expects the given `run-name` to end with the calling workflow's run ID and run attempt.

https://github.com/broadinstitute/terra-github-workflows/blob/8463d2aeaff46ed6b37af851e5a24d9810b075f1/.github/workflows/attach-billing-project-to-landing-zone.yaml#L121-L123

Adding a `-retry` suffix to the `run-name` causes the workflow to fail.

See https://broadinstitute.slack.com/archives/C031KGQUVB4/p1713867565816199 for an example.