### PR TITLE
AJ-1771: id filter for paginated record query

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
@@ -218,6 +218,7 @@ public class RecordOrchestratorService { // TODO give me a better name
             searchRequest.getOffset(),
             searchRequest.getSort().name().toLowerCase(),
             searchRequest.getSortAttribute(),
+            searchRequest.getFilter(),
             collectionId);
     List<RecordResponse> recordList =
         records.stream()

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/SearchFilter.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/SearchFilter.java
@@ -1,6 +1,6 @@
 package org.databiosphere.workspacedataservice.shared.model;
 
 import java.util.List;
-import org.springframework.lang.Nullable;
+import java.util.Optional;
 
-public record SearchFilter(@Nullable List<String> ids) {}
+public record SearchFilter(Optional<List<String>> ids) {}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/SearchFilter.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/SearchFilter.java
@@ -1,0 +1,6 @@
+package org.databiosphere.workspacedataservice.shared.model;
+
+import java.util.List;
+import org.springframework.lang.Nullable;
+
+public record SearchFilter(@Nullable List<String> ids) {}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/SearchRequest.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/SearchRequest.java
@@ -59,7 +59,6 @@ public class SearchRequest {
     this.sortAttribute = sortAttribute;
   }
 
-  @Nullable
   public Optional<SearchFilter> getFilter() {
     return filter;
   }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/SearchRequest.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/SearchRequest.java
@@ -8,6 +8,7 @@ public class SearchRequest {
   private int offset = 0;
   private SortDirection sort = SortDirection.ASC;
   @Nullable private String sortAttribute = null;
+  @Nullable private SearchFilter filter = null;
 
   public SearchRequest(int limit, int offset, SortDirection sort) {
     this.limit = limit;
@@ -55,5 +56,14 @@ public class SearchRequest {
 
   public void setSortAttribute(String sortAttribute) {
     this.sortAttribute = sortAttribute;
+  }
+
+  @Nullable
+  public SearchFilter getFilter() {
+    return filter;
+  }
+
+  public void setFilter(@Nullable SearchFilter filter) {
+    this.filter = filter;
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/SearchRequest.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/shared/model/SearchRequest.java
@@ -1,5 +1,6 @@
 package org.databiosphere.workspacedataservice.shared.model;
 
+import java.util.Optional;
 import org.springframework.lang.Nullable;
 
 public class SearchRequest {
@@ -8,7 +9,7 @@ public class SearchRequest {
   private int offset = 0;
   private SortDirection sort = SortDirection.ASC;
   @Nullable private String sortAttribute = null;
-  @Nullable private SearchFilter filter = null;
+  private Optional<SearchFilter> filter = Optional.empty();
 
   public SearchRequest(int limit, int offset, SortDirection sort) {
     this.limit = limit;
@@ -59,11 +60,12 @@ public class SearchRequest {
   }
 
   @Nullable
-  public SearchFilter getFilter() {
+  public Optional<SearchFilter> getFilter() {
     return filter;
   }
 
-  public void setFilter(@Nullable SearchFilter filter) {
+  public void setFilter(
+      @SuppressWarnings("OptionalUsedAsFieldOrParameterType") Optional<SearchFilter> filter) {
     this.filter = filter;
   }
 }

--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -1047,6 +1047,14 @@ components:
         primaryKey:
           type: string
           description: Attribute name that contains the value to uniquely identify each record, defined as a primary key column in the underlying table.
+    SearchFilter:
+      type: object
+      properties:
+        ids:
+          description: Record ids by which to filter the query
+          type: array
+          items:
+            type: string
     SearchLimit:
       type: integer
       default: 10
@@ -1069,6 +1077,8 @@ components:
           $ref: '#/components/schemas/SearchSortDirection'
         sortAttribute:
           type: string
+        filter:
+          $ref: '#/components/schemas/SearchFilter'
     SearchSortDirection:
       type: string
       enum: [ ASC, DESC ]

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerSearchFilterTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerSearchFilterTest.java
@@ -1,0 +1,204 @@
+package org.databiosphere.workspacedataservice.controller;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.databiosphere.workspacedataservice.dao.CollectionDao;
+import org.databiosphere.workspacedataservice.dao.RecordDao;
+import org.databiosphere.workspacedataservice.service.RecordOrchestratorService;
+import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
+import org.databiosphere.workspacedataservice.shared.model.RecordQueryResponse;
+import org.databiosphere.workspacedataservice.shared.model.RecordRequest;
+import org.databiosphere.workspacedataservice.shared.model.RecordResponse;
+import org.databiosphere.workspacedataservice.shared.model.RecordType;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MvcResult;
+
+@ActiveProfiles(profiles = "mock-sam")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class RecordControllerSearchFilterTest extends MockMvcTestBase {
+
+  private final UUID COLLECTION_ID = UUID.randomUUID();
+
+  private static final String VERSION = "v0.2";
+  private static final RecordType RECTYPE = RecordType.valueOf("mytype");
+
+  @Autowired RecordDao recordDao;
+  @Autowired CollectionDao collectionDao;
+  @Autowired RecordOrchestratorService recordOrchestratorService;
+  @Autowired ObjectMapper mapper;
+
+  // all tests in this class use the same set of data
+  @BeforeAll
+  void beforeAll() throws Exception {
+    // create collection
+    collectionDao.createSchema(COLLECTION_ID);
+    // insert 20 records into the collection
+    for (int i = 0; i < 20; i++) {
+      // for easy sorting:
+      String leadingZeroes = String.format("%03d", i);
+
+      recordOrchestratorService.upsertSingleRecord(
+          COLLECTION_ID,
+          VERSION,
+          RECTYPE,
+          leadingZeroes,
+          Optional.empty(),
+          new RecordRequest(new RecordAttributes(Map.of("sortByMe", leadingZeroes))));
+    }
+  }
+
+  @AfterAll
+  void deleteAllInstances() throws Exception {
+    collectionDao.dropSchema(COLLECTION_ID);
+  }
+
+  @Test
+  void nullFilter() {
+    String testCase = "when filter is entirely omitted";
+    String searchRequestPayload = """
+{"limit": 5, "sortAttribute": "sortByMe"}
+""";
+    List<String> expected = List.of("000", "001", "002", "003", "004");
+    executeTest(searchRequestPayload, expected, testCase);
+  }
+
+  @Test
+  void nullIds() {
+    String testCase = "when filter is specified but filter.ids is not";
+    String searchRequestPayload = """
+{"limit": 5, "sortAttribute": "sortByMe", "filter": {}}
+""";
+    List<String> expected = List.of("000", "001", "002", "003", "004");
+    executeTest(searchRequestPayload, expected, testCase);
+  }
+
+  @Test
+  void emptyIds() {
+    String testCase = "when filter.ids is specified but empty";
+    String searchRequestPayload =
+        """
+{"limit": 5, "sortAttribute": "sortByMe", "filter": {"ids": []}}
+""";
+    List<String> expected = List.of("000", "001", "002", "003", "004");
+    executeTest(searchRequestPayload, expected, testCase);
+  }
+
+  @Test
+  void oneId() {
+    String testCase = "when filter.ids contains a single matching id";
+    String searchRequestPayload =
+        """
+{"limit": 5, "sortAttribute": "sortByMe", "filter": {"ids": ["012"]}}
+""";
+    List<String> expected = List.of("012");
+    executeTest(searchRequestPayload, expected, testCase);
+  }
+
+  @Test
+  void multipleIds() {
+    String testCase = "when filter.ids contains multiple matching ids";
+    String searchRequestPayload =
+        """
+{"limit": 5, "sortAttribute": "sortByMe", "filter": {"ids": ["003", "009", "012"]}}
+""";
+    List<String> expected = List.of("003", "009", "012");
+    executeTest(searchRequestPayload, expected, testCase);
+  }
+
+  @Test
+  void someMatch() {
+    String testCase = "when filter.ids contains some known and some unknown ids";
+    String searchRequestPayload =
+        """
+{"limit": 5, "sortAttribute": "sortByMe", "filter": {"ids": ["003", "unknown", "012"]}}
+""";
+    List<String> expected = List.of("003", "012");
+    executeTest(searchRequestPayload, expected, testCase);
+  }
+
+  @Test
+  void unknownIds() {
+    String testCase = "when filter.ids contains ids that match nothing";
+    String searchRequestPayload =
+        """
+{"limit": 5, "sortAttribute": "sortByMe", "filter": {"ids": ["unknown1", "unknown2"]}}
+""";
+    List<String> expected = List.of();
+    executeTest(searchRequestPayload, expected, testCase);
+  }
+
+  @Test
+  void moreIdsThanLimit() {
+    String testCase = "when filter.ids contains more matching ids than the query limit";
+    String searchRequestPayload =
+        """
+{"limit": 2, "sortAttribute": "sortByMe", "filter": {"ids": ["002", "004", "006", "008"]}}
+""";
+    List<String> expected = List.of("002", "004");
+    executeTest(searchRequestPayload, expected, testCase);
+  }
+
+  @Test
+  void idOrderIsIgnored() {
+    String testCase = "when filter.ids contains more matching ids than the query limit";
+    String searchRequestPayload =
+        """
+{"limit": 3, "sortAttribute": "sortByMe", "sort": "DESC", "filter": {"ids": ["004", "006", "008"]}}
+""";
+    List<String> expected = List.of("008", "006", "004");
+    executeTest(searchRequestPayload, expected, testCase);
+  }
+
+  /**
+   * Implementation for all test cases in this class. Executes a query using the supplied payload,
+   * then validates that the returned record ids match the expected record ids.
+   *
+   * @param searchRequestPayload the payload to use when querying. This is specified as a String
+   *     instead of as a SearchRequest to ensure we test String-to-SearchRequest deserialization as
+   *     well as query functionality.
+   * @param expectedRecordIds the record ids expected to be returned by the query
+   * @param testCase descriptor for the test to be displayed in case of failures.
+   */
+  private void executeTest(
+      String searchRequestPayload, List<String> expectedRecordIds, String testCase) {
+    try {
+      // query for records using the input searchRequest
+      MvcResult mvcResult =
+          mockMvc
+              .perform(
+                  post(
+                          "/{instanceId}/search/{version}/{recordType}",
+                          COLLECTION_ID,
+                          VERSION,
+                          RECTYPE)
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .content(searchRequestPayload))
+              .andExpect(status().isOk())
+              .andReturn();
+
+      RecordQueryResponse recordQueryResponse =
+          mapper.readValue(mvcResult.getResponse().getContentAsString(), RecordQueryResponse.class);
+
+      List<RecordResponse> recordResponseList = recordQueryResponse.records();
+      List<String> actualRecordIds =
+          recordResponseList.stream().map(RecordResponse::recordId).toList();
+
+      assertThat(actualRecordIds).isEqualTo(expectedRecordIds).describedAs(testCase);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerSearchFilterTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerSearchFilterTest.java
@@ -166,7 +166,7 @@ class RecordControllerSearchFilterTest extends MockMvcTestBase {
 
   @Test
   void idOrderIsIgnored() {
-    String testCase = "when filter.ids contains more matching ids than the query limit";
+    String testCase = "when filter.ids order conflicts with sortAttribute, sortAttribute wins";
     String searchRequestPayload =
         """
 {"limit": 3, "sortAttribute": "sortByMe", "sort": "DESC", "filter": {"ids": ["004", "006", "008"]}}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerSearchFilterTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerSearchFilterTest.java
@@ -94,7 +94,7 @@ class RecordControllerSearchFilterTest extends MockMvcTestBase {
         """
 {"limit": 5, "sortAttribute": "sortByMe", "filter": {"ids": []}}
 """;
-    List<String> expected = List.of("000", "001", "002", "003", "004");
+    List<String> expected = List.of();
     executeTest(searchRequestPayload, expected, testCase);
   }
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerSearchFilterTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerSearchFilterTest.java
@@ -40,9 +40,11 @@ class RecordControllerSearchFilterTest extends MockMvcTestBase {
   @Autowired RecordOrchestratorService recordOrchestratorService;
   @Autowired ObjectMapper mapper;
 
-  // all tests in this class use the same set of data
+  // all tests in this class use the same set of data; all tests in this class are read-only.
+  // as setup, insert 20 records with ids "000" through "019". Each record has a "sortByMe"
+  // attribute using the same "000"-"019" value to ensure deterministic sorting.
   @BeforeAll
-  void beforeAll() throws Exception {
+  void beforeAll() {
     // create collection
     collectionDao.createSchema(COLLECTION_ID);
     // insert 20 records into the collection
@@ -61,7 +63,7 @@ class RecordControllerSearchFilterTest extends MockMvcTestBase {
   }
 
   @AfterAll
-  void deleteAllInstances() throws Exception {
+  void deleteAllInstances() {
     collectionDao.dropSchema(COLLECTION_ID);
   }
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerSearchFilterTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerSearchFilterTest.java
@@ -152,6 +152,17 @@ class RecordControllerSearchFilterTest extends MockMvcTestBase {
   }
 
   @Test
+  void offsetRespected() {
+    String testCase = "when filter.ids is over limit, offset is still respected";
+    String searchRequestPayload =
+        """
+{"limit": 2, "offset": 2, "sortAttribute": "sortByMe", "filter": {"ids": ["002", "004", "006", "008"]}}
+""";
+    List<String> expected = List.of("006", "008");
+    executeTest(searchRequestPayload, expected, testCase);
+  }
+
+  @Test
   void idOrderIsIgnored() {
     String testCase = "when filter.ids contains more matching ids than the query limit";
     String searchRequestPayload =

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerSearchFilterTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerSearchFilterTest.java
@@ -209,7 +209,7 @@ class RecordControllerSearchFilterTest extends MockMvcTestBase {
       List<String> actualRecordIds =
           recordResponseList.stream().map(RecordResponse::recordId).toList();
 
-      assertThat(actualRecordIds).isEqualTo(expectedRecordIds).describedAs(testCase);
+      assertThat(actualRecordIds).describedAs(testCase).isEqualTo(expectedRecordIds);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
@@ -193,7 +193,8 @@ class RecordDaoTest extends TestBase {
         Map.of("FOO", STRING, "foo", STRING, "Foo", STRING));
 
     // Act
-    List<Record> queryRes = recordDao.queryForRecords(recordType, 10, 0, "ASC", null, collectionId);
+    List<Record> queryRes =
+        recordDao.queryForRecords(recordType, 10, 0, "ASC", null, Optional.empty(), collectionId);
 
     // Assert
     Record returnedRecord = queryRes.get(0);
@@ -212,7 +213,8 @@ class RecordDaoTest extends TestBase {
         collectionId, Map.of("attr1", STRING), funkyPk, RelationCollection.empty(), sample_id);
     recordDao.batchUpsert(
         collectionId, funkyPk, Collections.singletonList(testRecord), emptyMap(), sample_id);
-    List<Record> queryRes = recordDao.queryForRecords(funkyPk, 10, 0, "ASC", null, collectionId);
+    List<Record> queryRes =
+        recordDao.queryForRecords(funkyPk, 10, 0, "ASC", null, Optional.empty(), collectionId);
     assertEquals(1, queryRes.size());
     assertTrue(recordDao.recordExists(collectionId, funkyPk, recordId));
     assertTrue(recordDao.getSingleRecord(collectionId, funkyPk, recordId).isPresent());


### PR DESCRIPTION
This PR modifies the pre-existing `POST /{instanceid}/search/{v}/{type}` API.

Before this PR, that API accepted a payload of:
```json
{
  "offset": 0,
  "limit": 10,
  "sort": "ASC",
  "sortAttribute": "string"
}
```

After this PR, it will accept a payload of:
```json
{
  "offset": 0,
  "limit": 10,
  "sort": "ASC",
  "sortAttribute": "string",
  "filter": {
    "ids": [
      "string"
    ]
  }
}
```

That is, it will now accept a `filter` object, which can contain an `ids` array of strings.

Both `filter` and `filter.ids` are optional for backwards compatibility. If you omit them, the API will behave as it previously did.

If you DO specify values in `filter.ids`, it will behave like a SQL `IN` clause, and filter the query results to only those records whose ids match one of the supplied values.

Some functional behaviors:
* sorting of results is still controlled by the `sort` and `sortAttribute` params. Sorting does not consider the order of ids in `filter.ids`.
* results still respect the `limit` and `offset` values. If you specify 20 `filter.ids` but a `limit` of 10, you'll get (up to) 10 records back. 

You may want to read through the test cases in `RecordControllerSearchFilterTest` in this PR for detailed examples of behavior.

Anyone who is using a Java/Python client will need to update their client after this PR to get access to the new models.

---

## Open Questions:
1. If the user specifies more `filter.ids` values than `limit`, should we return only `limit` records, or should we throw a 400 Bad Request error?
2. If the user specifies an empty `filter.ids: []`, should we return 0 results always, or should we treat that equivalent as having omitted `filter.ids` and return all results? Or, throw a 400 Bad Request?