### PR TITLE
[AJ-1822] Remove disk space from status endpoint

### DIFF
--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -35,6 +35,16 @@ management:
         info: version
         health: status
         prometheus: prometheus
+  health:
+    defaults:
+      enabled: false
+    db:
+      enabled: true
+    ping:
+      enabled: true
+    pubsub:
+      enabled: true
+
   # additional keys to expose in the actuator info endpoint:
   info:
     env:

--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -853,42 +853,6 @@ components:
         time:
           type: string
           format: date-time
-    component:
-      type: object
-      properties:
-        status:
-          type: string
-        details:
-          type: string
-    components:
-      type: object
-      properties:
-        Permissions:
-          $ref: '#/components/schemas/permissionsComponent'
-        db:
-          $ref: '#/components/schemas/dbComponent'
-        livenessState:
-          $ref: '#/components/schemas/component'
-        ping:
-          $ref: '#/components/schemas/component'
-        pubSub:
-          $ref: '#/components/schemas/component'
-        readinessState:
-          $ref: '#/components/schemas/component'
-    dbComponent:
-      type: object
-      properties:
-        status:
-          type: string
-        details:
-          $ref: '#/components/schemas/dbComponentDetails'
-    dbComponentDetails:
-      type: object
-      properties:
-        database:
-          type: string
-        validationQuery:
-          type: string
     ErrorResponse:
       required:
         - status
@@ -942,18 +906,6 @@ components:
           type: string
         errorMessage:
           type: string
-    permissionsComponent:
-      type: object
-      properties:
-        status:
-          type: string
-        details:
-          $ref: '#/components/schemas/permissionsComponentDetails'
-    permissionsComponentDetails:
-      type: object
-      properties:
-        samOk:
-          type: boolean
     RecordAttributes:
       type: object
       additionalProperties: true
@@ -1082,7 +1034,7 @@ components:
         status:
           type: string
         components:
-          $ref: '#/components/schemas/components'
+          type: object
     TsvUploadResponse:
       type: object
       required:

--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -865,8 +865,6 @@ components:
       properties:
         db:
           $ref: '#/components/schemas/dbComponent'
-        diskSpace:
-          $ref: '#/components/schemas/diskSpaceComponent'
         ping:
           $ref: '#/components/schemas/component'
         mainDb:
@@ -892,24 +890,6 @@ components:
           type: string
         validationQuery:
           type: string
-    diskSpaceComponent:
-      type: object
-      properties:
-        status:
-          type: string
-        details:
-          $ref: '#/components/schemas/diskSpaceComponentDetails'
-    diskSpaceComponentDetails:
-      type: object
-      properties:
-        total:
-          type: string
-        free:
-          type: number
-        threshold:
-          type: number
-        exists:
-          type: boolean
     ErrorResponse:
       required:
         - status

--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -863,27 +863,26 @@ components:
     components:
       type: object
       properties:
+        Permissions:
+          $ref: '#/components/schemas/permissionsComponent'
         db:
           $ref: '#/components/schemas/dbComponent'
+        livenessState:
+          $ref: '#/components/schemas/component'
         ping:
           $ref: '#/components/schemas/component'
-        mainDb:
-          $ref: '#/components/schemas/dbValidationcomponent'
+        pubSub:
+          $ref: '#/components/schemas/component'
+        readinessState:
+          $ref: '#/components/schemas/component'
     dbComponent:
       type: object
       properties:
         status:
           type: string
-        components:
-          $ref: '#/components/schemas/component'
-    dbValidationcomponent:
-      type: object
-      properties:
-        status:
-          type: string
-        components:
-          $ref: '#/components/schemas/dbValidationcomponentDetails'
-    dbValidationcomponentDetails:
+        details:
+          $ref: '#/components/schemas/dbComponentDetails'
+    dbComponentDetails:
       type: object
       properties:
         database:
@@ -943,6 +942,18 @@ components:
           type: string
         errorMessage:
           type: string
+    permissionsComponent:
+      type: object
+      properties:
+        status:
+          type: string
+        details:
+          $ref: '#/components/schemas/permissionsComponentDetails'
+    permissionsComponentDetails:
+      type: object
+      properties:
+        samOk:
+          type: boolean
     RecordAttributes:
       type: object
       additionalProperties: true


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1822

This removes the `diskSpace` section from the `/status` endpoint.

It does so by disabling the default health indicators and explicitly enabling the ones we do want.
https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html#actuator.endpoints.health

While I was here, I noticed the OpenAPI docs for the status endpoint were significantly out of sync with the actual response. So I updated those as well.