### PR TITLE
AJ-1771: add search.filter.ids to capabilities

### DIFF
--- a/service/src/main/resources/capabilities.json
+++ b/service/src/main/resources/capabilities.json
@@ -3,5 +3,6 @@
   "dataimport.pfb": true,
   "dataimport.tdrmanifest": false,
   "edit.deleteAttribute": true,
-  "edit.renameAttribute": true
+  "edit.renameAttribute": true,
+  "search.filter.ids": true
 }


### PR DESCRIPTION
Followup PR to #771 - add a new key to our capabilities that indicates this WDS supports `filter.ids` in the query API.