### PR TITLE
[AJ-1798] Support gs:// URLs for Rawls JSON imports in ImportValidator

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/DefaultImportValidator.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/DefaultImportValidator.java
@@ -32,7 +32,7 @@ public class DefaultImportValidator implements ImportValidator {
     this.allowedHosts = Sets.union(ALWAYS_ALLOWED_HOSTS, allowedHosts);
   }
 
-  private Set<Pattern> getAllowedHostsForImportRequest(ImportRequestServerModel importRequest) {
+  private Set<Pattern> getAllowedHosts(ImportRequestServerModel importRequest) {
     // Allow imports from any GCS bucket.
     if (importRequest.getUrl().getScheme().equals("gs")) {
       return Set.of(Pattern.compile(".*"));
@@ -52,7 +52,7 @@ public class DefaultImportValidator implements ImportValidator {
       throw new ValidationException("Files may not be imported from %s URLs.".formatted(urlScheme));
     }
 
-    if (getAllowedHostsForImportRequest(importRequest).stream()
+    if (getAllowedHosts(importRequest).stream()
         .noneMatch(allowedHost -> allowedHost.matcher(importUrl.getHost()).matches())) {
       throw new ValidationException(
           "Files may not be imported from %s.".formatted(importUrl.getHost()));

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/DefaultImportValidator.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/DefaultImportValidator.java
@@ -1,13 +1,22 @@
 package org.databiosphere.workspacedataservice.dataimport;
 
+import static java.util.Collections.emptySet;
+
 import com.google.common.collect.Sets;
 import java.net.URI;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
+import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel.TypeEnum;
 import org.databiosphere.workspacedataservice.service.model.exception.ValidationException;
 
 public class DefaultImportValidator implements ImportValidator {
+  private static final Map<TypeEnum, Set<String>> SUPPORTED_URL_SCHEMES_BY_IMPORT_TYPE =
+      Map.of(
+          TypeEnum.PFB, Set.of("https"),
+          TypeEnum.RAWLSJSON, Set.of("gs"),
+          TypeEnum.TDRMANIFEST, Set.of("https"));
   private static final Set<Pattern> ALWAYS_ALLOWED_HOSTS =
       Set.of(
           Pattern.compile("storage\\.googleapis\\.com"),
@@ -24,15 +33,21 @@ public class DefaultImportValidator implements ImportValidator {
   }
 
   public void validateImport(ImportRequestServerModel importRequest) {
+    TypeEnum importType = importRequest.getType();
+    Set<String> schemesSupportedForImportType =
+        SUPPORTED_URL_SCHEMES_BY_IMPORT_TYPE.getOrDefault(importType, emptySet());
+
     URI importUrl = importRequest.getUrl();
     String urlScheme = importUrl.getScheme();
-    if (!urlScheme.equals("https")) {
-      throw new ValidationException(
-          "Files may not be imported from %s URLs.".formatted(importUrl.getScheme()));
+    if (!schemesSupportedForImportType.contains(urlScheme)) {
+      throw new ValidationException("Files may not be imported from %s URLs.".formatted(urlScheme));
     }
 
-    if (allowedHosts.stream()
-        .noneMatch(allowedHost -> allowedHost.matcher(importUrl.getHost()).matches())) {
+    // Imports should be allowed from any GCS bucket.
+    boolean skipHostValidation = urlScheme.equals("gs");
+    if (!skipHostValidation
+        && allowedHosts.stream()
+            .noneMatch(allowedHost -> allowedHost.matcher(importUrl.getHost()).matches())) {
       throw new ValidationException(
           "Files may not be imported from %s.".formatted(importUrl.getHost()));
     }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/DefaultImportValidator.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/DefaultImportValidator.java
@@ -32,9 +32,9 @@ public class DefaultImportValidator implements ImportValidator {
     this.allowedHosts = Sets.union(ALWAYS_ALLOWED_HOSTS, allowedHosts);
   }
 
-  private Set<Pattern> getAllowedHostsForImportUrlScheme(String scheme) {
+  private Set<Pattern> getAllowedHostsForImportRequest(ImportRequestServerModel importRequest) {
     // Allow imports from any GCS bucket.
-    if (scheme.equals("gs")) {
+    if (importRequest.getUrl().getScheme().equals("gs")) {
       return Set.of(Pattern.compile(".*"));
     }
 
@@ -52,7 +52,7 @@ public class DefaultImportValidator implements ImportValidator {
       throw new ValidationException("Files may not be imported from %s URLs.".formatted(urlScheme));
     }
 
-    if (getAllowedHostsForImportUrlScheme(urlScheme).stream()
+    if (getAllowedHostsForImportRequest(importRequest).stream()
         .noneMatch(allowedHost -> allowedHost.matcher(importUrl.getHost()).matches())) {
       throw new ValidationException(
           "Files may not be imported from %s.".formatted(importUrl.getHost()));

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/DefaultImportValidatorTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/DefaultImportValidatorTest.java
@@ -88,4 +88,15 @@ class DefaultImportValidatorTest extends TestBase {
             ValidationException.class, () -> importValidator.validateImport(importRequest));
     assertEquals("Files may not be imported from example.com.", err.getMessage());
   }
+
+  @Test
+  void acceptsGsUrlsForRawlsJsonImports() {
+    // Arrange
+    URI importUri = URI.create("gs://test-bucket/file");
+    ImportRequestServerModel importRequest =
+        new ImportRequestServerModel(TypeEnum.RAWLSJSON, importUri);
+
+    // Act/Assert
+    assertDoesNotThrow(() -> importValidator.validateImport(importRequest));
+  }
 }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1798

Unlike the other import types, Rawls JSON import URLs will be `gs://` URLs. `ImportValidator` must accept those URLs.