### PR TITLE
[AJ-1840] Reject requests to import files from relative URLs

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/DefaultImportValidator.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/DefaultImportValidator.java
@@ -77,6 +77,11 @@ public class DefaultImportValidator implements ImportValidator {
         SUPPORTED_URL_SCHEMES_BY_IMPORT_TYPE.getOrDefault(importType, emptySet());
 
     URI importUrl = importRequest.getUrl();
+
+    if (!importUrl.isAbsolute()) {
+      throw new ValidationException("Invalid import URL.");
+    }
+
     String urlScheme = importUrl.getScheme();
     if (!schemesSupportedForImportType.contains(urlScheme)) {
       throw new ValidationException("Files may not be imported from %s URLs.".formatted(urlScheme));

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/DefaultImportValidatorTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/DefaultImportValidatorTest.java
@@ -85,6 +85,20 @@ class DefaultImportValidatorTest extends TestBase {
   }
 
   @Test
+  void rejectsRelativeUrls() {
+    // Arrange
+    URI importUri = URI.create("/path/to/file");
+    ImportRequestServerModel importRequest = new ImportRequestServerModel(TypeEnum.PFB, importUri);
+
+    // Act/Assert
+    ValidationException err =
+        assertThrows(
+            ValidationException.class,
+            () -> importValidator.validateImport(importRequest, destinationWorkspaceId));
+    assertEquals("Invalid import URL.", err.getMessage());
+  }
+
+  @Test
   void rejectsFileImportUrls() {
     // Arrange
     URI importUri = URI.create("file:///path/to/file");


### PR DESCRIPTION
An import request with a relative URL (for example: `/path/to/file`) causes DefaultImportValidator to throw a NullPointerException when it checks if the URL scheme is allowed for the import type.

This changes DefaultImportValidator to reject all relative URLs.