### PR TITLE
AJ-1812: Require gs:// URIs to match workspaceId

### DIFF
--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/DefaultImportValidatorTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/DefaultImportValidatorTest.java
@@ -1,5 +1,6 @@
 package org.databiosphere.workspacedataservice.dataimport;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -128,9 +129,10 @@ class DefaultImportValidatorTest extends TestBase {
   }
 
   @Test
-  void acceptsGsUrlsForRawlsJsonImports() {
+  void acceptsGsUrlsWithMatchingWorkspaceIdForRawlsJsonImports() {
     // Arrange
-    URI importUri = URI.create("gs://test-bucket/file");
+    URI importUri =
+        URI.create("gs://test-bucket/to-cwds/%s/random.json".formatted(destinationWorkspaceId));
     ImportRequestServerModel importRequest =
         new ImportRequestServerModel(TypeEnum.RAWLSJSON, importUri);
 
@@ -139,18 +141,48 @@ class DefaultImportValidatorTest extends TestBase {
   }
 
   @Test
-  void rejectGsUrlsWithMismatchingBucketForJsonImports() {
+  void rejectsGsUrlsWithCorrectBucketAndWorkspaceButUnexpectedFormat() {
     // Arrange
-    URI importUri = URI.create("gs://rando-bucket/file");
+    URI importUri =
+        URI.create("gs://test-bucket/random/%s/random.json".formatted(destinationWorkspaceId));
     ImportRequestServerModel importRequest =
         new ImportRequestServerModel(TypeEnum.RAWLSJSON, importUri);
 
     // Act/Assert
-    ValidationException err =
-        assertThrows(
-            ValidationException.class,
-            () -> importValidator.validateImport(importRequest, destinationWorkspaceId));
-    assertEquals("Files may not be imported from rando-bucket.", err.getMessage());
+    assertThatExceptionOfType(ValidationException.class)
+        .isThrownBy(() -> importValidator.validateImport(importRequest, destinationWorkspaceId))
+        .withMessageContaining("/to-cwds/%s/".formatted(destinationWorkspaceId));
+  }
+
+  @Test
+  void rejectGsUrlsWithMismatchingBucketForJsonImports() {
+    // Arrange
+    URI importUri =
+        URI.create("gs://rando-bucket/to-cwds/%s/random.json".formatted(destinationWorkspaceId));
+    ImportRequestServerModel importRequest =
+        new ImportRequestServerModel(TypeEnum.RAWLSJSON, importUri);
+
+    // Act/Assert
+    assertThatExceptionOfType(ValidationException.class)
+        .isThrownBy(
+            () -> importValidator.validateImport(importRequest, WorkspaceId.of(UUID.randomUUID())))
+        .withMessageContaining("Files may not be imported from rando-bucket.");
+  }
+
+  @Test
+  void rejectsGsUrlsWithMismatchingWorkspaceId() {
+    // Arrange
+    UUID otherWorkspaceId = UUID.randomUUID();
+    URI importUri =
+        URI.create(
+            "gs://test-bucket/to-cwds/%s/other-workspace-import.json".formatted(otherWorkspaceId));
+    ImportRequestServerModel importRequest =
+        new ImportRequestServerModel(TypeEnum.RAWLSJSON, importUri);
+
+    // Act/Assert
+    assertThatExceptionOfType(ValidationException.class)
+        .isThrownBy(() -> importValidator.validateImport(importRequest, destinationWorkspaceId))
+        .withMessageContaining("/to-cwds/%s/".formatted(destinationWorkspaceId));
   }
 
   @ParameterizedTest


### PR DESCRIPTION
This is a security measure to ensure that a bad actor can't craft a
`RAWLSJSON` URI that hijacks a request for a different workspace.

Paired with orchestration change:
https://github.com/broadinstitute/firecloud-orchestration/commit/16074dd555261e683651c3dfac280912577d49e9