### PR TITLE
AJ-1818: REFUSING_TRAFFIC is not an error

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/logging/AvailabilityListener.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/logging/AvailabilityListener.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class AvailabilityListener {
-  private static Logger logger = LoggerFactory.getLogger(AvailabilityListener.class);
+  private static final Logger logger = LoggerFactory.getLogger(AvailabilityListener.class);
 
   @EventListener
   public void onLivenessEvent(AvailabilityChangeEvent<LivenessState> event) {
@@ -30,7 +30,7 @@ public class AvailabilityListener {
   public void onReadinessEvent(AvailabilityChangeEvent<ReadinessState> event) {
     switch (event.getState()) {
       case REFUSING_TRAFFIC:
-        logger.error("ReadinessState: {}", event.getState());
+        logger.warn("ReadinessState: {}", event.getState());
         break;
       case ACCEPTING_TRAFFIC:
         logger.info("ReadinessState: {}", event.getState());


### PR DESCRIPTION
We should not log this at `error` level, since `error` level is picked up by Sentry.

k8s can and will shuffle pods around as a normal operation. There are other reasons a pod may shut down, such as app upgrades. These can all generate `REFUSING_TRAFFIC` log messages.