### PR TITLE
AJ-1817: reduce WDS metrics to app insights

### DIFF
--- a/service/src/main/resources/applicationinsights.json
+++ b/service/src/main/resources/applicationinsights.json
@@ -2,5 +2,36 @@
   "customDimensions": {
     "workspaceId": "${WORKSPACE_ID}",
     "service.version": "${RELEASE_NAME}"
+  },
+  "metricIntervalSeconds": 300,
+  "sampling": {
+    "percentage": 100
+  },
+  "instrumentation": {
+    "logging": {
+      "level": "WARN"
+    },
+    "azureSdk": {
+      "enabled": true
+    },
+    "jdbc": {
+      "enabled": true
+    },
+    "micrometer": {
+      "enabled": true
+    },
+    "quartz": {
+      "enabled": true
+    },
+    "springScheduling": {
+      "enabled": true
+    }
+  },
+  "preview": {
+    "instrumentation": {
+      "springIntegration": {
+        "enabled": true
+      }
+    }
   }
 }


### PR DESCRIPTION
AJ-1817

Reviewer: do you prefer this implementation or https://github.com/broadinstitute/terra-helmfile/pull/5519?

This PR configures WDS's usage of Application Insights to reduce the quantity of metrics we ingest into the `AppMetrics` table, and thus reduce the overall cost to the end user for Log Analytics within their landing zone.

See comments inline to understand individual settings.

Proof of concept shows that we are reducing logs. In this screenshot, `wds-sefkg2-wds-rls-wds-depl-9c9ddbf77-6s9r5` is a WDS without the changes, and `wm334-748` is my local WDS with the changes:
![Screenshot 08-05-2024 at 17 25](https://github.com/DataBiosphere/terra-workspace-data-service/assets/6041577/f8afc6af-aa7d-4fb4-97f0-d4cae2ebcbcc)
