### PR TITLE
AJ-1748: introduce JsonAttribute

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -728,17 +728,20 @@ public class RecordDao {
         return LocalDateTime.parse(sVal, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
       }
     }
+    // TSV-based uploads deserialize json as JsonAttribute.
     if (attVal instanceof JsonAttribute jsonAttribute) {
       return jsonAttribute.sqlValue();
     }
-    //    if (attVal instanceof Map<?, ?>) {
-    //      try {
-    //        return objectMapper.writeValueAsString(attVal);
-    //      } catch (JsonProcessingException e) {
-    //        LOGGER.error("Could not serialize Map to json string", e);
-    //        throw new RuntimeException(e);
-    //      }
-    //    }
+    // json-based APIs deserialize json as LinkedHashMap<String, Object>. Handle those here.
+    // TODO AJ-1748: how to deserialize json-based APIs into JsonAttribute instead?
+    if (attVal instanceof Map<?, ?>) {
+      try {
+        return objectMapper.writeValueAsString(attVal);
+      } catch (JsonProcessingException e) {
+        LOGGER.error("Could not serialize Map to json string", e);
+        throw new RuntimeException(e);
+      }
+    }
     if (typeMapping.isArrayType()) {
       return getArrayValues(attVal, typeMapping);
     }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -48,6 +48,7 @@ import org.databiosphere.workspacedataservice.service.model.exception.BatchDelet
 import org.databiosphere.workspacedataservice.service.model.exception.ConflictException;
 import org.databiosphere.workspacedataservice.service.model.exception.InvalidRelationException;
 import org.databiosphere.workspacedataservice.service.model.exception.MissingObjectException;
+import org.databiosphere.workspacedataservice.service.model.exception.SerializationException;
 import org.databiosphere.workspacedataservice.shared.model.AttributeComparator;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
@@ -733,8 +734,7 @@ public class RecordDao {
       try {
         return objectMapper.writeValueAsString(jsonAttribute.sqlValue());
       } catch (JsonProcessingException e) {
-        LOGGER.error("Could not serialize JsonAttribute to json string", e);
-        throw new RuntimeException(e);
+        throw new SerializationException("Could not serialize JsonAttribute to json string", e);
       }
     }
     // json-based APIs deserialize json as LinkedHashMap<String, Object>. Handle those here.
@@ -743,8 +743,7 @@ public class RecordDao {
       try {
         return objectMapper.writeValueAsString(attVal);
       } catch (JsonProcessingException e) {
-        LOGGER.error("Could not serialize Map to json string", e);
-        throw new RuntimeException(e);
+        throw new SerializationException("Could not serialize Map to json string", e);
       }
     }
     if (typeMapping.isArrayType()) {
@@ -790,8 +789,8 @@ public class RecordDao {
                 try {
                   return objectMapper.writeValueAsString(el);
                 } catch (JsonProcessingException e) {
-                  LOGGER.error("Could not serialize array element to json string", e);
-                  throw new RuntimeException(e);
+                  throw new SerializationException(
+                      "Could not serialize array element to json string", e);
                 }
               })
           .toList()

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -730,7 +730,12 @@ public class RecordDao {
     }
     // TSV-based uploads deserialize json as JsonAttribute.
     if (attVal instanceof JsonAttribute jsonAttribute) {
-      return jsonAttribute.sqlValue();
+      try {
+        return objectMapper.writeValueAsString(jsonAttribute.sqlValue());
+      } catch (JsonProcessingException e) {
+        LOGGER.error("Could not serialize JsonAttribute to json string", e);
+        throw new RuntimeException(e);
+      }
     }
     // json-based APIs deserialize json as LinkedHashMap<String, Object>. Handle those here.
     // TODO AJ-1748: how to deserialize json-based APIs into JsonAttribute instead?
@@ -1008,7 +1013,7 @@ public class RecordDao {
         return getArrayValue(pgArray.getArray(), typeMapping);
       }
       if (typeMapping == DataTypeMapping.JSON) {
-        return new JsonAttribute(objectMapper.readTree(object.toString()), objectMapper);
+        return new JsonAttribute(objectMapper.readTree(object.toString()));
       }
       return object;
     }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/DataTypeInferer.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/DataTypeInferer.java
@@ -21,8 +21,10 @@ import static org.databiosphere.workspacedataservice.service.model.DataTypeMappi
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.mu.util.stream.BiStream;
+import jakarta.annotation.Nullable;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.URI;
@@ -192,6 +194,7 @@ public class DataTypeInferer {
     }
   }
 
+  @Nullable
   private JsonNode parseToJsonNode(String val) {
     try {
       // We call .toLowerCase() to ensure that WDS interprets all different inputted spellings of
@@ -203,6 +206,26 @@ public class DataTypeInferer {
     }
   }
 
+  /**
+   * Attempts to parse the input as json. If the input parsed as a valid json object (not array!),
+   * return that ObjectNode; else return null.
+   *
+   * @param val the input to be parsed
+   * @return the ObjectNode, or null if the input was not a json object
+   */
+  @Nullable
+  public ObjectNode tryJsonObject(String val) {
+    JsonNode jsonNode = parseToJsonNode(val);
+    if (jsonNode instanceof ObjectNode objectNode) {
+      return objectNode;
+    }
+    return null;
+  }
+
+  /**
+   * @deprecated use tryJsonObject instead
+   */
+  @Deprecated(since = "2024-04-30")
   public boolean isValidJson(String val) {
     JsonNode jsonNode = parseToJsonNode(val);
     return jsonNode != null && jsonNode.isObject();

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/DataTypeInferer.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/DataTypeInferer.java
@@ -37,6 +37,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
 import org.databiosphere.workspacedataservice.service.model.Relation;
@@ -214,13 +215,12 @@ public class DataTypeInferer {
    * @param val the input to be parsed
    * @return the ObjectNode, or null if the input was not a json object
    */
-  @Nullable
-  public ObjectNode tryJsonObject(String val) {
+  public Optional<ObjectNode> tryJsonObject(String val) {
     JsonNode jsonNode = parseToJsonNode(val);
     if (jsonNode instanceof ObjectNode objectNode) {
-      return objectNode;
+      return Optional.of(objectNode);
     }
-    return null;
+    return Optional.empty();
   }
 
   /**
@@ -228,7 +228,7 @@ public class DataTypeInferer {
    */
   @Deprecated(since = "2024-04-30")
   public boolean isValidJson(String val) {
-    return tryJsonObject(val) != null;
+    return tryJsonObject(val).isPresent();
   }
 
   public boolean isArray(String val) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/DataTypeInferer.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/DataTypeInferer.java
@@ -129,7 +129,7 @@ public class DataTypeInferer {
     if (isValidBoolean(sVal)) {
       return BOOLEAN;
     }
-    if (isValidJson(sVal)) {
+    if (tryJsonObject(sVal).isPresent()) {
       return JSON;
     }
     if (isFileType(sVal)) {
@@ -221,14 +221,6 @@ public class DataTypeInferer {
       return Optional.of(objectNode);
     }
     return Optional.empty();
-  }
-
-  /**
-   * @deprecated use tryJsonObject instead
-   */
-  @Deprecated(since = "2024-04-30")
-  public boolean isValidJson(String val) {
-    return tryJsonObject(val).isPresent();
   }
 
   public boolean isArray(String val) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/DataTypeInferer.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/DataTypeInferer.java
@@ -210,10 +210,10 @@ public class DataTypeInferer {
 
   /**
    * Attempts to parse the input as json. If the input parsed as a valid json object (not array!),
-   * return that ObjectNode; else return null.
+   * return an Optional containing that ObjectNode; else return an empty Optional.
    *
    * @param val the input to be parsed
-   * @return the ObjectNode, or null if the input was not a json object
+   * @return Optional of the ObjectNode, or empty if the input was not a json object
    */
   public Optional<ObjectNode> tryJsonObject(String val) {
     JsonNode jsonNode = parseToJsonNode(val);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/DataTypeInferer.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/DataTypeInferer.java
@@ -44,6 +44,7 @@ import org.databiosphere.workspacedataservice.service.model.RelationCollection;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
+import org.databiosphere.workspacedataservice.shared.model.attributes.JsonAttribute;
 import org.springframework.util.CollectionUtils;
 
 public class DataTypeInferer {
@@ -174,7 +175,7 @@ public class DataTypeInferer {
       return findArrayType(listVal);
     }
 
-    if (val instanceof Map) {
+    if (val instanceof Map || val instanceof JsonAttribute) {
       return JSON;
     }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/DataTypeInferer.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/DataTypeInferer.java
@@ -227,8 +227,7 @@ public class DataTypeInferer {
    */
   @Deprecated(since = "2024-04-30")
   public boolean isValidJson(String val) {
-    JsonNode jsonNode = parseToJsonNode(val);
-    return jsonNode != null && jsonNode.isObject();
+    return tryJsonObject(val) != null;
   }
 
   public boolean isArray(String val) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/SerializationException.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/SerializationException.java
@@ -1,0 +1,12 @@
+package org.databiosphere.workspacedataservice.service.model.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(code = HttpStatus.BAD_REQUEST)
+public class SerializationException extends IllegalArgumentException {
+
+  public SerializationException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributes.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/RecordAttributes.java
@@ -28,6 +28,7 @@ public class RecordAttributes {
    */
   @JsonCreator
   public RecordAttributes(Map<String, Object> attributes) {
+    // AJ-858: post-process the attributes map to look for JsonAttribute, dates, etc.
     this.attributes = new TreeMap<>(attributes);
   }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/attributes/Attribute.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/attributes/Attribute.java
@@ -5,5 +5,11 @@ package org.databiosphere.workspacedataservice.shared.model.attributes;
  * RecordAttributes map.
  */
 public interface Attribute {
+  /**
+   * When WDS writes this Attribute value to the db, what object should it send as a parameter to
+   * the SQL statement?
+   *
+   * @return the SQL-compatible representation of this Attribute
+   */
   Object sqlValue();
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/attributes/Attribute.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/attributes/Attribute.java
@@ -4,4 +4,6 @@ package org.databiosphere.workspacedataservice.shared.model.attributes;
  * Base interface for an attribute of a WDS Record. This Attribute will be part of the
  * RecordAttributes map.
  */
-public interface Attribute {}
+public interface Attribute {
+  Object sqlValue();
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/attributes/JsonAttribute.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/attributes/JsonAttribute.java
@@ -35,4 +35,16 @@ public class JsonAttribute extends ScalarAttribute<JsonNode> {
       throw new RuntimeException(e);
     }
   }
+
+  @Override
+  public boolean equals(Object obj) {
+    // don't consider the mapper in equals
+    return super.equals(obj);
+  }
+
+  @Override
+  public int hashCode() {
+    // don't consider the mapper in hashcode
+    return super.hashCode();
+  }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/attributes/JsonAttribute.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/attributes/JsonAttribute.java
@@ -1,36 +1,32 @@
 package org.databiosphere.workspacedataservice.shared.model.attributes;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.annotation.Nullable;
 
 public class JsonAttribute extends ScalarAttribute<JsonNode> {
 
-  @Nullable private final ObjectMapper mapper;
-
-  JsonAttribute(JsonNode value) {
-    super(value);
-    this.mapper = null;
-  }
+  private final ObjectMapper mapper;
 
   public JsonAttribute(JsonNode value, ObjectMapper mapper) {
     super(value);
     this.mapper = mapper;
   }
 
+  @JsonValue
+  public JsonNode jsonValue() {
+    return this.value;
+  }
+
   @Override
   public String toString() {
     // if this JsonAttribute has an ObjectMapper reference, use that ObjectMapper
     // to generate the toString value. Else, use the built-in toString.
-    if (mapper == null) {
-      return value.toString();
-    } else {
-      try {
-        return mapper.writeValueAsString(this.value);
-      } catch (JsonProcessingException e) {
-        throw new RuntimeException(e);
-      }
+    try {
+      return mapper.writeValueAsString(this.value);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
     }
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/attributes/JsonAttribute.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/attributes/JsonAttribute.java
@@ -14,6 +14,12 @@ public class JsonAttribute extends ScalarAttribute<JsonNode> {
     this.mapper = mapper;
   }
 
+  /**
+   * When serializing the JsonAttribute class, what value should Jackson serialize? We should only
+   * serialize the underlying value, not the JsonAttribute wrapper itself.
+   *
+   * @return the value to use when serializing
+   */
   @JsonValue
   public JsonNode jsonValue() {
     return this.value;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/attributes/JsonAttribute.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/attributes/JsonAttribute.java
@@ -1,17 +1,12 @@
 package org.databiosphere.workspacedataservice.shared.model.attributes;
 
 import com.fasterxml.jackson.annotation.JsonValue;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class JsonAttribute extends ScalarAttribute<JsonNode> {
 
-  private final ObjectMapper mapper;
-
-  public JsonAttribute(JsonNode value, ObjectMapper mapper) {
+  public JsonAttribute(JsonNode value) {
     super(value);
-    this.mapper = mapper;
   }
 
   /**
@@ -29,11 +24,7 @@ public class JsonAttribute extends ScalarAttribute<JsonNode> {
   public String toString() {
     // use the supplied ObjectMapper to generate the toString value. This ensures serialization is
     // consistent with the settings configured on the ObjectMapper.
-    try {
-      return mapper.writeValueAsString(this.value);
-    } catch (JsonProcessingException e) {
-      throw new RuntimeException(e);
-    }
+    return this.value.toString();
   }
 
   @Override

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/attributes/JsonAttribute.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/attributes/JsonAttribute.java
@@ -14,7 +14,7 @@ public class JsonAttribute extends ScalarAttribute<JsonNode> {
     this.mapper = null;
   }
 
-  JsonAttribute(JsonNode value, ObjectMapper mapper) {
+  public JsonAttribute(JsonNode value, ObjectMapper mapper) {
     super(value);
     this.mapper = mapper;
   }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/attributes/JsonAttribute.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/attributes/JsonAttribute.java
@@ -20,22 +20,23 @@ public class JsonAttribute extends ScalarAttribute<JsonNode> {
     return this.value;
   }
 
+  /**
+   * Do not rely on toString() to return valid serialized JSON. Instead, call getValue() or
+   * sqlValue() to return a JsonNode, and serialize that yourself via your own ObjectMapper.
+   *
+   * @return a string representation of this JsonAttribute
+   */
   @Override
   public String toString() {
-    // use the supplied ObjectMapper to generate the toString value. This ensures serialization is
-    // consistent with the settings configured on the ObjectMapper.
-    return this.value.toString();
-  }
+    /* This calls JsonNode.toString(), which "will produce ... valid JSON using default settings"
+       and therefore can be DIFFERENT from the JSON produced by calling ObjectMapper.writeValueAsString
+       if the ObjectMapper has been configured with non-default flags. Such is the case in WDS; we
+       configure non-default flags in JsonConfig.
 
-  @Override
-  public boolean equals(Object obj) {
-    // don't consider the mapper in equals
-    return super.equals(obj);
-  }
-
-  @Override
-  public int hashCode() {
-    // don't consider the mapper in hashcode
-    return super.hashCode();
+       Because of these subtle differences in serialization, this toString() intentionally includes
+       a "JsonAttribute(...)" text surrounding the JSON value. This should be a breaking signal to
+       any callers who try to get JSON out of toString().
+    */
+    return "JsonAttribute(%s)".formatted(this.value.toString());
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/attributes/JsonAttribute.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/attributes/JsonAttribute.java
@@ -1,0 +1,36 @@
+package org.databiosphere.workspacedataservice.shared.model.attributes;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.Nullable;
+
+public class JsonAttribute extends ScalarAttribute<JsonNode> {
+
+  @Nullable private final ObjectMapper mapper;
+
+  JsonAttribute(JsonNode value) {
+    super(value);
+    this.mapper = null;
+  }
+
+  JsonAttribute(JsonNode value, ObjectMapper mapper) {
+    super(value);
+    this.mapper = mapper;
+  }
+
+  @Override
+  public String toString() {
+    // if this JsonAttribute has an ObjectMapper reference, use that ObjectMapper
+    // to generate the toString value. Else, use the built-in toString.
+    if (mapper == null) {
+      return value.toString();
+    } else {
+      try {
+        return mapper.writeValueAsString(this.value);
+      } catch (JsonProcessingException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/attributes/JsonAttribute.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/attributes/JsonAttribute.java
@@ -27,8 +27,8 @@ public class JsonAttribute extends ScalarAttribute<JsonNode> {
 
   @Override
   public String toString() {
-    // if this JsonAttribute has an ObjectMapper reference, use that ObjectMapper
-    // to generate the toString value. Else, use the built-in toString.
+    // use the supplied ObjectMapper to generate the toString value. This ensures serialization is
+    // consistent with the settings configured on the ObjectMapper.
     try {
       return mapper.writeValueAsString(this.value);
     } catch (JsonProcessingException e) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/attributes/ScalarAttribute.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/attributes/ScalarAttribute.java
@@ -14,7 +14,7 @@ public abstract class ScalarAttribute<T> implements Attribute {
 
   @Override
   public Object sqlValue() {
-    return toString();
+    return this.value;
   }
 
   @Override

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/attributes/ScalarAttribute.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/attributes/ScalarAttribute.java
@@ -13,6 +13,11 @@ public abstract class ScalarAttribute<T> implements Attribute {
   }
 
   @Override
+  public Object sqlValue() {
+    return toString();
+  }
+
+  @Override
   public String toString() {
     return this.value.toString();
   }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/tsv/TsvDeserializer.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/tsv/TsvDeserializer.java
@@ -132,7 +132,7 @@ public class TsvDeserializer extends StdDeserializer<RecordAttributes> {
     // JSON objects
     ObjectNode maybeJsonObject = inferer.tryJsonObject(val);
     if (maybeJsonObject != null) {
-      return new JsonAttribute(maybeJsonObject, objectMapper);
+      return new JsonAttribute(maybeJsonObject);
     }
 
     // arrays.
@@ -211,7 +211,7 @@ public class TsvDeserializer extends StdDeserializer<RecordAttributes> {
       return bn.asBoolean();
     }
     if (element instanceof ObjectNode on) {
-      return new JsonAttribute(on, objectMapper);
+      return new JsonAttribute(on);
     }
     if (element instanceof TextNode strElement) {
       return cellToAttribute(strElement.toString());

--- a/service/src/main/java/org/databiosphere/workspacedataservice/tsv/TsvDeserializer.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/tsv/TsvDeserializer.java
@@ -2,7 +2,6 @@ package org.databiosphere.workspacedataservice.tsv;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -28,6 +27,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.databiosphere.workspacedataservice.service.DataTypeInferer;
 import org.databiosphere.workspacedataservice.service.model.exception.UnexpectedTsvException;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
+import org.databiosphere.workspacedataservice.shared.model.attributes.JsonAttribute;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -130,15 +130,9 @@ public class TsvDeserializer extends StdDeserializer<RecordAttributes> {
       }
     }
     // JSON objects
-    // TODO: change the "is*" methods in inferer to return their value so we don't parse twice?
-    if (inferer.isValidJson(val)) {
-      try {
-        return objectMapper.readValue(val, new TypeReference<Map<String, Object>>() {});
-      } catch (JsonProcessingException jpe) {
-        // this shouldn't happen; if inferer.isValidJson(val) passes, so should the .readValue
-        LOGGER.error("Unable to parse validated JSON: {}", val);
-        return val;
-      }
+    ObjectNode maybeJsonObject = inferer.tryJsonObject(val);
+    if (maybeJsonObject != null) {
+      return maybeJsonObject;
     }
 
     // arrays.
@@ -217,13 +211,7 @@ public class TsvDeserializer extends StdDeserializer<RecordAttributes> {
       return bn.asBoolean();
     }
     if (element instanceof ObjectNode on) {
-      try {
-        return objectMapper.readValue(on.toString(), new TypeReference<Map<String, Object>>() {});
-      } catch (JsonProcessingException jpe) {
-        // this shouldn't happen since we've already parsed the array into JSON
-        LOGGER.error("Unable to parse array element JSON: {}", on);
-        return on.toString();
-      }
+      return new JsonAttribute(on, objectMapper);
     }
     if (element instanceof TextNode strElement) {
       return cellToAttribute(strElement.toString());

--- a/service/src/main/java/org/databiosphere/workspacedataservice/tsv/TsvDeserializer.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/tsv/TsvDeserializer.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.stream.Stream;
@@ -130,9 +131,9 @@ public class TsvDeserializer extends StdDeserializer<RecordAttributes> {
       }
     }
     // JSON objects
-    ObjectNode maybeJsonObject = inferer.tryJsonObject(val);
-    if (maybeJsonObject != null) {
-      return new JsonAttribute(maybeJsonObject);
+    Optional<ObjectNode> maybeJsonObject = inferer.tryJsonObject(val);
+    if (maybeJsonObject.isPresent()) {
+      return new JsonAttribute(maybeJsonObject.get());
     }
 
     // arrays.

--- a/service/src/main/java/org/databiosphere/workspacedataservice/tsv/TsvDeserializer.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/tsv/TsvDeserializer.java
@@ -132,7 +132,7 @@ public class TsvDeserializer extends StdDeserializer<RecordAttributes> {
     // JSON objects
     ObjectNode maybeJsonObject = inferer.tryJsonObject(val);
     if (maybeJsonObject != null) {
-      return maybeJsonObject;
+      return new JsonAttribute(maybeJsonObject, objectMapper);
     }
 
     // arrays.

--- a/service/src/main/java/org/databiosphere/workspacedataservice/tsv/TsvDeserializer.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/tsv/TsvDeserializer.java
@@ -177,6 +177,11 @@ public class TsvDeserializer extends StdDeserializer<RecordAttributes> {
   public List<?> jsonStringToList(String input) throws JsonProcessingException {
     JsonNode node = objectMapper.readTree(input);
     if (node instanceof ArrayNode arrayNode) {
+      // TODO AJ-1748:
+      //  is any element of this array an ObjectNode or ArrayNode?
+      //    if so, return List<JsonAttribute>.
+      //  are element types homogenous? If so, return a homogenous list.
+      //  are element types heterogenous? If so, this should return a non-list JsonAttribute
       Stream<JsonNode> jsonElements =
           StreamSupport.stream(
               Spliterators.spliteratorUnknownSize(arrayNode.elements(), Spliterator.ORDERED),

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/DataTypeInfererTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/DataTypeInfererTest.java
@@ -87,11 +87,11 @@ class DataTypeInfererTest extends TestBase {
 
   @Test
   void isValidJson() {
-    assertThat(inferer.isValidJson(RandomStringUtils.randomNumeric(10))).isFalse();
-    assertThat(inferer.isValidJson("Hello")).isFalse();
-    assertThat(inferer.isValidJson(Boolean.TRUE.toString())).isFalse();
-    assertThat(inferer.isValidJson("True")).isFalse();
-    assertThat(inferer.isValidJson("{\"foo\":\"bar\"}")).isTrue();
+    assertThat(inferer.tryJsonObject(RandomStringUtils.randomNumeric(10))).isEmpty();
+    assertThat(inferer.tryJsonObject("Hello")).isEmpty();
+    assertThat(inferer.tryJsonObject(Boolean.TRUE.toString())).isEmpty();
+    assertThat(inferer.tryJsonObject("True")).isEmpty();
+    assertThat(inferer.tryJsonObject("{\"foo\":\"bar\"}")).isPresent();
   }
 
   @Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvDeserializerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvDeserializerTest.java
@@ -2,39 +2,29 @@ package org.databiosphere.workspacedataservice.tsv;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.BigIntegerNode;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import java.math.BigInteger;
 import java.util.List;
 import java.util.Objects;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 /**
  * Tests that TSV uploads deserialize into the expected Java objects inside RecordAttributes.
  *
- * @see TsvOnlyArgumentsProvider
+ * @see TsvJsonArgumentsProvider
  */
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @SpringBootTest
-class TsvDeserializerTest extends TsvJsonArgumentsProvider {
+class TsvDeserializerTest extends TestBase {
 
   @Autowired TsvDeserializer tsvDeserializer;
-  @Autowired ObjectMapper mapper;
-
-  @Override
-  ObjectMapper getMapper() {
-    return mapper;
-  }
 
   // ===== nodeToObject tests:
   @Test
@@ -63,12 +53,12 @@ class TsvDeserializerTest extends TsvJsonArgumentsProvider {
   // ===== cellToAttribute tests:
 
   /**
-   * @see TsvOnlyArgumentsProvider for arguments
+   * @see TsvJsonArgumentsProvider for arguments
    */
   @ParameterizedTest(name = "cellToAttribute for input value <{0}> should return <{1}>")
-  @MethodSource("tsvJsonArguments")
+  @ArgumentsSource(TsvJsonArgumentsProvider.class)
   @ArgumentsSource(TsvOnlyArgumentsProvider.class)
-  void cellToAttributeTest(String input, Object expected) throws JsonProcessingException {
+  void cellToAttributeTest(String input, Object expected) {
     Object actual = tsvDeserializer.cellToAttribute(input);
 
     if (expected instanceof List<?> expectedList) {
@@ -76,13 +66,14 @@ class TsvDeserializerTest extends TsvJsonArgumentsProvider {
           expectedList,
           (List<?>) actual,
           "cellToAttribute for input value <%s> should return <%s>".formatted(input, expected));
-      //    } else if (expected instanceof Map) {
-      //      // map types can differ; don't check instanceof
-      //            assertEquals(
-      //                expected,
-      //                actual,
-      //                "cellToAttribute for input value <%s> should return <%s>".formatted(input,
-      //       expected));
+      /*
+      } else if (expected instanceof Map) {
+        // map types can differ; don't check instanceof
+        assertEquals(
+            expected,
+            actual,
+            "cellToAttribute for input value <%s> should return <%s>".formatted(input, expected));
+       */
     } else {
       if (Objects.isNull(expected)) {
         assertNull(actual);

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvDeserializerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvDeserializerTest.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import java.math.BigInteger;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvDeserializerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvDeserializerTest.java
@@ -66,14 +66,6 @@ class TsvDeserializerTest extends TestBase {
           expectedList,
           (List<?>) actual,
           "cellToAttribute for input value <%s> should return <%s>".formatted(input, expected));
-      /*
-      } else if (expected instanceof Map) {
-        // map types can differ; don't check instanceof
-        assertEquals(
-            expected,
-            actual,
-            "cellToAttribute for input value <%s> should return <%s>".formatted(input, expected));
-       */
     } else {
       if (Objects.isNull(expected)) {
         assertNull(actual);

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvJsonArgumentsProvider.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvJsonArgumentsProvider.java
@@ -1,14 +1,13 @@
 package org.databiosphere.workspacedataservice.tsv;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
 
 /**
  * Test fixtures for use by TsvDeserializerTest and TsvJsonEquivalenceTest.
@@ -19,11 +18,10 @@ import org.junit.jupiter.params.provider.Arguments;
  * @see TsvDeserializerTest
  * @see TsvJsonEquivalenceTest
  */
-public abstract class TsvJsonArgumentsProvider extends TestBase {
+public class TsvJsonArgumentsProvider implements ArgumentsProvider {
 
-  abstract ObjectMapper getMapper();
-
-  public Stream<? extends Arguments> tsvJsonArguments() throws JsonProcessingException {
+  @Override
+  public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
     /* Arguments are sets:
     	- first value is the text that would be contained in a TSV cell or JSON value
     	- second value is the expected Java type that the TsvConverter or JSON deserializer would create for that cell
@@ -78,14 +76,12 @@ public abstract class TsvJsonArgumentsProvider extends TestBase {
         // Arguments.of("\"false\"",               "false",                false),
         // Arguments.of("\"[1,2,3]\"",             "[1,2,3]",              false),
 
-        // json packet
         // TODO AJ-1748: where should this test live?
-        //        Arguments.of(
-        //            "{\"foo\":\"bar\", \"baz\": \"qux\"}",
-        //            new JsonAttribute(
-        //                getMapper().readTree("{\"foo\":\"bar\", \"baz\": \"qux\"}"), getMapper()),
-        //            false),
-
+        /*
+        // json packet
+        Arguments.of(
+            "{\"foo\":\"bar\", \"baz\": \"qux\"}", Map.of("foo", "bar", "baz", "qux"), false),
+         */
         // ========== arrays ==========
 
         // empty array
@@ -150,19 +146,14 @@ public abstract class TsvJsonArgumentsProvider extends TestBase {
             List.of("terra-wds:/type/id", "terra-wds:/type/id2"),
             false),
 
-        // array of JSON objects
         // TODO AJ-1748: where should this test live?
-        //        Arguments.of(
-        //            "[{\"first\":\"foo\"},{\"second\":\"bar\"},{\"third\":\"baz\"}]",
-        //            List.of(
-        //                new JsonAttribute(getMapper().readTree("{\"first\":\"foo\"}"),
-        // getMapper()),
-        //                new JsonAttribute(getMapper().readTree("{\"second\":\"bar\"}"),
-        // getMapper()),
-        //                new JsonAttribute(getMapper().readTree("{\"third\":\"baz\"}"),
-        // getMapper())),
-        //            false),
-
+        // array of JSON objects
+        /*
+        Arguments.of(
+            "[{\"value\":\"foo\"},{\"value\":\"bar\"},{\"value\":\"baz\"}]",
+            List.of(Map.of("value", "foo"), Map.of("value", "bar"), Map.of("value", "baz")),
+            false),
+         */
         // mixed array (these deserialize as mixed lists, will be coerced to a single data type
         // later in processing)
         Arguments.of(

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvJsonArgumentsProvider.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvJsonArgumentsProvider.java
@@ -76,12 +76,6 @@ public class TsvJsonArgumentsProvider implements ArgumentsProvider {
         // Arguments.of("\"false\"",               "false",                false),
         // Arguments.of("\"[1,2,3]\"",             "[1,2,3]",              false),
 
-        // TODO AJ-1748: where should this test live?
-        /*
-        // json packet
-        Arguments.of(
-            "{\"foo\":\"bar\", \"baz\": \"qux\"}", Map.of("foo", "bar", "baz", "qux"), false),
-         */
         // ========== arrays ==========
 
         // empty array
@@ -146,14 +140,6 @@ public class TsvJsonArgumentsProvider implements ArgumentsProvider {
             List.of("terra-wds:/type/id", "terra-wds:/type/id2"),
             false),
 
-        // TODO AJ-1748: where should this test live?
-        // array of JSON objects
-        /*
-        Arguments.of(
-            "[{\"value\":\"foo\"},{\"value\":\"bar\"},{\"value\":\"baz\"}]",
-            List.of(Map.of("value", "foo"), Map.of("value", "bar"), Map.of("value", "baz")),
-            false),
-         */
         // mixed array (these deserialize as mixed lists, will be coerced to a single data type
         // later in processing)
         Arguments.of(

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvJsonArgumentsProvider.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvJsonArgumentsProvider.java
@@ -8,7 +8,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 import org.databiosphere.workspacedataservice.common.TestBase;
-import org.databiosphere.workspacedataservice.shared.model.attributes.JsonAttribute;
 import org.junit.jupiter.params.provider.Arguments;
 
 /**
@@ -80,11 +79,12 @@ public abstract class TsvJsonArgumentsProvider extends TestBase {
         // Arguments.of("\"[1,2,3]\"",             "[1,2,3]",              false),
 
         // json packet
-        Arguments.of(
-            "{\"foo\":\"bar\", \"baz\": \"qux\"}",
-            new JsonAttribute(
-                getMapper().readTree("{\"foo\":\"bar\", \"baz\": \"qux\"}"), getMapper()),
-            false),
+        // TODO AJ-1748: where should this test live?
+        //        Arguments.of(
+        //            "{\"foo\":\"bar\", \"baz\": \"qux\"}",
+        //            new JsonAttribute(
+        //                getMapper().readTree("{\"foo\":\"bar\", \"baz\": \"qux\"}"), getMapper()),
+        //            false),
 
         // ========== arrays ==========
 
@@ -151,13 +151,17 @@ public abstract class TsvJsonArgumentsProvider extends TestBase {
             false),
 
         // array of JSON objects
-        Arguments.of(
-            "[{\"first\":\"foo\"},{\"second\":\"bar\"},{\"third\":\"baz\"}]",
-            List.of(
-                new JsonAttribute(getMapper().readTree("{\"first\":\"foo\"}"), getMapper()),
-                new JsonAttribute(getMapper().readTree("{\"second\":\"bar\"}"), getMapper()),
-                new JsonAttribute(getMapper().readTree("{\"third\":\"baz\"}"), getMapper())),
-            false),
+        // TODO AJ-1748: where should this test live?
+        //        Arguments.of(
+        //            "[{\"first\":\"foo\"},{\"second\":\"bar\"},{\"third\":\"baz\"}]",
+        //            List.of(
+        //                new JsonAttribute(getMapper().readTree("{\"first\":\"foo\"}"),
+        // getMapper()),
+        //                new JsonAttribute(getMapper().readTree("{\"second\":\"bar\"}"),
+        // getMapper()),
+        //                new JsonAttribute(getMapper().readTree("{\"third\":\"baz\"}"),
+        // getMapper())),
+        //            false),
 
         // mixed array (these deserialize as mixed lists, will be coerced to a single data type
         // later in processing)

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvJsonArgumentsProvider.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvJsonArgumentsProvider.java
@@ -1,14 +1,14 @@
 package org.databiosphere.workspacedataservice.tsv;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.extension.ExtensionContext;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.ArgumentsProvider;
 
 /**
  * Test fixtures for use by TsvDeserializerTest and TsvJsonEquivalenceTest.
@@ -19,10 +19,11 @@ import org.junit.jupiter.params.provider.ArgumentsProvider;
  * @see TsvDeserializerTest
  * @see TsvJsonEquivalenceTest
  */
-public class TsvJsonArgumentsProvider implements ArgumentsProvider {
+public abstract class TsvJsonArgumentsProvider extends TestBase {
 
-  @Override
-  public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+  abstract ObjectMapper getMapper();
+
+  public Stream<? extends Arguments> tsvJsonArguments() throws JsonProcessingException {
     /* Arguments are sets:
     	- first value is the text that would be contained in a TSV cell or JSON value
     	- second value is the expected Java type that the TsvConverter or JSON deserializer would create for that cell
@@ -79,7 +80,9 @@ public class TsvJsonArgumentsProvider implements ArgumentsProvider {
 
         // json packet
         Arguments.of(
-            "{\"foo\":\"bar\", \"baz\": \"qux\"}", Map.of("foo", "bar", "baz", "qux"), false),
+            "{\"foo\":\"bar\", \"baz\": \"qux\"}",
+            getMapper().readTree("{\"foo\":\"bar\", \"baz\": \"qux\"}"),
+            false),
 
         // ========== arrays ==========
 
@@ -147,8 +150,11 @@ public class TsvJsonArgumentsProvider implements ArgumentsProvider {
 
         // array of JSON objects
         Arguments.of(
-            "[{\"value\":\"foo\"},{\"value\":\"bar\"},{\"value\":\"baz\"}]",
-            List.of(Map.of("value", "foo"), Map.of("value", "bar"), Map.of("value", "baz")),
+            "[{\"first\":\"foo\"},{\"second\":\"bar\"},{\"third\":\"baz\"}]",
+            List.of(
+                getMapper().readTree("{\"first\":\"foo\"}"),
+                getMapper().readTree("{\"second\":\"bar\"}"),
+                getMapper().readTree("{\"third\":\"baz\"}")),
             false),
 
         // mixed array (these deserialize as mixed lists, will be coerced to a single data type

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvJsonArgumentsProvider.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvJsonArgumentsProvider.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.shared.model.attributes.JsonAttribute;
 import org.junit.jupiter.params.provider.Arguments;
 
 /**
@@ -81,7 +82,8 @@ public abstract class TsvJsonArgumentsProvider extends TestBase {
         // json packet
         Arguments.of(
             "{\"foo\":\"bar\", \"baz\": \"qux\"}",
-            getMapper().readTree("{\"foo\":\"bar\", \"baz\": \"qux\"}"),
+            new JsonAttribute(
+                getMapper().readTree("{\"foo\":\"bar\", \"baz\": \"qux\"}"), getMapper()),
             false),
 
         // ========== arrays ==========
@@ -152,9 +154,9 @@ public abstract class TsvJsonArgumentsProvider extends TestBase {
         Arguments.of(
             "[{\"first\":\"foo\"},{\"second\":\"bar\"},{\"third\":\"baz\"}]",
             List.of(
-                getMapper().readTree("{\"first\":\"foo\"}"),
-                getMapper().readTree("{\"second\":\"bar\"}"),
-                getMapper().readTree("{\"third\":\"baz\"}")),
+                new JsonAttribute(getMapper().readTree("{\"first\":\"foo\"}"), getMapper()),
+                new JsonAttribute(getMapper().readTree("{\"second\":\"bar\"}"), getMapper()),
+                new JsonAttribute(getMapper().readTree("{\"third\":\"baz\"}"), getMapper())),
             false),
 
         // mixed array (these deserialize as mixed lists, will be coerced to a single data type

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvJsonEquivalenceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvJsonEquivalenceTest.java
@@ -11,11 +11,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.List;
+import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
 import org.databiosphere.workspacedataservice.shared.model.RecordRequest;
-import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -25,18 +25,12 @@ import org.springframework.boot.test.context.SpringBootTest;
  *
  * @see TsvJsonArgumentsProvider
  */
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @SpringBootTest
-class TsvJsonEquivalenceTest extends TsvJsonArgumentsProvider {
+class TsvJsonEquivalenceTest extends TestBase {
 
   @Autowired private ObjectReader tsvReader;
 
-  @Autowired ObjectMapper mapper;
-
-  @Override
-  ObjectMapper getMapper() {
-    return mapper;
-  }
+  @Autowired private ObjectMapper mapper;
 
   private RecordAttributes readTsv(String tsvContent) throws IOException {
     InputStream inputStream = new ByteArrayInputStream(tsvContent.getBytes());
@@ -54,7 +48,7 @@ class TsvJsonEquivalenceTest extends TsvJsonArgumentsProvider {
    */
   @ParameterizedTest(
       name = "TSV and JSON deserialization should be equal for input value <{0}>, returning <{1}>")
-  @MethodSource("tsvJsonArguments")
+  @ArgumentsSource(TsvJsonArgumentsProvider.class)
   void tsvAndJsonShouldDeserializeSame(String input, Object expected, boolean quoteJson)
       throws IOException {
     String tsv = RECORD_ID + "\tcol1\n123\t" + input + "\n";

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvJsonEquivalenceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvJsonEquivalenceTest.java
@@ -11,11 +11,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.List;
-import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
 import org.databiosphere.workspacedataservice.shared.model.RecordRequest;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -25,12 +25,18 @@ import org.springframework.boot.test.context.SpringBootTest;
  *
  * @see TsvJsonArgumentsProvider
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @SpringBootTest
-class TsvJsonEquivalenceTest extends TestBase {
+class TsvJsonEquivalenceTest extends TsvJsonArgumentsProvider {
 
   @Autowired private ObjectReader tsvReader;
 
-  @Autowired private ObjectMapper mapper;
+  @Autowired ObjectMapper mapper;
+
+  @Override
+  ObjectMapper getMapper() {
+    return mapper;
+  }
 
   private RecordAttributes readTsv(String tsvContent) throws IOException {
     InputStream inputStream = new ByteArrayInputStream(tsvContent.getBytes());
@@ -48,7 +54,7 @@ class TsvJsonEquivalenceTest extends TestBase {
    */
   @ParameterizedTest(
       name = "TSV and JSON deserialization should be equal for input value <{0}>, returning <{1}>")
-  @ArgumentsSource(TsvJsonArgumentsProvider.class)
+  @MethodSource("tsvJsonArguments")
   void tsvAndJsonShouldDeserializeSame(String input, Object expected, boolean quoteJson)
       throws IOException {
     String tsv = RECORD_ID + "\tcol1\n123\t" + input + "\n";


### PR DESCRIPTION
This PR introduces a `JsonAttribute` class into the attribute hierarchy (see #759). TSV uploads now deserialize json columns, and arrays of json, into `JsonAttribute` instead of `Map<String, Object>`.

This is pre-work to supporting arrays-of-arrays. Since `JsonAttribute` can support either a json object or a json array, it is more flexible; the previous `Map<String, Object>` can only support a json object.

However, as prework, there should be no functional changes in this PR; it is only a refactor.


