### PR TITLE
[AJ-1811] Report version+hash to sherlock

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -110,7 +110,7 @@ jobs:
     needs: [build, tag]
     uses: ./.github/workflows/publish-docker.yml
     with:
-      new-tag: ${{ needs.tag-job.outputs.tag }}
+      new-tag: ${{ needs.tag-job.outputs.new-tag }}
     secrets:
       ACR_SP_PASSWORD: ${{ secrets.ACR_SP_PASSWORD }}
       ACR_SP_USER: ${{ secrets.ACR_SP_USER }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -99,14 +99,14 @@ jobs:
           event-name: ${{ github.event_name }}
 
   tag:
-    if: always() && needs.bump-check.outputs.is-bump == 'no'
+    if: always() && needs.bump-check.outputs.is-bump == 'no' && github.event_name == 'push'
     uses: ./.github/workflows/tag.yml
     needs: [ build, unit-tests, bump-check ]
     secrets: inherit
 
   # Publish Docker image to Google and Azure Container Registries, also reports to sherlock
   docker-image-job:
-    if: always() && needs.bump-check.outputs.is-bump == 'no'
+    if: always() && needs.bump-check.outputs.is-bump == 'no' && github.event_name == 'push'
     needs: [build, bump-check, tag]
     uses: ./.github/workflows/publish-docker.yml
     with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -85,28 +85,14 @@ jobs:
           name: Test Reports
           path: service/build/reports
           retention-days: 14
-          
-  # bump-check:
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     is-bump: ${{ steps.bumpcheck.outputs.is-bump }}
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - name: Skip version bump merges
-  #       id: bumpcheck
-  #       uses: ./.github/actions/bump-skip
-  #       with:
-  #         event-name: ${{ github.event_name }}
 
   tag:
-    # if: always() && needs.bump-check.outputs.is-bump == 'no' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     uses: ./.github/workflows/tag.yml
     needs: [ build, unit-tests ]
     secrets: inherit
 
   # Publish Docker image to Google and Azure Container Registries, also reports to sherlock
   docker-image-job:
-    # if: always() && needs.bump-check.outputs.is-bump == 'no' && github.event_name == 'push'
     needs: [build, tag]
     uses: ./.github/workflows/publish-docker.yml
     with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -106,7 +106,7 @@ jobs:
 
   # Publish Docker image to Google and Azure Container Registries, also reports to sherlock
   docker-image-job:
-    if: always() && needs.bump-check.outputs.is-bump == 'no' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: always() && needs.bump-check.outputs.is-bump == 'no' && github.event_name == 'push'
     needs: [build, bump-check, tag]
     uses: ./.github/workflows/publish-docker.yml
     with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -86,14 +86,28 @@ jobs:
           path: service/build/reports
           retention-days: 14
 
+  bump-check:
+    runs-on: ubuntu-latest
+    outputs:
+      is-bump: ${{ steps.bumpcheck.outputs.is-bump }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Skip version bump merges
+        id: bumpcheck
+        uses: ./.github/actions/bump-skip
+        with:
+          event-name: ${{ github.event_name }}
+
   tag:
+    if: always() && needs.bump-check.outputs.is-bump == 'no'
     uses: ./.github/workflows/tag.yml
-    needs: [ build, unit-tests ]
+    needs: [ build, unit-tests, bump-check ]
     secrets: inherit
 
   # Publish Docker image to Google and Azure Container Registries, also reports to sherlock
   docker-image-job:
-    needs: [build, tag]
+    if: always() && needs.bump-check.outputs.is-bump == 'no'
+    needs: [build, bump-check, tag]
     uses: ./.github/workflows/publish-docker.yml
     with:
       new-tag: ${{ needs.tag.outputs.new-tag }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -86,28 +86,28 @@ jobs:
           path: service/build/reports
           retention-days: 14
           
-  bump-check:
-    runs-on: ubuntu-latest
-    outputs:
-      is-bump: ${{ steps.bumpcheck.outputs.is-bump }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Skip version bump merges
-        id: bumpcheck
-        uses: ./.github/actions/bump-skip
-        with:
-          event-name: ${{ github.event_name }}
+  # bump-check:
+  #   runs-on: ubuntu-latest
+  #   outputs:
+  #     is-bump: ${{ steps.bumpcheck.outputs.is-bump }}
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Skip version bump merges
+  #       id: bumpcheck
+  #       uses: ./.github/actions/bump-skip
+  #       with:
+  #         event-name: ${{ github.event_name }}
 
   tag:
-    if: always() && needs.bump-check.outputs.is-bump == 'no' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # if: always() && needs.bump-check.outputs.is-bump == 'no' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     uses: ./.github/workflows/tag.yml
-    needs: [ build, unit-tests, bump-check ]
+    needs: [ build, unit-tests ]
     secrets: inherit
 
   # Publish Docker image to Google and Azure Container Registries, also reports to sherlock
   docker-image-job:
-    if: always() && needs.bump-check.outputs.is-bump == 'no' && github.event_name == 'push'
-    needs: [build, bump-check, tag]
+    # if: always() && needs.bump-check.outputs.is-bump == 'no' && github.event_name == 'push'
+    needs: [build, tag]
     uses: ./.github/workflows/publish-docker.yml
     with:
       new-tag: ${{ needs.tag-job.outputs.tag }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -110,7 +110,7 @@ jobs:
     needs: [build, bump-check, tag]
     uses: ./.github/workflows/publish-docker.yml
     with:
-      new-tag: ${{ needs.tag-job.outputs.new-tag }}
+      new-tag: ${{ needs.tag-job.outputs.tag }}
     secrets:
       ACR_SP_PASSWORD: ${{ secrets.ACR_SP_PASSWORD }}
       ACR_SP_USER: ${{ secrets.ACR_SP_USER }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -110,7 +110,7 @@ jobs:
     needs: [build, tag]
     uses: ./.github/workflows/publish-docker.yml
     with:
-      new-tag: ${{ needs.tag-job.outputs.new-tag }}
+      new-tag: ${{ needs.tag.outputs.new-tag }}
     secrets:
       ACR_SP_PASSWORD: ${{ secrets.ACR_SP_PASSWORD }}
       ACR_SP_USER: ${{ secrets.ACR_SP_USER }}

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -10,7 +10,7 @@ on:
         required: true
       ACR_SP_USER:
         required: true
-  pull_request:
+  # pull_request:
 
 env:
   SERVICE_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -3,14 +3,13 @@ on:
   workflow_call:
     inputs:
       new-tag:
-        required: false
+        required: true
         type: string
     secrets:
       ACR_SP_PASSWORD:
         required: true
       ACR_SP_USER:
         required: true
-  # pull_request:
 
 env:
   SERVICE_NAME: ${{ github.event.repository.name }}
@@ -25,8 +24,6 @@ jobs:
       contents: 'read'
       id-token: 'write'
     runs-on: ubuntu-latest
-    outputs:
-      newVersion: ${{ steps.newVersion.outputs.newVersion }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 17
@@ -43,10 +40,6 @@ jobs:
           git_short_sha=$(echo ${{ github.event.pull_request.head.sha || github.sha }} | cut -c1-7)
           echo $git_short_sha
           echo "git_short_sha=${git_short_sha}" >> $GITHUB_OUTPUT
-
-      - name: Determine new version
-        id: newVersion
-        run: echo "newVersion=${{ inputs.new-tag}}" >> "$GITHUB_OUTPUT"
 
       - name: Set up gcloud
         uses: google-github-actions/setup-gcloud@v2
@@ -85,7 +78,6 @@ jobs:
           -Djib.console=plain
 
       - name: Add version tag to GCR
-        if: ${{ inputs.new-tag != '' }}
         run: docker image tag ${{ steps.gcr-image-name.outputs.name }}:${{ steps.setHash.outputs.git_short_sha }} ${{ steps.gcr-image-name.outputs.name }}:${{ inputs.new-tag }}
 
       - name: Run Trivy vulnerability scanner
@@ -101,7 +93,6 @@ jobs:
         run: docker tag ${{ steps.gcr-image-name.outputs.name }}:${{ steps.setHash.outputs.git_short_sha }} ${{ steps.acr-image-name.outputs.name }}:${{ steps.setHash.outputs.git_short_sha }}
 
       - name: Add version tag to ACR
-        if: ${{ inputs.new-tag != '' }}
         run: docker image tag ${{ steps.acr-image-name.outputs.name }}:${{ steps.setHash.outputs.git_short_sha }} ${{ steps.acr-image-name.outputs.name }}:${{ inputs.new-tag }}
 
       - name: Push image to Azure
@@ -118,7 +109,7 @@ jobs:
     needs: publish-docker-job
     uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
     with:
-      new-version: ${{ needs.publish-docker-job.outputs.newVersion }}
+      new-version: ${{ inputs.new-tag }}
       chart-name: 'cwds'
     permissions:
       contents: 'read'

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Determine new version
         id: newVersion
-        run: echo "newVersion=${{ inputs.new-tag || steps.setHash.outputs.git_short_sha }}" >> "$GITHUB_OUTPUT"
+        run: echo "newVersion=${{ inputs.new-tag}}" >> "$GITHUB_OUTPUT"
 
       - name: Set up gcloud
         uses: google-github-actions/setup-gcloud@v2


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1811
When cwds reports a non-main version to [sherlock](https://beehive.dsp-devops-prod.broadinstitute.org/charts/cwds/app-versions), it just gives it the git hash, whereas (at least some) [other repos](https://beehive.dsp-devops-prod.broadinstitute.org/charts/rawls/app-versions) have the hash after the version, making it easier to sort.  

Previously, `publish-docker.yml` was called on PRs, lacking the tag, and so used the git hash as a tag.  Now `build-and-test` always calls `tag` and `publish-docker`, and uses the tag result from `tag.yml` to report to sherlock, which does include the version+hash.

Reviewers, please verify that I haven't ruined the tagging/versioning flow. I've mostly convinced myself that it's correct but definitely need a second pair of eyes.

To do after PR merges:

- [ ] update GHA diagram in the wiki

Reminder:

#### Releasing WDS ####
PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag-and-publish.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 

#### Keeping Docs Up To Date ####
If you make changes to the github actions or workflows, particularly when they are run or which other workflows they call, please update [the GHA wiki page](https://github.com/DataBiosphere/terra-workspace-data-service/wiki/GHA-structure-in-WDS) to stay up to date.
