### PR TITLE
[AJ-1798] Remove data-import.allowed-schemes configuration

### DIFF
--- a/.github/workflows/release-python-client.yml
+++ b/.github/workflows/release-python-client.yml
@@ -91,7 +91,7 @@ jobs:
           export SPRING_PROFILES_ACTIVE=data-plane,local
           ./gradlew --build-cache build -x test
           # Allow http imports from localhost to test with files from resources served by the mock API server
-          ./gradlew bootRun --args='--twds.data-import.allowed-hosts=localhost --twds.data-import.allow-http-urls=true' &
+          ./gradlew bootRun --args='--twds.data-import.allowed-hosts=localhost --twds.data-import.disable-validation=true' &
           count=20
           until $(curl --output /dev/null --silent --head --fail http://localhost:8080/status); do
             printf '.'

--- a/.github/workflows/release-python-client.yml
+++ b/.github/workflows/release-python-client.yml
@@ -91,7 +91,7 @@ jobs:
           export SPRING_PROFILES_ACTIVE=data-plane,local
           ./gradlew --build-cache build -x test
           # Allow http imports from localhost to test with files from resources served by the mock API server
-          ./gradlew bootRun --args='--twds.data-import.allowed-hosts=localhost --twds.data-import.disable-validation=true' &
+          ./gradlew bootRun --args='--twds.data-import.allowed-hosts=localhost --twds.data-import.require-validation=false' &
           count=20
           until $(curl --output /dev/null --silent --head --fail http://localhost:8080/status); do
             printf '.'

--- a/.github/workflows/release-python-client.yml
+++ b/.github/workflows/release-python-client.yml
@@ -91,7 +91,7 @@ jobs:
           export SPRING_PROFILES_ACTIVE=data-plane,local
           ./gradlew --build-cache build -x test
           # Allow http imports from localhost to test with files from resources served by the mock API server
-          ./gradlew bootRun --args='--twds.data-import.allowed-hosts=localhost --twds.data-import.allowed-schemes=http' &
+          ./gradlew bootRun --args='--twds.data-import.allowed-hosts=localhost --twds.data-import.allow-http-urls=true' &
           count=20
           until $(curl --output /dev/null --silent --head --fail http://localhost:8080/status); do
             printf '.'

--- a/service/src/main/java/org/databiosphere/workspacedataservice/config/DataImportProperties.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/config/DataImportProperties.java
@@ -25,7 +25,7 @@ public class DataImportProperties {
   private boolean enableTdrPermissionSync = false;
 
   private Set<Pattern> allowedHosts = emptySet();
-  private Set<String> allowedSchemes = Set.of("https");
+  private boolean allowHttpUrls = false;
   private String rawlsNotificationsTopic;
   private String statusUpdatesTopic;
   private String statusUpdatesSubscription;
@@ -91,12 +91,12 @@ public class DataImportProperties {
     this.allowedHosts = stream(allowedHosts).map(Pattern::compile).collect(Collectors.toSet());
   }
 
-  public Set<String> getAllowedSchemes() {
-    return allowedSchemes;
+  public boolean areHttpUrlsAllowed() {
+    return allowHttpUrls;
   }
 
-  public void setAllowedSchemes(String[] allowedSchemes) {
-    this.allowedSchemes = stream(allowedSchemes).collect(Collectors.toSet());
+  public void setAllowHttpUrls(boolean allowHttpUrls) {
+    this.allowHttpUrls = allowHttpUrls;
   }
 
   public String getRawlsNotificationsTopic() {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/config/DataImportProperties.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/config/DataImportProperties.java
@@ -3,29 +3,18 @@ package org.databiosphere.workspacedataservice.config;
 import static java.util.Arrays.stream;
 import static java.util.Collections.emptySet;
 
-import com.google.common.collect.Sets;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /** Properties that dictate how data import processes should behave. */
 public class DataImportProperties {
-  private static final Set<Pattern> DEFAULT_ALLOWED_HOSTS =
-      Set.of(
-          Pattern.compile("storage\\.googleapis\\.com"),
-          Pattern.compile(".*\\.core\\.windows\\.net"),
-          // S3 allows multiple URL formats
-          // https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html
-          Pattern.compile("s3\\.amazonaws\\.com"), // path style legacy global endpoint
-          Pattern.compile(".*\\.s3\\.amazonaws\\.com") // virtual host style legacy global endpoint
-          );
   private RecordSinkMode batchWriteRecordSink;
   private String rawlsBucketName;
   private boolean succeedOnCompletion;
   private boolean enableTdrPermissionSync = false;
 
   private Set<Pattern> allowedHosts = emptySet();
-  private boolean allowHttpUrls = false;
   private String rawlsNotificationsTopic;
   private String statusUpdatesTopic;
   private String statusUpdatesSubscription;
@@ -84,19 +73,11 @@ public class DataImportProperties {
    * always allowed sources (GCS buckets, Azure storage containers, and S3 buckets).
    */
   public Set<Pattern> getAllowedHosts() {
-    return Sets.union(DEFAULT_ALLOWED_HOSTS, allowedHosts);
+    return allowedHosts;
   }
 
   public void setAllowedHosts(String[] allowedHosts) {
     this.allowedHosts = stream(allowedHosts).map(Pattern::compile).collect(Collectors.toSet());
-  }
-
-  public boolean areHttpUrlsAllowed() {
-    return allowHttpUrls;
-  }
-
-  public void setAllowHttpUrls(boolean allowHttpUrls) {
-    this.allowHttpUrls = allowHttpUrls;
   }
 
   public String getRawlsNotificationsTopic() {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/DefaultImportValidator.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/DefaultImportValidator.java
@@ -1,0 +1,40 @@
+package org.databiosphere.workspacedataservice.dataimport;
+
+import com.google.common.collect.Sets;
+import java.net.URI;
+import java.util.Set;
+import java.util.regex.Pattern;
+import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
+import org.databiosphere.workspacedataservice.service.model.exception.ValidationException;
+
+public class DefaultImportValidator implements ImportValidator {
+  private static final Set<Pattern> ALWAYS_ALLOWED_HOSTS =
+      Set.of(
+          Pattern.compile("storage\\.googleapis\\.com"),
+          Pattern.compile(".*\\.core\\.windows\\.net"),
+          // S3 allows multiple URL formats
+          // https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html
+          Pattern.compile("s3\\.amazonaws\\.com"), // path style legacy global endpoint
+          Pattern.compile(".*\\.s3\\.amazonaws\\.com") // virtual host style legacy global endpoint
+          );
+  private final Set<Pattern> allowedHosts;
+
+  public DefaultImportValidator(Set<Pattern> allowedHosts) {
+    this.allowedHosts = Sets.union(ALWAYS_ALLOWED_HOSTS, allowedHosts);
+  }
+
+  public void validateImport(ImportRequestServerModel importRequest) {
+    URI importUrl = importRequest.getUrl();
+    String urlScheme = importUrl.getScheme();
+    if (!urlScheme.equals("https")) {
+      throw new ValidationException(
+          "Files may not be imported from %s URLs.".formatted(importUrl.getScheme()));
+    }
+
+    if (allowedHosts.stream()
+        .noneMatch(allowedHost -> allowedHost.matcher(importUrl.getHost()).matches())) {
+      throw new ValidationException(
+          "Files may not be imported from %s.".formatted(importUrl.getHost()));
+    }
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportValidator.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportValidator.java
@@ -1,35 +1,7 @@
 package org.databiosphere.workspacedataservice.dataimport;
 
-import java.net.URI;
-import java.util.Set;
-import java.util.regex.Pattern;
-import org.databiosphere.workspacedataservice.config.DataImportProperties;
 import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
-import org.databiosphere.workspacedataservice.service.model.exception.ValidationException;
-import org.springframework.stereotype.Component;
 
-@Component
-public class ImportValidator {
-  private final boolean allowHttpUrls;
-  private final Set<Pattern> allowedHosts;
-
-  public ImportValidator(DataImportProperties dataImportProperties) {
-    this.allowHttpUrls = dataImportProperties.areHttpUrlsAllowed();
-    this.allowedHosts = dataImportProperties.getAllowedHosts();
-  }
-
-  public void validateImport(ImportRequestServerModel importRequest) {
-    URI importUrl = importRequest.getUrl();
-    String urlScheme = importUrl.getScheme();
-    if (!(urlScheme.equals("https") || (urlScheme.equals("http") && allowHttpUrls))) {
-      throw new ValidationException(
-          "Files may not be imported from %s URLs.".formatted(importUrl.getScheme()));
-    }
-
-    if (allowedHosts.stream()
-        .noneMatch(allowedHost -> allowedHost.matcher(importUrl.getHost()).matches())) {
-      throw new ValidationException(
-          "Files may not be imported from %s.".formatted(importUrl.getHost()));
-    }
-  }
+public interface ImportValidator {
+  void validateImport(ImportRequestServerModel importRequest);
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportValidatorConfiguration.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportValidatorConfiguration.java
@@ -1,0 +1,26 @@
+package org.databiosphere.workspacedataservice.dataimport;
+
+import org.databiosphere.workspacedataservice.config.DataImportProperties;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+public class ImportValidatorConfiguration {
+  @Bean
+  @ConditionalOnProperty(
+      name = "twds.data-import.disable-validation",
+      havingValue = "false",
+      matchIfMissing = true)
+  ImportValidator getDefaultImportValidator(DataImportProperties dataImportProperties) {
+    return new DefaultImportValidator(dataImportProperties.getAllowedHosts());
+  }
+
+  @Bean
+  @ConditionalOnProperty(name = "twds.data-import.disable-validation", havingValue = "true")
+  @Profile("local")
+  ImportValidator getNoopImportValidator() {
+    return new NoopImportValidator();
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportValidatorConfiguration.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportValidatorConfiguration.java
@@ -1,10 +1,11 @@
 package org.databiosphere.workspacedataservice.dataimport;
 
+import org.databiosphere.workspacedataservice.config.ConfigurationException;
 import org.databiosphere.workspacedataservice.config.DataImportProperties;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
+import org.springframework.core.env.Environment;
 
 @Configuration
 public class ImportValidatorConfiguration {
@@ -19,8 +20,11 @@ public class ImportValidatorConfiguration {
 
   @Bean
   @ConditionalOnProperty(name = "twds.data-import.disable-validation", havingValue = "true")
-  @Profile("local")
-  ImportValidator getNoopImportValidator() {
+  ImportValidator getNoopImportValidator(Environment environment) {
+    if (!environment.matchesProfiles("local")) {
+      throw new ConfigurationException("Import validation can only be disabled in local mode.");
+    }
+
     return new NoopImportValidator();
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportValidatorConfiguration.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportValidatorConfiguration.java
@@ -11,15 +11,15 @@ import org.springframework.core.env.Environment;
 public class ImportValidatorConfiguration {
   @Bean
   @ConditionalOnProperty(
-      name = "twds.data-import.disable-validation",
-      havingValue = "false",
+      name = "twds.data-import.require-validation",
+      havingValue = "true",
       matchIfMissing = true)
   ImportValidator getDefaultImportValidator(DataImportProperties dataImportProperties) {
     return new DefaultImportValidator(dataImportProperties.getAllowedHosts());
   }
 
   @Bean
-  @ConditionalOnProperty(name = "twds.data-import.disable-validation", havingValue = "true")
+  @ConditionalOnProperty(name = "twds.data-import.require-validation", havingValue = "false")
   ImportValidator getNoopImportValidator(Environment environment) {
     if (!environment.matchesProfiles("local")) {
       throw new ConfigurationException("Import validation can only be disabled in local mode.");

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportValidatorConfiguration.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportValidatorConfiguration.java
@@ -18,6 +18,7 @@ public class ImportValidatorConfiguration {
     return new DefaultImportValidator(dataImportProperties.getAllowedHosts());
   }
 
+  /** Allow import validation to be disabled for some test workflows. */
   @Bean
   @ConditionalOnProperty(name = "twds.data-import.require-validation", havingValue = "false")
   ImportValidator getNoopImportValidator(Environment environment) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/NoopImportValidator.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/NoopImportValidator.java
@@ -1,0 +1,13 @@
+package org.databiosphere.workspacedataservice.dataimport;
+
+import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class NoopImportValidator implements ImportValidator {
+  private static final Logger LOGGER = LoggerFactory.getLogger(NoopImportValidator.class);
+
+  public void validateImport(ImportRequestServerModel importRequest) {
+    LOGGER.warn("Skipping import validation.");
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/NoopImportValidator.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/NoopImportValidator.java
@@ -5,9 +5,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class NoopImportValidator implements ImportValidator {
-  private static final Logger LOGGER = LoggerFactory.getLogger(NoopImportValidator.class);
+  private final Logger logger = LoggerFactory.getLogger(getClass());
 
   public void validateImport(ImportRequestServerModel importRequest) {
-    LOGGER.warn("Skipping import validation.");
+    logger.warn("Skipping import validation.");
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/DefaultImportValidatorTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/DefaultImportValidatorTest.java
@@ -1,6 +1,5 @@
 package org.databiosphere.workspacedataservice.dataimport;
 
-import static java.util.Collections.emptySet;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -17,11 +16,12 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class DefaultImportValidatorTest extends TestBase {
+  private final ImportValidator importValidator =
+      new DefaultImportValidator(Set.of(Pattern.compile(".*\\.terra\\.bio")));
+
   @Test
   void requiresHttpsImportUrls() {
     // Arrange
-    ImportValidator importValidator = new DefaultImportValidator(emptySet());
-
     URI importUri =
         URI.create("http://teststorageaccount.blob.core.windows.net/testcontainer/file");
     ImportRequestServerModel importRequest = new ImportRequestServerModel(TypeEnum.PFB, importUri);
@@ -36,8 +36,6 @@ class DefaultImportValidatorTest extends TestBase {
   @Test
   void rejectsFileImportUrls() {
     // Arrange
-    ImportValidator importValidator = new DefaultImportValidator(emptySet());
-
     URI importUri = URI.create("file:///path/to/file");
     ImportRequestServerModel importRequest = new ImportRequestServerModel(TypeEnum.PFB, importUri);
 
@@ -61,8 +59,6 @@ class DefaultImportValidatorTest extends TestBase {
       })
   void allowsImportsFromCloudStorage(String cloudStorageUrl) {
     // Arrange
-    ImportValidator importValidator = new DefaultImportValidator(emptySet());
-
     URI importUri = URI.create(cloudStorageUrl);
     ImportRequestServerModel importRequest = new ImportRequestServerModel(TypeEnum.PFB, importUri);
 
@@ -73,9 +69,6 @@ class DefaultImportValidatorTest extends TestBase {
   @Test
   void allowsImportsFromConfiguredSources() {
     // Arrange
-    ImportValidator importValidator =
-        new DefaultImportValidator(Set.of(Pattern.compile(".*\\.terra\\.bio")));
-
     URI importUri = URI.create("https://files.terra.bio/file");
     ImportRequestServerModel importRequest = new ImportRequestServerModel(TypeEnum.PFB, importUri);
 
@@ -86,9 +79,6 @@ class DefaultImportValidatorTest extends TestBase {
   @Test
   void rejectsImportsFromOtherSources() {
     // Arrange
-    ImportValidator importValidator =
-        new DefaultImportValidator(Set.of(Pattern.compile(".*\\.terra\\.bio")));
-
     URI importUri = URI.create("https://example.com/file");
     ImportRequestServerModel importRequest = new ImportRequestServerModel(TypeEnum.PFB, importUri);
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/DefaultImportValidatorTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/DefaultImportValidatorTest.java
@@ -1,10 +1,13 @@
 package org.databiosphere.workspacedataservice.dataimport;
 
+import static java.util.Collections.emptySet;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.net.URI;
+import java.util.Set;
+import java.util.regex.Pattern;
 import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
 import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel.TypeEnum;
@@ -12,16 +15,13 @@ import org.databiosphere.workspacedataservice.service.model.exception.Validation
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest(properties = {"twds.data-import.allowed-hosts=.*\\.terra\\.bio"})
-class ImportValidatorTest extends TestBase {
-  @Autowired ImportValidator importValidator;
-
+class DefaultImportValidatorTest extends TestBase {
   @Test
   void requiresHttpsImportUrls() {
     // Arrange
+    ImportValidator importValidator = new DefaultImportValidator(emptySet());
+
     URI importUri =
         URI.create("http://teststorageaccount.blob.core.windows.net/testcontainer/file");
     ImportRequestServerModel importRequest = new ImportRequestServerModel(TypeEnum.PFB, importUri);
@@ -36,6 +36,8 @@ class ImportValidatorTest extends TestBase {
   @Test
   void rejectsFileImportUrls() {
     // Arrange
+    ImportValidator importValidator = new DefaultImportValidator(emptySet());
+
     URI importUri = URI.create("file:///path/to/file");
     ImportRequestServerModel importRequest = new ImportRequestServerModel(TypeEnum.PFB, importUri);
 
@@ -59,6 +61,8 @@ class ImportValidatorTest extends TestBase {
       })
   void allowsImportsFromCloudStorage(String cloudStorageUrl) {
     // Arrange
+    ImportValidator importValidator = new DefaultImportValidator(emptySet());
+
     URI importUri = URI.create(cloudStorageUrl);
     ImportRequestServerModel importRequest = new ImportRequestServerModel(TypeEnum.PFB, importUri);
 
@@ -69,6 +73,9 @@ class ImportValidatorTest extends TestBase {
   @Test
   void allowsImportsFromConfiguredSources() {
     // Arrange
+    ImportValidator importValidator =
+        new DefaultImportValidator(Set.of(Pattern.compile(".*\\.terra\\.bio")));
+
     URI importUri = URI.create("https://files.terra.bio/file");
     ImportRequestServerModel importRequest = new ImportRequestServerModel(TypeEnum.PFB, importUri);
 
@@ -79,6 +86,9 @@ class ImportValidatorTest extends TestBase {
   @Test
   void rejectsImportsFromOtherSources() {
     // Arrange
+    ImportValidator importValidator =
+        new DefaultImportValidator(Set.of(Pattern.compile(".*\\.terra\\.bio")));
+
     URI importUri = URI.create("https://example.com/file");
     ImportRequestServerModel importRequest = new ImportRequestServerModel(TypeEnum.PFB, importUri);
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/ImportValidatorTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/ImportValidatorTest.java
@@ -33,6 +33,19 @@ class ImportValidatorTest extends TestBase {
     assertEquals("Files may not be imported from http URLs.", err.getMessage());
   }
 
+  @Test
+  void rejectsFileImportUrls() {
+    // Arrange
+    URI importUri = URI.create("file:///path/to/file");
+    ImportRequestServerModel importRequest = new ImportRequestServerModel(TypeEnum.PFB, importUri);
+
+    // Act/Assert
+    ValidationException err =
+        assertThrows(
+            ValidationException.class, () -> importValidator.validateImport(importRequest));
+    assertEquals("Files may not be imported from file URLs.", err.getMessage());
+  }
+
   @ParameterizedTest
   @ValueSource(
       strings = {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobControlPlaneE2ETest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobControlPlaneE2ETest.java
@@ -39,6 +39,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import org.databiosphere.workspacedataservice.annotations.WithTestObservationRegistry;
+import org.databiosphere.workspacedataservice.dataimport.ImportValidator;
 import org.databiosphere.workspacedataservice.pubsub.PubSub;
 import org.databiosphere.workspacedataservice.rawls.RawlsClient;
 import org.databiosphere.workspacedataservice.rawls.SnapshotListResponse;
@@ -88,8 +89,6 @@ import org.springframework.util.StreamUtils;
     properties = {
       // turn off pubsub autoconfiguration for tests
       "spring.cloud.gcp.pubsub.enabled=false",
-      // Allow file imports to test with files from resources.
-      "twds.data-import.allowed-schemes=file",
       // Rawls url must be valid, else context initialization (Spring startup) will fail
       "rawlsUrl=https://localhost/",
       "management.prometheus.metrics.export.enabled=true"
@@ -108,6 +107,8 @@ class PfbQuartzJobControlPlaneE2ETest {
 
   @SpyBean PubSub pubSub;
   @SpyBean SamDao samDao;
+  // Mock ImportValidator to allow importing test data from a file:// URL.
+  @MockBean ImportValidator importValidator;
   @MockBean RawlsClient rawlsClient;
 
   /** ArgumentCaptor for the message passed to {@link PubSub#publishSync(Map)}. */

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobDataPlaneE2ETest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobDataPlaneE2ETest.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.databiosphere.workspacedataservice.annotations.SingleTenant;
+import org.databiosphere.workspacedataservice.dataimport.ImportValidator;
 import org.databiosphere.workspacedataservice.sam.SamDao;
 import org.databiosphere.workspacedataservice.service.CollectionService;
 import org.databiosphere.workspacedataservice.service.RecordOrchestratorService;
@@ -52,17 +53,15 @@ import org.springframework.test.context.ActiveProfiles;
  */
 @ActiveProfiles(profiles = {"mock-sam", "noop-scheduler-dao", "data-plane"})
 @DirtiesContext
-@SpringBootTest(
-    properties = {
-      // Allow file imports to test with files from resources.
-      "twds.data-import.allowed-schemes=file"
-    })
+@SpringBootTest
 class PfbQuartzJobDataPlaneE2ETest {
   @Autowired @SingleTenant WorkspaceId workspaceId;
   @Autowired RecordOrchestratorService recordOrchestratorService;
   @Autowired CollectionService collectionService;
   @Autowired PfbTestSupport testSupport;
   @MockBean WorkspaceManagerDao wsmDao;
+  // Mock ImportValidator to allow importing test data from a file:// URL.
+  @MockBean ImportValidator importValidator;
   @SpyBean SamDao samDao;
 
   // test resources used below

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/rawlsjson/RawlsJsonQuartzJobControlPlaneE2ETest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/rawlsjson/RawlsJsonQuartzJobControlPlaneE2ETest.java
@@ -2,10 +2,12 @@ package org.databiosphere.workspacedataservice.dataimport.rawlsjson;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
+import org.databiosphere.workspacedataservice.dataimport.ImportValidator;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
@@ -22,13 +24,14 @@ import org.springframework.test.context.TestPropertySource;
     properties = {
       // turn off pubsub autoconfiguration for tests
       "spring.cloud.gcp.pubsub.enabled=false",
-      // Allow file imports to test with files from resources.
-      "twds.data-import.allowed-schemes=file",
       // Rawls url must be valid, else context initialization (Spring startup) will fail
       "rawlsUrl=https://localhost/",
     })
 @AutoConfigureMockMvc
 class RawlsJsonQuartzJobControlPlaneE2ETest {
+  // Mock ImportValidator to allow importing test data from a file:// URL.
+  @MockBean ImportValidator importValidator;
+
   @Disabled("Not yet implemented")
   @Test
   void happyPath() {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobE2ETest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobE2ETest.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.dataimport.ImportValidator;
 import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
 import org.databiosphere.workspacedataservice.service.CollectionService;
 import org.databiosphere.workspacedataservice.service.ImportService;
@@ -57,11 +58,7 @@ import org.springframework.test.context.ActiveProfiles;
  */
 @ActiveProfiles(profiles = {"mock-sam", "noop-scheduler-dao"})
 @DirtiesContext
-@SpringBootTest(
-    properties = {
-      // Allow file imports to test with files from resources.
-      "twds.data-import.allowed-schemes=file"
-    })
+@SpringBootTest
 @AutoConfigureMockMvc
 class TdrManifestQuartzJobE2ETest extends TestBase {
   @Autowired private RecordOrchestratorService recordOrchestratorService;
@@ -69,6 +66,8 @@ class TdrManifestQuartzJobE2ETest extends TestBase {
   @Autowired private CollectionService collectionService;
   @Autowired private TdrTestSupport testSupport;
 
+  // Mock ImportValidator to allow importing test data from a file:// URL.
+  @MockBean ImportValidator importValidator;
   @MockBean WorkspaceManagerDao wsmDao;
 
   @Value("classpath:tdrmanifest/v2f.json")


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1798

By default, `ImportValidator` only allows HTTPS import URLs. Attempts to import from URLs with other schemes are rejected with a 400 response.

However, `ImportValidator` can be configured to accept other schemes via the `twds.data-import.allowed-schemes` property. This is used only for tests, to allow a few e2e tests to import test fixtures from file URLs and to allow a Python test to import from an HTTP URL.

However, there is some risk that a misconfiguration would allow users to import file URLs, potentially giving them access to data on the server. To remove that risk, this PR removes the `twds.data-import.allowed-schemes` property.

e2e tests now use a `MockBean` annotation to skip `ImportValidator`'s validation entirely.

To support the Python test, this adds an `ImportValidatorConfiguration` that replaces the default import validator with a `NoopImportValidator` when the `twds.data-import.disable-validation` property is set to true. However, it will only do that when the `local` profile is active. If `twds.data-import.disable-validation` is set to true when the `local` profile is not active, the app will fail to start.