### PR TITLE
AJ-1658: Prefer `WorkspaceId` over `String workspaceId`

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/protecteddatasupport/WsmProtectedDataSupport.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/protecteddatasupport/WsmProtectedDataSupport.java
@@ -17,7 +17,7 @@ public class WsmProtectedDataSupport implements ProtectedDataSupport {
   }
 
   public boolean workspaceSupportsProtectedDataPolicy(WorkspaceId workspaceId) {
-    WorkspaceDescription workspace = wsmDao.getWorkspace(workspaceId.id());
+    WorkspaceDescription workspace = wsmDao.getWorkspace(workspaceId);
     return PolicyUtils.containsProtectedDataPolicy(workspace.getPolicies());
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/snapshotsupport/WsmSnapshotSupport.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/snapshotsupport/WsmSnapshotSupport.java
@@ -22,7 +22,7 @@ public class WsmSnapshotSupport extends SnapshotSupport {
 
   @Override
   protected ResourceList enumerateDataRepoSnapshotReferences(int offset, int pageSize) {
-    return wsmDao.enumerateDataRepoSnapshotReferences(workspaceId.id(), offset, pageSize);
+    return wsmDao.enumerateDataRepoSnapshotReferences(workspaceId, offset, pageSize);
   }
 
   @Override

--- a/service/src/main/java/org/databiosphere/workspacedataservice/storage/AzureBlobStorage.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/storage/AzureBlobStorage.java
@@ -13,6 +13,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import org.databiosphere.workspacedataservice.service.model.exception.LaunchProcessException;
+import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.databiosphere.workspacedataservice.workspacemanager.WorkspaceManagerDao;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -80,7 +81,8 @@ public class AzureBlobStorage implements BackUpFileStorage {
 
   private BlobContainerClient constructBlockBlobClient(String workspaceId, String authToken) {
     // get workspace blob storage endpoint and token
-    var blobstorageDetails = workspaceManagerDao.getBlobStorageUrl(workspaceId, authToken);
+    var blobstorageDetails =
+        workspaceManagerDao.getBlobStorageUrl(WorkspaceId.fromString(workspaceId), authToken);
 
     // the url we get from WSM already contains the token in it, so no need to specify sasToken
     // separately

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobTest.java
@@ -202,7 +202,7 @@ class PfbQuartzJobTest extends TestBase {
 
     // verify that snapshot operations use the appropriate workspaceId
     verify(wsmDao, times(1))
-        .enumerateDataRepoSnapshotReferences(eq(expectedWorkspaceId.id()), anyInt(), anyInt());
+        .enumerateDataRepoSnapshotReferences(eq(expectedWorkspaceId), anyInt(), anyInt());
     // The "790795c4..." UUID below is the snapshotId found in the "test.avro" resource used
     // by this unit test
     verify(wsmDao)

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/protecteddatasupport/WsmProtectedDataSupportTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/protecteddatasupport/WsmProtectedDataSupportTest.java
@@ -31,7 +31,7 @@ class WsmProtectedDataSupportTest extends TestBase {
     // Arrange
     WorkspaceId workspaceId = WorkspaceId.of(UUID.randomUUID());
 
-    when(wsmDao.getWorkspace(workspaceId.id())).thenReturn(workspaceDescription);
+    when(wsmDao.getWorkspace(workspaceId)).thenReturn(workspaceDescription);
 
     // Act
     boolean supportsProtectedDataPolicy =

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobTest.java
@@ -264,7 +264,7 @@ class TdrManifestQuartzJobTest extends TestBase {
     // WSM should report no snapshots already linked to this workspace
     // note that if enumerateDataRepoSnapshotReferences is called with the wrong workspaceId,
     // this test will fail
-    when(wsmDao.enumerateDataRepoSnapshotReferences(eq(workspaceId.id()), anyInt(), anyInt()))
+    when(wsmDao.enumerateDataRepoSnapshotReferences(eq(workspaceId), anyInt(), anyInt()))
         .thenReturn(new ResourceList());
 
     // set up the job
@@ -276,7 +276,7 @@ class TdrManifestQuartzJobTest extends TestBase {
     tdrManifestQuartzJob.executeInternal(jobId, mockContext);
 
     // ASSERT
-    verify(wsmDao).enumerateDataRepoSnapshotReferences(eq(workspaceId.id()), anyInt(), anyInt());
+    verify(wsmDao).enumerateDataRepoSnapshotReferences(eq(workspaceId), anyInt(), anyInt());
   }
 
   @Test
@@ -295,7 +295,7 @@ class TdrManifestQuartzJobTest extends TestBase {
     // WSM should report no snapshots already linked to this workspace
     // note that if enumerateDataRepoSnapshotReferences is called with the wrong workspaceId,
     // this test will fail
-    when(wsmDao.enumerateDataRepoSnapshotReferences(eq(workspaceId.id()), anyInt(), anyInt()))
+    when(wsmDao.enumerateDataRepoSnapshotReferences(eq(workspaceId), anyInt(), anyInt()))
         .thenReturn(new ResourceList());
     // mock property that only gets enabled in application-control-plane.yml
     when(dataImportProperties.isTdrPermissionSyncingEnabled()).thenReturn(true);
@@ -342,7 +342,7 @@ class TdrManifestQuartzJobTest extends TestBase {
     // WSM should report no snapshots already linked to this workspace
     // note that if enumerateDataRepoSnapshotReferences is called with the wrong workspaceId,
     // this test will fail
-    when(wsmDao.enumerateDataRepoSnapshotReferences(eq(workspaceId.id()), anyInt(), anyInt()))
+    when(wsmDao.enumerateDataRepoSnapshotReferences(eq(workspaceId), anyInt(), anyInt()))
         .thenReturn(new ResourceList());
 
     // Set up the job

--- a/service/src/test/java/org/databiosphere/workspacedataservice/pact/WsmPactTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/pact/WsmPactTest.java
@@ -56,6 +56,7 @@ class WsmPactTest {
   // UUIDs are hardcoded to prevent churn in pactfiles, and intended to be human memorable
   private static final UUID WORKSPACE_UUID =
       UUID.fromString("facade00-0000-4000-a000-000000000000");
+  private static final WorkspaceId WORKSPACE_ID = WorkspaceId.of(WORKSPACE_UUID);
   private static final UUID SNAPSHOT_UUID = UUID.fromString("decade00-0000-4000-a000-000000000000");
   private static final UUID RESOURCE_UUID = UUID.fromString("5ca1ab1e-0000-4000-a000-000000000000");
   private static final String SNAPSHOT_NAME = "hardcodedSnapshotName";
@@ -450,7 +451,7 @@ class WsmPactTest {
   void getBlobStorageUrl_ok(MockServer mockServer) {
     var wsmDao = buildWsmDao(mockServer);
 
-    var blobStorageUrl = wsmDao.getBlobStorageUrl(WORKSPACE_UUID.toString(), BEARER_TOKEN);
+    var blobStorageUrl = wsmDao.getBlobStorageUrl(WORKSPACE_ID, BEARER_TOKEN);
 
     assertNotNull(blobStorageUrl);
     // TODO: the sas URL has some pretty strict formatting requirements and making some assertions
@@ -499,7 +500,7 @@ class WsmPactTest {
     var thrown =
         assertThrows(
             WorkspaceManagerException.class,
-            () -> wsmDao.getBlobStorageUrl(WORKSPACE_UUID.toString(), BEARER_TOKEN));
+            () -> wsmDao.getBlobStorageUrl(WORKSPACE_ID, BEARER_TOKEN));
     assertEquals(HttpStatus.FORBIDDEN, thrown.getStatusCode());
   }
 
@@ -513,7 +514,7 @@ class WsmPactTest {
     var thrown =
         assertThrows(
             WorkspaceManagerException.class,
-            () -> wsmDao.getBlobStorageUrl(WORKSPACE_UUID.toString(), BEARER_TOKEN));
+            () -> wsmDao.getBlobStorageUrl(WORKSPACE_ID, BEARER_TOKEN));
     assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, thrown.getStatusCode());
   }
 


### PR DESCRIPTION
Specifically centered around Wsm interaction:
* WsmProtectedDataSupport
* WsmSnapshotSupport
* WorkspaceManagerDao)
* (and tests and immediate neighbors)