### PR TITLE
AJ-1658: Prefer `CollectionId`

### DIFF
--- a/service/src/integrationTest/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerCloneTest.java
+++ b/service/src/integrationTest/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerCloneTest.java
@@ -22,6 +22,7 @@ import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.databiosphere.workspacedataservice.leonardo.LeonardoDao;
 import org.databiosphere.workspacedataservice.shared.model.CloneResponse;
 import org.databiosphere.workspacedataservice.shared.model.CloneStatus;
+import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.databiosphere.workspacedataservice.shared.model.job.Job;
@@ -116,7 +117,7 @@ class CollectionInitializerCloneTest extends IntegrationServiceTestBase {
 
     // default collection should exist, with no tables in it
     UUID workspaceUuid = workspaceId.id();
-    assertTrue(collectionDao.collectionSchemaExists(workspaceUuid));
+    assertTrue(collectionDao.collectionSchemaExists(CollectionId.of(workspaceUuid)));
     assertThat(recordDao.getAllRecordTypes(workspaceUuid)).isEmpty();
   }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/CollectionDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/CollectionDao.java
@@ -6,7 +6,7 @@ import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 
 public interface CollectionDao {
-  boolean collectionSchemaExists(UUID collectionId);
+  boolean collectionSchemaExists(CollectionId collectionId);
 
   List<UUID> listCollectionSchemas();
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresCollectionDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresCollectionDao.java
@@ -38,11 +38,11 @@ public class PostgresCollectionDao implements CollectionDao {
   }
 
   @Override
-  public boolean collectionSchemaExists(UUID collectionId) {
+  public boolean collectionSchemaExists(CollectionId collectionId) {
     return Boolean.TRUE.equals(
         namedTemplate.queryForObject(
             "select exists(select from sys_wds.collection WHERE id = :collectionId)",
-            new MapSqlParameterSource("collectionId", collectionId),
+            new MapSqlParameterSource("collectionId", collectionId.id()),
             Boolean.class));
   }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/CollectionService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/CollectionService.java
@@ -90,7 +90,7 @@ public class CollectionService {
       throw new AuthorizationException("Caller does not have permission to create collection.");
     }
 
-    if (collectionDao.collectionSchemaExists(collectionId.id())) {
+    if (collectionDao.collectionSchemaExists(collectionId)) {
       throw new ResponseStatusException(HttpStatus.CONFLICT, "This collection already exists");
     }
 
@@ -124,7 +124,7 @@ public class CollectionService {
       return;
     }
     // else, check if this collection has a row in the collections table
-    if (!collectionDao.collectionSchemaExists(collectionId)) {
+    if (!collectionDao.collectionSchemaExists(CollectionId.of(collectionId))) {
       throw new MissingObjectException("Collection");
     }
   }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerBean.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerBean.java
@@ -16,6 +16,7 @@ import org.databiosphere.workspacedataservice.service.model.exception.RestExcept
 import org.databiosphere.workspacedataservice.shared.model.CloneResponse;
 import org.databiosphere.workspacedataservice.shared.model.CloneStatus;
 import org.databiosphere.workspacedataservice.shared.model.CloneTable;
+import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.databiosphere.workspacedataservice.shared.model.job.Job;
 import org.databiosphere.workspacedataservice.shared.model.job.JobInput;
@@ -136,7 +137,8 @@ public class CollectionInitializerBean {
       // If there's a clone entry and no default schema, another replica errored before completing.
       // If there's a clone entry and a default schema there's nothing for us to do here.
       if (cloneDao.cloneExistsForWorkspace(sourceWorkspaceId)) {
-        boolean collectionSchemaExists = collectionDao.collectionSchemaExists(workspaceId.id());
+        boolean collectionSchemaExists =
+            collectionDao.collectionSchemaExists(CollectionId.of(workspaceId.id()));
         LOGGER.info(
             "Previous clone entry found. Collection schema exists: {}.", collectionSchemaExists);
         return collectionSchemaExists;
@@ -286,7 +288,7 @@ public class CollectionInitializerBean {
     try {
       UUID collectionId = workspaceId.id();
 
-      if (!collectionDao.collectionSchemaExists(collectionId)) {
+      if (!collectionDao.collectionSchemaExists(CollectionId.of(workspaceId.id()))) {
         collectionDao.createSchema(collectionId);
         LOGGER.info("Creating default schema id succeeded for workspaceId {}.", workspaceId);
       } else {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/JobControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/JobControllerMockMvcTest.java
@@ -66,7 +66,7 @@ class JobControllerMockMvcTest extends MockMvcTestBase {
     // set created and updated to now, but in UTC because that's how Postgres stores it
     OffsetDateTime time = OffsetDateTime.now(ZoneId.of("Z"));
 
-    when(collectionDao.collectionSchemaExists(collectionId.id())).thenReturn(true);
+    when(collectionDao.collectionSchemaExists(collectionId)).thenReturn(true);
 
     List<GenericJobServerModel> expected = new ArrayList<GenericJobServerModel>(2);
     expected.add(

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/JobControllerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/JobControllerTest.java
@@ -86,7 +86,7 @@ class JobControllerTest extends TestBase {
   @ParameterizedTest(name = "Return all jobs with a querystring of {0}")
   @ValueSource(strings = {"", "?someOtherParam=whatever", "?statuses="})
   void instanceJobsReturnAll(String queryString) {
-    when(collectionDao.collectionSchemaExists(collectionId.id())).thenReturn(true);
+    when(collectionDao.collectionSchemaExists(collectionId)).thenReturn(true);
     HttpHeaders headers = new HttpHeaders();
     ResponseEntity<List<GenericJobServerModel>> result =
         restTemplate.exchange(
@@ -111,7 +111,7 @@ class JobControllerTest extends TestBase {
 
   @Test
   void instanceJobsWithMultipleStatuses() {
-    when(collectionDao.collectionSchemaExists(collectionId.id())).thenReturn(true);
+    when(collectionDao.collectionSchemaExists(collectionId)).thenReturn(true);
     assertDoesNotThrow(() -> jobDao.updateStatus(jobId, StatusEnum.CANCELLED));
     HttpHeaders headers = new HttpHeaders();
     ResponseEntity<List<GenericJobServerModel>> result =
@@ -133,7 +133,7 @@ class JobControllerTest extends TestBase {
 
   @Test
   void instanceJobsWithMultipleDelimitedStatuses() {
-    when(collectionDao.collectionSchemaExists(collectionId.id())).thenReturn(true);
+    when(collectionDao.collectionSchemaExists(collectionId)).thenReturn(true);
     assertDoesNotThrow(() -> jobDao.updateStatus(jobId, StatusEnum.CANCELLED));
     HttpHeaders headers = new HttpHeaders();
     ResponseEntity<List<GenericJobServerModel>> result =
@@ -156,7 +156,7 @@ class JobControllerTest extends TestBase {
   @ParameterizedTest(name = "Return Bad Request with ?statuses={0}")
   @ValueSource(strings = {"xasdaf", "QUEUED,bad,RUNNING"})
   void instanceJobsWithEmpStatuses(String statusValues) {
-    when(collectionDao.collectionSchemaExists(collectionId.id())).thenReturn(true);
+    when(collectionDao.collectionSchemaExists(collectionId)).thenReturn(true);
     HttpHeaders headers = new HttpHeaders();
     ResponseEntity<ErrorResponse> result =
         restTemplate.exchange(

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/MockCollectionDao.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/MockCollectionDao.java
@@ -21,8 +21,8 @@ public class MockCollectionDao implements CollectionDao {
   }
 
   @Override
-  public boolean collectionSchemaExists(UUID collectionId) {
-    return collections.contains(collectionId);
+  public boolean collectionSchemaExists(CollectionId collectionId) {
+    return collections.contains(collectionId.id());
   }
 
   @Override

--- a/service/src/test/java/org/databiosphere/workspacedataservice/datarepo/DataRepoDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/datarepo/DataRepoDaoTest.java
@@ -12,6 +12,7 @@ import java.util.UUID;
 import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.dao.CollectionDao;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
+import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,14 +42,14 @@ class DataRepoDaoTest extends TestBase {
   @BeforeEach
   void setUp() {
     given(mockDataRepoClientFactory.getRepositoryApi()).willReturn(mockRepositoryApi);
-    if (!collectionDao.collectionSchemaExists(COLLECTION)) {
+    if (!collectionDao.collectionSchemaExists(CollectionId.of(COLLECTION))) {
       collectionDao.createSchema(COLLECTION);
     }
   }
 
   @AfterEach
   void tearDown() {
-    if (collectionDao.collectionSchemaExists(COLLECTION)) {
+    if (collectionDao.collectionSchemaExists(CollectionId.of(COLLECTION))) {
       collectionDao.dropSchema(COLLECTION);
     }
   }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/BatchWriteServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/BatchWriteServiceTest.java
@@ -57,7 +57,7 @@ class BatchWriteServiceTest extends TestBase {
 
   @BeforeEach
   void setUp() {
-    if (!collectionDao.collectionSchemaExists(COLLECTION)) {
+    if (!collectionDao.collectionSchemaExists(CollectionId.of(COLLECTION))) {
       collectionDao.createSchema(COLLECTION);
     }
   }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceDataPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceDataPlaneTest.java
@@ -63,7 +63,7 @@ class ImportServiceDataPlaneTest extends TestBase {
   void userHasWritePermission() {
     // ARRANGE
     // collection dao says the collection exists and returns the expected workspace id
-    when(collectionDao.collectionSchemaExists(collectionId.id())).thenReturn(true);
+    when(collectionDao.collectionSchemaExists(collectionId)).thenReturn(true);
     when(collectionDao.getWorkspaceId(collectionId)).thenReturn(workspaceId);
     // sam dao says the user has write permission
     stubWriteWorkspacePermission(workspaceId).thenReturn(true);
@@ -82,7 +82,7 @@ class ImportServiceDataPlaneTest extends TestBase {
   void userHasOnlyReadPermission() {
     // ARRANGE
     // collection dao says the collection exists and returns the expected workspace id
-    when(collectionDao.collectionSchemaExists(collectionId.id())).thenReturn(true);
+    when(collectionDao.collectionSchemaExists(collectionId)).thenReturn(true);
     when(collectionDao.getWorkspaceId(collectionId)).thenReturn(workspaceId);
     // sam dao says the user has read but not write permission
     stubWriteWorkspacePermission(workspaceId).thenReturn(false);
@@ -109,7 +109,7 @@ class ImportServiceDataPlaneTest extends TestBase {
   void userDoesNotHaveAccess() {
     // ARRANGE
     // collection dao says the collection exists and returns the expected workspace id
-    when(collectionDao.collectionSchemaExists(collectionId.id())).thenReturn(true);
+    when(collectionDao.collectionSchemaExists(collectionId)).thenReturn(true);
     when(collectionDao.getWorkspaceId(collectionId)).thenReturn(workspaceId);
     // sam dao says the user does not have read or write permission
     stubWriteWorkspacePermission(workspaceId).thenReturn(false);
@@ -133,7 +133,7 @@ class ImportServiceDataPlaneTest extends TestBase {
   void errorCheckingReadAccess() {
     // ARRANGE
     // collection dao says the collection exists and returns the expected workspace id
-    when(collectionDao.collectionSchemaExists(collectionId.id())).thenReturn(true);
+    when(collectionDao.collectionSchemaExists(collectionId)).thenReturn(true);
     when(collectionDao.getWorkspaceId(collectionId)).thenReturn(workspaceId);
     // sam dao says the user does not have write permission, and fails to check read permission
     stubWriteWorkspacePermission(workspaceId).thenReturn(false);
@@ -163,7 +163,7 @@ class ImportServiceDataPlaneTest extends TestBase {
     // ARRANGE
     WorkspaceId nonMatchingWorkspaceId = WorkspaceId.of(UUID.randomUUID());
     // collection dao says the collection exists and returns an unexpected workspace id
-    when(collectionDao.collectionSchemaExists(collectionId.id())).thenReturn(true);
+    when(collectionDao.collectionSchemaExists(collectionId)).thenReturn(true);
     when(collectionDao.getWorkspaceId(collectionId)).thenReturn(nonMatchingWorkspaceId);
     // sam dao says the user has write permission
     stubWriteWorkspacePermission(nonMatchingWorkspaceId).thenReturn(true);
@@ -182,7 +182,7 @@ class ImportServiceDataPlaneTest extends TestBase {
   void collectionDoesNotExist() {
     // ARRANGE
     // collection dao says the collection does not exist
-    when(collectionDao.collectionSchemaExists(collectionId.id())).thenReturn(false);
+    when(collectionDao.collectionSchemaExists(collectionId)).thenReturn(false);
     when(collectionDao.getWorkspaceId(collectionId))
         .thenThrow(new EmptyResultDataAccessException("unit test intentional error", 1));
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/JobServiceDataPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/JobServiceDataPlaneTest.java
@@ -190,7 +190,7 @@ class JobServiceDataPlaneTest extends JobServiceTestBase {
     // Arrange
     CollectionId collectionId = CollectionId.of(UUID.randomUUID());
     // collection exists and is associated with the $WORKSPACE_ID workspace
-    when(collectionDao.collectionSchemaExists(collectionId.id())).thenReturn(true);
+    when(collectionDao.collectionSchemaExists(collectionId)).thenReturn(true);
     when(collectionDao.getWorkspaceId(collectionId)).thenReturn(getEnvWorkspaceId());
     // user has permission to that workspace
     stubReadWorkspacePermission(getEnvWorkspaceId()).thenReturn(true);
@@ -237,7 +237,7 @@ class JobServiceDataPlaneTest extends JobServiceTestBase {
     CollectionId collectionId = CollectionId.of(UUID.randomUUID());
     WorkspaceId nonMatchingWorkspaceId = WorkspaceId.of(UUID.randomUUID());
     // collection exists and is associated with a non-default workspace
-    when(collectionDao.collectionSchemaExists(collectionId.id())).thenReturn(true);
+    when(collectionDao.collectionSchemaExists(collectionId)).thenReturn(true);
     when(collectionDao.getWorkspaceId(collectionId)).thenReturn(nonMatchingWorkspaceId);
     // user has permission to that workspace
     stubReadWorkspacePermission(nonMatchingWorkspaceId).thenReturn(true);

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorSamTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorSamTest.java
@@ -14,6 +14,7 @@ import org.databiosphere.workspacedataservice.dao.CollectionDao;
 import org.databiosphere.workspacedataservice.sam.SamClientFactory;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthorizationException;
 import org.databiosphere.workspacedataservice.service.model.exception.RestException;
+import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -48,7 +49,7 @@ class RecordOrchestratorSamTest extends TestBase {
 
   @BeforeEach
   void setUp() {
-    if (!collectionDao.collectionSchemaExists(COLLECTION)) {
+    if (!collectionDao.collectionSchemaExists(CollectionId.of(COLLECTION))) {
       collectionDao.createSchema(COLLECTION);
     }
     given(mockSamClientFactory.getResourcesApi()).willReturn(mockResourcesApi);

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
@@ -25,6 +25,7 @@ import org.databiosphere.workspacedataservice.service.model.exception.ConflictEx
 import org.databiosphere.workspacedataservice.service.model.exception.ConflictingPrimaryKeysException;
 import org.databiosphere.workspacedataservice.service.model.exception.MissingObjectException;
 import org.databiosphere.workspacedataservice.service.model.exception.ValidationException;
+import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
 import org.databiosphere.workspacedataservice.shared.model.RecordQueryResponse;
 import org.databiosphere.workspacedataservice.shared.model.RecordRequest;
@@ -62,7 +63,7 @@ class RecordOrchestratorServiceTest extends TestBase {
 
   @BeforeEach
   void setUp() {
-    if (!collectionDao.collectionSchemaExists(COLLECTION)) {
+    if (!collectionDao.collectionSchemaExists(CollectionId.of(COLLECTION))) {
       collectionDao.createSchema(COLLECTION);
     }
   }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerBeanTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerBeanTest.java
@@ -20,6 +20,7 @@ import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.dao.*;
 import org.databiosphere.workspacedataservice.leonardo.LeonardoDao;
 import org.databiosphere.workspacedataservice.service.BackupRestoreService;
+import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.databiosphere.workspacedataservice.sourcewds.WorkspaceDataServiceDao;
 import org.junit.jupiter.api.AfterEach;
@@ -88,7 +89,7 @@ class CollectionInitializerBeanTest extends TestBase {
     // collection does not exist
     assertFalse(collectionDao.collectionSchemaExists(collectionIdMatchingWorkspaceId()));
     // create the collection outside the initializer
-    collectionDao.createSchema(collectionIdMatchingWorkspaceId());
+    collectionDao.createSchema(collectionUuidMatchingWorkspaceId());
     assertTrue(collectionDao.collectionSchemaExists(collectionIdMatchingWorkspaceId()));
     // now run the initializer
     getBean().initializeCollection();
@@ -129,7 +130,7 @@ class CollectionInitializerBeanTest extends TestBase {
   // exists.
   void cloneWithCloneTableAndCollectionExist() {
     // start with collection and clone entry
-    collectionDao.createSchema(collectionIdMatchingWorkspaceId());
+    collectionDao.createSchema(collectionUuidMatchingWorkspaceId());
     cloneDao.createCloneEntry(randomUUID(), sourceWorkspaceId);
     // enter clone mode
     boolean cleanExit = getBean().initCloneMode(sourceWorkspaceId);
@@ -181,7 +182,11 @@ class CollectionInitializerBeanTest extends TestBase {
     assertThat(getCloningSourceWorkspaceId(workspaceId.toString())).isEmpty();
   }
 
-  private UUID collectionIdMatchingWorkspaceId() {
+  private CollectionId collectionIdMatchingWorkspaceId() {
+    return CollectionId.of(workspaceId.id());
+  }
+
+  private UUID collectionUuidMatchingWorkspaceId() {
     return workspaceId.id();
   }
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvBatchTypeDetectionTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvBatchTypeDetectionTest.java
@@ -58,7 +58,7 @@ class TsvBatchTypeDetectionTest extends TestBase {
 
   @BeforeEach
   void setUp() {
-    if (!collectionDao.collectionSchemaExists(COLLECTION)) {
+    if (!collectionDao.collectionSchemaExists(CollectionId.of(COLLECTION))) {
       collectionDao.createSchema(COLLECTION);
     }
   }


### PR DESCRIPTION
Change signature of `CollectionDao#collectionSchemaExists` to use `CollectionId` instead of `UUID`.