### PR TITLE
AJ-1700: Fix bug while copying `RAWLSJSON` file.

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/rawlsjson/RawlsJsonQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/rawlsjson/RawlsJsonQuartzJob.java
@@ -6,6 +6,7 @@ import static org.databiosphere.workspacedataservice.shared.model.Schedulable.AR
 import static org.databiosphere.workspacedataservice.shared.model.job.JobType.DATA_IMPORT;
 
 import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
 import java.net.URI;
@@ -59,7 +60,7 @@ public class RawlsJsonQuartzJob extends QuartzJob {
   }
 
   private Blob moveBlob(URI sourceUri, String desiredBlobName) {
-    return storage.moveBlob(sourceUri, storage.createBlob(desiredBlobName));
+    return storage.moveBlob(sourceUri, BlobId.of(storage.getBucketName(), desiredBlobName));
   }
 
   private ImportDetails getImportDetails(UUID jobId, JobDataMapReader jobData) {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/storage/GcsStorageTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/storage/GcsStorageTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.util.Streams.stream;
 import static org.springframework.util.StreamUtils.copyToString;
 
 import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.StorageException;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -161,8 +162,7 @@ class GcsStorageTest extends TestBase {
 
     // Act
     URI sourceUri = getUri(sourceBlob);
-    Blob targetBlob = storage.createBlob(newBlobName);
-    Blob movedBlob = storage.moveBlob(sourceUri, targetBlob);
+    Blob movedBlob = storage.moveBlob(sourceUri, BlobId.of(storage.getBucketName(), newBlobName));
 
     // Assert
     assertThat(movedBlob.getName()).isEqualTo(newBlobName);
@@ -179,8 +179,9 @@ class GcsStorageTest extends TestBase {
 
     // Act / Assert
     assertThatExceptionOfType(StorageException.class)
-        .isThrownBy(() -> storage.moveBlob(sourceUri, storage.createBlob("targetBlobName")))
-        .withMessageContaining("nonExistentBlob");
+        .isThrownBy(
+            () -> storage.moveBlob(sourceUri, BlobId.of(storage.getBucketName(), "targetBlobName")))
+        .withMessageContaining("nonExistent");
   }
 
   private String getContentsAsString(String blobName) throws IOException {


### PR DESCRIPTION
Before this change, the `moveBlob` method would attempt to get the blob based on the original target to return a reference to it.  However, the original `BlobId` used as a reference also contained the original `generation`, and therefore the `getBlob` call would always return `null` and cause an NPE.  Instead, we use the resultant `Blob` from the copy, which has the correct new `generation`, and should actually exist.

Notes about the verifying issue:
- The local mock storage doesn't behave exactly the way the actual/production storage does with regards to existing blobs and how errors are surfaced, so it's not 100% reliable at detecting issues like this.
- In order to reproduce the actual issue I actually temporarily switched over to using the real version of the storage class in the E2E test, hardcoded the bucket name, and used the debugger to step through and understand the problem was related to the wrong `generation` on the `BlobId`.