### PR TITLE
AJ-1748: arrays of arrays in TSV

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -7,7 +7,6 @@ import static org.databiosphere.workspacedataservice.service.model.ReservedNames
 import static org.databiosphere.workspacedataservice.service.model.exception.InvalidNameException.NameType.ATTRIBUTE;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
@@ -1048,11 +1047,11 @@ public class RecordDao {
     }
 
     private Object[] convertToJson(Object object) throws JsonProcessingException {
+      // json arrays are returned from the db as String[]
       String[] jsonArray = (String[]) object;
-      Object[] result = new Object[jsonArray.length];
+      JsonAttribute[] result = new JsonAttribute[jsonArray.length];
       for (int i = 0; i < jsonArray.length; i++) {
-        result[i] =
-            objectMapper.readValue(jsonArray[i], new TypeReference<Map<String, Object>>() {});
+        result[i] = new JsonAttribute(objectMapper.readTree(jsonArray[i]));
       }
       return result;
     }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -3150,7 +3150,7 @@ class RecordControllerMockMvcTest extends MockMvcTestBase {
             .andReturn();
     RecordTypeSchema schema = fromJson(schemaResult, RecordTypeSchema.class);
 
-    assertEquals("ARRAY_OF_STRING", schema.getAttributeSchema(attributeName).datatype());
+    assertEquals("ARRAY_OF_JSON", schema.getAttributeSchema(attributeName).datatype());
 
     MvcResult mvcSingleResult =
         mockMvc
@@ -3165,7 +3165,8 @@ class RecordControllerMockMvcTest extends MockMvcTestBase {
             .andReturn();
     RecordResponse record = fromJson(mvcSingleResult, RecordResponse.class);
 
-    List<String> expectedValue = List.of("{value=foo}", "{value=bar}", "baz");
+    // note the mixed values here
+    List<Object> expectedValue = List.of(Map.of("value", "foo"), Map.of("value", "bar"), "baz");
     assertEquals(expectedValue, record.recordAttributes().getAttributeValue(attributeName));
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvInputFormatsTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvInputFormatsTest.java
@@ -149,7 +149,7 @@ class TsvInputFormatsTest extends TestBase {
               new JsonAttribute(mapper.readTree("[\"two\",\"three\"]")),
               new JsonAttribute(mapper.readTree("[\"four\",\"five\",\"six\"]"))
             },
-            "[[1],[2,3],[4,5,6]]"),
+            "[[\"one\"],[\"two\",\"three\"],[\"four\",\"five\",\"six\"]]"),
         // array of mixed json types
         Arguments.of(
             "[[1,2,3],[\"four\",\"five\"],67,{\"some\":\"object\",\"with\":[\"nesting\"]}]",

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvInputFormatsTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvInputFormatsTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Optional;
@@ -14,8 +16,10 @@ import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
+import org.databiosphere.workspacedataservice.shared.model.attributes.JsonAttribute;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -29,6 +33,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ActiveProfiles(profiles = "mock-sam")
 @DirtiesContext
 @SpringBootTest
@@ -37,6 +42,7 @@ class TsvInputFormatsTest extends TestBase {
 
   @Autowired private MockMvc mockMvc;
   @Autowired RecordDao recordDao;
+  @Autowired ObjectMapper mapper;
 
   private UUID instanceId;
 
@@ -82,7 +88,7 @@ class TsvInputFormatsTest extends TestBase {
     }
   }
 
-  private static Stream<Arguments> provideInputFormats() {
+  private Stream<Arguments> provideInputFormats() throws JsonProcessingException {
     /* Arguments are sets:
     - first value is the text that would be contained in a TSV cell
     - second value is the expected Java type that WDS would create, after saving the TSV and re-retrieving the record.
@@ -117,7 +123,43 @@ class TsvInputFormatsTest extends TestBase {
         Arguments.of(
             "[1,5.67]",
             new BigDecimal[] {BigDecimal.valueOf(1), BigDecimal.valueOf(5.67)},
-            "[1,5.67]")
+            "[1,5.67]"),
+        // array of json packets
+        Arguments.of(
+            "[{\"value\":\"foo\"},{\"value\":\"bar\"},{\"value\":\"baz\"}]",
+            new JsonAttribute[] {
+              new JsonAttribute(mapper.readTree("{\"value\":\"foo\"}")),
+              new JsonAttribute(mapper.readTree("{\"value\":\"bar\"}")),
+              new JsonAttribute(mapper.readTree("{\"value\":\"baz\"}"))
+            },
+            "[{\"value\":\"foo\"},{\"value\":\"bar\"},{\"value\":\"baz\"}]"),
+        // nested arrays
+        Arguments.of(
+            "[[1],[2,3],[4,5,6]]",
+            new JsonAttribute[] {
+              new JsonAttribute(mapper.readTree("[1]")),
+              new JsonAttribute(mapper.readTree("[2,3]")),
+              new JsonAttribute(mapper.readTree("[4,5,6]"))
+            },
+            "[[1],[2,3],[4,5,6]]"),
+        Arguments.of(
+            "[[\"one\"],[\"two\",\"three\"],[\"four\",\"five\",\"six\"]]",
+            new JsonAttribute[] {
+              new JsonAttribute(mapper.readTree("[\"one\"]")),
+              new JsonAttribute(mapper.readTree("[\"two\",\"three\"]")),
+              new JsonAttribute(mapper.readTree("[\"four\",\"five\",\"six\"]"))
+            },
+            "[[1],[2,3],[4,5,6]]"),
+        // array of mixed json types
+        Arguments.of(
+            "[[1,2,3],[\"four\",\"five\"],67,{\"some\":\"object\",\"with\":[\"nesting\"]}]",
+            new JsonAttribute[] {
+              new JsonAttribute(mapper.readTree("[1,2,3]")),
+              new JsonAttribute(mapper.readTree("[\"four\",\"five\"]")),
+              new JsonAttribute(mapper.readTree("67")),
+              new JsonAttribute(mapper.readTree("{\"some\":\"object\",\"with\":[\"nesting\"]}"))
+            },
+            "[[1,2,3],[\"four\",\"five\"],67,{\"some\":\"object\",\"with\":[\"nesting\"]}]")
         // TODO: array of numbers with leading zeros
         // TODO: smart-quotes?
         // TODO: string-escaping for special characters

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/DataTypeInfererTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/DataTypeInfererTest.java
@@ -184,6 +184,45 @@ class DataTypeInfererTest extends TestBase {
         .isEqualTo(DataTypeMapping.ARRAY_OF_STRING);
   }
 
+  @Test
+  void inferArraysOfJson() {
+    // array of json objects
+    assertThat(inferer.inferType(Arrays.asList(Map.of("foo", "bar"), Map.of("num", 42))))
+        .isEqualTo(DataTypeMapping.ARRAY_OF_JSON);
+    // array of nested json objects
+    assertThat(
+            inferer.inferType(
+                Arrays.asList(
+                    Map.of("foo", Map.of("one", "two")), Map.of("bar", Map.of("three", "four")))))
+        .isEqualTo(DataTypeMapping.ARRAY_OF_JSON);
+  }
+
+  @Test
+  void inferMixedArrays() {
+    // array of mixed values, including a json object
+    assertThat(
+            inferer.inferType(
+                Arrays.asList(Map.of("foo", "bar"), new BigInteger("11"), "I'm a string")))
+        .isEqualTo(DataTypeMapping.ARRAY_OF_JSON);
+  }
+
+  @Test
+  void inferNestedArrays() {
+    // nested array of numbers
+    assertThat(
+            inferer.inferType(
+                Arrays.asList(List.of(1), Arrays.asList(2, 3), Arrays.asList(4, 5, 6))))
+        .isEqualTo(DataTypeMapping.ARRAY_OF_JSON);
+    // nested array of strings
+    assertThat(
+            inferer.inferType(
+                Arrays.asList(
+                    List.of("one"),
+                    Arrays.asList("two", "three"),
+                    Arrays.asList("four", "five", "six"))))
+        .isEqualTo(DataTypeMapping.ARRAY_OF_JSON);
+  }
+
   // Test for [AJ-1143]: TSV fails to upload if it has nulls in a relation column
   @Test
   void allowNullRelations() {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvDeserializerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvDeserializerTest.java
@@ -98,11 +98,35 @@ class TsvDeserializerTest extends TestBase {
         Arguments.of(
             "{\"foo\":\"bar\", \"baz\": \"qux\"}",
             new JsonAttribute(mapper.readTree("{\"foo\":\"bar\", \"baz\": \"qux\"}"))),
+        // array of json packets
         Arguments.of(
             "[{\"value\":\"foo\"},{\"value\":\"bar\"},{\"value\":\"baz\"}]",
             List.of(
                 new JsonAttribute(mapper.readTree("{\"value\":\"foo\"}")),
                 new JsonAttribute(mapper.readTree("{\"value\":\"bar\"}")),
-                new JsonAttribute(mapper.readTree("{\"value\":\"baz\"}")))));
+                new JsonAttribute(mapper.readTree("{\"value\":\"baz\"}")))),
+        // nested arrays: numbers
+        Arguments.of(
+            "[[1],[2,3],[4,5,6]]",
+            List.of(
+                new JsonAttribute(mapper.readTree("[1]")),
+                new JsonAttribute(mapper.readTree("[2,3]")),
+                new JsonAttribute(mapper.readTree("[4,5,6]")))),
+        // nested arrays: strings
+        Arguments.of(
+            "[[\"one\"],[\"two\",\"three\"],[\"four\",\"five\",\"six\"]]",
+            List.of(
+                new JsonAttribute(mapper.readTree("[\"one\"]")),
+                new JsonAttribute(mapper.readTree("[\"two\",\"three\"]")),
+                new JsonAttribute(mapper.readTree("[\"four\",\"five\",\"six\"]")))),
+        // array of mixed json types
+        Arguments.of(
+            "[[1,2,3],[\"four\",\"five\"],67,{\"some\":\"object\",\"with\":[\"nesting\"]}]",
+            List.of(
+                new JsonAttribute(mapper.readTree("[1,2,3]")),
+                new JsonAttribute(mapper.readTree("[\"four\",\"five\"]")),
+                new JsonAttribute(mapper.readTree("67")),
+                new JsonAttribute(
+                    mapper.readTree("{\"some\":\"object\",\"with\":[\"nesting\"]}")))));
   }
 }


### PR DESCRIPTION
This supports arrays-of-arrays for TSV upload and our json-based REST APIs. It treats arrays-of-arrays as `ARRAY_OF_JSON`. So, we still get a count of the number of first-level elements, but each first-level element is a opaque json blob; we don't provide any special functionality for the nested structures.

`ARRAY_OF_JSON` _can_ support the following use cases:
* **arrays of json objects**: already supported before this PR.
* **arrays of arrays**: added support in this PR.
* **arrays of mixed types**: _partial_ support in this PR.
  * If at least one of the elements of the array is a nested array or object, we treat it as `ARRAY_OF_JSON`. Example: `["one", "two", ["nested", "array"], "three]`
  * If none of the mixed types is an array or object, we maintain the current behavior and treat it as an `ARRAY_OF_STRING`. Example: `[1, 2, "three", 4]`

Changing that last bullet point so that we use `ARRAY_OF_JSON` for _any_ mixed array is trivial and we could certainly add it. It's a behavior change and I want to vet it with the team before making that change.

_**important**_:  this PR only handles arrays-of-arrays for TSV and REST APIs. It does NOT fix it for PFB/TDR. I will handle that in yet another follow-on PR.