### PR TITLE
Revert "[AJ-1782]: Bump org.broadinstitute.dsde.workbench:leonardo-client_2.13 from 1.3.6-22ee00b to 1.3.6-9996462-SNAP"

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -79,7 +79,7 @@ dependencies {
 
     // Terra libraries
     implementation group: 'org.broadinstitute.dsde.workbench', name: 'sam-client_2.13', version: '0.1-752b4f3'
-    implementation group: 'org.broadinstitute.dsde.workbench', name: 'leonardo-client_2.13', version: '1.3.6-9996462-SNAP'
+    implementation group: 'org.broadinstitute.dsde.workbench', name: 'leonardo-client_2.13', version: '1.3.6-22ee00b'
     implementation 'com.squareup.okhttp3:okhttp' // required by Sam client
     implementation "bio.terra:datarepo-client:2.13.0-SNAPSHOT"
     implementation "bio.terra:workspace-manager-client:0.254.983-SNAPSHOT"

--- a/service/src/main/java/org/databiosphere/workspacedataservice/leonardo/LeonardoDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/leonardo/LeonardoDao.java
@@ -32,7 +32,7 @@ public class LeonardoDao {
     var workspaceApps = this.leonardoClientFactory.getAppsV2Api(token);
     try {
       RestCall<List<ListAppResponse>> listAppsFunction =
-          () -> workspaceApps.listAppsV2(workspaceId, null, false, null, null);
+          () -> workspaceApps.listAppsV2(workspaceId, null, false, null);
       List<ListAppResponse> response =
           restClientRetry.withRetryAndErrorHandling(listAppsFunction, "WorkspaceApps.listApps");
       // unsure what the key would be if there is more than 1 wds present in the listed apps, but in

--- a/service/src/test/java/org/databiosphere/workspacedataservice/leonardo/LeonardoDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/leonardo/LeonardoDaoTest.java
@@ -51,11 +51,7 @@ class LeonardoDaoTest extends TestBase {
     final int statusCode = HttpStatus.INTERNAL_SERVER_ERROR.value();
     given(
             mockAppsApi.listAppsV2(
-                anyString(),
-                nullable(String.class),
-                anyBoolean(),
-                nullable(String.class),
-                nullable(String.class)))
+                anyString(), nullable(String.class), anyBoolean(), nullable(String.class)))
         .willThrow(
             new org.broadinstitute.dsde.workbench.client.leonardo.ApiException(
                 statusCode, "Intentional error thrown for unit test"));


### PR DESCRIPTION
Reverts DataBiosphere/terra-workspace-data-service#755