### PR TITLE
[AJ-1777] Allow requiring a private workspace for imports from some sources

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/config/DataImportProperties.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/config/DataImportProperties.java
@@ -138,7 +138,8 @@ public class DataImportProperties {
     }
   }
 
-  public record ImportSourceConfig(List<Pattern> urls, boolean requireProtectedDataPolicy) {
+  public record ImportSourceConfig(
+      List<Pattern> urls, boolean requirePrivateWorkspace, boolean requireProtectedDataPolicy) {
     public boolean matchesUri(URI uri) {
       String uriString = uri.toString();
       return urls.stream().anyMatch(urlPattern -> urlPattern.matcher(uriString).find());

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/DefaultImportValidator.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/DefaultImportValidator.java
@@ -14,10 +14,12 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
+import org.broadinstitute.dsde.workbench.client.sam.model.UserResourcesResponse;
 import org.databiosphere.workspacedataservice.config.DataImportProperties.ImportSourceConfig;
 import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
 import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel.TypeEnum;
 import org.databiosphere.workspacedataservice.policy.PolicyUtils;
+import org.databiosphere.workspacedataservice.sam.SamDao;
 import org.databiosphere.workspacedataservice.service.model.exception.ValidationException;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.databiosphere.workspacedataservice.workspacemanager.WorkspaceManagerDao;
@@ -44,9 +46,11 @@ public class DefaultImportValidator implements ImportValidator {
           );
   private final Map<String, Set<Pattern>> allowedHostsByScheme;
   private final ImportRequirementsFactory importRequirementsFactory;
+  private final SamDao samDao;
   private final WorkspaceManagerDao wsmDao;
 
   public DefaultImportValidator(
+      SamDao samDao,
       WorkspaceManagerDao wsmDao,
       Set<Pattern> allowedHttpsHosts,
       List<ImportSourceConfig> sources,
@@ -63,6 +67,7 @@ public class DefaultImportValidator implements ImportValidator {
 
     this.allowedHostsByScheme = allowedHostsBuilder.build();
     this.importRequirementsFactory = new ImportRequirementsFactory(sources);
+    this.samDao = samDao;
     this.wsmDao = wsmDao;
   }
 
@@ -101,6 +106,11 @@ public class DefaultImportValidator implements ImportValidator {
       throw new ValidationException(
           "Data from this source can only be imported into a protected workspace.");
     }
+
+    if (requirements.privateWorkspace() && !checkWorkspaceIsPrivate(destinationWorkspaceId)) {
+      throw new ValidationException(
+          "Data from this source cannot be imported into a public workspace.");
+    }
   }
 
   private boolean checkWorkspaceHasProtectedDataPolicy(WorkspaceId workspaceId) {
@@ -110,11 +120,29 @@ public class DefaultImportValidator implements ImportValidator {
           Optional.ofNullable(workspace.getPolicies()).orElse(emptyList());
       return workspacePolicies.stream().anyMatch(PolicyUtils::isProtectedDataPolicy);
     } catch (WorkspaceManagerException e) {
+      // GCP workspaces without a policy will not be present in Workspace Manager.
       if (e.getStatusCode().equals(HttpStatus.NOT_FOUND)) {
         return false;
       } else {
         throw e;
       }
     }
+  }
+
+  private boolean checkWorkspaceIsPrivate(WorkspaceId workspaceId) {
+    // It's inefficient to request _all_ workspaces here when we're only interested in
+    // one of them, but Sam does not provide a way to retrieve this information for
+    // only a specific resource.
+    List<UserResourcesResponse> resources = samDao.listWorkspaceResourcesAndPolicies();
+
+    // Before import validation, we've verified that the user can write to the destination
+    // workspace. So it's safe to assume the workspace is in this list.
+    UserResourcesResponse workspaceResource =
+        resources.stream()
+            .filter(resource -> resource.getResourceId().equals(workspaceId.toString()))
+            .findFirst()
+            .orElseThrow();
+    return workspaceResource.getPublic().getRoles().isEmpty()
+        && workspaceResource.getPublic().getActions().isEmpty();
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportRequirements.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportRequirements.java
@@ -1,7 +1,7 @@
 package org.databiosphere.workspacedataservice.dataimport;
 
-public record ImportRequirements(boolean protectedDataPolicy) {
+public record ImportRequirements(boolean privateWorkspace, boolean protectedDataPolicy) {
   public ImportRequirements() {
-    this(false);
+    this(false, false);
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportValidatorConfiguration.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportValidatorConfiguration.java
@@ -2,6 +2,7 @@ package org.databiosphere.workspacedataservice.dataimport;
 
 import org.databiosphere.workspacedataservice.config.ConfigurationException;
 import org.databiosphere.workspacedataservice.config.DataImportProperties;
+import org.databiosphere.workspacedataservice.sam.SamDao;
 import org.databiosphere.workspacedataservice.workspacemanager.WorkspaceManagerDao;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -16,8 +17,9 @@ public class ImportValidatorConfiguration {
       havingValue = "true",
       matchIfMissing = true)
   ImportValidator getDefaultImportValidator(
-      WorkspaceManagerDao wsmDao, DataImportProperties dataImportProperties) {
+      SamDao samDao, WorkspaceManagerDao wsmDao, DataImportProperties dataImportProperties) {
     return new DefaultImportValidator(
+        samDao,
         wsmDao,
         dataImportProperties.getAllowedHosts(),
         dataImportProperties.getSources(),

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/HttpSamDao.java
@@ -7,6 +7,7 @@ import static org.databiosphere.workspacedataservice.sam.SamAuthorizationDao.RES
 import java.util.List;
 import java.util.UUID;
 import org.broadinstitute.dsde.workbench.client.sam.model.SystemStatus;
+import org.broadinstitute.dsde.workbench.client.sam.model.UserResourcesResponse;
 import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo;
 import org.databiosphere.workspacedataservice.retry.RestClientRetry;
 import org.databiosphere.workspacedataservice.retry.RestClientRetry.RestCall;
@@ -92,5 +93,12 @@ public class HttpSamDao implements SamDao {
                     readerRole,
                     null),
         "Sam.addWorkspacePoliciesAsSnapshotReader");
+  }
+
+  public List<UserResourcesResponse> listWorkspaceResourcesAndPolicies() {
+    return restClientRetry.withRetryAndErrorHandling(
+        () ->
+            samClientFactory.getResourcesApi().listResourcesAndPoliciesV2(RESOURCE_NAME_WORKSPACE),
+        "Sam.listResourcesAndPoliciesV2");
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/sam/SamDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/sam/SamDao.java
@@ -1,7 +1,9 @@
 package org.databiosphere.workspacedataservice.sam;
 
+import java.util.List;
 import java.util.UUID;
 import org.broadinstitute.dsde.workbench.client.sam.model.SystemStatus;
+import org.broadinstitute.dsde.workbench.client.sam.model.UserResourcesResponse;
 import org.databiosphere.workspacedataservice.shared.model.BearerToken;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 
@@ -27,4 +29,7 @@ public interface SamDao {
   /** Add reader policy to workspace. */
   void addWorkspacePoliciesAsSnapshotReader(
       WorkspaceId workspaceId, UUID snapshotId, String readerRole);
+
+  /** Get the user's workspaces and their roles and actions on them. */
+  public List<UserResourcesResponse> listWorkspaceResourcesAndPolicies();
 }

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -152,6 +152,7 @@ twds:
           - ^https:\/\/s3\.amazonaws.com\/gen3-biodatacatalyst-nhlbi-nih-gov-pfb-export\/
           - ^https:\/\/gen3-theanvil-io-pfb-export\.s3\.amazonaws\.com\/
           - ^https:\/\/s3\.amazonaws\.com\/gen3-theanvil-io-pfb-export\/
+        requirePrivateWorkspace: true
         requireProtectedDataPolicy: true
 
   pg_dump:

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/DefaultImportValidatorTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/DefaultImportValidatorTest.java
@@ -43,7 +43,7 @@ class DefaultImportValidatorTest extends TestBase {
           wsmDao,
           /* allowedHttpsHosts */ Set.of(Pattern.compile(".*\\.terra\\.bio")),
           /* sources */ List.of(
-              new ImportSourceConfig(List.of(Pattern.compile("protected\\.pfb")), true)),
+              new ImportSourceConfig(List.of(Pattern.compile("protected\\.pfb")), false, true)),
           /* allowedRawlsBucket */ "test-bucket");
     }
   }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1777

Similar to how #766 added the option to require a workspace with a `protected-data` policy for imports from specific sources, this adds the option to require a private workspace.