### PR TITLE
AJ-1844: snapshot import preserves primary key column

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -498,10 +498,6 @@ public class RecordDao {
         .toList();
   }
 
-  private static RecordColumn toColumn(Map.Entry<String, DataTypeMapping> entry) {
-    return new RecordColumn(entry.getKey(), entry.getValue());
-  }
-
   public boolean deleteSingleRecord(UUID collectionId, RecordType recordType, String recordId) {
     String recordTypePrimaryKey = primaryKeyDao.getPrimaryKeyColumn(recordType, collectionId);
     try {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/ParquetRecordConverter.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/ParquetRecordConverter.java
@@ -35,7 +35,7 @@ public class ParquetRecordConverter extends AvroRecordConverter {
   @Override
   protected final Record convertBaseAttributes(GenericRecord genericRecord) {
     Record record = createEmptyRecord(genericRecord);
-    // for base attributes, skip the id field and all relations
+    // for base attributes, skip all relations
     List<String> relationNames =
         relationshipModels.stream().map(r -> r.getFrom().getColumn()).toList();
     Set<String> allIgnores = new HashSet<>(relationNames);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/ParquetRecordConverter.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/ParquetRecordConverter.java
@@ -38,12 +38,7 @@ public class ParquetRecordConverter extends AvroRecordConverter {
     // for base attributes, skip the id field and all relations
     List<String> relationNames =
         relationshipModels.stream().map(r -> r.getFrom().getColumn()).toList();
-    Set<String> allIgnores = new HashSet<>();
-
-    if (ignorableIdField().equalsIgnoreCase(idField)) {
-      allIgnores.add(idField);
-    }
-    allIgnores.addAll(relationNames);
+    Set<String> allIgnores = new HashSet<>(relationNames);
 
     record.setAttributes(extractBaseAttributes(genericRecord, allIgnores));
 
@@ -102,9 +97,5 @@ public class ParquetRecordConverter extends AvroRecordConverter {
     record.setAttributes(attributes);
 
     return record;
-  }
-
-  private String ignorableIdField() {
-    return "%s_id".formatted(recordType.getName());
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/ParquetRecordConverter.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/ParquetRecordConverter.java
@@ -39,7 +39,10 @@ public class ParquetRecordConverter extends AvroRecordConverter {
     List<String> relationNames =
         relationshipModels.stream().map(r -> r.getFrom().getColumn()).toList();
     Set<String> allIgnores = new HashSet<>();
-    allIgnores.add(idField);
+
+    if (ignorableIdField().equalsIgnoreCase(idField)) {
+      allIgnores.add(idField);
+    }
     allIgnores.addAll(relationNames);
 
     record.setAttributes(extractBaseAttributes(genericRecord, allIgnores));
@@ -99,5 +102,9 @@ public class ParquetRecordConverter extends AvroRecordConverter {
     record.setAttributes(attributes);
 
     return record;
+  }
+
+  private String ignorableIdField() {
+    return "%s_id".formatted(recordType.getName());
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/ParquetDataTypesTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/ParquetDataTypesTest.java
@@ -197,7 +197,7 @@ class ParquetDataTypesTest extends TestBase {
   // even though the source TDR manifest contains a column of ${entityType}_id, translation should
   // include that column. The RawlsAttributePrefixer will later rename this to tdr:${entityType}_id.
   @Test
-  void primaryKeyIsSkippedWhenMatchingTypeId() {
+  void primaryKeyIsNotSkippedWhenMatchingTypeId() {
     // arrange
     TdrManifestImportTable testTable = makeTable("someTable", "someTable_id");
     ParquetRecordConverter converter = new ParquetRecordConverter(testTable, mapper);

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/ParquetDataTypesTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/ParquetDataTypesTest.java
@@ -194,6 +194,8 @@ class ParquetDataTypesTest extends TestBase {
                     .build()));
   }
 
+  // even though the source TDR manifest contains a column of ${entityType}_id, translation should
+  // include that column. The RawlsAttributePrefixer will later rename this to tdr:${entityType}_id.
   @Test
   void primaryKeyIsSkippedWhenMatchingTypeId() {
     // arrange
@@ -215,7 +217,8 @@ class ParquetDataTypesTest extends TestBase {
 
     // assert
     assertThat(result.getId()).isEqualTo("123");
-    assertThat(result.getAttributes()).isEqualTo(new RecordAttributes(Map.of("someField", "456")));
+    assertThat(result.getAttributes())
+        .isEqualTo(new RecordAttributes(Map.of("someField", "456", "someTable_id", "123")));
   }
 
   private TdrManifestImportTable makeTable(String recordTypeName, String primaryKey) {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/ParquetDataTypesTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/ParquetDataTypesTest.java
@@ -4,12 +4,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import org.apache.avro.Schema;
+import org.apache.avro.Schema.Field;
+import org.apache.avro.Schema.Type;
+import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.hadoop.ParquetReader;
@@ -19,6 +25,7 @@ import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.recordsource.RecordSource;
 import org.databiosphere.workspacedataservice.service.model.TdrManifestImportTable;
 import org.databiosphere.workspacedataservice.shared.model.Record;
+import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -48,9 +55,7 @@ class ParquetDataTypesTest extends TestBase {
   @Test
   void numericPrecision() throws IOException {
     // ARRANGE - create all the objects we'll need to do the conversions below
-    TdrManifestImportTable testTable =
-        new TdrManifestImportTable(RecordType.valueOf("test"), "pk", List.of(), List.of());
-
+    TdrManifestImportTable testTable = makeTable("test", "pk");
     ParquetRecordConverter converter = new ParquetRecordConverter(testTable, mapper);
 
     InputFile numericsFile =
@@ -99,9 +104,7 @@ class ParquetDataTypesTest extends TestBase {
   @Test
   void arrays() throws IOException {
     // ARRANGE - create all the objects we'll need to do the conversions below
-    TdrManifestImportTable testTable =
-        new TdrManifestImportTable(RecordType.valueOf("person"), "id", List.of(), List.of());
-
+    TdrManifestImportTable testTable = makeTable("person", "id");
     ParquetRecordConverter converter = new ParquetRecordConverter(testTable, mapper);
 
     InputFile arraysFile =
@@ -158,6 +161,78 @@ class ParquetDataTypesTest extends TestBase {
             assertThat(actualList).containsExactlyElementsOf(expected);
           });
     }
+  }
+
+  // This is set up to replicate the scenario detected by AJ-1844
+  @Test
+  void primaryKeyIsNormallyIncluded() {
+    // arrange
+    TdrManifestImportTable testTable = makeTable("ArraysInputsTable", "chip_well_barcode");
+    ParquetRecordConverter converter = new ParquetRecordConverter(testTable, mapper);
+
+    GenericData.Record genericRecord =
+        new GenericRecordBuilder(
+                schema(
+                    "ArraysInputsTable",
+                    field("chip_well_barcode", Type.STRING),
+                    field("lab_batch", Type.STRING)))
+            .set("chip_well_barcode", "123")
+            .set("lab_batch", "456")
+            .build();
+
+    // act
+    Record result = converter.convertBaseAttributes(genericRecord);
+
+    // assert
+    assertThat(result.getId()).isEqualTo("123");
+    assertThat(result.getAttributes())
+        .isEqualTo(
+            new RecordAttributes(
+                new ImmutableMap.Builder<String, Object>()
+                    .put("chip_well_barcode", "123")
+                    .put("lab_batch", "456")
+                    .build()));
+  }
+
+  @Test
+  void primaryKeyIsSkippedWhenMatchingTypeId() {
+    // arrange
+    TdrManifestImportTable testTable = makeTable("someTable", "someTable_id");
+    ParquetRecordConverter converter = new ParquetRecordConverter(testTable, mapper);
+
+    GenericData.Record genericRecord =
+        new GenericRecordBuilder(
+                schema(
+                    "ArraysInputsTable",
+                    field("someTable_id", Type.STRING),
+                    field("someField", Type.STRING)))
+            .set("someTable_id", "123")
+            .set("someField", "456")
+            .build();
+
+    // act
+    Record result = converter.convertBaseAttributes(genericRecord);
+
+    // assert
+    assertThat(result.getId()).isEqualTo("123");
+    assertThat(result.getAttributes()).isEqualTo(new RecordAttributes(Map.of("someField", "456")));
+  }
+
+  private TdrManifestImportTable makeTable(String recordTypeName, String primaryKey) {
+    return new TdrManifestImportTable(
+        RecordType.valueOf(recordTypeName),
+        primaryKey,
+        /* dataFiles= */ List.of(),
+        /* relations= */ List.of());
+  }
+
+  private Schema schema(String tableName, Field... fields) {
+    return Schema.createRecord(
+        tableName, "doc", "namespace", /* isError= */ false, List.of(fields));
+  }
+
+  private Field field(String name, Type type) {
+    return new Field(name, Schema.create(type));
   }
 
   private List<Object> getColumnValues(List<Record> records, String attributeName) {


### PR DESCRIPTION
This PR branches from, and supersedes, #794. This PR builds on the research, findings, and tests from that other PR but attempts to simplify the implementation.

* when translating TDR snapshots, don't exclude the snapshot's primary key column. End users expect that column and its values to exist.
* In WDS (irrelevant for cWDS), when batch-upserting, ensure the primary key column is a string. We have a few places ([example](https://github.com/DataBiosphere/terra-workspace-data-service/blob/11628f599f958f204a376641637ace93a2c46a7d/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java#L422)) that require WDS PKs to be a string, so we need to enforce that.
  * JSON and TSV APIs create PK columns as string. The TDR and PFB paths didn't do that, and the snapshot used in the [TdrManifestQuartzJobE2ETest.withEntityReferenceListsManifest](https://github.com/DataBiosphere/terra-workspace-data-service/blob/main/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobE2ETest.java#L225) test identified this problem.
  * TDR and PFB paths (and their RecordSinks) exclusively use batchUpsert, no other insert methods, so this is a safe place to add this constraint.

I would love to revisit the assumption that WDS PKs must be a string, but that's pretty well out of scope for this PR.