### PR TITLE
AJ-1848: Fix retryable bugs.

### DIFF
--- a/service/src/test/java/org/databiosphere/workspacedataservice/retry/RestClientRetryTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/retry/RestClientRetryTest.java
@@ -362,7 +362,7 @@ class RestClientRetryTest extends TestBase {
         .hasNumberOfObservationsWithNameEqualTo("wds.outbound", 1)
         .hasObservationWithNameEqualTo("wds.outbound")
         .that()
-        .doesNotHaveLowCardinalityKeyValue("retryAttempt", "0") // don't bother counting 0th attempt
+        .doesNotHaveLowCardinalityKeyValue("retryCount", "0")
         .hasBeenStarted()
         .hasBeenStopped();
   }


### PR DESCRIPTION
* Downgrade error logs to warning.  Eror logs are reported to Sentry via https://docs.sentry.io/platforms/java/guides/logback/; these should only be reported to Sentry when all retry attempts failed.
* Fix bug in test verifying behavior of first attempt, which was looking for an incorrect key, hiding the next bug...
* Fix bug where first attempt is recorded as `retryCount` = 0.  This makes the promQL to detect retries more complicated, so prefer not to count it.