### PR TITLE
AJ-1704 Error out stalled jobs

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/WorkspaceDataServiceApplication.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/WorkspaceDataServiceApplication.java
@@ -8,6 +8,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @SpringBootApplication(
@@ -20,6 +21,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 @EnableRetry
 @EnableTransactionManagement
 @EnableCaching
+@EnableScheduling
 public class WorkspaceDataServiceApplication {
 
   public static void main(String[] args) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/JobDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/JobDao.java
@@ -34,5 +34,5 @@ public interface JobDao {
   List<GenericJobServerModel> getJobsForCollection(
       CollectionId collectionId, Optional<List<String>> statuses);
 
-  List<GenericJobServerModel> getOldRunningJobs();
+  List<GenericJobServerModel> getOldNonTerminalJobs();
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/JobDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/JobDao.java
@@ -33,4 +33,6 @@ public interface JobDao {
 
   List<GenericJobServerModel> getJobsForCollection(
       CollectionId collectionId, Optional<List<String>> statuses);
+
+  List<GenericJobServerModel> getOldRunningJobs();
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/JobDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/JobDao.java
@@ -29,8 +29,6 @@ public interface JobDao {
 
   GenericJobServerModel fail(UUID jobId, Exception e);
 
-  GenericJobServerModel markError(UUID jobId, String errorMessage);
-
   GenericJobServerModel getJob(UUID jobId);
 
   List<GenericJobServerModel> getJobsForCollection(

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/JobDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/JobDao.java
@@ -29,6 +29,8 @@ public interface JobDao {
 
   GenericJobServerModel fail(UUID jobId, Exception e);
 
+  GenericJobServerModel markError(UUID jobId, String errorMessage);
+
   GenericJobServerModel getJob(UUID jobId);
 
   List<GenericJobServerModel> getJobsForCollection(

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresJobDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresJobDao.java
@@ -347,8 +347,6 @@ public class PostgresJobDao implements JobDao {
     OffsetDateTime lastUpdate =
         instantSource.instant().atOffset(ZoneOffset.UTC).minusHours(UPDATE_JOB_FREQUENCY_IN_HOURS);
 
-    // TODO should this be defined in JobService along with terminal job statuses?  Is there a way
-    // to programmatically make it anything that's not in terminal job statuses?
     List<String> nonterminalJobStatuses =
         List.of(
             StatusEnum.CREATED.name(),

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresJobDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresJobDao.java
@@ -145,8 +145,7 @@ public class PostgresJobDao implements JobDao {
    */
   @Override
   public GenericJobServerModel fail(UUID jobId, String errorMessage) {
-    logger.error("Job {} failed: {}", jobId, errorMessage);
-    return update(jobId, StatusEnum.ERROR, errorMessage, null);
+    return fail(jobId, errorMessage, null);
   }
 
   /**
@@ -173,6 +172,19 @@ public class PostgresJobDao implements JobDao {
   public GenericJobServerModel fail(UUID jobId, String errorMessage, Exception e) {
     logger.error("Job {} failed: {}", jobId, errorMessage, e);
     return update(jobId, StatusEnum.ERROR, errorMessage, e.getStackTrace());
+  }
+
+  /**
+   * Mark a job as error without logging at the error level
+   *
+   * @param jobId id of the job to update
+   * @param errorMessage a short error message, if the job is in error
+   * @return the updated job
+   */
+  @Override
+  public GenericJobServerModel markError(UUID jobId, String errorMessage) {
+    logger.info("Marking job {} as errored: {}", jobId, errorMessage);
+    return update(jobId, StatusEnum.ERROR, errorMessage, null);
   }
 
   private GenericJobServerModel update(

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresJobDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresJobDao.java
@@ -145,7 +145,8 @@ public class PostgresJobDao implements JobDao {
    */
   @Override
   public GenericJobServerModel fail(UUID jobId, String errorMessage) {
-    return fail(jobId, errorMessage, null);
+    logger.error("Job {} failed: {}", jobId, errorMessage);
+    return update(jobId, StatusEnum.ERROR, errorMessage, null);
   }
 
   /**

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresJobDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresJobDao.java
@@ -331,19 +331,12 @@ public class PostgresJobDao implements JobDao {
     return tags;
   }
 
-  // TODO: Genericize to a general get?
   public List<GenericJobServerModel> getOldNonTerminalJobs() {
     OffsetDateTime lastUpdate =
-        //
-        // instantSource.instant().atOffset(ZoneOffset.UTC).minusHours(UPDATE_JOB_FREQUENCY_IN_HOURS);
-        instantSource
-            .instant()
-            .atOffset(ZoneOffset.UTC)
-            .minusMinutes(UPDATE_JOB_FREQUENCY_IN_HOURS);
+        instantSource.instant().atOffset(ZoneOffset.UTC).minusHours(UPDATE_JOB_FREQUENCY_IN_HOURS);
 
     // TODO should this be defined in JobService along with terminal job statuses?  Is there a way
-    // to
-    // programmatically make it anything that's not in terminal job statuses?
+    // to programmatically make it anything that's not in terminal job statuses?
     List<String> nonterminalJobStatuses =
         List.of(
             StatusEnum.CREATED.name(),

--- a/service/src/main/java/org/databiosphere/workspacedataservice/jobexec/ImportJobUpdater.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/jobexec/ImportJobUpdater.java
@@ -27,7 +27,8 @@ public class ImportJobUpdater {
       //      initialDelayString =
       //          "#{ T(java.util.concurrent.ThreadLocalRandom).current().nextInt(60*1000) }",
       //      fixedRate = UPDATE_FREQUENCY_IN_MILLISECONDS)
-      fixedRate = 1000 * 60 * 5)
+      //      fixedRate = 1000 * 60 * 5)
+      cron = "0 15 20 * * ?")
   //  @Scheduled(fixedRate = 21600000) // run every 6 hours
   public void updateImportJobs() {
     List<GenericJobServerModel> jobsToUpdate = jobDao.getOldNonTerminalJobs();

--- a/service/src/main/java/org/databiosphere/workspacedataservice/jobexec/ImportJobUpdater.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/jobexec/ImportJobUpdater.java
@@ -24,8 +24,8 @@ public class ImportJobUpdater {
 
   @Scheduled(
       //      initialDelayString = "${random.int(${MAX_INITIAL_DELAY_IN_MILLISECONDS})}",
-      initialDelayString =
-          "#{ T(java.util.concurrent.ThreadLocalRandom).current().nextInt(60*1000) }",
+      //      initialDelayString =
+      //          "#{ T(java.util.concurrent.ThreadLocalRandom).current().nextInt(60*1000) }",
       //      fixedRate = UPDATE_FREQUENCY_IN_MILLISECONDS)
       fixedRate = 1000 * 60 * 5)
   //  @Scheduled(fixedRate = 21600000) // run every 6 hours

--- a/service/src/main/java/org/databiosphere/workspacedataservice/jobexec/ImportJobUpdater.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/jobexec/ImportJobUpdater.java
@@ -30,7 +30,7 @@ public class ImportJobUpdater {
       fixedRate = UPDATE_FREQUENCY_IN_MILLISECONDS)
   public void updateImportJobs() {
     List<GenericJobServerModel> jobsToUpdate = jobDao.getOldNonTerminalJobs();
-    logger.info("Updating " + jobsToUpdate.size() + " stalled import jobs");
+    logger.info("Updating {} stalled import jobs", jobsToUpdate.size());
     jobsToUpdate.stream()
         .forEach(job -> jobDao.fail(job.getJobId(), "Job failed to complete in 6 hours."));
   }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/jobexec/ImportJobUpdater.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/jobexec/ImportJobUpdater.java
@@ -32,6 +32,10 @@ public class ImportJobUpdater {
     List<GenericJobServerModel> jobsToUpdate = jobDao.getOldNonTerminalJobs();
     logger.info("Updating {} stalled import jobs", jobsToUpdate.size());
     jobsToUpdate.stream()
-        .forEach(job -> jobDao.markError(job.getJobId(), "Job failed to complete in 6 hours."));
+        .forEach(
+            job ->
+                jobDao.markError(
+                    job.getJobId(),
+                    "Job failed to complete in " + UPDATE_JOB_FREQUENCY_IN_HOURS + " hours."));
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/jobexec/ImportJobUpdater.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/jobexec/ImportJobUpdater.java
@@ -1,0 +1,24 @@
+package org.databiosphere.workspacedataservice.jobexec;
+
+import java.util.List;
+import org.databiosphere.workspacedataservice.dao.JobDao;
+import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ImportJobUpdater {
+
+  private final JobDao jobDao;
+
+  public ImportJobUpdater(JobDao jobDao) {
+    this.jobDao = jobDao;
+  }
+
+  @Scheduled(fixedRate = 21600000) // run every 6 hours
+  public void updateImportJobs() {
+    List<GenericJobServerModel> jobsToUpdate = jobDao.getOldRunningJobs();
+    jobsToUpdate.stream()
+        .forEach(job -> jobDao.fail(job.getJobId(), "Job failed to complete in 6 hours."));
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/jobexec/ImportJobUpdater.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/jobexec/ImportJobUpdater.java
@@ -15,7 +15,7 @@ public class ImportJobUpdater {
   public static final long UPDATE_JOB_FREQUENCY_IN_HOURS = 6;
   private static final long UPDATE_FREQUENCY_IN_MILLISECONDS =
       UPDATE_JOB_FREQUENCY_IN_HOURS * 3600 * 1000;
-  private static final long MAX_INITIAL_DELAY_IN_MILLISECONDS = 60 * 1000; // delay up to 1 minute
+  private static final long MAX_INITIAL_DELAY_IN_MILLISECONDS = 3600 * 1000; // delay up to 1 hour
   private static final Logger logger = LoggerFactory.getLogger(ImportJobUpdater.class);
 
   public ImportJobUpdater(JobDao jobDao) {
@@ -34,7 +34,7 @@ public class ImportJobUpdater {
     jobsToUpdate.stream()
         .forEach(
             job ->
-                jobDao.markError(
+                jobDao.fail(
                     job.getJobId(),
                     "Job failed to complete in " + UPDATE_JOB_FREQUENCY_IN_HOURS + " hours."));
   }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/jobexec/ImportJobUpdater.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/jobexec/ImportJobUpdater.java
@@ -23,13 +23,11 @@ public class ImportJobUpdater {
   }
 
   @Scheduled(
-      //      initialDelayString = "${random.int(${MAX_INITIAL_DELAY_IN_MILLISECONDS})}",
-      //      initialDelayString =
-      //          "#{ T(java.util.concurrent.ThreadLocalRandom).current().nextInt(60*1000) }",
-      //      fixedRate = UPDATE_FREQUENCY_IN_MILLISECONDS)
-      //      fixedRate = 1000 * 60 * 5)
-      cron = "0 15 20 * * ?")
-  //  @Scheduled(fixedRate = 21600000) // run every 6 hours
+      initialDelayString =
+          "#{ T(java.util.concurrent.ThreadLocalRandom).current().nextInt("
+              + MAX_INITIAL_DELAY_IN_MILLISECONDS
+              + ") }",
+      fixedRate = UPDATE_FREQUENCY_IN_MILLISECONDS)
   public void updateImportJobs() {
     List<GenericJobServerModel> jobsToUpdate = jobDao.getOldNonTerminalJobs();
     logger.info("Updating " + jobsToUpdate.size() + " stalled import jobs");

--- a/service/src/main/java/org/databiosphere/workspacedataservice/jobexec/ImportJobUpdater.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/jobexec/ImportJobUpdater.java
@@ -3,6 +3,8 @@ package org.databiosphere.workspacedataservice.jobexec;
 import java.util.List;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -10,14 +12,26 @@ import org.springframework.stereotype.Component;
 public class ImportJobUpdater {
 
   private final JobDao jobDao;
+  public static final long UPDATE_JOB_FREQUENCY_IN_HOURS = 6;
+  private static final long UPDATE_FREQUENCY_IN_MILLISECONDS =
+      UPDATE_JOB_FREQUENCY_IN_HOURS * 3600 * 1000;
+  private static final long MAX_INITIAL_DELAY_IN_MILLISECONDS = 60 * 1000; // delay up to 1 minute
+  private static final Logger logger = LoggerFactory.getLogger(ImportJobUpdater.class);
 
   public ImportJobUpdater(JobDao jobDao) {
     this.jobDao = jobDao;
   }
 
-  @Scheduled(fixedRate = 21600000) // run every 6 hours
+  @Scheduled(
+      //      initialDelayString = "${random.int(${MAX_INITIAL_DELAY_IN_MILLISECONDS})}",
+      initialDelayString =
+          "#{ T(java.util.concurrent.ThreadLocalRandom).current().nextInt(60*1000) }",
+      //      fixedRate = UPDATE_FREQUENCY_IN_MILLISECONDS)
+      fixedRate = 1000 * 60 * 5)
+  //  @Scheduled(fixedRate = 21600000) // run every 6 hours
   public void updateImportJobs() {
-    List<GenericJobServerModel> jobsToUpdate = jobDao.getOldRunningJobs();
+    List<GenericJobServerModel> jobsToUpdate = jobDao.getOldNonTerminalJobs();
+    logger.info("Updating " + jobsToUpdate.size() + " stalled import jobs");
     jobsToUpdate.stream()
         .forEach(job -> jobDao.fail(job.getJobId(), "Job failed to complete in 6 hours."));
   }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/jobexec/ImportJobUpdater.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/jobexec/ImportJobUpdater.java
@@ -32,6 +32,6 @@ public class ImportJobUpdater {
     List<GenericJobServerModel> jobsToUpdate = jobDao.getOldNonTerminalJobs();
     logger.info("Updating {} stalled import jobs", jobsToUpdate.size());
     jobsToUpdate.stream()
-        .forEach(job -> jobDao.fail(job.getJobId(), "Job failed to complete in 6 hours."));
+        .forEach(job -> jobDao.markError(job.getJobId(), "Job failed to complete in 6 hours."));
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/JobService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/JobService.java
@@ -2,6 +2,7 @@ package org.databiosphere.workspacedataservice.service;
 
 import static java.util.Objects.requireNonNullElse;
 
+import com.google.common.collect.Sets;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -21,6 +22,9 @@ import org.springframework.stereotype.Service;
 public class JobService {
   private static final Set<StatusEnum> TERMINAL_JOB_STATUSES =
       Set.of(StatusEnum.SUCCEEDED, StatusEnum.ERROR, StatusEnum.CANCELLED);
+
+  public static final Set<StatusEnum> NONTERMINAL_JOB_STATUSES =
+      Sets.difference(Set.of(StatusEnum.values()), TERMINAL_JOB_STATUSES);
 
   JobDao jobDao;
   CollectionService collectionService;

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -112,10 +112,6 @@ spring:
     # always run on the replica where they were created.
     job-store-type: memory
     wait-for-jobs-to-complete-on-shutdown: true
-  task:
-    scheduling:
-      pool:
-        size: 5
 
 #   # activate the "local" profile to turn on CORS response headers,
 #   # which may be necessary for local development.

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -112,6 +112,10 @@ spring:
     # always run on the replica where they were created.
     job-store-type: memory
     wait-for-jobs-to-complete-on-shutdown: true
+  task:
+    scheduling:
+      pool:
+        size: 5
 
 #   # activate the "local" profile to turn on CORS response headers,
 #   # which may be necessary for local development.

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/PostgresJobDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/PostgresJobDaoTest.java
@@ -33,7 +33,6 @@ import org.databiosphere.workspacedataservice.shared.model.job.Job;
 import org.databiosphere.workspacedataservice.shared.model.job.JobInput;
 import org.databiosphere.workspacedataservice.shared.model.job.JobResult;
 import org.databiosphere.workspacedataservice.shared.model.job.JobType;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -63,16 +62,12 @@ class PostgresJobDaoTest extends TestBase {
   @Autowired MeterRegistry metrics;
   @Autowired MockInstantSource mockInstantSource;
 
-  @AfterAll
-  void afterAll() {
-    // cleanup: delete everything from the job table
-    namedTemplate.getJdbcTemplate().update("delete from sys_wds.job;");
-  }
-
   @AfterEach
   void afterEach() {
     metrics.clear();
     Metrics.globalRegistry.clear();
+    // cleanup: delete everything from the job table
+    namedTemplate.getJdbcTemplate().update("delete from sys_wds.job;");
   }
 
   private GenericJobServerModel assertJobCreation(JobType jobType) {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/jobexec/ImportJobUpdaterTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/jobexec/ImportJobUpdaterTest.java
@@ -1,0 +1,63 @@
+package org.databiosphere.workspacedataservice.jobexec;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.Duration;
+import java.util.UUID;
+import org.databiosphere.workspacedataservice.common.MockInstantSource;
+import org.databiosphere.workspacedataservice.common.MockInstantSourceConfig;
+import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.dao.PostgresJobDao;
+import org.databiosphere.workspacedataservice.dataimport.ImportJobInput;
+import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
+import org.databiosphere.workspacedataservice.generated.GenericJobServerModel.StatusEnum;
+import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
+import org.databiosphere.workspacedataservice.shared.model.CollectionId;
+import org.databiosphere.workspacedataservice.shared.model.job.Job;
+import org.databiosphere.workspacedataservice.shared.model.job.JobInput;
+import org.databiosphere.workspacedataservice.shared.model.job.JobResult;
+import org.databiosphere.workspacedataservice.shared.model.job.JobType;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+@SpringBootTest
+@Import(MockInstantSourceConfig.class)
+public class ImportJobUpdaterTest extends TestBase {
+
+  @Autowired PostgresJobDao jobDao;
+  @Autowired MockInstantSource mockInstantSource;
+
+  @Test
+  public void testUpdateImportJobs() throws URISyntaxException {
+    // Arrange
+    JobType jobType = JobType.DATA_IMPORT;
+    CollectionId collectionId = CollectionId.of(UUID.randomUUID());
+    ImportJobInput jobInput =
+        new ImportJobInput(new URI("http://some/uri"), ImportRequestServerModel.TypeEnum.PFB);
+
+    Job<JobInput, JobResult> testJob = Job.newJob(collectionId, jobType, jobInput);
+
+    GenericJobServerModel job = jobDao.createJob(testJob);
+    // TODO will import job updater only do running or also queued and created jobs?
+    jobDao.running(job.getJobId());
+
+    GenericJobServerModel createdJob = jobDao.getJob(job.getJobId());
+    assertEquals(StatusEnum.RUNNING, createdJob.getStatus());
+    mockInstantSource.add(Duration.ofHours(7));
+
+    ImportJobUpdater updater = new ImportJobUpdater(jobDao);
+
+    // Act
+    updater.updateImportJobs();
+
+    // Assert
+    //    Mockito.verify(jobDao).getOldRunningJobs();
+    //    Mockito.verify(jobDao).fail(job.getJobId(), "Job failed to complete in 6 hours.");
+    GenericJobServerModel updatedJob = jobDao.getJob(job.getJobId());
+    assertEquals(StatusEnum.ERROR, updatedJob.getStatus());
+  }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/jobexec/ImportJobUpdaterTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/jobexec/ImportJobUpdaterTest.java
@@ -55,8 +55,6 @@ public class ImportJobUpdaterTest extends TestBase {
     updater.updateImportJobs();
 
     // Assert
-    //    Mockito.verify(jobDao).getOldRunningJobs();
-    //    Mockito.verify(jobDao).fail(job.getJobId(), "Job failed to complete in 6 hours.");
     GenericJobServerModel updatedJob = jobDao.getJob(job.getJobId());
     assertEquals(StatusEnum.ERROR, updatedJob.getStatus());
   }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1704
This PR sets up a scheduled task to update any import jobs that haven't completed in 6 hours to `ERROR` status.

I chose not to use a lock or Shedlock to deal with updating multiple replicas at once; all we're doing is changing the status from `RUNNING` to `ERROR`, and as far as I can tell interference would just result in updating a job that's already in `ERROR` to still be in error.  I tried this out on my BEE and although I saw all the replicas update at the same time, I didn't see any other problems.

Reminder:

#### Releasing WDS ####
PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag-and-publish.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 

#### Keeping Docs Up To Date ####
If you make changes to the github actions or workflows, particularly when they are run or which other workflows they call, please update [the GHA wiki page](https://github.com/DataBiosphere/terra-workspace-data-service/wiki/GHA-structure-in-WDS) to stay up to date.
