### PR TITLE
AJ-1844: include snapshot PK column in imports; ensure WDS PKs are strings

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/ParquetRecordConverter.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/ParquetRecordConverter.java
@@ -38,9 +38,7 @@ public class ParquetRecordConverter extends AvroRecordConverter {
     // for base attributes, skip the id field and all relations
     List<String> relationNames =
         relationshipModels.stream().map(r -> r.getFrom().getColumn()).toList();
-    Set<String> allIgnores = new HashSet<>();
-    allIgnores.add(idField);
-    allIgnores.addAll(relationNames);
+    Set<String> allIgnores = new HashSet<>(relationNames);
 
     record.setAttributes(extractBaseAttributes(genericRecord, allIgnores));
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/BatchWriteService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/BatchWriteService.java
@@ -100,6 +100,11 @@ public class BatchWriteService {
         // `typeSchemas` map
         if (opType == OperationType.UPSERT) {
           Map<String, DataTypeMapping> inferredSchema = inferer.inferTypes(records);
+
+          // if the inferred schema says the primary key column is not a string, make it a string.
+          // WDS requires the pk column to be a string.
+          inferredSchema.computeIfPresent(primaryKey, (k, v) -> DataTypeMapping.STRING);
+
           Map<String, DataTypeMapping> finalSchema =
               recordSink.createOrModifyRecordType(recType, inferredSchema, records, primaryKey);
           typeSchemas.put(recType, finalSchema);


### PR DESCRIPTION
Supersedes #794 but builds on the great research and comments from that PR.

In this PR:
* when translating TDR snapshots, don't exclude the snapshot's primary key column. End users expect that column and its values to exist.
* In WDS (irrelevant for cWDS), when inferring schemas from inbound records, ensure the primary key column is a string. We have a few places ([example](https://github.com/DataBiosphere/terra-workspace-data-service/blob/11628f599f958f204a376641637ace93a2c46a7d/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java#L422)) that require WDS PKs to be a string, so we need to enforce that.
  * JSON and TSV APIs create PK columns as string. The TDR and PFB paths didn't do that, and the snapshot in question for this ticket found this flaw.

I would love to revisit the assumption that WDS PKs must be a string, but that's pretty well out of scope for this PR.