### PR TITLE
[AJ-1777] Fix check for protected workspace

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/DefaultImportValidator.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/DefaultImportValidator.java
@@ -1,32 +1,25 @@
 package org.databiosphere.workspacedataservice.dataimport;
 
-import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
 import static java.util.regex.Pattern.compile;
 
-import bio.terra.workspace.model.WorkspaceDescription;
-import bio.terra.workspace.model.WsmPolicyInput;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import io.micrometer.common.util.StringUtils;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.broadinstitute.dsde.workbench.client.sam.model.UserResourcesResponse;
 import org.databiosphere.workspacedataservice.config.DataImportProperties.ImportSourceConfig;
+import org.databiosphere.workspacedataservice.dataimport.protecteddatasupport.ProtectedDataSupport;
 import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
 import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel.TypeEnum;
-import org.databiosphere.workspacedataservice.policy.PolicyUtils;
 import org.databiosphere.workspacedataservice.sam.SamDao;
 import org.databiosphere.workspacedataservice.service.model.exception.ValidationException;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
-import org.databiosphere.workspacedataservice.workspacemanager.WorkspaceManagerDao;
-import org.databiosphere.workspacedataservice.workspacemanager.WorkspaceManagerException;
-import org.springframework.http.HttpStatus;
 import org.springframework.lang.Nullable;
 
 public class DefaultImportValidator implements ImportValidator {
@@ -48,12 +41,12 @@ public class DefaultImportValidator implements ImportValidator {
           );
   private final Map<String, Set<Pattern>> allowedHostsByScheme;
   private final ImportRequirementsFactory importRequirementsFactory;
+  private final ProtectedDataSupport protectedDataSupport;
   private final SamDao samDao;
-  private final WorkspaceManagerDao wsmDao;
 
   public DefaultImportValidator(
+      ProtectedDataSupport protectedDataSupport,
       SamDao samDao,
-      WorkspaceManagerDao wsmDao,
       Set<Pattern> allowedHttpsHosts,
       List<ImportSourceConfig> sources,
       @Nullable String allowedRawlsBucket) {
@@ -69,8 +62,8 @@ public class DefaultImportValidator implements ImportValidator {
 
     this.allowedHostsByScheme = allowedHostsBuilder.build();
     this.importRequirementsFactory = new ImportRequirementsFactory(sources);
+    this.protectedDataSupport = protectedDataSupport;
     this.samDao = samDao;
-    this.wsmDao = wsmDao;
   }
 
   private Set<Pattern> getAllowedHosts(ImportRequestServerModel importRequest) {
@@ -119,7 +112,7 @@ public class DefaultImportValidator implements ImportValidator {
         importRequirementsFactory.getRequirementsForImport(importRequest.getUrl());
 
     if (requirements.protectedDataPolicy()
-        && !checkWorkspaceHasProtectedDataPolicy(destinationWorkspaceId)) {
+        && !protectedDataSupport.workspaceSupportsProtectedDataPolicy(destinationWorkspaceId)) {
       throw new ValidationException(
           "Data from this source can only be imported into a protected workspace.");
     }
@@ -127,22 +120,6 @@ public class DefaultImportValidator implements ImportValidator {
     if (requirements.privateWorkspace() && !checkWorkspaceIsPrivate(destinationWorkspaceId)) {
       throw new ValidationException(
           "Data from this source cannot be imported into a public workspace.");
-    }
-  }
-
-  private boolean checkWorkspaceHasProtectedDataPolicy(WorkspaceId workspaceId) {
-    try {
-      WorkspaceDescription workspace = wsmDao.getWorkspace(workspaceId.id());
-      List<WsmPolicyInput> workspacePolicies =
-          Optional.ofNullable(workspace.getPolicies()).orElse(emptyList());
-      return workspacePolicies.stream().anyMatch(PolicyUtils::isProtectedDataPolicy);
-    } catch (WorkspaceManagerException e) {
-      // GCP workspaces without a policy will not be present in Workspace Manager.
-      if (e.getStatusCode().equals(HttpStatus.NOT_FOUND)) {
-        return false;
-      } else {
-        throw e;
-      }
     }
   }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportValidatorConfiguration.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/ImportValidatorConfiguration.java
@@ -2,8 +2,8 @@ package org.databiosphere.workspacedataservice.dataimport;
 
 import org.databiosphere.workspacedataservice.config.ConfigurationException;
 import org.databiosphere.workspacedataservice.config.DataImportProperties;
+import org.databiosphere.workspacedataservice.dataimport.protecteddatasupport.ProtectedDataSupport;
 import org.databiosphere.workspacedataservice.sam.SamDao;
-import org.databiosphere.workspacedataservice.workspacemanager.WorkspaceManagerDao;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -17,10 +17,12 @@ public class ImportValidatorConfiguration {
       havingValue = "true",
       matchIfMissing = true)
   ImportValidator getDefaultImportValidator(
-      SamDao samDao, WorkspaceManagerDao wsmDao, DataImportProperties dataImportProperties) {
+      ProtectedDataSupport protectedDataSupport,
+      SamDao samDao,
+      DataImportProperties dataImportProperties) {
     return new DefaultImportValidator(
+        protectedDataSupport,
         samDao,
-        wsmDao,
         dataImportProperties.getAllowedHosts(),
         dataImportProperties.getSources(),
         dataImportProperties.getRawlsBucketName());

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/protecteddatasupport/ProtectedDataSupport.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/protecteddatasupport/ProtectedDataSupport.java
@@ -1,0 +1,7 @@
+package org.databiosphere.workspacedataservice.dataimport.protecteddatasupport;
+
+import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
+
+public interface ProtectedDataSupport {
+  boolean workspaceSupportsProtectedDataPolicy(WorkspaceId workspaceId);
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/protecteddatasupport/RawlsProtectedDataSupport.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/protecteddatasupport/RawlsProtectedDataSupport.java
@@ -1,10 +1,5 @@
 package org.databiosphere.workspacedataservice.dataimport.protecteddatasupport;
 
-import static java.util.Collections.emptyList;
-
-import bio.terra.workspace.model.WsmPolicyInput;
-import java.util.List;
-import java.util.Optional;
 import org.databiosphere.workspacedataservice.annotations.DeploymentMode.ControlPlane;
 import org.databiosphere.workspacedataservice.policy.PolicyUtils;
 import org.databiosphere.workspacedataservice.rawls.RawlsClient;
@@ -26,15 +21,8 @@ public class RawlsProtectedDataSupport implements ProtectedDataSupport {
     RawlsWorkspaceDetails workspaceDetails = rawlsClient.getWorkspaceDetails(workspaceId.id());
     WorkspaceType workspaceType = workspaceDetails.workspace().workspaceType();
     return switch (workspaceType) {
-      case MC -> {
-        List<WsmPolicyInput> workspacePolicies =
-            Optional.ofNullable(workspaceDetails.policies()).orElse(emptyList());
-        yield workspacePolicies.stream().anyMatch(PolicyUtils::isProtectedDataPolicy);
-      }
-      case RAWLS -> {
-        String bucketName = workspaceDetails.workspace().bucketName();
-        yield bucketName.startsWith("fc-secure-");
-      }
+      case MC -> PolicyUtils.containsProtectedDataPolicy(workspaceDetails.policies());
+      case RAWLS -> workspaceDetails.workspace().bucketName().startsWith("fc-secure-");
     };
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/protecteddatasupport/RawlsProtectedDataSupport.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/protecteddatasupport/RawlsProtectedDataSupport.java
@@ -1,0 +1,40 @@
+package org.databiosphere.workspacedataservice.dataimport.protecteddatasupport;
+
+import static java.util.Collections.emptyList;
+
+import bio.terra.workspace.model.WsmPolicyInput;
+import java.util.List;
+import java.util.Optional;
+import org.databiosphere.workspacedataservice.annotations.DeploymentMode.ControlPlane;
+import org.databiosphere.workspacedataservice.policy.PolicyUtils;
+import org.databiosphere.workspacedataservice.rawls.RawlsClient;
+import org.databiosphere.workspacedataservice.rawls.RawlsWorkspaceDetails;
+import org.databiosphere.workspacedataservice.rawls.RawlsWorkspaceDetails.RawlsWorkspace.WorkspaceType;
+import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
+import org.springframework.stereotype.Component;
+
+@Component
+@ControlPlane
+public class RawlsProtectedDataSupport implements ProtectedDataSupport {
+  private final RawlsClient rawlsClient;
+
+  public RawlsProtectedDataSupport(RawlsClient rawlsClient) {
+    this.rawlsClient = rawlsClient;
+  }
+
+  public boolean workspaceSupportsProtectedDataPolicy(WorkspaceId workspaceId) {
+    RawlsWorkspaceDetails workspaceDetails = rawlsClient.getWorkspaceDetails(workspaceId.id());
+    WorkspaceType workspaceType = workspaceDetails.workspace().workspaceType();
+    return switch (workspaceType) {
+      case MC -> {
+        List<WsmPolicyInput> workspacePolicies =
+            Optional.ofNullable(workspaceDetails.policies()).orElse(emptyList());
+        yield workspacePolicies.stream().anyMatch(PolicyUtils::isProtectedDataPolicy);
+      }
+      case RAWLS -> {
+        String bucketName = workspaceDetails.workspace().bucketName();
+        yield bucketName.startsWith("fc-secure-");
+      }
+    };
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/protecteddatasupport/WsmProtectedDataSupport.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/protecteddatasupport/WsmProtectedDataSupport.java
@@ -1,0 +1,30 @@
+package org.databiosphere.workspacedataservice.dataimport.protecteddatasupport;
+
+import static java.util.Collections.emptyList;
+
+import bio.terra.workspace.model.WorkspaceDescription;
+import bio.terra.workspace.model.WsmPolicyInput;
+import java.util.List;
+import java.util.Optional;
+import org.databiosphere.workspacedataservice.annotations.DeploymentMode.DataPlane;
+import org.databiosphere.workspacedataservice.policy.PolicyUtils;
+import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
+import org.databiosphere.workspacedataservice.workspacemanager.WorkspaceManagerDao;
+import org.springframework.stereotype.Component;
+
+@Component
+@DataPlane
+public class WsmProtectedDataSupport implements ProtectedDataSupport {
+  private final WorkspaceManagerDao wsmDao;
+
+  public WsmProtectedDataSupport(WorkspaceManagerDao wsmDao) {
+    this.wsmDao = wsmDao;
+  }
+
+  public boolean workspaceSupportsProtectedDataPolicy(WorkspaceId workspaceId) {
+    WorkspaceDescription workspace = wsmDao.getWorkspace(workspaceId.id());
+    List<WsmPolicyInput> workspacePolicies =
+        Optional.ofNullable(workspace.getPolicies()).orElse(emptyList());
+    return workspacePolicies.stream().anyMatch(PolicyUtils::isProtectedDataPolicy);
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/protecteddatasupport/WsmProtectedDataSupport.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/protecteddatasupport/WsmProtectedDataSupport.java
@@ -1,11 +1,6 @@
 package org.databiosphere.workspacedataservice.dataimport.protecteddatasupport;
 
-import static java.util.Collections.emptyList;
-
 import bio.terra.workspace.model.WorkspaceDescription;
-import bio.terra.workspace.model.WsmPolicyInput;
-import java.util.List;
-import java.util.Optional;
 import org.databiosphere.workspacedataservice.annotations.DeploymentMode.DataPlane;
 import org.databiosphere.workspacedataservice.policy.PolicyUtils;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
@@ -23,8 +18,6 @@ public class WsmProtectedDataSupport implements ProtectedDataSupport {
 
   public boolean workspaceSupportsProtectedDataPolicy(WorkspaceId workspaceId) {
     WorkspaceDescription workspace = wsmDao.getWorkspace(workspaceId.id());
-    List<WsmPolicyInput> workspacePolicies =
-        Optional.ofNullable(workspace.getPolicies()).orElse(emptyList());
-    return workspacePolicies.stream().anyMatch(PolicyUtils::isProtectedDataPolicy);
+    return PolicyUtils.containsProtectedDataPolicy(workspace.getPolicies());
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/policy/PolicyUtils.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/policy/PolicyUtils.java
@@ -1,6 +1,11 @@
 package org.databiosphere.workspacedataservice.policy;
 
+import static java.util.Collections.emptyList;
+
 import bio.terra.workspace.model.WsmPolicyInput;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.lang.Nullable;
 
 public final class PolicyUtils {
   public static final String TERRA_NAMESPACE = "terra";
@@ -9,6 +14,11 @@ public final class PolicyUtils {
   public static boolean isProtectedDataPolicy(WsmPolicyInput wsmPolicyInput) {
     return wsmPolicyInput.getNamespace().equals(TERRA_NAMESPACE)
         && wsmPolicyInput.getName().equals(PROTECTED_DATA_POLICY_NAME);
+  }
+
+  public static boolean containsProtectedDataPolicy(@Nullable List<WsmPolicyInput> policies) {
+    return Optional.ofNullable(policies).orElse(emptyList()).stream()
+        .anyMatch(PolicyUtils::isProtectedDataPolicy);
   }
 
   private PolicyUtils() {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/rawls/RawlsApi.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/rawls/RawlsApi.java
@@ -14,6 +14,17 @@ import org.springframework.web.service.annotation.PostExchange;
 public interface RawlsApi {
 
   /**
+   * Get a single workspace's details, optionally filtered to only the specified fields.
+   *
+   * @param workspaceId target workspace
+   * @param fields comma separated list of fields
+   * @return workspace details
+   */
+  @GetExchange("/api/workspaces/id/{workspaceId}")
+  RawlsWorkspaceDetails getWorkspaceDetails(
+      @PathVariable UUID workspaceId, @RequestParam String fields);
+
+  /**
    * List snapshot references in a workspace.
    *
    * @param workspaceId target workspace

--- a/service/src/main/java/org/databiosphere/workspacedataservice/rawls/RawlsClient.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/rawls/RawlsClient.java
@@ -17,6 +17,21 @@ public class RawlsClient {
     this.restClientRetry = restClientRetry;
   }
 
+  public RawlsWorkspaceDetails getWorkspaceDetails(UUID workspaceId) {
+    try {
+      RestCall<RawlsWorkspaceDetails> restCall =
+          () ->
+              rawlsApi.getWorkspaceDetails(
+                  workspaceId,
+                  /* RawlsWorkspaceDetails only includes the subset of workspace fields needed by CWDS. */
+                  /* fields */ String.join(",", RawlsWorkspaceDetails.SUPPORTED_FIELDS));
+
+      return restClientRetry.withRetryAndErrorHandling(restCall, "Rawls.getWorkspaceDetails");
+    } catch (RestClientResponseException restException) {
+      throw new RawlsException(restException);
+    }
+  }
+
   public SnapshotListResponse enumerateDataRepoSnapshotReferences(
       UUID workspaceId, int offset, int limit) {
     try {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/rawls/RawlsClient.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/rawls/RawlsClient.java
@@ -9,6 +9,10 @@ import org.springframework.web.client.RestClientResponseException;
 
 /** Client to make REST calls to Rawls */
 public class RawlsClient {
+  /* RawlsWorkspaceDetails only includes the subset of workspace fields needed by CWDS.
+   * Thus, RawlsClient should request only those fields when getting workspace details. */
+  private final String GET_WORKSPACE_DETAILS_FIELDS_PARAM =
+      String.join(",", RawlsWorkspaceDetails.SUPPORTED_FIELDS);
   private final RawlsApi rawlsApi;
   private final RestClientRetry restClientRetry;
 
@@ -20,11 +24,7 @@ public class RawlsClient {
   public RawlsWorkspaceDetails getWorkspaceDetails(UUID workspaceId) {
     try {
       RestCall<RawlsWorkspaceDetails> restCall =
-          () ->
-              rawlsApi.getWorkspaceDetails(
-                  workspaceId,
-                  /* RawlsWorkspaceDetails only includes the subset of workspace fields needed by CWDS. */
-                  /* fields */ String.join(",", RawlsWorkspaceDetails.SUPPORTED_FIELDS));
+          () -> rawlsApi.getWorkspaceDetails(workspaceId, GET_WORKSPACE_DETAILS_FIELDS_PARAM);
 
       return restClientRetry.withRetryAndErrorHandling(restCall, "Rawls.getWorkspaceDetails");
     } catch (RestClientResponseException restException) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/rawls/RawlsWorkspaceDetails.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/rawls/RawlsWorkspaceDetails.java
@@ -1,0 +1,55 @@
+package org.databiosphere.workspacedataservice.rawls;
+
+import bio.terra.workspace.model.WsmPolicyInput;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.List;
+
+public record RawlsWorkspaceDetails(
+    @JsonProperty RawlsWorkspace workspace, @JsonProperty List<WsmPolicyInput> policies) {
+
+  /**
+   * RawlsWorkspaceDetails only includes the subset of workspace fields needed by CWDS. This list
+   * defines the fields parameter for the Rawls getWorkspaceDetails request such that the request
+   * will return only the fields included in RawlsWorkspaceDetails.
+   */
+  public static final List<String> SUPPORTED_FIELDS =
+      List.of("policies", "workspace.bucketName", "workspace.workspaceType");
+
+  public record RawlsWorkspace(
+      @JsonProperty String bucketName, @JsonProperty WorkspaceType workspaceType) {
+
+    public enum WorkspaceType {
+      MC("mc"),
+
+      RAWLS("rawls");
+
+      private final String value;
+
+      WorkspaceType(String value) {
+        this.value = value;
+      }
+
+      @JsonValue
+      public String getValue() {
+        return value;
+      }
+
+      @Override
+      public String toString() {
+        return String.valueOf(value);
+      }
+
+      @JsonCreator
+      public static WorkspaceType fromValue(String value) {
+        for (WorkspaceType candidate : WorkspaceType.values()) {
+          if (candidate.value.equals(value)) {
+            return candidate;
+          }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+      }
+    }
+  }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/annotations/AnnotatedApisTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/annotations/AnnotatedApisTest.java
@@ -8,6 +8,8 @@ import org.databiosphere.workspacedataservice.annotations.DeploymentMode.Control
 import org.databiosphere.workspacedataservice.annotations.DeploymentMode.DataPlane;
 import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
+import org.databiosphere.workspacedataservice.dataimport.protecteddatasupport.ProtectedDataSupport;
+import org.databiosphere.workspacedataservice.dataimport.protecteddatasupport.WsmProtectedDataSupport;
 import org.databiosphere.workspacedataservice.dataimport.snapshotsupport.SnapshotSupportFactory;
 import org.databiosphere.workspacedataservice.dataimport.snapshotsupport.WsmSnapshotSupportFactory;
 import org.databiosphere.workspacedataservice.recordsink.RecordSinkFactory;
@@ -57,6 +59,12 @@ class AnnotatedApisTest extends TestBase {
     SnapshotSupportFactory overrideSnapshotSupportFactory(
         ActivityLogger activityLogger, WorkspaceManagerDao wsmDao) {
       return new WsmSnapshotSupportFactory(activityLogger, wsmDao);
+    }
+
+    @Primary
+    @Bean("overrideProtectedDataSupport")
+    ProtectedDataSupport overrideProtectedDataSupport(WorkspaceManagerDao wsmDao) {
+      return new WsmProtectedDataSupport(wsmDao);
     }
   }
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/protecteddatasupport/RawlsProtectedDataSupportTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/protecteddatasupport/RawlsProtectedDataSupportTest.java
@@ -1,0 +1,83 @@
+package org.databiosphere.workspacedataservice.dataimport.protecteddatasupport;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.when;
+
+import bio.terra.workspace.model.WsmPolicyInput;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.rawls.RawlsClient;
+import org.databiosphere.workspacedataservice.rawls.RawlsWorkspaceDetails;
+import org.databiosphere.workspacedataservice.rawls.RawlsWorkspaceDetails.RawlsWorkspace.WorkspaceType;
+import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles(profiles = "control-plane", inheritProfiles = false)
+public class RawlsProtectedDataSupportTest extends TestBase {
+  @MockBean RawlsClient rawlsClient;
+
+  @Autowired RawlsProtectedDataSupport rawlsProtectedDataSupport;
+
+  @ParameterizedTest(name = "{0} workspaceSupportsProtectedDataPolicy {3}")
+  @MethodSource("workspaceSupportsProtectedDataPolicyTestCases")
+  void workspaceSupportsProtectedDataPolicy(
+      String testName,
+      WorkspaceId workspaceId,
+      RawlsWorkspaceDetails workspaceDetails,
+      boolean expectedToSupportProtectedDataPolicy) {
+    // Arrange
+    when(rawlsClient.getWorkspaceDetails(workspaceId.id())).thenReturn(workspaceDetails);
+
+    // Act
+    boolean supportsProtectedDataPolicy =
+        rawlsProtectedDataSupport.workspaceSupportsProtectedDataPolicy(workspaceId);
+
+    // Assert
+    assertThat(supportsProtectedDataPolicy).isEqualTo(expectedToSupportProtectedDataPolicy);
+  }
+
+  static Stream<Arguments> workspaceSupportsProtectedDataPolicyTestCases() {
+    WorkspaceId workspaceId = WorkspaceId.of(UUID.randomUUID());
+
+    WsmPolicyInput protectedDataPolicy = new WsmPolicyInput();
+    protectedDataPolicy.setNamespace("terra");
+    protectedDataPolicy.setName("protected-data");
+
+    RawlsWorkspaceDetails azureProtectedWorkspace =
+        new RawlsWorkspaceDetails(
+            new RawlsWorkspaceDetails.RawlsWorkspace(null, WorkspaceType.MC),
+            List.of(protectedDataPolicy));
+
+    RawlsWorkspaceDetails azureUnprotectedWorkspace =
+        new RawlsWorkspaceDetails(
+            new RawlsWorkspaceDetails.RawlsWorkspace(null, WorkspaceType.MC), emptyList());
+
+    RawlsWorkspaceDetails googleProtectedWorkspace =
+        new RawlsWorkspaceDetails(
+            new RawlsWorkspaceDetails.RawlsWorkspace(
+                "fc-secure-%s".formatted(workspaceId.id()), WorkspaceType.RAWLS),
+            emptyList());
+
+    RawlsWorkspaceDetails googleUnprotectedWorkspace =
+        new RawlsWorkspaceDetails(
+            new RawlsWorkspaceDetails.RawlsWorkspace(
+                "fc-%s".formatted(workspaceId.id()), WorkspaceType.RAWLS),
+            emptyList());
+
+    return Stream.of(
+        Arguments.of("Azure", workspaceId, azureProtectedWorkspace, true),
+        Arguments.of("Azure", workspaceId, azureUnprotectedWorkspace, false),
+        Arguments.of("Google", workspaceId, googleProtectedWorkspace, true),
+        Arguments.of("Google", workspaceId, googleUnprotectedWorkspace, false));
+  }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/protecteddatasupport/RawlsProtectedDataSupportTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/protecteddatasupport/RawlsProtectedDataSupportTest.java
@@ -23,7 +23,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles(profiles = "control-plane", inheritProfiles = false)
-public class RawlsProtectedDataSupportTest extends TestBase {
+class RawlsProtectedDataSupportTest extends TestBase {
   @MockBean RawlsClient rawlsClient;
 
   @Autowired RawlsProtectedDataSupport rawlsProtectedDataSupport;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/protecteddatasupport/RawlsProtectedDataSupportTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/protecteddatasupport/RawlsProtectedDataSupportTest.java
@@ -1,7 +1,7 @@
 package org.databiosphere.workspacedataservice.dataimport.protecteddatasupport;
 
 import static java.util.Collections.emptyList;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import bio.terra.workspace.model.WsmPolicyInput;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/protecteddatasupport/WsmProtectedDataSupportTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/protecteddatasupport/WsmProtectedDataSupportTest.java
@@ -1,0 +1,57 @@
+package org.databiosphere.workspacedataservice.dataimport.protecteddatasupport;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.when;
+
+import bio.terra.workspace.model.WorkspaceDescription;
+import bio.terra.workspace.model.WsmPolicyInput;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
+import org.databiosphere.workspacedataservice.workspacemanager.WorkspaceManagerDao;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@SpringBootTest
+public class WsmProtectedDataSupportTest extends TestBase {
+  @MockBean WorkspaceManagerDao wsmDao;
+
+  @Autowired WsmProtectedDataSupport wsmProtectedDataSupport;
+
+  @ParameterizedTest(name = "workspaceSupportsProtectedDataPolicy {1}")
+  @MethodSource("workspaceSupportsProtectedDataPolicyTestCases")
+  void workspaceSupportsProtectedDataPolicy(
+      WorkspaceDescription workspaceDescription, boolean expectedToSupportProtectedDataPolicy) {
+    // Arrange
+    WorkspaceId workspaceId = WorkspaceId.of(UUID.randomUUID());
+
+    when(wsmDao.getWorkspace(workspaceId.id())).thenReturn(workspaceDescription);
+
+    // Act
+    boolean supportsProtectedDataPolicy =
+        wsmProtectedDataSupport.workspaceSupportsProtectedDataPolicy(workspaceId);
+
+    // Assert
+    assertThat(supportsProtectedDataPolicy).isEqualTo(expectedToSupportProtectedDataPolicy);
+  }
+
+  static Stream<Arguments> workspaceSupportsProtectedDataPolicyTestCases() {
+    WorkspaceDescription workspaceWithProtectedDataPolicy = new WorkspaceDescription();
+    WsmPolicyInput policy = new WsmPolicyInput();
+    policy.setNamespace("terra");
+    policy.setName("protected-data");
+    workspaceWithProtectedDataPolicy.setPolicies(List.of(policy));
+
+    WorkspaceDescription workspaceWithoutProtectedDataPolicy = new WorkspaceDescription();
+
+    return Stream.of(
+        Arguments.of(workspaceWithProtectedDataPolicy, true),
+        Arguments.of(workspaceWithoutProtectedDataPolicy, false));
+  }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/protecteddatasupport/WsmProtectedDataSupportTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/protecteddatasupport/WsmProtectedDataSupportTest.java
@@ -1,6 +1,6 @@
 package org.databiosphere.workspacedataservice.dataimport.protecteddatasupport;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import bio.terra.workspace.model.WorkspaceDescription;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/protecteddatasupport/WsmProtectedDataSupportTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/protecteddatasupport/WsmProtectedDataSupportTest.java
@@ -19,7 +19,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
 @SpringBootTest
-public class WsmProtectedDataSupportTest extends TestBase {
+class WsmProtectedDataSupportTest extends TestBase {
   @MockBean WorkspaceManagerDao wsmDao;
 
   @Autowired WsmProtectedDataSupport wsmProtectedDataSupport;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/policy/PolicyUtilsTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/policy/PolicyUtilsTest.java
@@ -1,0 +1,62 @@
+package org.databiosphere.workspacedataservice.policy;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import bio.terra.workspace.model.WsmPolicyInput;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.lang.Nullable;
+
+class PolicyUtilsTest {
+  @ParameterizedTest(name = "isProtectedDataPolicy {1}")
+  @MethodSource("isProtectedDataTestCases")
+  void isProtectedDataPolicy(WsmPolicyInput policy, boolean expected) {
+    // Act
+    boolean actual = PolicyUtils.isProtectedDataPolicy(policy);
+
+    // Assert
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  static Stream<Arguments> isProtectedDataTestCases() {
+    WsmPolicyInput protectedDataPolicy = new WsmPolicyInput();
+    protectedDataPolicy.setNamespace(PolicyUtils.TERRA_NAMESPACE);
+    protectedDataPolicy.setName(PolicyUtils.PROTECTED_DATA_POLICY_NAME);
+
+    WsmPolicyInput otherPolicy = new WsmPolicyInput();
+    otherPolicy.setNamespace(PolicyUtils.TERRA_NAMESPACE);
+    otherPolicy.setName("other-policy");
+
+    return Stream.of(Arguments.of(protectedDataPolicy, true), Arguments.of(otherPolicy, false));
+  }
+
+  @ParameterizedTest(name = "containsProtectedDataTestCases {1}")
+  @MethodSource("containsProtectedDataTestCases")
+  void containsProtectedDataPolicy(@Nullable List<WsmPolicyInput> policies, boolean expected) {
+    // Act
+    boolean actual = PolicyUtils.containsProtectedDataPolicy(policies);
+
+    // Assert
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  static Stream<Arguments> containsProtectedDataTestCases() {
+    WsmPolicyInput protectedDataPolicy = new WsmPolicyInput();
+    protectedDataPolicy.setNamespace(PolicyUtils.TERRA_NAMESPACE);
+    protectedDataPolicy.setName(PolicyUtils.PROTECTED_DATA_POLICY_NAME);
+
+    WsmPolicyInput otherPolicy = new WsmPolicyInput();
+    otherPolicy.setNamespace(PolicyUtils.TERRA_NAMESPACE);
+    otherPolicy.setName("other-policy");
+
+    return Stream.of(
+        Arguments.of(List.of(protectedDataPolicy), true),
+        Arguments.of(List.of(otherPolicy), false),
+        Arguments.of(emptyList(), false),
+        Arguments.of(null, false));
+  }
+}


### PR DESCRIPTION
(C)WDS is configured to require a "protected workspace" for imports from BioData Catalyst. "Protected workspace" means a workspace that has additional security monitoring enabled and would be allowed to import data that has a "protected data" policy.

Currently, CWDS determines if a workspace is protected by checking if the workspace has a protected data policy. That works for Azure workspaces, but not for GCP workspaces. For GCP workspaces, the only indication that the workspace is protected is the name of the GCS bucket. For workspaces with additional security monitoring enabled, the bucket name starts with "fc-secure-" instead of "fc-".

To get the bucket name, CWDS has to get the workspace details from Rawls. However, for WDS, we don't want to involve Rawls and since we're only dealing with Azure workspaces there, we can continue to get workspace policies from WSM. To handle this difference, this adds a `ProtectedDataSupport` interface with Rawls and WSM implementations for the control plane and data plane. `DefaultImportValidator` then uses `ProtectedDataSupport` to check if the import's destination workspace is protected.