### PR TITLE
AJ-1658: Prefer `CollectionId` over `UUID`

### DIFF
--- a/service/src/integrationTest/java/org/databiosphere/workspacedataservice/IntegrationServiceTestBase.java
+++ b/service/src/integrationTest/java/org/databiosphere/workspacedataservice/IntegrationServiceTestBase.java
@@ -22,7 +22,9 @@ public class IntegrationServiceTestBase {
     namedTemplate.getJdbcTemplate().update("delete from sys_wds.restore");
 
     // delete all collections that are currently known to WDS
-    collectionDao.listCollectionSchemas().forEach(collectionDao::dropSchema);
+    collectionDao
+        .listCollectionSchemas()
+        .forEach(collectionId -> collectionDao.dropSchema(collectionId.id()));
 
     // and drop any orphaned Postgres schemas
     dropOrphanedSchemas(namedTemplate);

--- a/service/src/integrationTest/java/org/databiosphere/workspacedataservice/service/RestoreServiceIntegrationTest.java
+++ b/service/src/integrationTest/java/org/databiosphere/workspacedataservice/service/RestoreServiceIntegrationTest.java
@@ -10,6 +10,7 @@ import org.databiosphere.workspacedataservice.IntegrationServiceTestBase;
 import org.databiosphere.workspacedataservice.annotations.SingleTenant;
 import org.databiosphere.workspacedataservice.dao.CollectionDao;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
+import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.databiosphere.workspacedataservice.shared.model.job.JobStatus;
@@ -56,11 +57,11 @@ class RestoreServiceIntegrationTest extends IntegrationServiceTestBase {
   // this test references the file src/integrationTest/resources/backup-test.sql as its backup
   @Test
   void testRestoreAzureWDS() {
-    UUID destCollection = workspaceId.id();
+    CollectionId destCollection = CollectionId.of(workspaceId.id());
 
     // confirm neither source nor destination collection should exist in our list of schemas to
     // start
-    List<UUID> collectionsBefore = collectionDao.listCollectionSchemas();
+    List<CollectionId> collectionsBefore = collectionDao.listCollectionSchemas();
     assertThat(collectionsBefore).isEmpty();
 
     // perform the restore
@@ -70,14 +71,14 @@ class RestoreServiceIntegrationTest extends IntegrationServiceTestBase {
 
     // After restore, we should have one collection, the destination collection.
     // The source collection should not exist in the db.
-    List<UUID> expectedCollections = List.of(destCollection);
-    List<UUID> actualCollections = collectionDao.listCollectionSchemas();
+    List<CollectionId> expectedCollections = List.of(destCollection);
+    List<CollectionId> actualCollections = collectionDao.listCollectionSchemas();
     assertEquals(expectedCollections, actualCollections);
 
     // after restore, destination collection should have one table named "thing"
     // this matches the contents of WDS-integrationTest-LocalFileStorage-input.sql
     List<RecordType> expectedTables = List.of(RecordType.valueOf("thing"));
-    List<RecordType> actualTables = recordDao.getAllRecordTypes(destCollection);
+    List<RecordType> actualTables = recordDao.getAllRecordTypes(destCollection.id());
     assertEquals(expectedTables, actualTables);
   }
 }

--- a/service/src/integrationTest/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerCloneTest.java
+++ b/service/src/integrationTest/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerCloneTest.java
@@ -157,8 +157,8 @@ class CollectionInitializerCloneTest extends IntegrationServiceTestBase {
     // default collection should exist, with a single table named "thing" in it
     // the "thing" table is defined in WDS-integrationTest-LocalFileStorage-input.sql.
     UUID workspaceUuid = workspaceId.id();
-    List<UUID> actualCollections = collectionDao.listCollectionSchemas();
-    assertEquals(List.of(workspaceUuid), actualCollections);
+    List<CollectionId> actualCollections = collectionDao.listCollectionSchemas();
+    assertEquals(List.of(CollectionId.of(workspaceUuid)), actualCollections);
     List<RecordType> actualTypes = recordDao.getAllRecordTypes(workspaceUuid);
     assertEquals(List.of(RecordType.valueOf("thing")), actualTypes);
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/CollectionDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/CollectionDao.java
@@ -8,7 +8,7 @@ import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 public interface CollectionDao {
   boolean collectionSchemaExists(CollectionId collectionId);
 
-  List<UUID> listCollectionSchemas();
+  List<CollectionId> listCollectionSchemas();
 
   void createSchema(UUID collectionId);
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresCollectionDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresCollectionDao.java
@@ -47,10 +47,13 @@ public class PostgresCollectionDao implements CollectionDao {
   }
 
   @Override
-  public List<UUID> listCollectionSchemas() {
+  public List<CollectionId> listCollectionSchemas() {
     return namedTemplate
         .getJdbcTemplate()
-        .queryForList("select id from sys_wds.collection order by id", UUID.class);
+        .queryForList("select id from sys_wds.collection order by id", UUID.class)
+        .stream()
+        .map(CollectionId::of)
+        .toList();
   }
 
   @Override

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/BackupRestoreService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/BackupRestoreService.java
@@ -21,6 +21,7 @@ import org.databiosphere.workspacedataservice.service.model.exception.MissingObj
 import org.databiosphere.workspacedataservice.shared.model.BackupResponse;
 import org.databiosphere.workspacedataservice.shared.model.BackupRestoreRequest;
 import org.databiosphere.workspacedataservice.shared.model.CloneResponse;
+import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.databiosphere.workspacedataservice.shared.model.RestoreResponse;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.databiosphere.workspacedataservice.shared.model.job.Job;
@@ -255,7 +256,7 @@ public class BackupRestoreService {
       command.put(pgDumpPath, null);
       command.put("-b", null);
       // Grab all workspace collections/schemas in wds
-      for (UUID id : collectionDao.listCollectionSchemas()) {
+      for (CollectionId id : collectionDao.listCollectionSchemas()) {
         command.put("-n", id.toString());
       }
     } else {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/CollectionService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/CollectionService.java
@@ -53,7 +53,7 @@ public class CollectionService {
 
   public List<UUID> listCollections(String version) {
     validateVersion(version);
-    return collectionDao.listCollectionSchemas();
+    return collectionDao.listCollectionSchemas().stream().map(CollectionId::id).toList();
   }
 
   /**

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/MockCollectionDao.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/MockCollectionDao.java
@@ -26,8 +26,8 @@ public class MockCollectionDao implements CollectionDao {
   }
 
   @Override
-  public List<UUID> listCollectionSchemas() {
-    return collections.stream().toList();
+  public List<CollectionId> listCollectionSchemas() {
+    return collections.stream().map(CollectionId::of).toList();
   }
 
   @Override

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/PostgresCollectionDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/PostgresCollectionDaoTest.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.annotations.SingleTenant;
 import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,16 +32,16 @@ class PostgresCollectionDaoTest extends TestBase {
   // clean up all collections before each test to ensure tests start from a clean slate
   @BeforeEach
   void beforeEach() {
-    List<UUID> allCollections = collectionDao.listCollectionSchemas();
-    allCollections.forEach(collectionId -> collectionDao.dropSchema(collectionId));
+    List<CollectionId> allCollections = collectionDao.listCollectionSchemas();
+    allCollections.forEach(collectionId -> collectionDao.dropSchema(collectionId.id()));
   }
 
   // clean up all collections after all tests to ensure tests in other files start from a clean
   // slate
   @AfterAll
   void afterAll() {
-    List<UUID> allCollections = collectionDao.listCollectionSchemas();
-    allCollections.forEach(collectionId -> collectionDao.dropSchema(collectionId));
+    List<CollectionId> allCollections = collectionDao.listCollectionSchemas();
+    allCollections.forEach(collectionId -> collectionDao.dropSchema(collectionId.id()));
   }
 
   // is this test set up correctly?
@@ -57,9 +58,7 @@ class PostgresCollectionDaoTest extends TestBase {
   // do we populate all db columns correctly?
   @Test
   void insertPopulatesAllColumns() {
-
-    List<UUID> allCollections = collectionDao.listCollectionSchemas();
-    assertEquals(0, allCollections.size());
+    assertEquals(0, collectionDao.listCollectionSchemas().size());
 
     UUID collectionId = UUID.randomUUID();
     collectionDao.createSchema(collectionId);
@@ -79,9 +78,7 @@ class PostgresCollectionDaoTest extends TestBase {
   // do we populate all db columns correctly?
   @Test
   void defaultPopulatesAllColumns() {
-
-    List<UUID> allCollections = collectionDao.listCollectionSchemas();
-    assertEquals(0, allCollections.size());
+    assertEquals(0, collectionDao.listCollectionSchemas().size());
 
     UUID collectionId = workspaceId.id();
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceSamExceptionTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceSamExceptionTest.java
@@ -19,6 +19,7 @@ import org.databiosphere.workspacedataservice.sam.SamClientFactory;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthenticationException;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthorizationException;
 import org.databiosphere.workspacedataservice.service.model.exception.RestException;
+import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -81,8 +82,8 @@ class CollectionServiceSamExceptionTest extends TestBase {
   @AfterEach
   void tearDown() {
     // clean up any collections left in the db
-    List<UUID> allCollections = collectionDao.listCollectionSchemas();
-    allCollections.forEach(collectionId -> collectionDao.dropSchema(collectionId));
+    List<CollectionId> allCollections = collectionDao.listCollectionSchemas();
+    allCollections.forEach(collectionId -> collectionDao.dropSchema(collectionId.id()));
   }
 
   @DisplayName(

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceTest.java
@@ -33,7 +33,7 @@ class CollectionServiceTest extends TestBase {
     // Delete all collections
     collectionDao
         .listCollectionSchemas()
-        .forEach(collection -> collectionDao.dropSchema(collection));
+        .forEach(collection -> collectionDao.dropSchema(collection.id()));
   }
 
   @Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerBeanTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerBeanTest.java
@@ -72,8 +72,8 @@ class CollectionInitializerBeanTest extends TestBase {
   @AfterEach
   void tearDown() {
     // clean up any collections left in the db
-    List<UUID> allCollections = collectionDao.listCollectionSchemas();
-    allCollections.forEach(collectionId -> collectionDao.dropSchema(collectionId));
+    List<CollectionId> allCollections = collectionDao.listCollectionSchemas();
+    allCollections.forEach(collectionId -> collectionDao.dropSchema(collectionId.id()));
   }
 
   @Test


### PR DESCRIPTION
Change signature of CollectionDao#listCollectionSchemas to return `List<CollectionId>` instead of `List<UUID>`.