### PR TITLE
AJ-1782: spring boot 3.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
 plugins {
-    id 'org.springframework.boot' version '3.2.5' apply false
+    id 'org.springframework.boot' version '3.3.0' apply false
     id 'io.spring.dependency-management' version '1.1.5' apply false
     id 'com.google.cloud.tools.jib' version '3.2.1' apply false
     id "org.sonarqube" version "5.0.0.4638" apply false

--- a/build.gradle
+++ b/build.gradle
@@ -37,10 +37,7 @@ subprojects {
             mavenBom(SpringBootPlugin.BOM_COORDINATES)
         }
         dependencies {
-            // WDS requires a version of Liquibase with
-            // https://github.com/liquibase/liquibase/pull/5391
-            // "This bug existed from 4.22.0 to 4.25.1"
-            dependency 'org.liquibase:liquibase-core:4.27.0'
+            // no dependencyManagement overrides at this time
         }
     }
 }

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -148,8 +148,6 @@ dependencies {
         implementation('org.codehaus.jettison:jettison:1.5.4') {
             because("CVE-2022-40149, CVE-2022-40150, CVE-2022-45685, CVE-2022-45693, CVE-2023-1436")
         }
-        // SEE ALSO:
-        //  - org.liquibase:liquibase-core:4.26.0, configured in build.gradle
     }
 }
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobControlPlaneE2ETest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobControlPlaneE2ETest.java
@@ -314,8 +314,8 @@ class PfbQuartzJobControlPlaneE2ETest {
 
     // by the time we get here, there are no currently running jobs and so the _active_ metrics
     // should all be zero.
-    assertMetric(metrics, "wds_job_execute_active_seconds_active_count", "0.0");
-    assertMetric(metrics, "wds_job_execute_active_seconds_duration_sum", "0.0");
+    assertMetric(metrics, "wds_job_execute_active_seconds_count", "0");
+    assertMetric(metrics, "wds_job_execute_active_seconds_sum", "0.0");
     assertMetric(metrics, "wds_job_execute_active_seconds_max", "0.0");
 
     // (counter) we should have counted one job.execute event regardless of outcome
@@ -329,7 +329,7 @@ class PfbQuartzJobControlPlaneE2ETest {
             .build());
 
     // (counter) of job.execute events
-    assertMetric(metrics, "wds_job_execute_seconds_count", "1.0", successTags);
+    assertMetric(metrics, "wds_job_execute_seconds_count", "1", successTags);
 
     // (summary) sum of all job durations, and when divided by count, can get the average
     assertMetric(metrics, "wds_job_execute_seconds_sum", ".*", successTags);
@@ -358,8 +358,8 @@ class PfbQuartzJobControlPlaneE2ETest {
 
     // by the time we get here, there are no currently running jobs and so the _active_ metrics
     // should all be zero.
-    assertMetric(metrics, "wds_job_execute_active_seconds_active_count", "0.0");
-    assertMetric(metrics, "wds_job_execute_active_seconds_duration_sum", "0.0");
+    assertMetric(metrics, "wds_job_execute_active_seconds_count", "0");
+    assertMetric(metrics, "wds_job_execute_active_seconds_sum", "0.0");
     assertMetric(metrics, "wds_job_execute_active_seconds_max", "0.0");
 
     // (counter) we should have counted one job.execute event regardless of outcome
@@ -373,7 +373,7 @@ class PfbQuartzJobControlPlaneE2ETest {
             .build());
 
     // (counter) of job.execute events
-    assertMetric(metrics, "wds_job_execute_seconds_count", "1.0", failureTags);
+    assertMetric(metrics, "wds_job_execute_seconds_count", "1", failureTags);
 
     // (summary) sum of all job durations, and when divided by count, can get the average
     assertMetric(metrics, "wds_job_execute_seconds_sum", ".*", failureTags);


### PR DESCRIPTION
Update to Spring Boot 3.3.0: https://spring.io/blog/2024/05/23/spring-boot-3-3-0-available-now

This will supersede parts of #804.

In this PR:
* the Spring Boot update
* remove our version override for Liquibase, since Spring Boot now includes the version of Liquibase we want (doc at https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.3-Release-Notes)
* updates to unit tests for metrics - looks like the autocollected metrics names changed slightly

I reviewed the rest of WDS's version overrides and do not see anything else that can be removed.

I reviewed the release notes and do not see any7 compatibility issues.

I reviewed the changed metrics keys w/r/t the [cWDS dashboard](https://grafana.dsp-devops.broadinstitute.org/d/m4cmXc0Sk/cwds?orgId=1&refresh=5s) and do not see any required changes; the renamed metrics aren't used in the dashoard. _However, I am wary other metrics names not caught by unit tests might have changed_