### PR TITLE
AJ-1782: add generated client test that uses RecordAttributes

### DIFF
--- a/service/src/test/java/org/databiosphere/workspacedataservice/GeneratedClientTests.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/GeneratedClientTests.java
@@ -250,6 +250,34 @@ class GeneratedClientTests extends TestBase {
     assertThat(actual).isEqualTo(expected);
   }
 
+  @Test
+  void recordAttributesAccess() throws URISyntaxException, ApiException {
+    // create the two records "a" and "b" from small-test.tsv
+    RecordsApi recordsApi = new RecordsApi(apiClient);
+
+    String recordType = "foo";
+
+    TsvUploadResponse tsvUploadResponse =
+        recordsApi.uploadTSV(
+            new File(this.getClass().getResource("/tsv/small-test.tsv").toURI()),
+            collectionId.toString(),
+            version,
+            recordType,
+            null);
+    assertThat(tsvUploadResponse.getRecordsModified()).isEqualTo(2);
+
+    // get record "a"
+    RecordResponse recordResponse =
+        recordsApi.getRecord(collectionId.toString(), version, recordType, "a");
+
+    // spot-check a couple attributes. These assertions are about validating that the Java client
+    // can read RecordAttributes; less about ensuring that the TSV upload was correct.
+    RecordAttributes recordAttributes = recordResponse.getAttributes();
+    assertThat(recordAttributes.entrySet()).hasSize(14);
+    assertThat(recordAttributes.get("greeting")).isEqualTo("hello");
+    assertThat(recordAttributes.get("double")).isEqualTo(-2.287);
+  }
+
   private void createNewCollection(UUID collectionId) throws ApiException {
     InstancesApi instancesApi = new InstancesApi(apiClient);
     instancesApi.createWDSInstance(collectionId.toString(), version);

--- a/service/src/test/java/org/databiosphere/workspacedataservice/GeneratedClientTests.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/GeneratedClientTests.java
@@ -274,8 +274,8 @@ class GeneratedClientTests extends TestBase {
     // can read RecordAttributes; less about ensuring that the TSV upload was correct.
     RecordAttributes recordAttributes = recordResponse.getAttributes();
     assertThat(recordAttributes.entrySet()).hasSize(14);
-    assertThat(recordAttributes.get("greeting")).isEqualTo("hello");
-    assertThat(recordAttributes.get("double")).isEqualTo(-2.287);
+    assertThat(recordAttributes).containsEntry("greeting", "hello");
+    assertThat(recordAttributes).containsEntry("double", -2.287);
   }
 
   private void createNewCollection(UUID collectionId) throws ApiException {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/GeneratedClientTests.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/GeneratedClientTests.java
@@ -274,8 +274,7 @@ class GeneratedClientTests extends TestBase {
     // can read RecordAttributes; less about ensuring that the TSV upload was correct.
     RecordAttributes recordAttributes = recordResponse.getAttributes();
     assertThat(recordAttributes.entrySet()).hasSize(14);
-    assertThat(recordAttributes).containsEntry("greeting", "hello");
-    assertThat(recordAttributes).containsEntry("double", -2.287);
+    assertThat(recordAttributes).containsEntry("greeting", "hello").containsEntry("double", -2.287);
   }
 
   private void createNewCollection(UUID collectionId) throws ApiException {


### PR DESCRIPTION
A little pre-work towards the goal of update our openapi-generator version in #780.

In that other PR, I have worries that the openapi-generator update changes how users of the client would access `RecordAttributes`. This PR adds a test against the client code that uses `RecordAttributes`. I plan to merge this test and then rebase the other PR on top of this and see if the test breaks.