### PR TITLE
[AJ-1782] Configure Dependabot to ignore Terra client libraries

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
   - package-ecosystem: "gradle"
     registries:
       - "broad-artifactory"
+    ignore:
+      - dependency-name: "bio.terra:datarepo-client"
+      - dependency-name: "bio.terra:workspace-manager-client"
+      - dependency-name: "org.broadinstitute.dsde.workbench:leonardo-client_*"
+      - dependency-name: "org.broadinstitute.dsde.workbench:sam-client_*"
     directory: "/"
     labels:
       - "dependencies"


### PR DESCRIPTION
At least by default, Dependabot doesn't seem to handle updates to Terra client libraries since the version identifiers include git revisions. This configures Dependabot to ignore updates to those client libraries.

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore