### PR TITLE
AJ-1819: release drafter default bump should be minor

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -26,7 +26,7 @@ version-resolver:
   patch:
     labels:
       - 'patch'
-  default: patch
+  default: minor
 template: |
   | Corresponding `terra-helmfile` chart | `???` |
   | :--- | :--- |


### PR DESCRIPTION
Now that we bump the minor (not patch) version on releases, we need to change the default bump for our draft release notes.