### PR TITLE
AJ-1817: disable logback_event metrics

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/WorkspaceDataServiceApplication.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/WorkspaceDataServiceApplication.java
@@ -5,6 +5,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.actuate.autoconfigure.metrics.LogbackMetricsAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.retry.annotation.EnableRetry;
@@ -16,6 +17,10 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
       "org.databiosphere.workspacedataservice",
       // terra-common-lib transaction management and DB retry configuration
       "bio.terra.common.retry.transaction"
+    },
+    exclude = {
+      // disable "logback_events" in Micrometer/Prometheus to reduce overall metrics volume
+      LogbackMetricsAutoConfiguration.class
     })
 @EnableRetry
 @EnableTransactionManagement


### PR DESCRIPTION
This disables the "logback_event" Micrometer metrics. These don't seem immediately useful and contribute to overall metrics volume in end users' App Insights (WDS) and in Prometheus/Grafana (cWDS). These metrics simply count how many logback invocations have occurred; the log messages themselves are totally separate.

Here's an example of the metrics, from cWDS dev env:
```
# HELP logback_events_total Number of log events that were enabled by the effective log level
# TYPE logback_events_total counter
logback_events_total{level="info",service="wds",version="0.2.167-SNAPSHOT",} 24.0
logback_events_total{level="debug",service="wds",version="0.2.167-SNAPSHOT",} 0.0
logback_events_total{level="error",service="wds",version="0.2.167-SNAPSHOT",} 0.0
logback_events_total{level="warn",service="wds",version="0.2.167-SNAPSHOT",} 542.0
logback_events_total{level="trace",service="wds",version="0.2.167-SNAPSHOT",} 130252.0
```

In my MRG in the dev env, logback events are the 6th most populous event type in the `AppMetrics` table:
![Screenshot 09-05-2024 at 11 31](https://github.com/DataBiosphere/terra-workspace-data-service/assets/6041577/9bf55ec9-5a79-4c6d-8ca7-bc6cc29f7ad4)

And since all they do is count logback invocations, I don't see them as super useful. We can get similar metrics by counting/summarizing the actual log messages themselves; do we need to track the metrics separately? Note that it appears logback_event tracks invocations _before_ any loglevel filters in logback-spring.xml; so, logback_event will count TRACE invocations, while we don't actually log any traces and thus wouldn't know how many there are:
![Screenshot 09-05-2024 at 11 14](https://github.com/DataBiosphere/terra-workspace-data-service/assets/6041577/e87c7eb2-16f6-4ecc-8056-00024862d0e5)


