### PR TITLE
AJ-1700 Implement `RAWLSJSON` support.

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/config/DataImportProperties.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/config/DataImportProperties.java
@@ -18,7 +18,6 @@ public class DataImportProperties {
   private String rawlsNotificationsTopic;
   private String statusUpdatesTopic;
   private String statusUpdatesSubscription;
-  private String rawlsJsonDirectImportBucket;
 
   /** Where to write records after import, options are defined by {@link RecordSinkMode} */
   public RecordSinkMode getBatchWriteRecordSink() {
@@ -36,15 +35,6 @@ public class DataImportProperties {
 
   void setRawlsBucketName(String rawlsBucketName) {
     this.rawlsBucketName = rawlsBucketName;
-  }
-
-  /** A bucket from which Rawls JSON files can be directly imported without conversion. */
-  public String getRawlsJsonDirectImportBucket() {
-    return rawlsJsonDirectImportBucket;
-  }
-
-  void setRawlsJsonDirectImportBucket(String rawlsJsonDirectImportBucket) {
-    this.rawlsJsonDirectImportBucket = rawlsJsonDirectImportBucket;
   }
 
   /**

--- a/service/src/main/java/org/databiosphere/workspacedataservice/config/DataImportProperties.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/config/DataImportProperties.java
@@ -6,6 +6,7 @@ import static java.util.Collections.emptySet;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import org.springframework.lang.Nullable;
 
 /** Properties that dictate how data import processes should behave. */
 public class DataImportProperties {
@@ -29,6 +30,7 @@ public class DataImportProperties {
   }
 
   /** Where to write Rawls JSON files after import. */
+  @Nullable
   public String getRawlsBucketName() {
     return rawlsBucketName;
   }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/config/DataImportProperties.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/config/DataImportProperties.java
@@ -18,6 +18,7 @@ public class DataImportProperties {
   private String rawlsNotificationsTopic;
   private String statusUpdatesTopic;
   private String statusUpdatesSubscription;
+  private String rawlsJsonDirectImportBucket;
 
   /** Where to write records after import, options are defined by {@link RecordSinkMode} */
   public RecordSinkMode getBatchWriteRecordSink() {
@@ -28,12 +29,22 @@ public class DataImportProperties {
     this.batchWriteRecordSink = RecordSinkMode.fromValue(batchWriteRecordSink);
   }
 
+  /** Where to write Rawls JSON files after import. */
   public String getRawlsBucketName() {
     return rawlsBucketName;
   }
 
   void setRawlsBucketName(String rawlsBucketName) {
     this.rawlsBucketName = rawlsBucketName;
+  }
+
+  /** A bucket from which Rawls JSON files can be directly imported without conversion. */
+  public String getRawlsJsonDirectImportBucket() {
+    return rawlsJsonDirectImportBucket;
+  }
+
+  void setRawlsJsonDirectImportBucket(String rawlsJsonDirectImportBucket) {
+    this.rawlsJsonDirectImportBucket = rawlsJsonDirectImportBucket;
   }
 
   /**

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/DefaultImportValidator.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/DefaultImportValidator.java
@@ -15,11 +15,13 @@ import org.databiosphere.workspacedataservice.service.model.exception.Validation
 import org.springframework.lang.Nullable;
 
 public class DefaultImportValidator implements ImportValidator {
+  private static final String SCHEME_HTTPS = "https";
+  private static final String SCHEME_GS = "gs";
   private static final Map<TypeEnum, Set<String>> SUPPORTED_URL_SCHEMES_BY_IMPORT_TYPE =
       Map.of(
-          TypeEnum.PFB, Set.of("https"),
-          TypeEnum.RAWLSJSON, Set.of("gs"),
-          TypeEnum.TDRMANIFEST, Set.of("https"));
+          TypeEnum.PFB, Set.of(SCHEME_HTTPS),
+          TypeEnum.RAWLSJSON, Set.of(SCHEME_GS),
+          TypeEnum.TDRMANIFEST, Set.of(SCHEME_HTTPS));
   private static final Set<Pattern> ALWAYS_ALLOWED_HOSTS =
       Set.of(
           Pattern.compile("storage\\.googleapis\\.com"),
@@ -35,12 +37,12 @@ public class DefaultImportValidator implements ImportValidator {
       Set<Pattern> allowedHttpsHosts, @Nullable String allowedRawlsBucket) {
     var allowedHostsBuilder =
         ImmutableMap.<String, Set<Pattern>>builder()
-            .put("https", Sets.union(ALWAYS_ALLOWED_HOSTS, allowedHttpsHosts));
+            .put(SCHEME_HTTPS, Sets.union(ALWAYS_ALLOWED_HOSTS, allowedHttpsHosts));
 
     if (StringUtils.isNotBlank(allowedRawlsBucket)) {
-      allowedHostsBuilder.put("gs", Set.of(Pattern.compile(allowedRawlsBucket)));
+      allowedHostsBuilder.put(SCHEME_GS, Set.of(Pattern.compile(allowedRawlsBucket)));
     } else {
-      allowedHostsBuilder.put("gs", emptySet());
+      allowedHostsBuilder.put(SCHEME_GS, emptySet());
     }
 
     this.allowedHostsByScheme = allowedHostsBuilder.build();

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportDetailsRetriever.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportDetailsRetriever.java
@@ -14,6 +14,7 @@ import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.springframework.stereotype.Component;
 
+/** Retrieves various common details needed for import jobs. */
 @Component
 public class ImportDetailsRetriever {
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportDetailsRetriever.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportDetailsRetriever.java
@@ -32,8 +32,6 @@ public class ImportDetailsRetriever {
     String authToken = jobData.getString(ARG_TOKEN);
     Supplier<String> userEmailSupplier = () -> samDao.getUserEmail(BearerToken.of(authToken));
 
-    // Import all the tables and rows inside the PFB.
-    //
     // determine the workspace for the target collection
     CollectionId collectionId = CollectionId.of(targetCollection);
     WorkspaceId workspaceId = collectionService.getWorkspaceId(collectionId);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportDetailsRetriever.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportDetailsRetriever.java
@@ -1,0 +1,41 @@
+package org.databiosphere.workspacedataservice.dataimport;
+
+import static org.databiosphere.workspacedataservice.shared.model.Schedulable.ARG_COLLECTION;
+import static org.databiosphere.workspacedataservice.shared.model.Schedulable.ARG_TOKEN;
+
+import java.util.UUID;
+import java.util.function.Supplier;
+import org.databiosphere.workspacedataservice.jobexec.JobDataMapReader;
+import org.databiosphere.workspacedataservice.recordsink.RawlsAttributePrefixer.PrefixStrategy;
+import org.databiosphere.workspacedataservice.sam.SamDao;
+import org.databiosphere.workspacedataservice.service.CollectionService;
+import org.databiosphere.workspacedataservice.shared.model.BearerToken;
+import org.databiosphere.workspacedataservice.shared.model.CollectionId;
+import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ImportDetailsRetriever {
+
+  private final SamDao samDao;
+  private final CollectionService collectionService;
+
+  ImportDetailsRetriever(SamDao samDao, CollectionService collectionService) {
+    this.samDao = samDao;
+    this.collectionService = collectionService;
+  }
+
+  public ImportDetails fetch(UUID jobId, JobDataMapReader jobData, PrefixStrategy prefixStrategy) {
+    // Collect details needed for import
+    UUID targetCollection = jobData.getUUID(ARG_COLLECTION);
+    String authToken = jobData.getString(ARG_TOKEN);
+    Supplier<String> userEmailSupplier = () -> samDao.getUserEmail(BearerToken.of(authToken));
+
+    // Import all the tables and rows inside the PFB.
+    //
+    // determine the workspace for the target collection
+    CollectionId collectionId = CollectionId.of(targetCollection);
+    WorkspaceId workspaceId = collectionService.getWorkspaceId(collectionId);
+    return new ImportDetails(jobId, userEmailSupplier, workspaceId, collectionId, prefixStrategy);
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportValidatorConfiguration.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportValidatorConfiguration.java
@@ -15,7 +15,8 @@ public class ImportValidatorConfiguration {
       havingValue = "true",
       matchIfMissing = true)
   ImportValidator getDefaultImportValidator(DataImportProperties dataImportProperties) {
-    return new DefaultImportValidator(dataImportProperties.getAllowedHosts());
+    return new DefaultImportValidator(
+        dataImportProperties.getAllowedHosts(), dataImportProperties.getRawlsBucketName());
   }
 
   /** Allow import validation to be disabled for some test workflows. */

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/rawlsjson/RawlsJsonQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/rawlsjson/RawlsJsonQuartzJob.java
@@ -1,26 +1,46 @@
 package org.databiosphere.workspacedataservice.dataimport.rawlsjson;
 
 import static org.databiosphere.workspacedataservice.generated.ImportRequestServerModel.TypeEnum.RAWLSJSON;
+import static org.databiosphere.workspacedataservice.shared.model.Schedulable.ARG_URL;
 import static org.databiosphere.workspacedataservice.shared.model.job.JobType.DATA_IMPORT;
 
+import com.google.cloud.storage.Blob;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
+import java.net.URI;
 import java.util.UUID;
+import org.databiosphere.workspacedataservice.annotations.DeploymentMode.ControlPlane;
 import org.databiosphere.workspacedataservice.config.DataImportProperties;
 import org.databiosphere.workspacedataservice.dao.JobDao;
+import org.databiosphere.workspacedataservice.dataimport.ImportDetails;
+import org.databiosphere.workspacedataservice.dataimport.ImportDetailsRetriever;
+import org.databiosphere.workspacedataservice.jobexec.JobDataMapReader;
 import org.databiosphere.workspacedataservice.jobexec.QuartzJob;
+import org.databiosphere.workspacedataservice.pubsub.PubSub;
+import org.databiosphere.workspacedataservice.pubsub.RawlsJsonPublisher;
+import org.databiosphere.workspacedataservice.recordsink.RawlsAttributePrefixer.PrefixStrategy;
+import org.databiosphere.workspacedataservice.storage.GcsStorage;
 import org.quartz.JobExecutionContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
 
+@ControlPlane
+@Component
 public class RawlsJsonQuartzJob extends QuartzJob {
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private final ImportDetailsRetriever importDetailsRetriever;
+  private final GcsStorage storage;
+  private final PubSub pubSub;
 
   public RawlsJsonQuartzJob(
       DataImportProperties dataImportProperties,
       ObservationRegistry observationRegistry,
-      JobDao jobDao) {
+      JobDao jobDao,
+      ImportDetailsRetriever importDetailsRetriever,
+      GcsStorage storage,
+      PubSub pubSub) {
     super(jobDao, observationRegistry, dataImportProperties);
+    this.importDetailsRetriever = importDetailsRetriever;
+    this.storage = storage;
+    this.pubSub = pubSub;
   }
 
   @Override
@@ -31,7 +51,27 @@ public class RawlsJsonQuartzJob extends QuartzJob {
 
   @Override
   protected void executeInternal(UUID jobId, JobExecutionContext context) {
-    logger.atInfo().log(
-        "RawlsJsonQuartzJob.executeInternal: jobId={} - not yet implemented (no op)!", jobId);
+    JobDataMapReader jobData = JobDataMapReader.fromContext(context);
+    URI sourceUri = jobData.getURI(ARG_URL);
+    Blob destination = moveBlob(sourceUri, rawlsJsonBlobName(jobId));
+    publishToRawls(jobId, jobData, destination);
+  }
+
+  private Blob moveBlob(URI sourceUri, String desiredBlobName) {
+    return storage.moveBlob(sourceUri, storage.createBlob(desiredBlobName));
+  }
+
+  private ImportDetails getImportDetails(UUID jobId, JobDataMapReader jobData) {
+    return importDetailsRetriever.fetch(jobId, jobData, PrefixStrategy.NONE);
+  }
+
+  private void publishToRawls(UUID jobId, JobDataMapReader jobData, Blob destination) {
+    new RawlsJsonPublisher(
+            pubSub, getImportDetails(jobId, jobData), destination, jobData.getBoolean("isUpsert"))
+        .publish();
+  }
+
+  public static String rawlsJsonBlobName(UUID jobId) {
+    return "%s-rawls-batch-write.json".formatted(jobId.toString());
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/rawlsjson/RawlsJsonQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/rawlsjson/RawlsJsonQuartzJob.java
@@ -1,6 +1,7 @@
 package org.databiosphere.workspacedataservice.dataimport.rawlsjson;
 
 import static org.databiosphere.workspacedataservice.generated.ImportRequestServerModel.TypeEnum.RAWLSJSON;
+import static org.databiosphere.workspacedataservice.service.ImportService.ARG_IS_UPSERT;
 import static org.databiosphere.workspacedataservice.shared.model.Schedulable.ARG_URL;
 import static org.databiosphere.workspacedataservice.shared.model.job.JobType.DATA_IMPORT;
 
@@ -67,7 +68,10 @@ public class RawlsJsonQuartzJob extends QuartzJob {
 
   private void publishToRawls(UUID jobId, JobDataMapReader jobData, Blob destination) {
     new RawlsJsonPublisher(
-            pubSub, getImportDetails(jobId, jobData), destination, jobData.getBoolean("isUpsert"))
+            pubSub,
+            getImportDetails(jobId, jobData),
+            destination,
+            jobData.getBoolean(ARG_IS_UPSERT))
         .publish();
   }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJob.java
@@ -19,6 +19,7 @@ import io.micrometer.observation.ObservationRegistry;
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.Collection;
 import java.util.List;
@@ -107,15 +108,15 @@ public class TdrManifestQuartzJob extends QuartzJob {
   // TODO AJ-1523 unit tests
   @Override
   protected void executeInternal(UUID jobId, JobExecutionContext context) {
-    // Grab the manifest url from the job's data map
+    // Grab the manifest uri from the job's data map
     JobDataMapReader jobData = JobDataMapReader.fromContext(context);
-    URL url = jobData.getURL(ARG_URL);
+    URI uri = jobData.getURI(ARG_URL);
 
     // Collect details needed for import
     ImportDetails details = importDetailsRetriever.fetch(jobId, jobData, PrefixStrategy.TDR);
 
     // read manifest
-    SnapshotExportResponseModel snapshotExportResponseModel = parseManifest(url);
+    SnapshotExportResponseModel snapshotExportResponseModel = parseManifest(uri);
 
     // get the snapshot id from the manifest
     UUID snapshotId = snapshotExportResponseModel.getSnapshot().getId();
@@ -298,14 +299,14 @@ public class TdrManifestQuartzJob extends QuartzJob {
   /**
    * Read the manifest from the user-specified URL into a SnapshotExportResponseModel java object
    *
-   * @param manifestUrl url to the manifest
+   * @param manifestUri url to the manifest
    * @return parsed object
    */
   @VisibleForTesting
-  SnapshotExportResponseModel parseManifest(URL manifestUrl) {
+  SnapshotExportResponseModel parseManifest(URI manifestUri) {
     // read manifest
     try {
-      return mapper.readValue(manifestUrl, SnapshotExportResponseModel.class);
+      return mapper.readValue(manifestUri.toURL(), SnapshotExportResponseModel.class);
     } catch (IOException e) {
       throw new JobExecutionException(
           "Error reading TDR snapshot manifest: %s".formatted(e.getMessage()), e);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJob.java
@@ -4,8 +4,6 @@ import static org.apache.parquet.avro.AvroReadSupport.READ_INT96_AS_FIXED;
 import static org.databiosphere.workspacedataservice.generated.ImportRequestServerModel.TypeEnum.TDRMANIFEST;
 import static org.databiosphere.workspacedataservice.sam.SamAuthorizationDao.WORKSPACE_ROLES;
 import static org.databiosphere.workspacedataservice.service.ImportService.ARG_TDR_SYNC_PERMISSION;
-import static org.databiosphere.workspacedataservice.shared.model.Schedulable.ARG_COLLECTION;
-import static org.databiosphere.workspacedataservice.shared.model.Schedulable.ARG_TOKEN;
 import static org.databiosphere.workspacedataservice.shared.model.Schedulable.ARG_URL;
 import static org.databiosphere.workspacedataservice.shared.model.job.JobType.DATA_IMPORT;
 
@@ -27,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.function.Supplier;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.avro.AvroParquetReader;
@@ -39,8 +36,10 @@ import org.databiosphere.workspacedataservice.config.DataImportProperties;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.dataimport.FileDownloadHelper;
 import org.databiosphere.workspacedataservice.dataimport.ImportDetails;
+import org.databiosphere.workspacedataservice.dataimport.ImportDetailsRetriever;
 import org.databiosphere.workspacedataservice.dataimport.snapshotsupport.SnapshotSupport;
 import org.databiosphere.workspacedataservice.dataimport.snapshotsupport.SnapshotSupportFactory;
+import org.databiosphere.workspacedataservice.jobexec.JobDataMapReader;
 import org.databiosphere.workspacedataservice.jobexec.JobExecutionException;
 import org.databiosphere.workspacedataservice.jobexec.QuartzJob;
 import org.databiosphere.workspacedataservice.recordsink.RawlsAttributePrefixer.PrefixStrategy;
@@ -50,16 +49,12 @@ import org.databiosphere.workspacedataservice.recordsource.RecordSource.ImportMo
 import org.databiosphere.workspacedataservice.recordsource.RecordSourceFactory;
 import org.databiosphere.workspacedataservice.sam.SamDao;
 import org.databiosphere.workspacedataservice.service.BatchWriteService;
-import org.databiosphere.workspacedataservice.service.CollectionService;
 import org.databiosphere.workspacedataservice.service.model.BatchWriteResult;
 import org.databiosphere.workspacedataservice.service.model.TdrManifestImportTable;
 import org.databiosphere.workspacedataservice.service.model.exception.RestException;
 import org.databiosphere.workspacedataservice.service.model.exception.TdrManifestImportException;
-import org.databiosphere.workspacedataservice.shared.model.BearerToken;
-import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
-import org.quartz.JobDataMap;
 import org.quartz.JobExecutionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,41 +62,40 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class TdrManifestQuartzJob extends QuartzJob {
+  private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
   private final RecordSinkFactory recordSinkFactory;
   private final BatchWriteService batchWriteService;
-  private final CollectionService collectionService;
   private final ActivityLogger activityLogger;
   private final ObjectMapper mapper;
   private final RecordSourceFactory recordSourceFactory;
   private final SnapshotSupportFactory snapshotSupportFactory;
   private final SamDao samDao;
   private final boolean isTdrPermissionSyncingEnabled;
-
-  private final Logger logger = LoggerFactory.getLogger(this.getClass());
+  private final ImportDetailsRetriever importDetailsRetriever;
 
   public TdrManifestQuartzJob(
       JobDao jobDao,
       RecordSourceFactory recordSourceFactory,
       RecordSinkFactory recordSinkFactory,
       BatchWriteService batchWriteService,
-      CollectionService collectionService,
       ActivityLogger activityLogger,
       ObjectMapper mapper,
       ObservationRegistry observationRegistry,
       DataImportProperties dataImportProperties,
       SnapshotSupportFactory snapshotSupportFactory,
-      SamDao samDao) {
+      SamDao samDao,
+      ImportDetailsRetriever importDetailsRetriever) {
     super(jobDao, observationRegistry, dataImportProperties);
     this.recordSinkFactory = recordSinkFactory;
     this.recordSourceFactory = recordSourceFactory;
     this.batchWriteService = batchWriteService;
-    this.collectionService = collectionService;
     this.activityLogger = activityLogger;
     this.mapper = mapper;
     this.snapshotSupportFactory = snapshotSupportFactory;
     this.samDao = samDao;
     this.isTdrPermissionSyncingEnabled = dataImportProperties.isTdrPermissionSyncingEnabled();
+    this.importDetailsRetriever = importDetailsRetriever;
   }
 
   @Override
@@ -114,38 +108,31 @@ public class TdrManifestQuartzJob extends QuartzJob {
   @Override
   protected void executeInternal(UUID jobId, JobExecutionContext context) {
     // Grab the manifest url from the job's data map
-    JobDataMap jobDataMap = context.getMergedJobDataMap();
-    URL url = getJobDataUrl(jobDataMap, ARG_URL);
+    JobDataMapReader jobData = JobDataMapReader.fromContext(context);
+    URL url = jobData.getURL(ARG_URL);
 
     // Collect details needed for import
-    UUID targetCollection = getJobDataUUID(jobDataMap, ARG_COLLECTION);
-    String authToken = getJobDataString(jobDataMap, ARG_TOKEN);
-    Supplier<String> userEmailSupplier = () -> samDao.getUserEmail(BearerToken.of(authToken));
-
-    // determine the workspace for the target collection
-    CollectionId collectionId = CollectionId.of(targetCollection);
-    WorkspaceId workspaceId = collectionService.getWorkspaceId(collectionId);
-    ImportDetails importDetails =
-        new ImportDetails(jobId, userEmailSupplier, workspaceId, collectionId, PrefixStrategy.TDR);
+    ImportDetails details = importDetailsRetriever.fetch(jobId, jobData, PrefixStrategy.TDR);
 
     // read manifest
     SnapshotExportResponseModel snapshotExportResponseModel = parseManifest(url);
 
     // get the snapshot id from the manifest
     UUID snapshotId = snapshotExportResponseModel.getSnapshot().getId();
-    logger.info("Starting import of snapshot {} to collection {}", snapshotId, targetCollection);
+    logger.info(
+        "Starting import of snapshot {} to collection {}", snapshotId, details.collectionId());
 
     // Create snapshot reference
-    linkSnapshots(Set.of(snapshotId), workspaceId);
+    linkSnapshots(Set.of(snapshotId), details.workspaceId());
 
     // read the manifest and extract the information necessary to perform the import
     List<TdrManifestImportTable> tdrManifestImportTables =
-        extractTableInfo(snapshotExportResponseModel, workspaceId);
+        extractTableInfo(snapshotExportResponseModel, details.workspaceId());
 
     // get all the parquet files from the manifests
 
     FileDownloadHelper fileDownloadHelper = getFilesForImport(tdrManifestImportTables);
-    try (RecordSink recordSink = recordSinkFactory.buildRecordSink(importDetails)) {
+    try (RecordSink recordSink = recordSinkFactory.buildRecordSink(details)) {
       // loop through the tables to be imported and upsert base attributes
       var result =
           importTables(
@@ -175,8 +162,8 @@ public class TdrManifestQuartzJob extends QuartzJob {
                               .withRecordType(entry.getKey())
                               .ofQuantity(entry.getValue())));
       // sync permissions if option is enabled and we're running in the control-plane
-      if (isTdrPermissionSyncingEnabled && jobDataMap.getBoolean(ARG_TDR_SYNC_PERMISSION)) {
-        syncPermissions(workspaceId, snapshotId);
+      if (isTdrPermissionSyncingEnabled && jobData.getBoolean(ARG_TDR_SYNC_PERMISSION)) {
+        syncPermissions(details.workspaceId(), snapshotId);
       }
     } catch (Exception e) {
       throw new TdrManifestImportException(e.getMessage(), e);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJob.java
@@ -163,6 +163,7 @@ public class TdrManifestQuartzJob extends QuartzJob {
                               .withRecordType(entry.getKey())
                               .ofQuantity(entry.getValue())));
       // sync permissions if option is enabled and we're running in the control-plane
+      // TODO(AJ-1809): do defaulting here when we have a more generic way to handle passed options
       if (isTdrPermissionSyncingEnabled && jobData.getBoolean(ARG_TDR_SYNC_PERMISSION)) {
         syncPermissions(details.workspaceId(), snapshotId);
       }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/jobexec/JobDataMapReader.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/jobexec/JobDataMapReader.java
@@ -1,0 +1,86 @@
+package org.databiosphere.workspacedataservice.jobexec;
+
+import java.net.URL;
+import java.util.UUID;
+import org.quartz.JobDataMap;
+import org.quartz.JobExecutionContext;
+
+public class JobDataMapReader {
+
+  private final JobDataMap jobDataMap;
+
+  JobDataMapReader(JobDataMap jobDataMap) {
+    this.jobDataMap = jobDataMap;
+  }
+
+  public static JobDataMapReader fromContext(JobExecutionContext context) {
+    return new JobDataMapReader(context.getMergedJobDataMap());
+  }
+
+  /**
+   * Retrieve a String value from a JobDataMap. Throws a JobExecutionException if the value is not
+   * found/null or not a String.
+   *
+   * @param key where to find the String in the map
+   * @return value from the JobDataMap
+   */
+  public String getString(String key) {
+    String returnValue;
+    try {
+      returnValue = jobDataMap.getString(key);
+      if (returnValue == null) {
+        throw new JobExecutionException("Key '%s' was null in JobDataMap".formatted(key));
+      }
+      return returnValue;
+    } catch (Exception e) {
+      throw new JobExecutionException(
+          "Error retrieving key %s from JobDataMap: %s".formatted(key, e.getMessage()), e);
+    }
+  }
+
+  /**
+   * Retrieve a UUID value from a JobDataMap. Throws a JobExecutionException if the value is not
+   * found/null or not a UUID.
+   *
+   * @param key where to find the UUID in the map
+   * @return value from the JobDataMap
+   */
+  public UUID getUUID(String key) {
+    try {
+      return UUID.fromString(jobDataMap.getString(key));
+    } catch (Exception e) {
+      throw new JobExecutionException(
+          "Error retrieving key %s as UUID from JobDataMap: %s".formatted(key, e.getMessage()), e);
+    }
+  }
+
+  /**
+   * Retrieve a URL value from a JobDataMap. Throws a JobExecutionException if the value is not
+   * found/null or cannot be parsed into a URL.
+   *
+   * @param key where to find the URL in the map
+   * @return value from the JobDataMap
+   */
+  public URL getURL(String key) {
+    try {
+      return new URL(jobDataMap.getString(key));
+    } catch (Exception e) {
+      throw new JobExecutionException(
+          "Error retrieving key %s as URL from JobDataMap: %s".formatted(key, e.getMessage()), e);
+    }
+  }
+
+  /**
+   * Retrieve a Boolean from a JobDataMap. Throws a JobExecutionException if the value is not
+   * found/null or cannot be parsed into a Boolean.
+   */
+  public Boolean getBoolean(String key) {
+    try {
+      return jobDataMap.getBooleanValue(key);
+    } catch (Exception e) {
+      throw new JobExecutionException(
+          "Error retrieving key %s as Boolean from JobDataMap: %s".formatted(key, e.getMessage()),
+          e);
+    }
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/jobexec/JobDataMapReader.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/jobexec/JobDataMapReader.java
@@ -1,10 +1,11 @@
 package org.databiosphere.workspacedataservice.jobexec;
 
-import java.net.URL;
+import java.net.URI;
 import java.util.UUID;
 import org.quartz.JobDataMap;
 import org.quartz.JobExecutionContext;
 
+/** Utility class to read typed keys from a {@link JobDataMap}. */
 public class JobDataMapReader {
 
   private final JobDataMap jobDataMap;
@@ -55,15 +56,15 @@ public class JobDataMapReader {
   }
 
   /**
-   * Retrieve a URL value from a JobDataMap. Throws a JobExecutionException if the value is not
-   * found/null or cannot be parsed into a URL.
+   * Retrieve a URI value from a JobDataMap. Throws a JobExecutionException if the value is not
+   * found/null or cannot be parsed into a URI.
    *
-   * @param key where to find the URL in the map
-   * @return value from the JobDataMap
+   * @param key where to find the URI in the map
+   * @return {@link URI} from the JobDataMap
    */
-  public URL getURL(String key) {
+  public URI getURI(String key) {
     try {
-      return new URL(jobDataMap.getString(key));
+      return new URI(jobDataMap.getString(key));
     } catch (Exception e) {
       throw new JobExecutionException(
           "Error retrieving key %s as URL from JobDataMap: %s".formatted(key, e.getMessage()), e);
@@ -74,7 +75,7 @@ public class JobDataMapReader {
    * Retrieve a Boolean from a JobDataMap. Throws a JobExecutionException if the value is not
    * found/null or cannot be parsed into a Boolean.
    */
-  public Boolean getBoolean(String key) {
+  public boolean getBoolean(String key) {
     try {
       return jobDataMap.getBooleanValue(key);
     } catch (Exception e) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/pubsub/RawlsJsonPublisher.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/pubsub/RawlsJsonPublisher.java
@@ -1,0 +1,49 @@
+package org.databiosphere.workspacedataservice.pubsub;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.cloud.storage.Blob;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import java.util.UUID;
+import org.databiosphere.workspacedataservice.dataimport.ImportDetails;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RawlsJsonPublisher {
+  private final Logger logger = LoggerFactory.getLogger(getClass());
+
+  private final PubSub pubSub;
+  private final Blob blob;
+  private final ImportDetails importDetails;
+  private final boolean isUpsert;
+
+  public RawlsJsonPublisher(
+      PubSub pubSub, ImportDetails importDetails, Blob blob, boolean isUpsert) {
+    this.pubSub = pubSub;
+    this.blob = blob;
+    this.importDetails = importDetails;
+    this.isUpsert = isUpsert;
+  }
+
+  public void publish() {
+    UUID jobId = requireNonNull(importDetails.jobId());
+    String user =
+        requireNonNull(
+                importDetails.userEmailSupplier(),
+                "Expected ImportDetails.userEmailSupplier to be non-null for async imports")
+            .get();
+    Map<String, String> message =
+        new ImmutableMap.Builder<String, String>()
+            .put("workspaceId", importDetails.workspaceId().toString())
+            .put("userEmail", user)
+            .put("jobId", jobId.toString())
+            .put("upsertFile", blob.getBucket() + "/" + blob.getName())
+            .put("isUpsert", String.valueOf(isUpsert))
+            .put("isCWDS", "true")
+            .build();
+    logger.info("Publishing message to pub/sub for job {} ...", jobId);
+    String publishResult = pubSub.publishSync(message);
+    logger.info("Pub/sub publishing complete for job {}: {}", jobId, publishResult);
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/pubsub/RawlsJsonPublisher.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/pubsub/RawlsJsonPublisher.java
@@ -10,6 +10,7 @@ import org.databiosphere.workspacedataservice.dataimport.ImportDetails;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** Publishes a message to pub/sub for the given {@link ImportDetails}. */
 public class RawlsJsonPublisher {
   private final Logger logger = LoggerFactory.getLogger(getClass());
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSink.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSink.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 import org.databiosphere.workspacedataservice.dataimport.ImportDetails;
+import org.databiosphere.workspacedataservice.dataimport.rawlsjson.RawlsJsonQuartzJob;
 import org.databiosphere.workspacedataservice.pubsub.PubSub;
 import org.databiosphere.workspacedataservice.pubsub.RawlsJsonPublisher;
 import org.databiosphere.workspacedataservice.recordsink.RawlsModel.AddListMember;
@@ -60,8 +61,7 @@ public class RawlsRecordSink implements RecordSink {
    */
   public static RawlsRecordSink create(
       ObjectMapper mapper, GcsStorage storage, PubSub pubSub, ImportDetails details) {
-    String blobName = "%s.rawlsUpsert".formatted(details.jobId().toString());
-    Blob blob = storage.createBlob(blobName);
+    Blob blob = storage.createBlob(RawlsJsonQuartzJob.rawlsJsonBlobName(details.jobId()));
     return new RawlsRecordSink(
         new RawlsAttributePrefixer(details.prefixStrategy()),
         JsonWriter.create(storage.getOutputStream(blob), mapper),

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSink.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSink.java
@@ -58,6 +58,7 @@ public class RawlsRecordSink implements RecordSink {
    *
    * @param mapper used to generate the stream of JSON entities
    * @param storage where the JSON stream will be written
+   * @param pubSub to notify upon JSON stream completion
    * @param details to use for generating the message to send to PubSub
    */
   public static RawlsRecordSink create(

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSink.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSink.java
@@ -1,22 +1,19 @@
 package org.databiosphere.workspacedataservice.recordsink;
 
-import static java.util.Objects.requireNonNull;
-
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.cloud.spring.storage.GoogleStorageResource;
 import com.google.cloud.storage.Blob;
-import com.google.common.collect.ImmutableMap;
 import com.google.mu.util.stream.BiStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.UUID;
 import java.util.stream.Stream;
 import org.databiosphere.workspacedataservice.dataimport.ImportDetails;
 import org.databiosphere.workspacedataservice.pubsub.PubSub;
+import org.databiosphere.workspacedataservice.pubsub.RawlsJsonPublisher;
 import org.databiosphere.workspacedataservice.recordsink.RawlsModel.AddListMember;
 import org.databiosphere.workspacedataservice.recordsink.RawlsModel.AddUpdateAttribute;
 import org.databiosphere.workspacedataservice.recordsink.RawlsModel.AttributeOperation;
@@ -32,8 +29,6 @@ import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 import org.databiosphere.workspacedataservice.shared.model.attributes.RelationAttribute;
 import org.databiosphere.workspacedataservice.storage.GcsStorage;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.util.function.ThrowingConsumer;
 
 /**
@@ -42,28 +37,17 @@ import org.springframework.util.function.ThrowingConsumer;
  */
 public class RawlsRecordSink implements RecordSink {
   private final RawlsAttributePrefixer attributePrefixer;
-  private final PubSub pubSub;
-  private final ImportDetails importDetails;
 
   private final JsonWriter jsonWriter;
-  private final Blob blob;
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(RawlsRecordSink.class);
+  private final RawlsJsonPublisher publisher;
 
   RawlsRecordSink(
       RawlsAttributePrefixer attributePrefixer,
       JsonWriter jsonWriter,
-      PubSub pubSub,
-      ImportDetails importDetails,
-      Blob blob) {
+      RawlsJsonPublisher publisher) {
     this.attributePrefixer = attributePrefixer;
     this.jsonWriter = jsonWriter;
-
-    // TODO: These three instance variables are used exclusively for pubsub concerns; if we can
-    //   factor the pubsub responsibility out somehow, RawlsRecordSink can be a lot more focused.
-    this.pubSub = pubSub;
-    this.importDetails = importDetails;
-    this.blob = blob;
+    this.publisher = publisher;
   }
 
   /**
@@ -72,19 +56,16 @@ public class RawlsRecordSink implements RecordSink {
    *
    * @param mapper used to generate the stream of JSON entities
    * @param storage where the JSON stream will be written
-   * @param pubSub to notify upon JSON stream completion
-   * @param importDetails to use for generating the message to send to PubSub
+   * @param details to use for generating the message to send to PubSub
    */
   public static RawlsRecordSink create(
-      ObjectMapper mapper, GcsStorage storage, PubSub pubSub, ImportDetails importDetails) {
-    String blobName = getBlobName(requireNonNull(importDetails.jobId()));
+      ObjectMapper mapper, GcsStorage storage, PubSub pubSub, ImportDetails details) {
+    String blobName = "%s.rawlsUpsert".formatted(details.jobId().toString());
     Blob blob = storage.createBlob(blobName);
     return new RawlsRecordSink(
-        new RawlsAttributePrefixer(importDetails.prefixStrategy()),
+        new RawlsAttributePrefixer(details.prefixStrategy()),
         JsonWriter.create(storage.getOutputStream(blob), mapper),
-        pubSub,
-        importDetails,
-        blob);
+        new RawlsJsonPublisher(pubSub, details, blob, /* isUpsert= */ true));
   }
 
   @Override
@@ -115,7 +96,9 @@ public class RawlsRecordSink implements RecordSink {
   @Override
   public void close() {
     jsonWriter.close();
-    publishToPubSub(importDetails);
+
+    // TODO: add failure detection so we don't publish on failures
+    publisher.publish();
   }
 
   private Entity toEntity(Record wdsRecord) {
@@ -162,31 +145,6 @@ public class RawlsRecordSink implements RecordSink {
       return AttributeValue.of(EntityReference.fromRelationAttribute(relationAttribute));
     }
     return AttributeValue.of(originalValue);
-  }
-
-  static String getBlobName(UUID jobId) {
-    return "%s.rawlsUpsert".formatted(jobId.toString());
-  }
-
-  private void publishToPubSub(ImportDetails importDetails) {
-    UUID jobId = requireNonNull(importDetails.jobId());
-    String user =
-        requireNonNull(
-                importDetails.userEmailSupplier(),
-                "Expected ImportDetails.userEmailSupplier to be non-null for async imports")
-            .get();
-    Map<String, String> message =
-        new ImmutableMap.Builder<String, String>()
-            .put("workspaceId", importDetails.workspaceId().toString())
-            .put("userEmail", user)
-            .put("jobId", jobId.toString())
-            .put("upsertFile", blob.getBucket() + "/" + blob.getName())
-            .put("isUpsert", "true")
-            .put("isCWDS", "true")
-            .build();
-    LOGGER.info("Publishing message to pub/sub for job {} ...", jobId);
-    String publishResult = pubSub.publishSync(message);
-    LOGGER.info("Pub/sub publishing complete for job {}: {}", jobId, publishResult);
   }
 
   /**

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkFactory.java
@@ -25,9 +25,6 @@ public class RawlsRecordSinkFactory implements RecordSinkFactory {
     this.pubSub = pubSub;
   }
 
-  // TODO(AJ-1589): make prefix assignment dynamic. However, of note: the prefix is currently
-  //   ignored for RecordSinkMode.WDS.  In this case, it might be worth adding support for omitting
-  //   the prefix as part of supporting the prefix assignment.
   public RecordSink buildRecordSink(ImportDetails importDetails) {
     return rawlsRecordSink(importDetails);
   }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RecordSink.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RecordSink.java
@@ -49,5 +49,7 @@ public interface RecordSink extends AutoCloseable {
    *
    * @throws DataImportException if an error occurs while closing the sink
    */
-  void close() throws DataImportException;
+  default void close() throws DataImportException {
+    // no-op
+  }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/WdsRecordSink.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/WdsRecordSink.java
@@ -69,9 +69,4 @@ public class WdsRecordSink implements RecordSink {
   public void deleteBatch(RecordType recordType, List<Record> records) {
     recordDao.batchDelete(collectionId.id(), recordType, records);
   }
-
-  @Override
-  public void close() {
-    // no-op
-  }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
@@ -19,6 +19,7 @@ import org.databiosphere.workspacedataservice.dataimport.rawlsjson.RawlsJsonSche
 import org.databiosphere.workspacedataservice.dataimport.tdr.TdrManifestSchedulable;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
 import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
+import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel.TypeEnum;
 import org.databiosphere.workspacedataservice.sam.SamDao;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthenticationException;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthenticationMaskableException;
@@ -41,6 +42,7 @@ public class ImportService {
   private final SamDao samDao;
   private final JobDao jobDao;
   private final SchedulerDao schedulerDao;
+
   private final ImportValidator importValidator;
 
   public ImportService(
@@ -89,8 +91,6 @@ public class ImportService {
     // get a token to execute the job
     String petToken = samDao.getPetToken();
 
-    // TODO: translate the ImportRequestServerModel into a Job
-    // for now, just make an example job
     logger.info("Data import of type {} requested", importRequest.getType());
 
     ImportJobInput importJobInput = ImportJobInput.from(importRequest);
@@ -153,9 +153,7 @@ public class ImportService {
 
   @VisibleForTesting
   public static Schedulable createSchedulable(
-      ImportRequestServerModel.TypeEnum importType,
-      UUID jobId,
-      Map<String, Serializable> arguments) {
+      TypeEnum importType, UUID jobId, Map<String, Serializable> arguments) {
     return switch (importType) {
       case PFB -> new PfbSchedulable(jobId.toString(), "PFB import", arguments);
       case RAWLSJSON -> new RawlsJsonSchedulable(jobId.toString(), "RAWLSJSON import", arguments);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
@@ -37,6 +37,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class ImportService {
   public static final String ARG_TDR_SYNC_PERMISSION = "tdrSyncPermissions";
+  public static final String ARG_IS_UPSERT = "isUpsert";
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
   private final CollectionService collectionService;
   private final SamDao samDao;
@@ -110,10 +111,9 @@ public class ImportService {
       arguments.put(ARG_TOKEN, petToken);
       arguments.put(ARG_URL, importRequest.getUrl().toString());
       arguments.put(ARG_COLLECTION, collectionId.toString());
-      // try to retrieve the tdrSyncPermissions option if available (first as string, then bool)
-      String tdrSyncPermissions =
-          importRequest.getOptions().getOrDefault(ARG_TDR_SYNC_PERMISSION, "false").toString();
-      arguments.put(ARG_TDR_SYNC_PERMISSION, Boolean.parseBoolean(tdrSyncPermissions));
+
+      // maybe pass through import-type specific options
+      maybePassThroughOptions(importRequest, arguments);
 
       // if we can find an MDC id, add it to the job context
       safeGetMdcId(createdJob.getJobId())
@@ -138,6 +138,23 @@ public class ImportService {
 
     // return the queued job
     return createdJob;
+  }
+
+  // TODO(AJ-1809): Handle opts passthrough more generically/effectively:
+  //   Ideally when creating Schedulable, it would have the correct args serialized through to
+  //   ImportJobInput.  Note: auth token should not be persisted to the database, but other args
+  //   are fair game.
+  private static void maybePassThroughOptions(
+      ImportRequestServerModel importRequest, Map<String, Serializable> arguments) {
+    // try to retrieve the tdrSyncPermissions option if available (first as string, then bool)
+    String tdrSyncPermissions =
+        importRequest.getOptions().getOrDefault(ARG_TDR_SYNC_PERMISSION, "false").toString();
+    arguments.put(ARG_TDR_SYNC_PERMISSION, Boolean.parseBoolean(tdrSyncPermissions));
+
+    // pass through isUpsert if available
+    String isUpsertString =
+        importRequest.getOptions().getOrDefault(ARG_IS_UPSERT, "true").toString();
+    arguments.put(ARG_IS_UPSERT, Boolean.parseBoolean(isUpsertString));
   }
 
   // attempt to get the requestId from MDC. We expect this to always succeed, but if it doesn't,

--- a/service/src/main/resources/application-control-plane.yml
+++ b/service/src/main/resources/application-control-plane.yml
@@ -10,8 +10,9 @@ twds:
   data-import:
     batch-write-record-sink: "rawls"
     succeed-on-completion: false
-    # Name of the Google Cloud Storage bucket where JSON files are uploaded for import.
-    rawls-bucket-name: ${SERVICE_GOOGLE_BUCKET}
+    # Name of the Google Cloud Storage bucket where JSON files are uploaded for import and sent to
+    # Rawls for upserting.
+    rawls-bucket-name: ${SERVICE_GOOGLE_BUCKET:}
     enable-tdr-permission-sync: true
     # Name of PubSub topic to notify Rawls of JSON files ready for import.
     rawls-notifications-topic: ${RAWLS_NOTIFY_TOPIC}

--- a/service/src/main/resources/application-control-plane.yml
+++ b/service/src/main/resources/application-control-plane.yml
@@ -12,8 +12,6 @@ twds:
     succeed-on-completion: false
     # Name of the Google Cloud Storage bucket where JSON files are uploaded for import.
     rawls-bucket-name: ${SERVICE_GOOGLE_BUCKET}
-    # Name of the Google Cloud Storage bucket where JSON files can be directly imported from.
-    rawls-json-direct-import-bucket: ${RAWLS_JSON_DIRECT_IMPORT_BUCKET:}
     enable-tdr-permission-sync: true
     # Name of PubSub topic to notify Rawls of JSON files ready for import.
     rawls-notifications-topic: ${RAWLS_NOTIFY_TOPIC}

--- a/service/src/main/resources/application-control-plane.yml
+++ b/service/src/main/resources/application-control-plane.yml
@@ -10,7 +10,10 @@ twds:
   data-import:
     batch-write-record-sink: "rawls"
     succeed-on-completion: false
+    # Name of the Google Cloud Storage bucket where JSON files are uploaded for import.
     rawls-bucket-name: ${SERVICE_GOOGLE_BUCKET}
+    # Name of the Google Cloud Storage bucket where JSON files can be directly imported from.
+    rawls-json-direct-import-bucket: ${RAWLS_JSON_DIRECT_IMPORT_BUCKET:}
     enable-tdr-permission-sync: true
     # Name of PubSub topic to notify Rawls of JSON files ready for import.
     rawls-notifications-topic: ${RAWLS_NOTIFY_TOPIC}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobControlPlaneE2ETest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobControlPlaneE2ETest.java
@@ -5,6 +5,7 @@ import static java.util.stream.Collectors.counting;
 import static java.util.stream.Collectors.groupingBy;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.databiosphere.workspacedataservice.TestTags.SLOW;
+import static org.databiosphere.workspacedataservice.dataimport.rawlsjson.RawlsJsonQuartzJob.rawlsJsonBlobName;
 import static org.databiosphere.workspacedataservice.recordsink.RawlsModel.AttributeOperation;
 import static org.databiosphere.workspacedataservice.recordsink.RawlsModel.Entity;
 import static org.databiosphere.workspacedataservice.recordsink.RawlsModel.Op;
@@ -154,8 +155,8 @@ class PfbQuartzJobControlPlaneE2ETest {
 
     // Assert
     assertPubSubMessage(expectedPubSubMessageFor(jobId));
-    assertSingleBlobWritten(blobNameFor(jobId));
-    InputStream writtenJson = storage.getBlobContents(blobNameFor(jobId));
+    assertSingleBlobWritten(rawlsJsonBlobName(jobId));
+    InputStream writtenJson = storage.getBlobContents(rawlsJsonBlobName(jobId));
 
     var entities = assertRecordedEntitiesSerde(writtenJson, minimalDataExpectedJson);
     assertThat(entities.size()).isEqualTo(1);
@@ -212,9 +213,9 @@ class PfbQuartzJobControlPlaneE2ETest {
 
     // Assert
     assertPubSubMessage(expectedPubSubMessageFor(jobId));
-    assertSingleBlobWritten(blobNameFor(jobId));
+    assertSingleBlobWritten(rawlsJsonBlobName(jobId));
 
-    InputStream writtenJson = storage.getBlobContents(blobNameFor(jobId));
+    InputStream writtenJson = storage.getBlobContents(rawlsJsonBlobName(jobId));
     var entities = assertRecordedEntitiesSerde(writtenJson, dataWithArrayExpectedJson);
 
     assertThat(entities.size()).isEqualTo(1);
@@ -261,8 +262,8 @@ class PfbQuartzJobControlPlaneE2ETest {
 
     // Assert
     assertPubSubMessage(expectedPubSubMessageFor(jobId));
-    assertSingleBlobWritten(blobNameFor(jobId));
-    InputStream jsonStream = storage.getBlobContents(blobNameFor(jobId));
+    assertSingleBlobWritten(rawlsJsonBlobName(jobId));
+    InputStream jsonStream = storage.getBlobContents(rawlsJsonBlobName(jobId));
 
     List<Entity> entities = mapper.readValue(jsonStream, new TypeReference<>() {});
 
@@ -386,14 +387,10 @@ class PfbQuartzJobControlPlaneE2ETest {
         .put("workspaceId", collectionId.toString())
         .put("userEmail", MockSamUsersApi.MOCK_USER_EMAIL)
         .put("jobId", jobId.toString())
-        .put("upsertFile", storage.getBucketName() + "/" + blobNameFor(jobId))
+        .put("upsertFile", storage.getBucketName() + "/" + rawlsJsonBlobName(jobId))
         .put("isUpsert", "true")
         .put("isCWDS", "true")
         .build();
-  }
-
-  private static String blobNameFor(UUID jobId) {
-    return "%s.rawlsUpsert".formatted(jobId);
   }
 
   private void assertPubSubMessage(Map<String, String> expectedMessage) {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbTestSupport.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbTestSupport.java
@@ -8,15 +8,14 @@ import java.util.UUID;
 import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
 import org.databiosphere.workspacedataservice.config.DataImportProperties;
 import org.databiosphere.workspacedataservice.dao.JobDao;
+import org.databiosphere.workspacedataservice.dataimport.ImportDetailsRetriever;
 import org.databiosphere.workspacedataservice.dataimport.snapshotsupport.SnapshotSupportFactory;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
 import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
 import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel.TypeEnum;
 import org.databiosphere.workspacedataservice.recordsink.RecordSinkFactory;
 import org.databiosphere.workspacedataservice.recordsource.RecordSourceFactory;
-import org.databiosphere.workspacedataservice.sam.SamDao;
 import org.databiosphere.workspacedataservice.service.BatchWriteService;
-import org.databiosphere.workspacedataservice.service.CollectionService;
 import org.databiosphere.workspacedataservice.service.ImportService;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
@@ -32,13 +31,12 @@ class PfbTestSupport {
   @Autowired private RecordSourceFactory recordSourceFactory;
   @Autowired private RecordSinkFactory recordSinkFactory;
   @Autowired private BatchWriteService batchWriteService;
-  @Autowired private CollectionService collectionService;
   @Autowired private ActivityLogger activityLogger;
   @Autowired private ObservationRegistry observationRegistry;
   @Autowired private ImportService importService;
-  @Autowired private SamDao samDao;
   @Autowired private SnapshotSupportFactory snapshotSupportFactory;
   @Autowired private DataImportProperties dataImportProperties;
+  @Autowired private ImportDetailsRetriever importDetailsRetriever;
 
   UUID executePfbImportQuartzJob(UUID collectionId, Resource pfbResource)
       throws IOException, JobExecutionException {
@@ -63,11 +61,10 @@ class PfbTestSupport {
         recordSourceFactory,
         recordSinkFactory,
         batchWriteService,
-        collectionService,
         activityLogger,
-        samDao,
         observationRegistry,
         snapshotSupportFactory,
-        dataImportProperties);
+        dataImportProperties,
+        importDetailsRetriever);
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbTestUtils.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbTestUtils.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.io.Serializable;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -155,12 +156,21 @@ public class PfbTestUtils {
 
   public static JobExecutionContext stubJobContext(UUID jobId, Resource resource, UUID collectionId)
       throws IOException {
-    return stubJobContext(jobId, resource, collectionId, false);
+    return stubJobContext(jobId, resource, collectionId, /* shouldPermissionSync= */ false);
+  }
+
+  public static JobExecutionContext stubJobContext(UUID jobId, URI uri, UUID collectionId) {
+    return stubJobContext(jobId, uri, collectionId, /* shouldPermissionSync= */ false);
   }
 
   public static JobExecutionContext stubJobContext(
       UUID jobId, Resource resource, UUID collectionId, boolean shouldPermissionSync)
       throws IOException {
+    return stubJobContext(jobId, resource.getURI(), collectionId, shouldPermissionSync);
+  }
+
+  public static JobExecutionContext stubJobContext(
+      UUID jobId, URI resourceUri, UUID collectionId, boolean shouldPermissionSync) {
     JobExecutionContext mockContext = mock(JobExecutionContext.class);
 
     var schedulable =
@@ -169,7 +179,7 @@ public class PfbTestUtils {
             jobId,
             new ImmutableMap.Builder<String, Serializable>()
                 .put(ARG_TOKEN, BEARER_TOKEN)
-                .put(ARG_URL, resource.getURL().toString())
+                .put(ARG_URL, resourceUri.toString())
                 .put(ARG_COLLECTION, collectionId.toString())
                 .put(ARG_TDR_SYNC_PERMISSION, shouldPermissionSync)
                 .build());

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/rawlsjson/RawlsJsonQuartzJobControlPlaneE2ETest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/rawlsjson/RawlsJsonQuartzJobControlPlaneE2ETest.java
@@ -1,13 +1,38 @@
 package org.databiosphere.workspacedataservice.dataimport.rawlsjson;
 
-import static org.junit.jupiter.api.Assertions.fail;
+import static java.util.stream.StreamSupport.stream;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.databiosphere.workspacedataservice.dataimport.rawlsjson.RawlsJsonQuartzJob.rawlsJsonBlobName;
+import static org.databiosphere.workspacedataservice.dataimport.rawlsjson.RawlsJsonTestSupport.stubJobContext;
+import static org.databiosphere.workspacedataservice.generated.ImportRequestServerModel.TypeEnum.RAWLSJSON;
+import static org.mockito.Mockito.verify;
 
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper;
+import com.google.common.collect.ImmutableMap;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import org.databiosphere.workspacedataservice.dataimport.ImportValidator;
-import org.junit.jupiter.api.Disabled;
+import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
+import org.databiosphere.workspacedataservice.pubsub.PubSub;
+import org.databiosphere.workspacedataservice.sam.MockSamUsersApi;
+import org.databiosphere.workspacedataservice.service.ImportService;
+import org.databiosphere.workspacedataservice.storage.GcsStorage;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
@@ -29,12 +54,93 @@ import org.springframework.test.context.TestPropertySource;
     })
 @AutoConfigureMockMvc
 class RawlsJsonQuartzJobControlPlaneE2ETest {
+  static final String INCOMING_BUCKET = "allowed-bucket";
+
+  @Autowired private RawlsJsonTestSupport testSupport;
+  @Autowired private ImportService importService;
+  @SpyBean private PubSub pubSub;
   // Mock ImportValidator to allow importing test data from a file:// URL.
   @MockBean ImportValidator importValidator;
 
-  @Disabled("Not yet implemented")
+  GcsStorage incomingStorage;
+
+  @Autowired
+  @Qualifier("mockGcsStorage")
+  GcsStorage outgoingStorage;
+
+  /** ArgumentCaptor for the message passed to {@link PubSub#publishSync(Map)}. */
+  @Captor private ArgumentCaptor<Map<String, String>> pubSubMessageCaptor;
+
+  private UUID collectionId;
+
+  @BeforeEach
+  void setup() {
+    collectionId = UUID.randomUUID();
+    incomingStorage = new GcsStorage(LocalStorageHelper.getOptions().getService(), INCOMING_BUCKET);
+  }
+
+  @AfterEach
+  void teardown() {
+    deleteAllBlobs(incomingStorage);
+    deleteAllBlobs(outgoingStorage);
+  }
+
   @Test
-  void happyPath() {
-    fail("Not yet implemented!");
+  void rewritesBlobToOutgoingBucketOnSuccess() throws JobExecutionException {
+    // Arrange
+    URI incomingBlobUri = getUri(createRandomBlob());
+    var importRequest = new ImportRequestServerModel(RAWLSJSON, incomingBlobUri);
+
+    var genericJobServerModel = importService.createImport(collectionId, importRequest);
+
+    UUID jobId = genericJobServerModel.getJobId();
+    JobExecutionContext mockContext =
+        stubJobContext(jobId, incomingBlobUri, collectionId, /* isUpsert= */ true);
+
+    // Act
+    testSupport.buildRawlsJsonQuartzJob().execute(mockContext);
+
+    // Assert
+    assertPubSubMessage(expectedPubSubMessageFor(jobId, /* isUpsert= */ true));
+    assertSingleBlobWritten(rawlsJsonBlobName(jobId));
+    assertThat(listBlobs(incomingStorage)).isEmpty(); // original blob should be deleted
+  }
+
+  private ImmutableMap<String, String> expectedPubSubMessageFor(UUID jobId, boolean isUpsert) {
+    return new ImmutableMap.Builder<String, String>()
+        .put("workspaceId", collectionId.toString())
+        .put("userEmail", MockSamUsersApi.MOCK_USER_EMAIL)
+        .put("jobId", jobId.toString())
+        .put("upsertFile", outgoingStorage.getBucketName() + "/" + rawlsJsonBlobName(jobId))
+        .put("isUpsert", String.valueOf(isUpsert))
+        .put("isCWDS", "true")
+        .build();
+  }
+
+  private void assertPubSubMessage(Map<String, String> expectedMessage) {
+    verify(pubSub).publishSync(pubSubMessageCaptor.capture());
+    assertThat(pubSubMessageCaptor.getValue()).isEqualTo(expectedMessage);
+  }
+
+  private void assertSingleBlobWritten(String expectedBlobName) {
+    List<Blob> blobsWritten = listBlobs(outgoingStorage);
+    assertThat(blobsWritten).hasSize(1);
+    assertThat(blobsWritten.get(0).getName()).isEqualTo(expectedBlobName);
+  }
+
+  private List<Blob> listBlobs(GcsStorage storage) {
+    return stream(storage.getBlobsInBucket().spliterator(), /* parallel= */ false).toList();
+  }
+
+  private Blob createRandomBlob() {
+    return incomingStorage.createBlob(UUID.randomUUID().toString());
+  }
+
+  private URI getUri(Blob blob) {
+    return URI.create(blob.getBlobId().toGsUtilUri());
+  }
+
+  private void deleteAllBlobs(GcsStorage storage) {
+    storage.getBlobsInBucket().forEach(blob -> storage.deleteBlob(blob.getName()));
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/rawlsjson/RawlsJsonQuartzJobTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/rawlsjson/RawlsJsonQuartzJobTest.java
@@ -20,6 +20,8 @@ import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.databiosphere.workspacedataservice.storage.GcsStorage;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
@@ -87,6 +89,25 @@ class RawlsJsonQuartzJobTest extends TestBase {
     // assert
     assertSingleBlobWritten(rawlsJsonBlobName(jobId));
     assertPubSubMessage(expectedPubSubMessageFor(jobId, isUpsert));
+  }
+
+  //    This test can't be run until RawlsJsonQuartzJob is updated to handle defaulting isUpsert.
+  //    However, this is difficult due to how the JobInput map is represented, and JobDataReader
+  //    needs improvements to deal with null values without crashing.
+  @Disabled("TODO(AJ-1809): defaulting should be handled by RawlsJsonQuartzJob")
+  @Test
+  void isUpsertTrueByDefault() throws JobExecutionException {
+    // arrange
+    UUID jobId = UUID.randomUUID();
+    Blob incoming = createRandomBlob();
+    JobExecutionContext mockContext = stubJobContext(jobId, getUri(incoming), collectionId.id());
+
+    // act
+    testSupport.buildRawlsJsonQuartzJob().execute(mockContext);
+
+    // assert
+    assertSingleBlobWritten(rawlsJsonBlobName(jobId));
+    assertPubSubMessage(expectedPubSubMessageFor(jobId, /* isUpsert= */ true));
   }
 
   private ImmutableMap<String, String> expectedPubSubMessageFor(UUID jobId, boolean isUpsert) {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/rawlsjson/RawlsJsonQuartzJobTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/rawlsjson/RawlsJsonQuartzJobTest.java
@@ -1,19 +1,135 @@
 package org.databiosphere.workspacedataservice.dataimport.rawlsjson;
 
-import static org.junit.jupiter.api.Assertions.fail;
+import static java.util.stream.StreamSupport.stream;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.databiosphere.workspacedataservice.dataimport.rawlsjson.RawlsJsonQuartzJob.rawlsJsonBlobName;
+import static org.databiosphere.workspacedataservice.dataimport.rawlsjson.RawlsJsonQuartzJobTest.INCOMING_BUCKET;
+import static org.databiosphere.workspacedataservice.dataimport.rawlsjson.RawlsJsonTestSupport.stubJobContext;
+import static org.mockito.Mockito.verify;
 
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper;
+import com.google.common.collect.ImmutableMap;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import org.databiosphere.workspacedataservice.common.TestBase;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
+import org.databiosphere.workspacedataservice.dao.JobDao;
+import org.databiosphere.workspacedataservice.pubsub.PubSub;
+import org.databiosphere.workspacedataservice.sam.MockSamUsersApi;
+import org.databiosphere.workspacedataservice.shared.model.CollectionId;
+import org.databiosphere.workspacedataservice.storage.GcsStorage;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 
+@DirtiesContext
 @SpringBootTest
-@ActiveProfiles("mock-sam")
+@ActiveProfiles(
+    value = {"mock-sam", "control-plane"},
+    inheritProfiles = false)
+@TestPropertySource(
+    properties = {
+      // turn off pubsub autoconfiguration for tests
+      "spring.cloud.gcp.pubsub.enabled=false",
+      "twds.data-import.rawls-json-direct-import-bucket=" + INCOMING_BUCKET,
+      "rawlsUrl=https://localhost/",
+    })
 class RawlsJsonQuartzJobTest extends TestBase {
-  @Disabled("Not yet implemented")
-  @Test
-  void happyPath() {
-    fail("Not yet implemented!");
+  static final String INCOMING_BUCKET = "allowed-bucket";
+  @Autowired private RawlsJsonTestSupport testSupport;
+  @SpyBean private PubSub pubSub;
+  @MockBean private JobDao jobDao;
+
+  private GcsStorage incomingStorage;
+
+  @Autowired
+  @Qualifier("mockGcsStorage")
+  private GcsStorage outgoingStorage;
+
+  /** ArgumentCaptor for the message passed to {@link PubSub#publishSync(Map)}. */
+  @Captor private ArgumentCaptor<Map<String, String>> pubSubMessageCaptor;
+
+  private CollectionId collectionId;
+
+  @BeforeEach
+  void setup() {
+    collectionId = CollectionId.of(UUID.randomUUID());
+    incomingStorage = new GcsStorage(LocalStorageHelper.getOptions().getService(), INCOMING_BUCKET);
+  }
+
+  @AfterEach
+  void teardown() {
+    deleteAllBlobs(incomingStorage);
+    deleteAllBlobs(outgoingStorage);
+  }
+
+  @ParameterizedTest(name = "isUpsert should be passed through to pubsub ({0})")
+  @ValueSource(booleans = {true, false})
+  void passesThroughIsUpsert(boolean isUpsert) throws JobExecutionException {
+    // arrange
+    UUID jobId = UUID.randomUUID();
+    Blob incoming = createRandomBlob();
+    JobExecutionContext mockContext =
+        stubJobContext(jobId, getUri(incoming), collectionId.id(), isUpsert);
+
+    // act
+    testSupport.buildRawlsJsonQuartzJob().execute(mockContext);
+
+    // assert
+    assertSingleBlobWritten(rawlsJsonBlobName(jobId));
+    assertPubSubMessage(expectedPubSubMessageFor(jobId, isUpsert));
+  }
+
+  private ImmutableMap<String, String> expectedPubSubMessageFor(UUID jobId, boolean isUpsert) {
+    return new ImmutableMap.Builder<String, String>()
+        .put("workspaceId", collectionId.toString())
+        .put("userEmail", MockSamUsersApi.MOCK_USER_EMAIL)
+        .put("jobId", jobId.toString())
+        .put("upsertFile", outgoingStorage.getBucketName() + "/" + rawlsJsonBlobName(jobId))
+        .put("isUpsert", String.valueOf(isUpsert))
+        .put("isCWDS", "true")
+        .build();
+  }
+
+  private void assertPubSubMessage(Map<String, String> expectedMessage) {
+    verify(pubSub).publishSync(pubSubMessageCaptor.capture());
+    assertThat(pubSubMessageCaptor.getValue()).isEqualTo(expectedMessage);
+  }
+
+  private void assertSingleBlobWritten(String expectedBlobName) {
+    List<Blob> blobsWritten = listBlobs(outgoingStorage);
+    assertThat(blobsWritten).hasSize(1);
+    assertThat(blobsWritten.get(0).getName()).isEqualTo(expectedBlobName);
+  }
+
+  private List<Blob> listBlobs(GcsStorage storage) {
+    return stream(storage.getBlobsInBucket().spliterator(), /* parallel= */ false).toList();
+  }
+
+  private Blob createRandomBlob() {
+    return incomingStorage.createBlob(UUID.randomUUID().toString());
+  }
+
+  private URI getUri(Blob blob) {
+    return URI.create(blob.getBlobId().toGsUtilUri());
+  }
+
+  private void deleteAllBlobs(GcsStorage storage) {
+    storage.getBlobsInBucket().forEach(blob -> storage.deleteBlob(blob.getName()));
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/rawlsjson/RawlsJsonTestSupport.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/rawlsjson/RawlsJsonTestSupport.java
@@ -1,0 +1,63 @@
+package org.databiosphere.workspacedataservice.dataimport.rawlsjson;
+
+import static org.databiosphere.workspacedataservice.shared.model.Schedulable.ARG_COLLECTION;
+import static org.databiosphere.workspacedataservice.shared.model.Schedulable.ARG_TOKEN;
+import static org.databiosphere.workspacedataservice.shared.model.Schedulable.ARG_URL;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import io.micrometer.observation.ObservationRegistry;
+import java.io.Serializable;
+import java.net.URI;
+import java.util.UUID;
+import org.databiosphere.workspacedataservice.config.DataImportProperties;
+import org.databiosphere.workspacedataservice.dao.JobDao;
+import org.databiosphere.workspacedataservice.dataimport.ImportDetailsRetriever;
+import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
+import org.databiosphere.workspacedataservice.pubsub.PubSub;
+import org.databiosphere.workspacedataservice.service.ImportService;
+import org.databiosphere.workspacedataservice.storage.GcsStorage;
+import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+@Lazy // only used by a few tests; don't instantiate when not needed
+@Component
+public class RawlsJsonTestSupport {
+  @Autowired private DataImportProperties dataImportProperties;
+  @Autowired private ObservationRegistry observations;
+  @Autowired private JobDao jobDao;
+  @Autowired private ImportDetailsRetriever importDetailsRetriever;
+  @Autowired private GcsStorage storage;
+  @Autowired private PubSub pubSub;
+
+  RawlsJsonQuartzJob buildRawlsJsonQuartzJob() {
+    return new RawlsJsonQuartzJob(
+        dataImportProperties, observations, jobDao, importDetailsRetriever, storage, pubSub);
+  }
+
+  static JobExecutionContext stubJobContext(
+      UUID jobId, URI resourceUri, UUID collectionId, boolean isUpsert) {
+    JobExecutionContext mockContext = mock(JobExecutionContext.class);
+
+    var schedulable =
+        ImportService.createSchedulable(
+            ImportRequestServerModel.TypeEnum.RAWLSJSON,
+            jobId,
+            new ImmutableMap.Builder<String, Serializable>()
+                .put(ARG_TOKEN, "fake-bearer-token")
+                .put(ARG_URL, resourceUri.toString())
+                .put(ARG_COLLECTION, collectionId.toString())
+                .put("isUpsert", String.valueOf(isUpsert))
+                .build());
+
+    JobDetail jobDetail = schedulable.getJobDetail();
+    when(mockContext.getMergedJobDataMap()).thenReturn(jobDetail.getJobDataMap());
+    when(mockContext.getJobDetail()).thenReturn(jobDetail);
+
+    return mockContext;
+  }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/rawlsjson/RawlsJsonTestSupport.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/rawlsjson/RawlsJsonTestSupport.java
@@ -10,6 +10,7 @@ import com.google.common.collect.ImmutableMap;
 import io.micrometer.observation.ObservationRegistry;
 import java.io.Serializable;
 import java.net.URI;
+import java.util.Map;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.config.DataImportProperties;
 import org.databiosphere.workspacedataservice.dao.JobDao;
@@ -39,8 +40,12 @@ public class RawlsJsonTestSupport {
         dataImportProperties, observations, jobDao, importDetailsRetriever, storage, pubSub);
   }
 
+  static JobExecutionContext stubJobContext(UUID jobId, URI resourceUri, UUID collectionId) {
+    return stubJobContext(jobId, resourceUri, collectionId, Map.of());
+  }
+
   static JobExecutionContext stubJobContext(
-      UUID jobId, URI resourceUri, UUID collectionId, boolean isUpsert) {
+      UUID jobId, URI resourceUri, UUID collectionId, Map<String, String> extraArgs) {
     JobExecutionContext mockContext = mock(JobExecutionContext.class);
 
     var schedulable =
@@ -48,10 +53,10 @@ public class RawlsJsonTestSupport {
             ImportRequestServerModel.TypeEnum.RAWLSJSON,
             jobId,
             new ImmutableMap.Builder<String, Serializable>()
+                .putAll(extraArgs)
                 .put(ARG_TOKEN, "fake-bearer-token")
                 .put(ARG_URL, resourceUri.toString())
                 .put(ARG_COLLECTION, collectionId.toString())
-                .put("isUpsert", String.valueOf(isUpsert))
                 .build());
 
     JobDetail jobDetail = schedulable.getJobDetail();
@@ -59,5 +64,11 @@ public class RawlsJsonTestSupport {
     when(mockContext.getJobDetail()).thenReturn(jobDetail);
 
     return mockContext;
+  }
+
+  static JobExecutionContext stubJobContext(
+      UUID jobId, URI resourceUri, UUID collectionId, boolean isUpsert) {
+    return stubJobContext(
+        jobId, resourceUri, collectionId, Map.of("isUpsert", String.valueOf(isUpsert)));
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobTest.java
@@ -120,7 +120,7 @@ class TdrManifestQuartzJobTest extends TestBase {
     UUID workspaceId = UUID.randomUUID();
     TdrManifestQuartzJob tdrManifestQuartzJob = testSupport.buildTdrManifestQuartzJob();
     SnapshotExportResponseModel snapshotExportResponseModel =
-        tdrManifestQuartzJob.parseManifest(manifestAzure.getURL());
+        tdrManifestQuartzJob.parseManifest(manifestAzure.getURI());
 
     // this manifest describes tables for project, edges, test_result, genome in the snapshot,
     // but only contains export data files for project, edges, and test_result.
@@ -184,7 +184,7 @@ class TdrManifestQuartzJobTest extends TestBase {
     TdrManifestQuartzJob tdrManifestQuartzJob = testSupport.buildTdrManifestQuartzJob();
     SnapshotExportResponseModel snapshotExportResponseModel =
         assertDoesNotThrow(
-            () -> tdrManifestQuartzJob.parseManifest(manifestWithUnknownProperties.getURL()));
+            () -> tdrManifestQuartzJob.parseManifest(manifestWithUnknownProperties.getURI()));
 
     // smoke-test that it parsed correctly
     assertEquals(

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrTestSupport.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrTestSupport.java
@@ -6,12 +6,12 @@ import java.net.URL;
 import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
 import org.databiosphere.workspacedataservice.config.DataImportProperties;
 import org.databiosphere.workspacedataservice.dao.JobDao;
+import org.databiosphere.workspacedataservice.dataimport.ImportDetailsRetriever;
 import org.databiosphere.workspacedataservice.dataimport.snapshotsupport.SnapshotSupportFactory;
 import org.databiosphere.workspacedataservice.recordsink.RecordSinkFactory;
 import org.databiosphere.workspacedataservice.recordsource.RecordSourceFactory;
 import org.databiosphere.workspacedataservice.sam.SamDao;
 import org.databiosphere.workspacedataservice.service.BatchWriteService;
-import org.databiosphere.workspacedataservice.service.CollectionService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
@@ -24,7 +24,7 @@ class TdrTestSupport {
   @Autowired private RecordSourceFactory recordSourceFactory;
   @Autowired private RecordSinkFactory recordSinkFactory;
   @Autowired private BatchWriteService batchWriteService;
-  @Autowired private CollectionService collectionService;
+  @Autowired private ImportDetailsRetriever importDetailsRetriever;
   @Autowired private ActivityLogger activityLogger;
   @Autowired private ObjectMapper objectMapper;
   @Autowired private ObservationRegistry observationRegistry;
@@ -38,13 +38,13 @@ class TdrTestSupport {
         recordSourceFactory,
         recordSinkFactory,
         batchWriteService,
-        collectionService,
         activityLogger,
         objectMapper,
         observationRegistry,
         dataImportProperties,
         snapshotSupportFactory,
-        samDao) {
+        samDao,
+        importDetailsRetriever) {
       @Override
       protected URL parseUrl(String path) {
         if (path.startsWith("classpath:")) {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkTest.java
@@ -5,6 +5,7 @@ import static java.util.Arrays.stream;
 import static java.util.Collections.emptyMap;
 import static java.util.stream.Stream.concat;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.databiosphere.workspacedataservice.dataimport.rawlsjson.RawlsJsonQuartzJob.rawlsJsonBlobName;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.times;
@@ -330,7 +331,7 @@ class RawlsRecordSinkTest extends TestBase {
             .put("workspaceId", WORKSPACE_ID.toString())
             .put("userEmail", USER_EMAIL.get())
             .put("jobId", JOB_ID.toString())
-            .put("upsertFile", storage.getBucketName() + "/" + JOB_ID + ".rawlsUpsert")
+            .put("upsertFile", storage.getBucketName() + "/" + rawlsJsonBlobName(JOB_ID))
             .put("isUpsert", "true")
             .put("isCWDS", "true")
             .build();

--- a/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkTest.java
@@ -8,6 +8,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.databiosphere.workspacedataservice.dataimport.rawlsjson.RawlsJsonQuartzJob.rawlsJsonBlobName;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -17,6 +22,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.HashMap;
@@ -29,6 +35,7 @@ import java.util.stream.Stream;
 import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.dataimport.ImportDetails;
 import org.databiosphere.workspacedataservice.pubsub.PubSub;
+import org.databiosphere.workspacedataservice.pubsub.RawlsJsonPublisher;
 import org.databiosphere.workspacedataservice.recordsink.RawlsAttributePrefixer.PrefixStrategy;
 import org.databiosphere.workspacedataservice.recordsink.RawlsModel.AddListMember;
 import org.databiosphere.workspacedataservice.recordsink.RawlsModel.AddUpdateAttribute;
@@ -39,6 +46,7 @@ import org.databiosphere.workspacedataservice.recordsink.RawlsModel.CreateAttrib
 import org.databiosphere.workspacedataservice.recordsink.RawlsModel.Entity;
 import org.databiosphere.workspacedataservice.recordsink.RawlsModel.EntityReference;
 import org.databiosphere.workspacedataservice.recordsink.RawlsModel.RemoveAttribute;
+import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
 import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
@@ -47,6 +55,7 @@ import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.databiosphere.workspacedataservice.shared.model.attributes.RelationAttribute;
 import org.databiosphere.workspacedataservice.storage.GcsStorage;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -339,6 +348,40 @@ class RawlsRecordSinkTest extends TestBase {
     verify(pubSub, times(1)).publishSync(pubSubMessageCaptor.capture());
 
     assertThat(pubSubMessageCaptor.getValue()).isEqualTo(expectedMessage);
+  }
+
+  @Disabled("AJ-1808: Don't publish to Rawls on failure.")
+  @Test
+  void doesNotSendPubSubOnFailure() throws IOException {
+    // Arrange
+    Record record = makeRecord(/* type= */ "widget", /* id= */ "id", emptyMap());
+
+    // partially mock JsonWriter to throw an exception when writeEntity() is called
+    var mockJsonWriter = spy(RawlsRecordSink.JsonWriter.create(mock(OutputStream.class), mapper));
+    doAnswer(
+            invocation -> {
+              throw new IOException("stubbed exception");
+            })
+        .when(mockJsonWriter)
+        .writeEntity(any(Entity.class));
+    var mockJsonPublisher = mock(RawlsJsonPublisher.class);
+
+    // Act / Assert
+    try (RecordSink recordSink =
+        new RawlsRecordSink(
+            new RawlsAttributePrefixer(PrefixStrategy.NONE), mockJsonWriter, mockJsonPublisher)) {
+
+      RecordType recordType = record.getRecordType();
+      Map<String, DataTypeMapping> ignoredSchema = Map.of();
+      List<Record> records = List.of(record);
+
+      assertThrows(
+          IOException.class,
+          () -> recordSink.upsertBatch(recordType, ignoredSchema, records, "ignoredPrimaryKey"));
+    }
+
+    // Assert
+    verify(mockJsonPublisher, never()).publish();
   }
 
   private Record makeRecord(String type, String id, Map<String, Object> attributes) {


### PR DESCRIPTION
This is logic replicated from import-service to just move a given incoming rawls JSON file from its original location to the upsert location and notify Rawls.

Some prefactoring commits which eased implementation can be more easily reviewed on their own.