### PR TITLE
AJ-1819: update to latest bumper, use FORCE_WITHOUT_CHANGES for releases

### DIFF
--- a/.github/workflows/tag-and-publish.yml
+++ b/.github/workflows/tag-and-publish.yml
@@ -26,11 +26,12 @@ jobs:
 
       - name: Bump the tag to a new version
         # https://github.com/DataBiosphere/github-actions/tree/master/actions/bumper
-        uses: databiosphere/github-actions/actions/bumper@bumper-0.3.0
+        uses: databiosphere/github-actions/actions/bumper@bumper-0.4.0
         id: tag
         env:
           GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
           DEFAULT_BUMP: minor
+          FORCE_WITHOUT_CHANGES: true
           RELEASE_BRANCHES: main
           VERSION_FILE_PATH: build.gradle
           VERSION_LINE_MATCH: "^\\s*version\\s*=\\s*'.*'"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -51,7 +51,7 @@ jobs:
           token: ${{ secrets.BROADBOT_TOKEN }} # this allows the push to succeed later
       - name: Bump the tag to a new version
         # https://github.com/DataBiosphere/github-actions/tree/master/actions/bumper
-        uses: databiosphere/github-actions/actions/bumper@bumper-0.3.0
+        uses: databiosphere/github-actions/actions/bumper@bumper-0.4.0
         id: tag
         env:
           GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}


### PR DESCRIPTION
The latest (0.4.0) version of bumper supports a `FORCE_WITHOUT_CHANGES` config flag.

This should allow our tag-and-publish release workflow to properly bump the minor version of a release, instead of the patch version.