### PR TITLE
AJ-1658: Prefer `WorkspaceId` over `String workspaceId`

### DIFF
--- a/service/src/integrationTest/java/org/databiosphere/workspacedataservice/storage/LocalFileStorage.java
+++ b/service/src/integrationTest/java/org/databiosphere/workspacedataservice/storage/LocalFileStorage.java
@@ -4,13 +4,14 @@ import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import org.databiosphere.workspacedataservice.service.model.exception.LaunchProcessException;
+import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 
 public class LocalFileStorage implements BackUpFileStorage {
   public LocalFileStorage() {}
 
   @Override
   public void streamOutputToBlobStorage(
-      InputStream fromStream, String blobName, String workspaceId) {
+      InputStream fromStream, String blobName, WorkspaceId workspaceId) {
     File targetFile;
     try {
       targetFile = File.createTempFile("WDS-integrationTest-LocalFileStorage-", ".sql");
@@ -40,7 +41,7 @@ public class LocalFileStorage implements BackUpFileStorage {
 
   @Override
   public void streamInputFromBlobStorage(
-      OutputStream toStream, String blobName, String workspaceId, String authToken) {
+      OutputStream toStream, String blobName, WorkspaceId workspaceId, String authToken) {
     try (InputStream inStream =
         LocalFileStorage.class.getResourceAsStream(
             "/WDS-integrationTest-LocalFileStorage-input.sql")) {
@@ -57,7 +58,7 @@ public class LocalFileStorage implements BackUpFileStorage {
   }
 
   @Override
-  public void deleteBlob(String blobFile, String workspaceId, String authToken) {
+  public void deleteBlob(String blobFile, WorkspaceId workspaceId, String authToken) {
     // delete is handled in stream output for local set up
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/storage/BackUpFileStorage.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/storage/BackUpFileStorage.java
@@ -2,14 +2,15 @@ package org.databiosphere.workspacedataservice.storage;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 
 /* Allow for blob storage mocking. */
 public interface BackUpFileStorage {
   default void streamOutputToBlobStorage(
-      InputStream fromStream, String blobName, String workspaceId) {}
+      InputStream fromStream, String blobName, WorkspaceId workspaceId) {}
 
   default void streamInputFromBlobStorage(
-      OutputStream toStream, String blobName, String workspaceId, String authToken) {}
+      OutputStream toStream, String blobName, WorkspaceId workspaceId, String authToken) {}
 
-  default void deleteBlob(String blobFile, String workspaceId, String authToken) {}
+  default void deleteBlob(String blobFile, WorkspaceId workspaceId, String authToken) {}
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/workspacemanager/WorkspaceManagerDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/workspacemanager/WorkspaceManagerDao.java
@@ -91,7 +91,7 @@ public class WorkspaceManagerDao {
   }
 
   /** Retrieves the azure storage container url and sas token for a given workspace. */
-  public String getBlobStorageUrl(WorkspaceId storageWorkspaceId, String authToken) {
+  public String getBlobStorageUrl(WorkspaceId storageWorkspaceId, @Nullable String authToken) {
     try {
       final ControlledAzureResourceApi azureResourceApi =
           this.workspaceManagerClientFactory.getAzureResourceApi(authToken);


### PR DESCRIPTION
Specifically focused on `BackupFileStorage` and its subclasses.