### PR TITLE
[AJ-1798] Refactor import validation to consider the full request vs only the URL

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportValidator.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportValidator.java
@@ -4,20 +4,22 @@ import java.net.URI;
 import java.util.Set;
 import java.util.regex.Pattern;
 import org.databiosphere.workspacedataservice.config.DataImportProperties;
+import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
 import org.databiosphere.workspacedataservice.service.model.exception.ValidationException;
 import org.springframework.stereotype.Component;
 
 @Component
-public class ImportSourceValidator {
+public class ImportValidator {
   private final Set<String> allowedSchemes;
   private final Set<Pattern> allowedHosts;
 
-  public ImportSourceValidator(DataImportProperties dataImportProperties) {
+  public ImportValidator(DataImportProperties dataImportProperties) {
     this.allowedSchemes = dataImportProperties.getAllowedSchemes();
     this.allowedHosts = dataImportProperties.getAllowedHosts();
   }
 
-  public void validateImport(URI importUrl) {
+  public void validateImport(ImportRequestServerModel importRequest) {
+    URI importUrl = importRequest.getUrl();
     if (!allowedSchemes.contains(importUrl.getScheme())) {
       throw new ValidationException(
           "Files may not be imported from %s URLs.".formatted(importUrl.getScheme()));

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.dao.SchedulerDao;
 import org.databiosphere.workspacedataservice.dataimport.ImportJobInput;
-import org.databiosphere.workspacedataservice.dataimport.ImportSourceValidator;
+import org.databiosphere.workspacedataservice.dataimport.ImportValidator;
 import org.databiosphere.workspacedataservice.dataimport.pfb.PfbSchedulable;
 import org.databiosphere.workspacedataservice.dataimport.rawlsjson.RawlsJsonSchedulable;
 import org.databiosphere.workspacedataservice.dataimport.tdr.TdrManifestSchedulable;
@@ -41,19 +41,19 @@ public class ImportService {
   private final SamDao samDao;
   private final JobDao jobDao;
   private final SchedulerDao schedulerDao;
-  private final ImportSourceValidator importSourceValidator;
+  private final ImportValidator importValidator;
 
   public ImportService(
       CollectionService collectionService,
       SamDao samDao,
       JobDao jobDao,
       SchedulerDao schedulerDao,
-      ImportSourceValidator importSourceValidator) {
+      ImportValidator importValidator) {
     this.collectionService = collectionService;
     this.samDao = samDao;
     this.jobDao = jobDao;
     this.schedulerDao = schedulerDao;
-    this.importSourceValidator = importSourceValidator;
+    this.importValidator = importValidator;
   }
 
   public GenericJobServerModel createImport(
@@ -84,7 +84,7 @@ public class ImportService {
       }
     }
 
-    importSourceValidator.validateImport(importRequest.getUrl());
+    importValidator.validateImport(importRequest);
 
     // get a token to execute the job
     String petToken = samDao.getPetToken();

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/ImportValidatorTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/ImportValidatorTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.net.URI;
 import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
+import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel.TypeEnum;
 import org.databiosphere.workspacedataservice.service.model.exception.ValidationException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -23,8 +24,7 @@ class ImportValidatorTest extends TestBase {
     // Arrange
     URI importUri =
         URI.create("http://teststorageaccount.blob.core.windows.net/testcontainer/file");
-    ImportRequestServerModel importRequest =
-        new ImportRequestServerModel(ImportRequestServerModel.TypeEnum.PFB, importUri);
+    ImportRequestServerModel importRequest = new ImportRequestServerModel(TypeEnum.PFB, importUri);
 
     // Act/Assert
     ValidationException err =
@@ -47,8 +47,7 @@ class ImportValidatorTest extends TestBase {
   void allowsImportsFromCloudStorage(String cloudStorageUrl) {
     // Arrange
     URI importUri = URI.create(cloudStorageUrl);
-    ImportRequestServerModel importRequest =
-        new ImportRequestServerModel(ImportRequestServerModel.TypeEnum.PFB, importUri);
+    ImportRequestServerModel importRequest = new ImportRequestServerModel(TypeEnum.PFB, importUri);
 
     // Act/Assert
     assertDoesNotThrow(() -> importValidator.validateImport(importRequest));
@@ -58,8 +57,7 @@ class ImportValidatorTest extends TestBase {
   void allowsImportsFromConfiguredSources() {
     // Arrange
     URI importUri = URI.create("https://files.terra.bio/file");
-    ImportRequestServerModel importRequest =
-        new ImportRequestServerModel(ImportRequestServerModel.TypeEnum.PFB, importUri);
+    ImportRequestServerModel importRequest = new ImportRequestServerModel(TypeEnum.PFB, importUri);
 
     // Act/Assert
     assertDoesNotThrow(() -> importValidator.validateImport(importRequest));
@@ -69,8 +67,7 @@ class ImportValidatorTest extends TestBase {
   void rejectsImportsFromOtherSources() {
     // Arrange
     URI importUri = URI.create("https://example.com/file");
-    ImportRequestServerModel importRequest =
-        new ImportRequestServerModel(ImportRequestServerModel.TypeEnum.PFB, importUri);
+    ImportRequestServerModel importRequest = new ImportRequestServerModel(TypeEnum.PFB, importUri);
 
     // Act/Assert
     ValidationException err =


### PR DESCRIPTION
In preparation for a couple of changes to import validation, expand the current `ImportSourceValidator` to an `ImportValidator` that considers the full import request instead of only the URL.