### PR TITLE
AJ-1700: Minor cleanup of tes support classes

### DIFF
--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbTestSupport.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbTestSupport.java
@@ -11,6 +11,7 @@ import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.dataimport.snapshotsupport.SnapshotSupportFactory;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
 import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
+import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel.TypeEnum;
 import org.databiosphere.workspacedataservice.recordsink.RecordSinkFactory;
 import org.databiosphere.workspacedataservice.recordsource.RecordSourceFactory;
 import org.databiosphere.workspacedataservice.sam.SamDao;
@@ -37,12 +38,12 @@ class PfbTestSupport {
   @Autowired private ImportService importService;
   @Autowired private SamDao samDao;
   @Autowired private SnapshotSupportFactory snapshotSupportFactory;
-  @Autowired DataImportProperties dataImportProperties;
+  @Autowired private DataImportProperties dataImportProperties;
 
   UUID executePfbImportQuartzJob(UUID collectionId, Resource pfbResource)
       throws IOException, JobExecutionException {
     ImportRequestServerModel importRequest =
-        new ImportRequestServerModel(ImportRequestServerModel.TypeEnum.PFB, pfbResource.getURI());
+        new ImportRequestServerModel(TypeEnum.PFB, pfbResource.getURI());
 
     // because we have a mock scheduler dao, this won't trigger Quartz
     GenericJobServerModel genericJobServerModel =
@@ -51,16 +52,12 @@ class PfbTestSupport {
     UUID jobId = genericJobServerModel.getJobId();
     JobExecutionContext mockContext = stubJobContext(jobId, pfbResource, collectionId);
 
-    buildPfbQuartzJob(collectionId).execute(mockContext);
+    buildPfbQuartzJob().execute(mockContext);
 
     return jobId;
   }
 
   PfbQuartzJob buildPfbQuartzJob() {
-    return buildPfbQuartzJob(UUID.randomUUID());
-  }
-
-  private PfbQuartzJob buildPfbQuartzJob(UUID workspaceId) {
     return new PfbQuartzJob(
         jobDao,
         recordSourceFactory,

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobE2ETest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobE2ETest.java
@@ -105,9 +105,7 @@ class TdrManifestQuartzJobE2ETest extends TestBase {
     when(wsmDao.enumerateDataRepoSnapshotReferences(any(), anyInt(), anyInt()))
         .thenReturn(new ResourceList());
 
-    testSupport
-        .buildTdrManifestQuartzJob(/* workspaceId= */ UUID.randomUUID())
-        .execute(mockContext);
+    testSupport.buildTdrManifestQuartzJob().execute(mockContext);
 
     List<RecordTypeSchema> allTypes =
         recordOrchestratorService.describeAllRecordTypes(collectionId, "v0.2");
@@ -240,9 +238,7 @@ class TdrManifestQuartzJobE2ETest extends TestBase {
     when(wsmDao.enumerateDataRepoSnapshotReferences(any(), anyInt(), anyInt()))
         .thenReturn(new ResourceList());
 
-    testSupport
-        .buildTdrManifestQuartzJob(/* workspaceId= */ UUID.randomUUID())
-        .execute(mockContext);
+    testSupport.buildTdrManifestQuartzJob().execute(mockContext);
 
     List<RecordTypeSchema> allTypes =
         recordOrchestratorService.describeAllRecordTypes(collectionId, "v0.2");

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobTest.java
@@ -118,7 +118,7 @@ class TdrManifestQuartzJobTest extends TestBase {
   @Test
   void extractSnapshotInfo() throws IOException {
     UUID workspaceId = UUID.randomUUID();
-    TdrManifestQuartzJob tdrManifestQuartzJob = testSupport.buildTdrManifestQuartzJob(workspaceId);
+    TdrManifestQuartzJob tdrManifestQuartzJob = testSupport.buildTdrManifestQuartzJob();
     SnapshotExportResponseModel snapshotExportResponseModel =
         tdrManifestQuartzJob.parseManifest(manifestAzure.getURL());
 
@@ -160,7 +160,7 @@ class TdrManifestQuartzJobTest extends TestBase {
   @Test
   void parseEmptyParquet() throws IOException {
     UUID workspaceId = UUID.randomUUID();
-    TdrManifestQuartzJob tdrManifestQuartzJob = testSupport.buildTdrManifestQuartzJob(workspaceId);
+    TdrManifestQuartzJob tdrManifestQuartzJob = testSupport.buildTdrManifestQuartzJob();
     TdrManifestImportTable table =
         new TdrManifestImportTable(
             RecordType.valueOf("data"),
@@ -181,7 +181,7 @@ class TdrManifestQuartzJobTest extends TestBase {
   @Test
   void parseUnknownFieldsInManifest() {
     UUID workspaceId = UUID.randomUUID();
-    TdrManifestQuartzJob tdrManifestQuartzJob = testSupport.buildTdrManifestQuartzJob(workspaceId);
+    TdrManifestQuartzJob tdrManifestQuartzJob = testSupport.buildTdrManifestQuartzJob();
     SnapshotExportResponseModel snapshotExportResponseModel =
         assertDoesNotThrow(
             () -> tdrManifestQuartzJob.parseManifest(manifestWithUnknownProperties.getURL()));
@@ -197,7 +197,7 @@ class TdrManifestQuartzJobTest extends TestBase {
     UUID workspaceId = UUID.randomUUID();
     UUID jobId = UUID.randomUUID();
     Supplier<String> emailSupplier = () -> "testEmail";
-    TdrManifestQuartzJob tdrManifestQuartzJob = testSupport.buildTdrManifestQuartzJob(workspaceId);
+    TdrManifestQuartzJob tdrManifestQuartzJob = testSupport.buildTdrManifestQuartzJob();
     TdrManifestImportTable table =
         new TdrManifestImportTable(
             RecordType.valueOf("data"),
@@ -244,8 +244,7 @@ class TdrManifestQuartzJobTest extends TestBase {
         .thenReturn(new ResourceList());
 
     // set up the job
-    TdrManifestQuartzJob tdrManifestQuartzJob =
-        testSupport.buildTdrManifestQuartzJob(workspaceId.id());
+    TdrManifestQuartzJob tdrManifestQuartzJob = testSupport.buildTdrManifestQuartzJob();
     JobExecutionContext mockContext = stubJobContext(jobId, v2fManifestResource, collectionId.id());
 
     // ACT
@@ -280,8 +279,7 @@ class TdrManifestQuartzJobTest extends TestBase {
     doNothing().when(samDao).addWorkspacePoliciesAsSnapshotReader(any(), any(), anyString());
 
     // set up the job
-    TdrManifestQuartzJob tdrManifestQuartzJob =
-        testSupport.buildTdrManifestQuartzJob(workspaceId.id());
+    TdrManifestQuartzJob tdrManifestQuartzJob = testSupport.buildTdrManifestQuartzJob();
     JobExecutionContext mockContext =
         stubJobContext(
             jobId, v2fManifestResource, collectionId.id(), /* shouldPermissionSync= */ true);

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrTestSupport.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrTestSupport.java
@@ -3,7 +3,6 @@ package org.databiosphere.workspacedataservice.dataimport.tdr;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micrometer.observation.ObservationRegistry;
 import java.net.URL;
-import java.util.UUID;
 import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
 import org.databiosphere.workspacedataservice.config.DataImportProperties;
 import org.databiosphere.workspacedataservice.dao.JobDao;
@@ -29,11 +28,11 @@ class TdrTestSupport {
   @Autowired private ActivityLogger activityLogger;
   @Autowired private ObjectMapper objectMapper;
   @Autowired private ObservationRegistry observationRegistry;
-  @Autowired DataImportProperties dataImportProperties;
+  @Autowired private DataImportProperties dataImportProperties;
   @Autowired private SnapshotSupportFactory snapshotSupportFactory;
 
   /** Returns a TdrManifestQuartzJob that is capable of pulling parquet files from the classpath. */
-  TdrManifestQuartzJob buildTdrManifestQuartzJob(UUID workspaceId) {
+  TdrManifestQuartzJob buildTdrManifestQuartzJob() {
     return new TdrManifestQuartzJob(
         jobDao,
         recordSourceFactory,


### PR DESCRIPTION
Planning to add `RawlsJsonTestSupport` as part of a larger PR, but I wanted to get this cleanup in place so that the various `TestSupport` classes maintain a consistent implementation.