### PR TITLE
AJ-1658 Prefer `CollectionId` over `UUID`

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/CollectionDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/CollectionDao.java
@@ -10,7 +10,7 @@ public interface CollectionDao {
 
   List<CollectionId> listCollectionSchemas();
 
-  void createSchema(UUID collectionId);
+  void createSchema(CollectionId collectionId);
 
   void dropSchema(UUID collectionId);
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresCollectionDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresCollectionDao.java
@@ -59,9 +59,9 @@ public class PostgresCollectionDao implements CollectionDao {
   @Override
   @WriteTransaction
   @SuppressWarnings("squid:S2077") // since collectionId must be a UUID, it is safe to use inline
-  public void createSchema(UUID collectionId) {
+  public void createSchema(CollectionId collectionId) {
     // insert to collection table
-    insertCollectionRow(collectionId, /* ignoreConflict= */ false);
+    insertCollectionRow(collectionId.id(), /* ignoreConflict= */ false);
     // create the postgres schema
     namedTemplate.getJdbcTemplate().update("create schema " + quote(collectionId.toString()));
   }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/CollectionService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/CollectionService.java
@@ -94,9 +94,10 @@ public class CollectionService {
       throw new ResponseStatusException(HttpStatus.CONFLICT, "This collection already exists");
     }
 
+    // TODO(AJ-1662): this needs to pass the workspaceId argument so the collection is created
+    //   correctly
     // create collection schema in Postgres
-    // TODO: this needs to pass the workspaceId argument so the collection is created correctly
-    collectionDao.createSchema(collectionId.id());
+    collectionDao.createSchema(collectionId);
 
     activityLogger.saveEventForCurrentUser(
         user -> user.created().collection().withUuid(collectionId.id()));

--- a/service/src/main/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerBean.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerBean.java
@@ -286,9 +286,9 @@ public class CollectionInitializerBean {
   */
   private void initializeDefaultCollection() {
     try {
-      UUID collectionId = workspaceId.id();
+      CollectionId collectionId = CollectionId.of(workspaceId.id());
 
-      if (!collectionDao.collectionSchemaExists(CollectionId.of(workspaceId.id()))) {
+      if (!collectionDao.collectionSchemaExists(collectionId)) {
         collectionDao.createSchema(collectionId);
         LOGGER.info("Creating default schema id succeeded for workspaceId {}.", workspaceId);
       } else {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/ImportControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/ImportControllerMockMvcTest.java
@@ -1,14 +1,15 @@
 package org.databiosphere.workspacedataservice.controller;
 
+import static java.util.UUID.randomUUID;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.net.URI;
-import java.util.UUID;
 import org.databiosphere.workspacedataservice.dao.CollectionDao;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
 import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
+import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
@@ -24,8 +25,8 @@ class ImportControllerMockMvcTest extends MockMvcTestBase {
 
   @Test
   void smokeTestCreateImport() throws Exception {
-    UUID instanceId = UUID.randomUUID();
-    collectionDao.createSchema(instanceId);
+    CollectionId collectionId = CollectionId.of(randomUUID());
+    collectionDao.createSchema(collectionId);
     ImportRequestServerModel importRequest =
         new ImportRequestServerModel(
             ImportRequestServerModel.TypeEnum.PFB,
@@ -35,7 +36,7 @@ class ImportControllerMockMvcTest extends MockMvcTestBase {
     MvcResult mvcResult =
         mockMvc
             .perform(
-                post("/{instanceUuid}/import/v1", instanceId)
+                post("/{instanceUuid}/import/v1", collectionId)
                     .content(toJson(importRequest))
                     .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isAccepted())

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerSearchFilterTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerSearchFilterTest.java
@@ -1,5 +1,6 @@
 package org.databiosphere.workspacedataservice.controller;
 
+import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -12,6 +13,7 @@ import java.util.UUID;
 import org.databiosphere.workspacedataservice.dao.CollectionDao;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.databiosphere.workspacedataservice.service.RecordOrchestratorService;
+import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
 import org.databiosphere.workspacedataservice.shared.model.RecordQueryResponse;
 import org.databiosphere.workspacedataservice.shared.model.RecordRequest;
@@ -30,7 +32,8 @@ import org.springframework.test.web.servlet.MvcResult;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class RecordControllerSearchFilterTest extends MockMvcTestBase {
 
-  private final UUID COLLECTION_ID = UUID.randomUUID();
+  private static final UUID COLLECTION_UUID = randomUUID();
+  private static final CollectionId COLLECTION_ID = CollectionId.of(COLLECTION_UUID);
 
   private static final String VERSION = "v0.2";
   private static final RecordType RECTYPE = RecordType.valueOf("mytype");
@@ -53,7 +56,7 @@ class RecordControllerSearchFilterTest extends MockMvcTestBase {
       String leadingZeroes = String.format("%03d", i);
 
       recordOrchestratorService.upsertSingleRecord(
-          COLLECTION_ID,
+          COLLECTION_UUID,
           VERSION,
           RECTYPE,
           leadingZeroes,
@@ -64,7 +67,7 @@ class RecordControllerSearchFilterTest extends MockMvcTestBase {
 
   @AfterAll
   void deleteAllInstances() {
-    collectionDao.dropSchema(COLLECTION_ID);
+    collectionDao.dropSchema(COLLECTION_UUID);
   }
 
   @Test
@@ -194,7 +197,7 @@ class RecordControllerSearchFilterTest extends MockMvcTestBase {
               .perform(
                   post(
                           "/{instanceId}/search/{version}/{recordType}",
-                          COLLECTION_ID,
+                          COLLECTION_UUID,
                           VERSION,
                           RECTYPE)
                       .contentType(MediaType.APPLICATION_JSON)

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/MockCollectionDao.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/MockCollectionDao.java
@@ -31,8 +31,8 @@ public class MockCollectionDao implements CollectionDao {
   }
 
   @Override
-  public void createSchema(UUID collectionId) {
-    if (collections.contains(collectionId)) {
+  public void createSchema(CollectionId collectionId) {
+    if (collections.contains(collectionId.id())) {
       ServerErrorMessage sqlMsg =
           new ServerErrorMessage(
               "ERROR: schema \"" + collectionId.toString() + "\" already exists");
@@ -40,7 +40,7 @@ public class MockCollectionDao implements CollectionDao {
       String sql = "create schema \"" + collectionId + "\"";
       throw new org.springframework.jdbc.BadSqlGrammarException("StatementCallback", sql, ex);
     }
-    collections.add(collectionId);
+    collections.add(collectionId.id());
   }
 
   @Override

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/PostgresCollectionDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/PostgresCollectionDaoTest.java
@@ -1,5 +1,6 @@
 package org.databiosphere.workspacedataservice.dao;
 
+import static java.util.UUID.randomUUID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
@@ -60,15 +61,17 @@ class PostgresCollectionDaoTest extends TestBase {
   void insertPopulatesAllColumns() {
     assertEquals(0, collectionDao.listCollectionSchemas().size());
 
-    UUID collectionId = UUID.randomUUID();
+    CollectionId collectionId = CollectionId.of(randomUUID());
+    UUID collectionUuid = collectionId.id();
+
     collectionDao.createSchema(collectionId);
 
     Map<String, Object> rowMap =
         namedParameterJdbcTemplate.queryForMap(
             "select id, workspace_id, name, description from sys_wds.collection where id = :id",
-            new MapSqlParameterSource("id", collectionId));
+            new MapSqlParameterSource("id", collectionUuid));
 
-    assertEquals(collectionId, rowMap.get("id"));
+    assertEquals(collectionUuid, rowMap.get("id"));
     assertEquals(workspaceId.id(), rowMap.get("workspace_id"));
     assertEquals(collectionId.toString(), rowMap.get("name"));
     assertEquals(collectionId.toString(), rowMap.get("description"));
@@ -80,16 +83,17 @@ class PostgresCollectionDaoTest extends TestBase {
   void defaultPopulatesAllColumns() {
     assertEquals(0, collectionDao.listCollectionSchemas().size());
 
-    UUID collectionId = workspaceId.id();
+    UUID collectionUuid = workspaceId.id();
+    CollectionId collectionId = CollectionId.of(collectionUuid);
 
     collectionDao.createSchema(collectionId);
 
     Map<String, Object> rowMap =
         namedParameterJdbcTemplate.queryForMap(
             "select id, workspace_id, name, description from sys_wds.collection where id = :id",
-            new MapSqlParameterSource("id", collectionId));
+            new MapSqlParameterSource("id", collectionUuid));
 
-    assertEquals(collectionId, rowMap.get("id"));
+    assertEquals(collectionUuid, rowMap.get("id"));
     assertEquals(workspaceId.id(), rowMap.get("workspace_id"));
     assertEquals("default", rowMap.get("name"));
     assertEquals("default", rowMap.get("description"));

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
@@ -1,6 +1,7 @@
 package org.databiosphere.workspacedataservice.dao;
 
 import static java.util.Collections.emptyMap;
+import static java.util.UUID.randomUUID;
 import static org.databiosphere.workspacedataservice.service.model.DataTypeMapping.*;
 import static org.databiosphere.workspacedataservice.service.model.DataTypeMapping.ARRAY_OF_NUMBER;
 import static org.databiosphere.workspacedataservice.service.model.DataTypeMapping.ARRAY_OF_STRING;
@@ -54,7 +55,7 @@ class RecordDaoTest extends TestBase {
 
   @Autowired CollectionDao collectionDao;
 
-  UUID collectionId;
+  UUID collectionUuid;
   RecordType recordType;
 
   @Autowired TestDao testDao;
@@ -69,17 +70,18 @@ class RecordDaoTest extends TestBase {
 
   @BeforeEach
   void setUp() {
-    collectionId = UUID.randomUUID();
+    CollectionId collectionId = CollectionId.of(randomUUID());
+    collectionUuid = collectionId.id();
     recordType = RecordType.valueOf("testRecordType");
 
     collectionDao.createSchema(collectionId);
     recordDao.createRecordType(
-        collectionId, emptyMap(), recordType, RelationCollection.empty(), PRIMARY_KEY);
+        collectionUuid, emptyMap(), recordType, RelationCollection.empty(), PRIMARY_KEY);
   }
 
   @AfterEach
   void tearDown() {
-    collectionDao.dropSchema(collectionId);
+    collectionDao.dropSchema(collectionUuid);
   }
 
   /**
@@ -96,7 +98,7 @@ class RecordDaoTest extends TestBase {
 
     // generate some new UUIDs
     List<CollectionId> someCollectionsToCreate =
-        IntStream.range(0, 5).mapToObj(i -> CollectionId.of(UUID.randomUUID())).toList();
+        IntStream.range(0, 5).mapToObj(i -> CollectionId.of(randomUUID())).toList();
 
     // check that the new UUIDs do not exist in our collections list yet.
     someCollectionsToCreate.forEach(
@@ -106,7 +108,7 @@ class RecordDaoTest extends TestBase {
                 "initial schema list should not contain brand new UUIDs"));
 
     // create the collections
-    someCollectionsToCreate.forEach(collectionId -> collectionDao.createSchema(collectionId.id()));
+    someCollectionsToCreate.forEach(collectionId -> collectionDao.createSchema(collectionId));
 
     // get the list of collections again
     List<CollectionId> actualSchemasAfterCreation = collectionDao.listCollectionSchemas();
@@ -154,14 +156,14 @@ class RecordDaoTest extends TestBase {
     String recordId = "testRecord";
     Record testRecord = new Record(recordId, recordType, RecordAttributes.empty());
     recordDao.batchUpsert(
-        collectionId, recordType, Collections.singletonList(testRecord), emptyMap());
+        collectionUuid, recordType, Collections.singletonList(testRecord), emptyMap());
 
     // make sure record is fetched
-    Record search = recordDao.getSingleRecord(collectionId, recordType, recordId).get();
+    Record search = recordDao.getSingleRecord(collectionUuid, recordType, recordId).get();
     assertEquals(testRecord, search);
 
     // nonexistent record should be null
-    Optional<Record> none = recordDao.getSingleRecord(collectionId, recordType, "noRecord");
+    Optional<Record> none = recordDao.getSingleRecord(collectionUuid, recordType, "noRecord");
     assertEquals(none, Optional.empty());
   }
 
@@ -179,20 +181,20 @@ class RecordDaoTest extends TestBase {
                 .putAttribute("Foo", "Foo"));
 
     recordDao.createRecordType(
-        collectionId,
+        collectionUuid,
         Map.of("FOO", STRING, "foo", STRING, "Foo", STRING),
         recordType,
         RelationCollection.empty(),
         "id");
     recordDao.batchUpsert(
-        collectionId,
+        collectionUuid,
         recordType,
         Collections.singletonList(upsertedRecord),
         Map.of("FOO", STRING, "foo", STRING, "Foo", STRING));
 
     // Act
     List<Record> queryRes =
-        recordDao.queryForRecords(recordType, 10, 0, "ASC", null, Optional.empty(), collectionId);
+        recordDao.queryForRecords(recordType, 10, 0, "ASC", null, Optional.empty(), collectionUuid);
 
     // Assert
     Record returnedRecord = queryRes.get(0);
@@ -208,15 +210,15 @@ class RecordDaoTest extends TestBase {
     String recordId = "1199";
     Record testRecord = new Record(recordId, funkyPk, RecordAttributes.empty());
     recordDao.createRecordType(
-        collectionId, Map.of("attr1", STRING), funkyPk, RelationCollection.empty(), sample_id);
+        collectionUuid, Map.of("attr1", STRING), funkyPk, RelationCollection.empty(), sample_id);
     recordDao.batchUpsert(
-        collectionId, funkyPk, Collections.singletonList(testRecord), emptyMap(), sample_id);
+        collectionUuid, funkyPk, Collections.singletonList(testRecord), emptyMap(), sample_id);
     List<Record> queryRes =
-        recordDao.queryForRecords(funkyPk, 10, 0, "ASC", null, Optional.empty(), collectionId);
+        recordDao.queryForRecords(funkyPk, 10, 0, "ASC", null, Optional.empty(), collectionUuid);
     assertEquals(1, queryRes.size());
-    assertTrue(recordDao.recordExists(collectionId, funkyPk, recordId));
-    assertTrue(recordDao.getSingleRecord(collectionId, funkyPk, recordId).isPresent());
-    assertTrue(recordDao.deleteSingleRecord(collectionId, funkyPk, recordId));
+    assertTrue(recordDao.recordExists(collectionUuid, funkyPk, recordId));
+    assertTrue(recordDao.getSingleRecord(collectionUuid, funkyPk, recordId).isPresent());
+    assertTrue(recordDao.deleteSingleRecord(collectionUuid, funkyPk, recordId));
   }
 
   @Test
@@ -227,12 +229,12 @@ class RecordDaoTest extends TestBase {
     Record testRecord = new Record(recordId, referencedRt, RecordAttributes.empty());
     Map<String, DataTypeMapping> schema = Map.of("attr1", RELATION);
     recordDao.createRecordType(
-        collectionId, schema, referencedRt, RelationCollection.empty(), sample_id);
+        collectionUuid, schema, referencedRt, RelationCollection.empty(), sample_id);
     recordDao.batchUpsert(
-        collectionId, referencedRt, Collections.singletonList(testRecord), emptyMap(), sample_id);
+        collectionUuid, referencedRt, Collections.singletonList(testRecord), emptyMap(), sample_id);
     RecordType referencer = RecordType.valueOf("referencer");
     recordDao.createRecordType(
-        collectionId,
+        collectionUuid,
         schema,
         referencer,
         new RelationCollection(
@@ -245,10 +247,10 @@ class RecordDaoTest extends TestBase {
             RecordAttributes.empty()
                 .putAttribute("attr1", RelationUtils.createRelationString(referencedRt, recordId)));
     recordDao.batchUpsert(
-        collectionId, referencer, Collections.singletonList(referencerRecord), schema, sample_id);
-    recordDao.batchDelete(collectionId, referencer, Collections.singletonList(referencerRecord));
-    recordDao.batchDelete(collectionId, referencedRt, Collections.singletonList(testRecord));
-    assertTrue(recordDao.getSingleRecord(collectionId, referencer, recordId).isEmpty());
+        collectionUuid, referencer, Collections.singletonList(referencerRecord), schema, sample_id);
+    recordDao.batchDelete(collectionUuid, referencer, Collections.singletonList(referencerRecord));
+    recordDao.batchDelete(collectionUuid, referencedRt, Collections.singletonList(testRecord));
+    assertTrue(recordDao.getSingleRecord(collectionUuid, referencer, recordId).isEmpty());
   }
 
   @Test
@@ -261,15 +263,15 @@ class RecordDaoTest extends TestBase {
             .map(i -> new Record("id" + i, referencedRt, RecordAttributes.empty()))
             .collect(Collectors.toList());
     recordDao.createRecordType(
-        collectionId, emptyMap(), referencedRt, RelationCollection.empty(), RECORD_ID);
-    recordDao.batchUpsert(collectionId, referencedRt, referencedRecords, emptyMap());
+        collectionUuid, emptyMap(), referencedRt, RelationCollection.empty(), RECORD_ID);
+    recordDao.batchUpsert(collectionUuid, referencedRt, referencedRecords, emptyMap());
 
     // Create records to do the referencing
     Map<String, DataTypeMapping> schema = Map.of("attr1", ARRAY_OF_RELATION);
     RecordType referencer = RecordType.valueOf("referencer");
     Relation arrayRel = new Relation("attr1", referencedRt);
     recordDao.createRecordType(
-        collectionId,
+        collectionUuid,
         schema,
         referencer,
         new RelationCollection(Collections.emptySet(), Collections.singleton(arrayRel)),
@@ -290,23 +292,23 @@ class RecordDaoTest extends TestBase {
                         RecordAttributes.empty().putAttribute("attr1", relArr)))
             .collect(Collectors.toList());
 
-    recordDao.batchUpsert(collectionId, referencer, referencingRecords, schema, RECORD_ID);
+    recordDao.batchUpsert(collectionUuid, referencer, referencingRecords, schema, RECORD_ID);
     // Normally insert into join is called from the service level, so when working directly with the
     // dao must call it manually
     for (Record rec : referencingRecords) {
       recordDao.insertIntoJoin(
-          collectionId,
+          collectionUuid,
           arrayRel,
           referencer,
           referencedRecords.stream().map(rel -> new RelationValue(rec, rel)).toList());
     }
 
     // Delete
-    recordDao.batchDelete(collectionId, referencer, referencingRecords);
+    recordDao.batchDelete(collectionUuid, referencer, referencingRecords);
     for (Record rec : referencingRecords) {
-      assertTrue(recordDao.getSingleRecord(collectionId, referencer, rec.getId()).isEmpty());
+      assertTrue(recordDao.getSingleRecord(collectionUuid, referencer, rec.getId()).isEmpty());
       assertTrue(
-          testDao.getRelationArrayValues(collectionId, "attr1", rec, referencedRt).isEmpty());
+          testDao.getRelationArrayValues(collectionUuid, "attr1", rec, referencedRt).isEmpty());
     }
   }
 
@@ -315,9 +317,9 @@ class RecordDaoTest extends TestBase {
   void testGetRecordsWithRelations() {
     // Create two records of the same type, one with a value for a relation
     // attribute, the other without
-    recordDao.addColumn(collectionId, recordType, "foo", STRING);
-    recordDao.addColumn(collectionId, recordType, "relationAttr", RELATION);
-    recordDao.addForeignKeyForReference(recordType, recordType, collectionId, "relationAttr");
+    recordDao.addColumn(collectionUuid, recordType, "foo", STRING);
+    recordDao.addColumn(collectionUuid, recordType, "relationAttr", RELATION);
+    recordDao.addForeignKeyForReference(recordType, recordType, collectionUuid, "relationAttr");
 
     String refRecordId = "referencedRecord";
     Record referencedRecord =
@@ -331,23 +333,24 @@ class RecordDaoTest extends TestBase {
         new Record(recordId, recordType, new RecordAttributes(Map.of("relationAttr", reference)));
 
     recordDao.batchUpsert(
-        collectionId, recordType, Collections.singletonList(referencedRecord), emptyMap());
+        collectionUuid, recordType, Collections.singletonList(referencedRecord), emptyMap());
     recordDao.batchUpsert(
-        collectionId,
+        collectionUuid,
         recordType,
         List.of(referencedRecord, testRecord),
         Map.of("foo", STRING, "relationAttr", RELATION));
 
-    List<Relation> relations = recordDao.getRelationCols(collectionId, recordType);
+    List<Relation> relations = recordDao.getRelationCols(collectionUuid, recordType);
 
-    Record testRecordFetched = recordDao.getSingleRecord(collectionId, recordType, recordId).get();
+    Record testRecordFetched =
+        recordDao.getSingleRecord(collectionUuid, recordType, recordId).get();
     // Relation attribute should be in the form of "terra-wds:/recordType/recordId"
     assertEquals(
         RelationUtils.createRelationString(recordType, refRecordId),
         testRecordFetched.getAttributeValue("relationAttr").toString());
 
     Record referencedRecordFetched =
-        recordDao.getSingleRecord(collectionId, recordType, refRecordId).get();
+        recordDao.getSingleRecord(collectionUuid, recordType, refRecordId).get();
     // Null relation attribute should be null
     assertNull(referencedRecordFetched.getAttributeValue("relationAttr"));
   }
@@ -355,15 +358,15 @@ class RecordDaoTest extends TestBase {
   @Test
   @Transactional
   void testCreateSingleRecord() throws InvalidRelationException {
-    recordDao.addColumn(collectionId, recordType, "foo", STRING);
+    recordDao.addColumn(collectionUuid, recordType, "foo", STRING);
 
     // create record with no attributes
     String recordId = "testRecord";
     Record testRecord = new Record(recordId, recordType, RecordAttributes.empty());
     recordDao.batchUpsert(
-        collectionId, recordType, Collections.singletonList(testRecord), emptyMap());
+        collectionUuid, recordType, Collections.singletonList(testRecord), emptyMap());
 
-    Record search = recordDao.getSingleRecord(collectionId, recordType, recordId).get();
+    Record search = recordDao.getSingleRecord(collectionUuid, recordType, recordId).get();
     assertEquals(testRecord, search, "Created record should match entered record");
 
     // create record with attributes
@@ -371,9 +374,12 @@ class RecordDaoTest extends TestBase {
     Record recordWithAttr =
         new Record(attrId, recordType, new RecordAttributes(Map.of("foo", "bar")));
     recordDao.batchUpsert(
-        collectionId, recordType, Collections.singletonList(recordWithAttr), Map.of("foo", STRING));
+        collectionUuid,
+        recordType,
+        Collections.singletonList(recordWithAttr),
+        Map.of("foo", STRING));
 
-    search = recordDao.getSingleRecord(collectionId, recordType, attrId).get();
+    search = recordDao.getSingleRecord(collectionUuid, recordType, attrId).get();
     assertEquals(
         recordWithAttr, search, "Created record with attributes should match entered record");
   }
@@ -383,16 +389,16 @@ class RecordDaoTest extends TestBase {
   void testCreateRecordWithRelations() {
     // make sure columns are in recordType, as this will be taken care of before we
     // get to the dao
-    recordDao.addColumn(collectionId, recordType, "foo", STRING);
+    recordDao.addColumn(collectionUuid, recordType, "foo", STRING);
 
-    recordDao.addColumn(collectionId, recordType, "testRecordType", RELATION);
-    recordDao.addForeignKeyForReference(recordType, recordType, collectionId, "testRecordType");
+    recordDao.addColumn(collectionUuid, recordType, "testRecordType", RELATION);
+    recordDao.addForeignKeyForReference(recordType, recordType, collectionUuid, "testRecordType");
 
     String refRecordId = "referencedRecord";
     Record referencedRecord =
         new Record(refRecordId, recordType, new RecordAttributes(Map.of("foo", "bar")));
     recordDao.batchUpsert(
-        collectionId, recordType, Collections.singletonList(referencedRecord), emptyMap());
+        collectionUuid, recordType, Collections.singletonList(referencedRecord), emptyMap());
 
     String recordId = "testRecord";
     String reference =
@@ -401,22 +407,22 @@ class RecordDaoTest extends TestBase {
     Record testRecord =
         new Record(recordId, recordType, new RecordAttributes(Map.of("testRecordType", reference)));
     recordDao.batchUpsert(
-        collectionId,
+        collectionUuid,
         recordType,
         Collections.singletonList(testRecord),
         Map.of("foo", STRING, "testRecordType", RELATION));
 
-    Record search = recordDao.getSingleRecord(collectionId, recordType, recordId).get();
+    Record search = recordDao.getSingleRecord(collectionUuid, recordType, recordId).get();
     assertEquals(testRecord, search, "Created record with references should match entered record");
   }
 
   @Test
   @Transactional
   void testGetReferenceCols() {
-    recordDao.addColumn(collectionId, recordType, "referenceCol", STRING);
-    recordDao.addForeignKeyForReference(recordType, recordType, collectionId, "referenceCol");
+    recordDao.addColumn(collectionUuid, recordType, "referenceCol", STRING);
+    recordDao.addForeignKeyForReference(recordType, recordType, collectionUuid, "referenceCol");
 
-    List<Relation> refCols = recordDao.getRelationCols(collectionId, recordType);
+    List<Relation> refCols = recordDao.getRelationCols(collectionUuid, recordType);
     assertEquals(1, refCols.size(), "There should be one referenced column");
     assertEquals(
         "referenceCol",
@@ -431,12 +437,12 @@ class RecordDaoTest extends TestBase {
     String recordId = "testRecord";
     Record testRecord = new Record(recordId, recordType, RecordAttributes.empty());
     recordDao.batchUpsert(
-        collectionId, recordType, Collections.singletonList(testRecord), emptyMap());
+        collectionUuid, recordType, Collections.singletonList(testRecord), emptyMap());
 
-    recordDao.deleteSingleRecord(collectionId, recordType, "testRecord");
+    recordDao.deleteSingleRecord(collectionUuid, recordType, "testRecord");
 
     // make sure record not fetched
-    Optional<Record> none = recordDao.getSingleRecord(collectionId, recordType, "testRecord");
+    Optional<Record> none = recordDao.getSingleRecord(collectionUuid, recordType, "testRecord");
     assertEquals(Optional.empty(), none, "Deleted record should not be found");
   }
 
@@ -444,16 +450,20 @@ class RecordDaoTest extends TestBase {
   void testDeleteRelatedRecord() {
     // make sure columns are in recordType, as this will be taken care of before we
     // get to the dao
-    recordDao.addColumn(collectionId, recordType, "foo", STRING);
+    recordDao.addColumn(collectionUuid, recordType, "foo", STRING);
 
     recordDao.addColumn(
-        collectionId, recordType, "testRecordType", RELATION, RecordType.valueOf("testRecordType"));
+        collectionUuid,
+        recordType,
+        "testRecordType",
+        RELATION,
+        RecordType.valueOf("testRecordType"));
 
     String refRecordId = "referencedRecord";
     Record referencedRecord =
         new Record(refRecordId, recordType, new RecordAttributes(Map.of("foo", "bar")));
     recordDao.batchUpsert(
-        collectionId, recordType, Collections.singletonList(referencedRecord), emptyMap());
+        collectionUuid, recordType, Collections.singletonList(referencedRecord), emptyMap());
 
     String recordId = "testRecord";
     String reference =
@@ -462,7 +472,7 @@ class RecordDaoTest extends TestBase {
     Record testRecord =
         new Record(recordId, recordType, new RecordAttributes(Map.of("testRecordType", reference)));
     recordDao.batchUpsert(
-        collectionId,
+        collectionUuid,
         recordType,
         Collections.singletonList(testRecord),
         Map.of("foo", STRING, "testRecordType", RELATION));
@@ -470,11 +480,11 @@ class RecordDaoTest extends TestBase {
     // Should throw an error
     assertThrows(
         ResponseStatusException.class,
-        () -> recordDao.deleteSingleRecord(collectionId, recordType, "referencedRecord"),
+        () -> recordDao.deleteSingleRecord(collectionUuid, recordType, "referencedRecord"),
         "Exception should be thrown when attempting to delete related record");
 
     // Record should not have been deleted
-    assert (recordDao.getSingleRecord(collectionId, recordType, "referencedRecord").isPresent());
+    assert (recordDao.getSingleRecord(collectionUuid, recordType, "referencedRecord").isPresent());
   }
 
   @Test
@@ -486,14 +496,14 @@ class RecordDaoTest extends TestBase {
     Record referencedRecord2 =
         new Record(refRecordId2, recordType, new RecordAttributes(Map.of("foo", "bar2")));
     recordDao.batchUpsert(
-        collectionId, recordType, List.of(referencedRecord, referencedRecord2), emptyMap());
+        collectionUuid, recordType, List.of(referencedRecord, referencedRecord2), emptyMap());
 
     // Create record type
     RecordType relationArrayType = RecordType.valueOf("relationArrayType");
     Relation arrayRelation = new Relation("relArrAttr", recordType);
     Map<String, DataTypeMapping> schema = Map.of("relArrAttr", ARRAY_OF_RELATION);
     recordDao.createRecordType(
-        collectionId,
+        collectionUuid,
         schema,
         relationArrayType,
         new RelationCollection(Collections.emptySet(), Set.of(arrayRelation)),
@@ -508,7 +518,7 @@ class RecordDaoTest extends TestBase {
     Record recordWithRelationArray =
         new Record(relArrId, relationArrayType, new RecordAttributes(Map.of("relArrAttr", relArr)));
     recordDao.batchUpsert(
-        collectionId,
+        collectionUuid,
         relationArrayType,
         Collections.singletonList(recordWithRelationArray),
         schema);
@@ -516,7 +526,7 @@ class RecordDaoTest extends TestBase {
     // Normally insert into join is called from the service level, so when working directly with the
     // dao must call it manually
     recordDao.insertIntoJoin(
-        collectionId,
+        collectionUuid,
         arrayRelation,
         relationArrayType,
         List.of(
@@ -526,11 +536,11 @@ class RecordDaoTest extends TestBase {
     // Should throw an error
     assertThrows(
         ResponseStatusException.class,
-        () -> recordDao.deleteSingleRecord(collectionId, recordType, "referencedRecord1"),
+        () -> recordDao.deleteSingleRecord(collectionUuid, recordType, "referencedRecord1"),
         "Exception should be thrown when attempting to delete related record");
 
     // Record should not have been deleted
-    assert (recordDao.getSingleRecord(collectionId, recordType, "referencedRecord1").isPresent());
+    assert (recordDao.getSingleRecord(collectionUuid, recordType, "referencedRecord1").isPresent());
   }
 
   @Test
@@ -542,14 +552,14 @@ class RecordDaoTest extends TestBase {
     Record referencedRecord2 =
         new Record(refRecordId2, recordType, new RecordAttributes(Map.of("foo", "bar2")));
     recordDao.batchUpsert(
-        collectionId, recordType, List.of(referencedRecord, referencedRecord2), emptyMap());
+        collectionUuid, recordType, List.of(referencedRecord, referencedRecord2), emptyMap());
 
     // Create record type
     RecordType relationArrayType = RecordType.valueOf("relationArrayType");
     Relation arrayRelation = new Relation("relArrAttr", recordType);
     Map<String, DataTypeMapping> schema = Map.of("relArrAttr", ARRAY_OF_RELATION);
     recordDao.createRecordType(
-        collectionId,
+        collectionUuid,
         schema,
         relationArrayType,
         new RelationCollection(Collections.emptySet(), Set.of(arrayRelation)),
@@ -564,7 +574,7 @@ class RecordDaoTest extends TestBase {
     Record recordWithRelationArray =
         new Record(relArrId, relationArrayType, new RecordAttributes(Map.of("relArrAttr", relArr)));
     recordDao.batchUpsert(
-        collectionId,
+        collectionUuid,
         relationArrayType,
         Collections.singletonList(recordWithRelationArray),
         schema);
@@ -572,36 +582,39 @@ class RecordDaoTest extends TestBase {
     // Normally insert into join is called from the service level, so when working directly with the
     // dao must call it manually
     recordDao.insertIntoJoin(
-        collectionId,
+        collectionUuid,
         arrayRelation,
         relationArrayType,
         List.of(
             new RelationValue(recordWithRelationArray, referencedRecord),
             new RelationValue(recordWithRelationArray, referencedRecord2)));
 
-    recordDao.deleteSingleRecord(collectionId, relationArrayType, "recordWithRelationArr");
+    recordDao.deleteSingleRecord(collectionUuid, relationArrayType, "recordWithRelationArr");
 
     // Record should have been deleted
-    assert (recordDao.getSingleRecord(collectionId, recordType, "recordWithRelationArr").isEmpty());
+    assert (recordDao
+        .getSingleRecord(collectionUuid, recordType, "recordWithRelationArr")
+        .isEmpty());
     // Check that values are removed from join table
     assertTrue(
         testDao
-            .getRelationArrayValues(collectionId, "relArrAttr", recordWithRelationArray, recordType)
+            .getRelationArrayValues(
+                collectionUuid, "relArrAttr", recordWithRelationArray, recordType)
             .isEmpty());
   }
 
   @Test
   @Transactional
   void testGetAllRecordTypes() {
-    List<RecordType> typesList = recordDao.getAllRecordTypes(collectionId);
+    List<RecordType> typesList = recordDao.getAllRecordTypes(collectionUuid);
     assertEquals(1, typesList.size());
     assertTrue(typesList.contains(recordType));
 
     RecordType newRecordType = RecordType.valueOf("newRecordType");
     recordDao.createRecordType(
-        collectionId, emptyMap(), newRecordType, RelationCollection.empty(), RECORD_ID);
+        collectionUuid, emptyMap(), newRecordType, RelationCollection.empty(), RECORD_ID);
 
-    List<RecordType> newTypesList = recordDao.getAllRecordTypes(collectionId);
+    List<RecordType> newTypesList = recordDao.getAllRecordTypes(collectionUuid);
     assertEquals(2, newTypesList.size());
     assertTrue(newTypesList.contains(recordType));
     assertTrue(newTypesList.contains(newRecordType));
@@ -610,20 +623,20 @@ class RecordDaoTest extends TestBase {
   @Test
   @Transactional
   void testGetAllRecordTypesNoJoins() {
-    List<RecordType> typesList = recordDao.getAllRecordTypes(collectionId);
+    List<RecordType> typesList = recordDao.getAllRecordTypes(collectionUuid);
     assertEquals(1, typesList.size());
     assertTrue(typesList.contains(recordType));
 
     RecordType relationArrayType = RecordType.valueOf("relationArrayType");
     Relation arrayRelation = new Relation("relArrAttr", recordType);
     recordDao.createRecordType(
-        collectionId,
+        collectionUuid,
         Map.of("relArrAttr", ARRAY_OF_RELATION),
         relationArrayType,
         new RelationCollection(Collections.emptySet(), Set.of(arrayRelation)),
         RECORD_ID);
 
-    List<RecordType> newTypesList = recordDao.getAllRecordTypes(collectionId);
+    List<RecordType> newTypesList = recordDao.getAllRecordTypes(collectionUuid);
     assertEquals(2, newTypesList.size());
     assertTrue(newTypesList.contains(recordType));
     assertTrue(newTypesList.contains(relationArrayType));
@@ -633,15 +646,15 @@ class RecordDaoTest extends TestBase {
   @Transactional
   void testCountRecords() {
     // ensure we start with a count of 0 records
-    assertEquals(0, recordDao.countRecords(collectionId, recordType));
+    assertEquals(0, recordDao.countRecords(collectionUuid, recordType));
     // insert records and test the count after each insert
     for (int i = 0; i < 10; i++) {
       Record testRecord = new Record("record" + i, recordType, RecordAttributes.empty());
       recordDao.batchUpsert(
-          collectionId, recordType, Collections.singletonList(testRecord), emptyMap());
+          collectionUuid, recordType, Collections.singletonList(testRecord), emptyMap());
       assertEquals(
           i + 1,
-          recordDao.countRecords(collectionId, recordType),
+          recordDao.countRecords(collectionUuid, recordType),
           "after inserting " + (i + 1) + " records");
     }
   }
@@ -649,23 +662,23 @@ class RecordDaoTest extends TestBase {
   @Test
   @Transactional
   void testRecordExists() {
-    assertFalse(recordDao.recordExists(collectionId, recordType, "aRecord"));
+    assertFalse(recordDao.recordExists(collectionUuid, recordType, "aRecord"));
     recordDao.batchUpsert(
-        collectionId,
+        collectionUuid,
         recordType,
         Collections.singletonList(new Record("aRecord", recordType, RecordAttributes.empty())),
         emptyMap());
-    assertTrue(recordDao.recordExists(collectionId, recordType, "aRecord"));
+    assertTrue(recordDao.recordExists(collectionUuid, recordType, "aRecord"));
   }
 
   @Test
   @Transactional
   void testDeleteRecordType() {
     // make sure type already exists
-    assertTrue(recordDao.recordTypeExists(collectionId, recordType));
-    recordDao.deleteRecordType(collectionId, recordType);
+    assertTrue(recordDao.recordTypeExists(collectionUuid, recordType));
+    recordDao.deleteRecordType(collectionUuid, recordType);
     // make sure type no longer exists
-    assertFalse(recordDao.recordTypeExists(collectionId, recordType));
+    assertFalse(recordDao.recordTypeExists(collectionUuid, recordType));
   }
 
   @Test
@@ -673,21 +686,21 @@ class RecordDaoTest extends TestBase {
     RecordType recordTypeName = recordType;
     RecordType referencedType = RecordType.valueOf("referencedType");
     recordDao.createRecordType(
-        collectionId, emptyMap(), referencedType, RelationCollection.empty(), RECORD_ID);
+        collectionUuid, emptyMap(), referencedType, RelationCollection.empty(), RECORD_ID);
 
-    recordDao.addColumn(collectionId, recordTypeName, "relation", RELATION, referencedType);
+    recordDao.addColumn(collectionUuid, recordTypeName, "relation", RELATION, referencedType);
 
     String refRecordId = "referencedRecord";
     Record referencedRecord = new Record(refRecordId, referencedType, RecordAttributes.empty());
     recordDao.batchUpsert(
-        collectionId, referencedType, Collections.singletonList(referencedRecord), emptyMap());
+        collectionUuid, referencedType, Collections.singletonList(referencedRecord), emptyMap());
 
     String recordId = "testRecord";
     String reference = RelationUtils.createRelationString(referencedType, refRecordId);
     Record testRecord =
         new Record(recordId, recordType, new RecordAttributes(Map.of("relation", reference)));
     recordDao.batchUpsert(
-        collectionId,
+        collectionUuid,
         recordTypeName,
         Collections.singletonList(testRecord),
         Map.of("relation", RELATION));
@@ -695,7 +708,7 @@ class RecordDaoTest extends TestBase {
     // Should throw an error
     assertThrows(
         ResponseStatusException.class,
-        () -> recordDao.deleteRecordType(collectionId, referencedType),
+        () -> recordDao.deleteRecordType(collectionUuid, referencedType),
         "Exception should be thrown when attempting to delete record type with relation");
   }
 
@@ -709,14 +722,14 @@ class RecordDaoTest extends TestBase {
     Record referencedRecord2 =
         new Record(refRecordId2, recordType, new RecordAttributes(Map.of("foo", "bar2")));
     recordDao.batchUpsert(
-        collectionId, recordType, List.of(referencedRecord, referencedRecord2), emptyMap());
+        collectionUuid, recordType, List.of(referencedRecord, referencedRecord2), emptyMap());
 
     // Create referencing record type
     RecordType relationArrayType = RecordType.valueOf("relationArrayType");
     Relation arrayRelation = new Relation("relArrAttr", recordType);
     Map<String, DataTypeMapping> schema = Map.of("relArrAttr", ARRAY_OF_RELATION);
     recordDao.createRecordType(
-        collectionId,
+        collectionUuid,
         schema,
         relationArrayType,
         new RelationCollection(Collections.emptySet(), Set.of(arrayRelation)),
@@ -731,7 +744,7 @@ class RecordDaoTest extends TestBase {
     Record recordWithRelationArray =
         new Record(relArrId, relationArrayType, new RecordAttributes(Map.of("relArrAttr", relArr)));
     recordDao.batchUpsert(
-        collectionId,
+        collectionUuid,
         relationArrayType,
         Collections.singletonList(recordWithRelationArray),
         schema);
@@ -739,7 +752,7 @@ class RecordDaoTest extends TestBase {
     // Normally insert into join is called from the service level, so when working directly with the
     // dao must call it manually
     recordDao.insertIntoJoin(
-        collectionId,
+        collectionUuid,
         arrayRelation,
         relationArrayType,
         List.of(
@@ -747,13 +760,13 @@ class RecordDaoTest extends TestBase {
             new RelationValue(recordWithRelationArray, referencedRecord2)));
 
     // Delete record type
-    recordDao.deleteRecordType(collectionId, relationArrayType);
+    recordDao.deleteRecordType(collectionUuid, relationArrayType);
 
     // Record table should have been deleted
-    assertFalse(recordDao.recordTypeExists(collectionId, relationArrayType));
+    assertFalse(recordDao.recordTypeExists(collectionUuid, relationArrayType));
 
     // check that join table is gone as well
-    assertFalse(testDao.joinTableExists(collectionId, "relArrAttr", relationArrayType));
+    assertFalse(testDao.joinTableExists(collectionUuid, "relArrAttr", relationArrayType));
   }
 
   @Test
@@ -762,18 +775,18 @@ class RecordDaoTest extends TestBase {
     // Arrange
     RecordType recordTypeWithAttributes = RecordType.valueOf("withAttributes");
     recordDao.createRecordType(
-        collectionId,
+        collectionUuid,
         Map.of("foo", STRING, "bar", STRING),
         recordTypeWithAttributes,
         RelationCollection.empty(),
         PRIMARY_KEY);
 
     // Act
-    recordDao.renameAttribute(collectionId, recordTypeWithAttributes, "bar", "baz");
+    recordDao.renameAttribute(collectionUuid, recordTypeWithAttributes, "bar", "baz");
 
     // Assert
     Set<String> attributeNames =
-        Set.copyOf(recordDao.getAllAttributeNames(collectionId, recordTypeWithAttributes));
+        Set.copyOf(recordDao.getAllAttributeNames(collectionUuid, recordTypeWithAttributes));
     assertEquals(Set.of(PRIMARY_KEY, "foo", "baz"), attributeNames);
   }
 
@@ -984,18 +997,18 @@ class RecordDaoTest extends TestBase {
     // Arrange
     RecordType recordTypeWithAttributes = RecordType.valueOf("withAttributes");
     recordDao.createRecordType(
-        collectionId,
+        collectionUuid,
         Map.of("attr1", STRING, "attr2", STRING),
         recordTypeWithAttributes,
         RelationCollection.empty(),
         PRIMARY_KEY);
 
     // Act
-    recordDao.deleteAttribute(collectionId, recordTypeWithAttributes, "attr2");
+    recordDao.deleteAttribute(collectionUuid, recordTypeWithAttributes, "attr2");
 
     // Assert
     Set<String> attributeNames =
-        Set.copyOf(recordDao.getAllAttributeNames(collectionId, recordTypeWithAttributes));
+        Set.copyOf(recordDao.getAllAttributeNames(collectionUuid, recordTypeWithAttributes));
     assertEquals(Set.of(PRIMARY_KEY, "attr1"), attributeNames);
   }
 
@@ -1004,14 +1017,15 @@ class RecordDaoTest extends TestBase {
   void testCreateRelationJoinTable() {
     RecordType secondRecordType = RecordType.valueOf("secondRecordType");
     recordDao.createRecordType(
-        collectionId, emptyMap(), secondRecordType, RelationCollection.empty(), RECORD_ID);
+        collectionUuid, emptyMap(), secondRecordType, RelationCollection.empty(), RECORD_ID);
 
-    recordDao.createRelationJoinTable(collectionId, "refArray", secondRecordType, recordType);
+    recordDao.createRelationJoinTable(collectionUuid, "refArray", secondRecordType, recordType);
 
-    List<Relation> relationArrays = recordDao.getRelationArrayCols(collectionId, secondRecordType);
+    List<Relation> relationArrays =
+        recordDao.getRelationArrayCols(collectionUuid, secondRecordType);
     assertEquals(1, relationArrays.size());
     assertTrue(relationArrays.contains(new Relation("refArray", recordType)));
-    assertTrue(testDao.joinTableExists(collectionId, "refArray", secondRecordType));
+    assertTrue(testDao.joinTableExists(collectionUuid, "refArray", secondRecordType));
   }
 
   @Test
@@ -1021,24 +1035,24 @@ class RecordDaoTest extends TestBase {
     Relation singleRelation = new Relation("refAttr", recordType);
     Relation arrayRelation = new Relation("relArrAttr", recordType);
     recordDao.createRecordType(
-        collectionId,
+        collectionUuid,
         Map.of("stringAttr", STRING, "refAttr", RELATION, "relArrAttr", ARRAY_OF_RELATION),
         relationarrayType,
         new RelationCollection(Set.of(singleRelation), Set.of(arrayRelation)),
         RECORD_ID);
 
     Map<String, DataTypeMapping> schema =
-        recordDao.getExistingTableSchemaLessPrimaryKey(collectionId, relationarrayType);
+        recordDao.getExistingTableSchemaLessPrimaryKey(collectionUuid, relationarrayType);
     assertEquals(3, schema.size());
     assertEquals(STRING, schema.get("stringAttr"));
     assertEquals(RELATION, schema.get("refAttr"));
     assertEquals(ARRAY_OF_RELATION, schema.get("relArrAttr"));
-    List<Relation> relationCols = recordDao.getRelationCols(collectionId, relationarrayType);
+    List<Relation> relationCols = recordDao.getRelationCols(collectionUuid, relationarrayType);
     assertEquals(List.of(singleRelation), relationCols);
     List<Relation> relationArrayCols =
-        recordDao.getRelationArrayCols(collectionId, relationarrayType);
+        recordDao.getRelationArrayCols(collectionUuid, relationarrayType);
     assertEquals(List.of(arrayRelation), relationArrayCols);
-    assertTrue(testDao.joinTableExists(collectionId, "relArrAttr", relationarrayType));
+    assertTrue(testDao.joinTableExists(collectionUuid, "relArrAttr", relationarrayType));
   }
 
   @Test
@@ -1052,7 +1066,7 @@ class RecordDaoTest extends TestBase {
     Record referencedRecord2 =
         new Record(refRecordId2, recordType, new RecordAttributes(Map.of("foo", "bar2")));
     recordDao.batchUpsert(
-        collectionId, recordType, List.of(referencedRecord, referencedRecord2), emptyMap());
+        collectionUuid, recordType, List.of(referencedRecord, referencedRecord2), emptyMap());
 
     // Create record type
     RecordType relationArrayType = RecordType.valueOf("relationArrayType");
@@ -1060,7 +1074,7 @@ class RecordDaoTest extends TestBase {
     Map<String, DataTypeMapping> schema =
         Map.of("stringAttr", STRING, "refAttr", RELATION, "relArrAttr", ARRAY_OF_RELATION);
     recordDao.createRecordType(
-        collectionId,
+        collectionUuid,
         schema,
         relationArrayType,
         new RelationCollection(Collections.emptySet(), Set.of(arrayRelation)),
@@ -1075,18 +1089,18 @@ class RecordDaoTest extends TestBase {
     Record recordWithRelationArray =
         new Record(relArrId, relationArrayType, new RecordAttributes(Map.of("relArrAttr", relArr)));
     recordDao.batchUpsert(
-        collectionId,
+        collectionUuid,
         relationArrayType,
         Collections.singletonList(recordWithRelationArray),
         schema);
 
     Map<String, DataTypeMapping> createdSchema =
-        recordDao.getExistingTableSchemaLessPrimaryKey(collectionId, relationArrayType);
+        recordDao.getExistingTableSchemaLessPrimaryKey(collectionUuid, relationArrayType);
     assertEquals(3, createdSchema.size());
     List<Relation> relationArrayCols =
-        recordDao.getRelationArrayCols(collectionId, relationArrayType);
+        recordDao.getRelationArrayCols(collectionUuid, relationArrayType);
     assertEquals(List.of(arrayRelation), relationArrayCols);
-    Record record = recordDao.getSingleRecord(collectionId, relationArrayType, relArrId).get();
+    Record record = recordDao.getSingleRecord(collectionUuid, relationArrayType, relArrId).get();
     assertNotNull(record);
     String[] actualAttrValue =
         assertInstanceOf(String[].class, record.getAttributeValue("relArrAttr"));
@@ -1097,7 +1111,7 @@ class RecordDaoTest extends TestBase {
     assertDoesNotThrow(
         () ->
             recordDao.insertIntoJoin(
-                collectionId,
+                collectionUuid,
                 arrayRelation,
                 relationArrayType,
                 List.of(
@@ -1105,7 +1119,7 @@ class RecordDaoTest extends TestBase {
                     new RelationValue(record, referencedRecord2))));
     assertEquals(
         List.of(refRecordId, refRecordId2),
-        testDao.getRelationArrayValues(collectionId, "relArrAttr", record, recordType));
+        testDao.getRelationArrayValues(collectionUuid, "relArrAttr", record, recordType));
   }
 
   @Test
@@ -1116,13 +1130,13 @@ class RecordDaoTest extends TestBase {
     Relation arrayRelation1 = new Relation("relArr1", recordType);
     Relation arrayRelation2 = new Relation("relArr2", recordType);
     recordDao.createRecordType(
-        collectionId,
+        collectionUuid,
         Map.of("relArr1", ARRAY_OF_RELATION, "relArr2", ARRAY_OF_RELATION),
         relationarrayType,
         new RelationCollection(Collections.emptySet(), Set.of(arrayRelation1, arrayRelation2)),
         RECORD_ID);
 
-    List<Relation> cols = recordDao.getRelationArrayCols(collectionId, relationarrayType);
+    List<Relation> cols = recordDao.getRelationArrayCols(collectionUuid, relationarrayType);
     assertEquals(2, cols.size());
     assertTrue(cols.contains(arrayRelation1));
     assertTrue(cols.contains(arrayRelation2));
@@ -1139,24 +1153,24 @@ class RecordDaoTest extends TestBase {
     String fromRecordId3 = "fromRecord3";
     Record fromRecord3 = new Record(fromRecordId3, recordType, RecordAttributes.empty());
     recordDao.batchUpsert(
-        collectionId, recordType, List.of(fromRecord, fromRecord2, fromRecord3), emptyMap());
+        collectionUuid, recordType, List.of(fromRecord, fromRecord2, fromRecord3), emptyMap());
 
     RecordType toType = RecordType.valueOf("toType");
     recordDao.createRecordType(
-        collectionId, emptyMap(), toType, RelationCollection.empty(), RECORD_ID);
+        collectionUuid, emptyMap(), toType, RelationCollection.empty(), RECORD_ID);
     String toRecordId = "toRecord1";
     Record toRecord = new Record(toRecordId, toType, RecordAttributes.empty());
     String toRecordId2 = "toRecord2";
     Record toRecord2 = new Record(toRecordId2, toType, RecordAttributes.empty());
-    recordDao.batchUpsert(collectionId, toType, List.of(toRecord, toRecord2), emptyMap());
+    recordDao.batchUpsert(collectionUuid, toType, List.of(toRecord, toRecord2), emptyMap());
 
     // create join table
-    recordDao.createRelationJoinTable(collectionId, "referenceArray", recordType, toType);
+    recordDao.createRelationJoinTable(collectionUuid, "referenceArray", recordType, toType);
 
     // insert into join table
     Relation rel = new Relation("referenceArray", toType);
     recordDao.insertIntoJoin(
-        collectionId,
+        collectionUuid,
         rel,
         recordType,
         List.of(
@@ -1166,25 +1180,28 @@ class RecordDaoTest extends TestBase {
 
     // Check that values are in join table
     List<String> joinVals1 =
-        testDao.getRelationArrayValues(collectionId, "referenceArray", fromRecord, toType);
+        testDao.getRelationArrayValues(collectionUuid, "referenceArray", fromRecord, toType);
     assertIterableEquals(List.of(toRecordId, toRecordId2), joinVals1);
     List<String> joinVals2 =
-        testDao.getRelationArrayValues(collectionId, "referenceArray", fromRecord2, toType);
+        testDao.getRelationArrayValues(collectionUuid, "referenceArray", fromRecord2, toType);
     assertIterableEquals(List.of(toRecordId, toRecordId2), joinVals2);
     List<String> joinVals3 =
-        testDao.getRelationArrayValues(collectionId, "referenceArray", fromRecord3, toType);
+        testDao.getRelationArrayValues(collectionUuid, "referenceArray", fromRecord3, toType);
     assertIterableEquals(List.of(toRecordId, toRecordId2), joinVals3);
 
     // remove from join table
-    recordDao.removeFromJoin(collectionId, rel, recordType, List.of(fromRecordId, fromRecordId3));
+    recordDao.removeFromJoin(collectionUuid, rel, recordType, List.of(fromRecordId, fromRecordId3));
 
     // Make sure values have been removed
-    joinVals1 = testDao.getRelationArrayValues(collectionId, "referenceArray", fromRecord, toType);
+    joinVals1 =
+        testDao.getRelationArrayValues(collectionUuid, "referenceArray", fromRecord, toType);
     assert (joinVals1.isEmpty());
-    joinVals3 = testDao.getRelationArrayValues(collectionId, "referenceArray", fromRecord3, toType);
+    joinVals3 =
+        testDao.getRelationArrayValues(collectionUuid, "referenceArray", fromRecord3, toType);
     assert (joinVals3.isEmpty());
     // But not other values
-    joinVals2 = testDao.getRelationArrayValues(collectionId, "referenceArray", fromRecord2, toType);
+    joinVals2 =
+        testDao.getRelationArrayValues(collectionUuid, "referenceArray", fromRecord2, toType);
     assertIterableEquals(List.of(toRecordId, toRecordId2), joinVals2);
   }
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
@@ -2,6 +2,7 @@ package org.databiosphere.workspacedataservice.dao;
 
 import static java.util.Collections.emptyMap;
 import static java.util.UUID.randomUUID;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.databiosphere.workspacedataservice.service.model.DataTypeMapping.*;
 import static org.databiosphere.workspacedataservice.service.model.DataTypeMapping.ARRAY_OF_NUMBER;
 import static org.databiosphere.workspacedataservice.service.model.DataTypeMapping.ARRAY_OF_STRING;
@@ -341,6 +342,7 @@ class RecordDaoTest extends TestBase {
         Map.of("foo", STRING, "relationAttr", RELATION));
 
     List<Relation> relations = recordDao.getRelationCols(collectionUuid, recordType);
+    assertThat(relations).hasSize(1);
 
     Record testRecordFetched =
         recordDao.getSingleRecord(collectionUuid, recordType, recordId).get();
@@ -1100,10 +1102,10 @@ class RecordDaoTest extends TestBase {
     List<Relation> relationArrayCols =
         recordDao.getRelationArrayCols(collectionUuid, relationArrayType);
     assertEquals(List.of(arrayRelation), relationArrayCols);
-    Record record = recordDao.getSingleRecord(collectionUuid, relationArrayType, relArrId).get();
-    assertNotNull(record);
+    Record rec = recordDao.getSingleRecord(collectionUuid, relationArrayType, relArrId).get();
+    assertNotNull(rec);
     String[] actualAttrValue =
-        assertInstanceOf(String[].class, record.getAttributeValue("relArrAttr"));
+        assertInstanceOf(String[].class, rec.getAttributeValue("relArrAttr"));
     assertIterableEquals(relArr, Arrays.asList(actualAttrValue));
 
     // The purpose of inserting in to the join is to make sure foreign keys are consistent
@@ -1115,11 +1117,11 @@ class RecordDaoTest extends TestBase {
                 arrayRelation,
                 relationArrayType,
                 List.of(
-                    new RelationValue(record, referencedRecord),
-                    new RelationValue(record, referencedRecord2))));
+                    new RelationValue(rec, referencedRecord),
+                    new RelationValue(rec, referencedRecord2))));
     assertEquals(
         List.of(refRecordId, refRecordId2),
-        testDao.getRelationArrayValues(collectionUuid, "relArrAttr", record, recordType));
+        testDao.getRelationArrayValues(collectionUuid, "relArrAttr", rec, recordType));
   }
 
   @Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/datarepo/DataRepoDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/datarepo/DataRepoDaoTest.java
@@ -68,8 +68,9 @@ class DataRepoDaoTest extends TestBase {
     final int statusCode = HttpStatus.UNAUTHORIZED.value();
     given(mockRepositoryApi.retrieveSnapshot(any(), any()))
         .willThrow(new ApiException(statusCode, "Intentional error thrown for unit test"));
+    UUID randomUuid = randomUUID();
     var exception =
-        assertThrows(DataRepoException.class, () -> dataRepoDao.getSnapshot(randomUUID()));
+        assertThrows(DataRepoException.class, () -> dataRepoDao.getSnapshot(randomUuid));
     assertEquals(statusCode, exception.getStatusCode().value());
     Mockito.clearInvocations(mockRepositoryApi);
   }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/datarepo/DataRepoDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/datarepo/DataRepoDaoTest.java
@@ -1,5 +1,6 @@
 package org.databiosphere.workspacedataservice.datarepo;
 
+import static java.util.UUID.randomUUID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -36,28 +37,27 @@ class DataRepoDaoTest extends TestBase {
   @MockBean DataRepoClientFactory mockDataRepoClientFactory;
 
   final RepositoryApi mockRepositoryApi = Mockito.mock(RepositoryApi.class);
-
-  private static final UUID COLLECTION = UUID.fromString("111e9999-e89b-12d3-a456-426614174000");
+  private static final UUID COLLECTION_UUID = randomUUID();
+  private static final CollectionId COLLECTION_ID = CollectionId.of(COLLECTION_UUID);
 
   @BeforeEach
   void setUp() {
     given(mockDataRepoClientFactory.getRepositoryApi()).willReturn(mockRepositoryApi);
-    if (!collectionDao.collectionSchemaExists(CollectionId.of(COLLECTION))) {
-      collectionDao.createSchema(COLLECTION);
+    if (!collectionDao.collectionSchemaExists(COLLECTION_ID)) {
+      collectionDao.createSchema(COLLECTION_ID);
     }
   }
 
   @AfterEach
   void tearDown() {
-    if (collectionDao.collectionSchemaExists(CollectionId.of(COLLECTION))) {
-      collectionDao.dropSchema(COLLECTION);
+    if (collectionDao.collectionSchemaExists(COLLECTION_ID)) {
+      collectionDao.dropSchema(COLLECTION_UUID);
     }
   }
 
   @Test
   void testSnapshotReturned() throws ApiException {
-    final SnapshotModel testSnapshot =
-        new SnapshotModel().name("test snapshot").id(UUID.randomUUID());
+    final SnapshotModel testSnapshot = new SnapshotModel().name("test snapshot").id(randomUUID());
     given(mockRepositoryApi.retrieveSnapshot(any(), any())).willReturn(testSnapshot);
     assertEquals(testSnapshot, dataRepoDao.getSnapshot(testSnapshot.getId()));
     Mockito.clearInvocations(mockRepositoryApi);
@@ -69,7 +69,7 @@ class DataRepoDaoTest extends TestBase {
     given(mockRepositoryApi.retrieveSnapshot(any(), any()))
         .willThrow(new ApiException(statusCode, "Intentional error thrown for unit test"));
     var exception =
-        assertThrows(DataRepoException.class, () -> dataRepoDao.getSnapshot(UUID.randomUUID()));
+        assertThrows(DataRepoException.class, () -> dataRepoDao.getSnapshot(randomUUID()));
     assertEquals(statusCode, exception.getStatusCode().value());
     Mockito.clearInvocations(mockRepositoryApi);
   }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/BatchWriteServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/BatchWriteServiceTest.java
@@ -1,5 +1,6 @@
 package org.databiosphere.workspacedataservice.service;
 
+import static java.util.UUID.randomUUID;
 import static org.databiosphere.workspacedataservice.dataimport.pfb.PfbRecordConverter.ID_FIELD;
 import static org.databiosphere.workspacedataservice.service.model.ReservedNames.RECORD_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -52,19 +53,20 @@ class BatchWriteServiceTest extends TestBase {
   @SpyBean DataTypeInferer inferer;
   @SpyBean RecordService recordService;
 
-  private static final UUID COLLECTION = UUID.fromString("aaaabbbb-cccc-dddd-1111-222233334444");
+  private static final UUID COLLECTION_UUID = randomUUID();
+  private static final CollectionId COLLECTION_ID = CollectionId.of(COLLECTION_UUID);
   private static final RecordType THING_TYPE = RecordType.valueOf("thing");
 
   @BeforeEach
   void setUp() {
-    if (!collectionDao.collectionSchemaExists(CollectionId.of(COLLECTION))) {
-      collectionDao.createSchema(COLLECTION);
+    if (!collectionDao.collectionSchemaExists(COLLECTION_ID)) {
+      collectionDao.createSchema(COLLECTION_ID);
     }
   }
 
   @AfterEach
   void tearDown() {
-    collectionDao.dropSchema(COLLECTION);
+    collectionDao.dropSchema(COLLECTION_UUID);
   }
 
   @Test
@@ -74,7 +76,8 @@ class BatchWriteServiceTest extends TestBase {
     InputStream is = new ByteArrayInputStream(streamContents.getBytes());
 
     RecordSource recordSource = recordSourceFactory.forJson(is);
-    try (RecordSink recordSink = recordSinkFactory.buildRecordSink(CollectionId.of(COLLECTION))) {
+    try (RecordSink recordSink =
+        recordSinkFactory.buildRecordSink(CollectionId.of(COLLECTION_UUID))) {
       Exception ex =
           assertThrows(
               BadStreamingWriteRequestException.class,
@@ -157,7 +160,8 @@ class BatchWriteServiceTest extends TestBase {
   private BatchWriteResult batchWritePfbStream(
       DataFileStream<GenericRecord> pfbStream, String primaryKey, ImportMode importMode)
       throws IOException {
-    try (RecordSink recordSink = recordSinkFactory.buildRecordSink(CollectionId.of(COLLECTION))) {
+    try (RecordSink recordSink =
+        recordSinkFactory.buildRecordSink(CollectionId.of(COLLECTION_UUID))) {
       return batchWriteService.batchWrite(
           recordSourceFactory.forPfb(pfbStream, importMode),
           recordSink,

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceNoPermissionSamTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceNoPermissionSamTest.java
@@ -13,6 +13,7 @@ import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.dao.CollectionDao;
 import org.databiosphere.workspacedataservice.sam.SamClientFactory;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthorizationException;
+import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.mockito.Mockito;
@@ -71,7 +72,7 @@ class CollectionServiceNoPermissionSamTest extends TestBase {
 
     UUID collectionId = UUID.randomUUID();
     // create the collection (directly in the db, bypassing Sam)
-    collectionDao.createSchema(collectionId);
+    collectionDao.createSchema(CollectionId.of(collectionId));
 
     assertThrows(
         AuthorizationException.class,

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceSamExceptionTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceSamExceptionTest.java
@@ -206,7 +206,7 @@ class CollectionServiceSamExceptionTest extends TestBase {
   private void doAuthnDeleteTest(
       UUID collectionId, Class<? extends Exception> expectedExceptionClass) {
     // create the collection (directly in the db, bypassing Sam)
-    collectionDao.createSchema(collectionId);
+    collectionDao.createSchema(CollectionId.of(collectionId));
     List<UUID> allCollections = collectionService.listCollections(VERSION);
     assertTrue(
         allCollections.contains(collectionId), "unit test should have created the collections.");
@@ -245,7 +245,7 @@ class CollectionServiceSamExceptionTest extends TestBase {
 
   private void doSamDeleteTest(UUID collectionId, int expectedSamExceptionCode) {
     // bypass Sam and create the collection directly in the db
-    collectionDao.createSchema(collectionId);
+    collectionDao.createSchema(CollectionId.of(collectionId));
     List<UUID> allCollections = collectionService.listCollections(VERSION);
     assertTrue(
         allCollections.contains(collectionId), "unit test should have created the collections.");

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceSamTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceSamTest.java
@@ -1,10 +1,10 @@
 package org.databiosphere.workspacedataservice.service;
 
+import static java.util.UUID.randomUUID;
 import static org.databiosphere.workspacedataservice.service.RecordUtils.VERSION;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
-import java.util.UUID;
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
 import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
 import org.broadinstitute.dsde.workbench.client.sam.model.CreateResourceRequestV2;
@@ -13,6 +13,7 @@ import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.dao.CollectionDao;
 import org.databiosphere.workspacedataservice.sam.SamAuthorizationDao;
 import org.databiosphere.workspacedataservice.sam.SamClientFactory;
+import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -56,28 +57,25 @@ class CollectionServiceSamTest extends TestBase {
 
   @Test
   void createCollectionSamCalls() throws ApiException {
-    UUID collectionId = UUID.randomUUID();
-    doCreateCollectionTest(collectionId);
+    doCreateCollectionTest(randomCollectionId());
   }
 
   @Test
   void createCollectionWithWorkspaceIdSamCalls() throws ApiException {
-    UUID collectionId = UUID.randomUUID();
-    doCreateCollectionTest(collectionId);
+    doCreateCollectionTest(randomCollectionId());
   }
 
   @Test
   void deleteCollectionSamCalls() throws ApiException {
-    UUID collectionId = UUID.randomUUID();
-    doDeleteCollectionTest(collectionId);
+    doDeleteCollectionTest(randomCollectionId());
   }
 
-  void doCreateCollectionTest(UUID collectionId) throws ApiException {
+  void doCreateCollectionTest(CollectionId collectionId) throws ApiException {
     // setup: capture order of calls to Sam
     InOrder callOrder = inOrder(mockResourcesApi);
 
     // call createCollection
-    collectionService.createCollection(collectionId, VERSION);
+    collectionService.createCollection(collectionId.id(), VERSION);
 
     // createCollection should check permission with Sam exactly once:
     verify(mockResourcesApi, times(1)).resourcePermissionV2(anyString(), anyString(), anyString());
@@ -100,7 +98,7 @@ class CollectionServiceSamTest extends TestBase {
     verifyNoMoreInteractions(mockResourcesApi);
   }
 
-  void doDeleteCollectionTest(UUID collectionId) throws ApiException {
+  void doDeleteCollectionTest(CollectionId collectionId) throws ApiException {
     // setup: capture order of calls to Sam
     InOrder callOrder = inOrder(mockResourcesApi);
 
@@ -108,7 +106,7 @@ class CollectionServiceSamTest extends TestBase {
     collectionDao.createSchema(collectionId);
 
     // call deleteCollection
-    collectionService.deleteCollection(collectionId, VERSION);
+    collectionService.deleteCollection(collectionId.id(), VERSION);
 
     // deleteCollection should check permission with Sam exactly once:
     verify(mockResourcesApi, times(1)).resourcePermissionV2(anyString(), anyString(), anyString());
@@ -128,5 +126,9 @@ class CollectionServiceSamTest extends TestBase {
 
     // and that should be the only call we made to Sam
     verifyNoMoreInteractions(mockResourcesApi);
+  }
+
+  private CollectionId randomCollectionId() {
+    return CollectionId.of(randomUUID());
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorSamTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorSamTest.java
@@ -1,5 +1,6 @@
 package org.databiosphere.workspacedataservice.service;
 
+import static java.util.UUID.randomUUID;
 import static org.databiosphere.workspacedataservice.service.RecordUtils.VERSION;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -45,12 +46,13 @@ class RecordOrchestratorSamTest extends TestBase {
   // to mock it manually
   final ResourcesApi mockResourcesApi = Mockito.mock(ResourcesApi.class);
 
-  private static final UUID COLLECTION = UUID.fromString(HARDCODED_WORKSPACE_ID);
+  private static final UUID COLLECTION_UUID = randomUUID();
+  private static final CollectionId COLLECTION_ID = CollectionId.of(COLLECTION_UUID);
 
   @BeforeEach
   void setUp() {
-    if (!collectionDao.collectionSchemaExists(CollectionId.of(COLLECTION))) {
-      collectionDao.createSchema(COLLECTION);
+    if (!collectionDao.collectionSchemaExists(CollectionId.of(COLLECTION_UUID))) {
+      collectionDao.createSchema(COLLECTION_ID);
     }
     given(mockSamClientFactory.getResourcesApi()).willReturn(mockResourcesApi);
 
@@ -60,7 +62,7 @@ class RecordOrchestratorSamTest extends TestBase {
 
   @AfterEach
   void tearDown() {
-    collectionDao.dropSchema(COLLECTION);
+    collectionDao.dropSchema(COLLECTION_UUID);
   }
 
   @Test
@@ -73,7 +75,7 @@ class RecordOrchestratorSamTest extends TestBase {
 
     assertThrows(
         AuthorizationException.class,
-        () -> recordOrchestratorService.validateAndPermissions(COLLECTION, VERSION),
+        () -> recordOrchestratorService.validateAndPermissions(COLLECTION_UUID, VERSION),
         "validateAndPermissions should throw if caller does not have write permission in Sam");
   }
 
@@ -84,7 +86,7 @@ class RecordOrchestratorSamTest extends TestBase {
         .willReturn(true);
 
     assertDoesNotThrow(
-        () -> recordOrchestratorService.validateAndPermissions(COLLECTION, VERSION),
+        () -> recordOrchestratorService.validateAndPermissions(COLLECTION_UUID, VERSION),
         "validateAndPermissions should not throw if caller has write permission in Sam");
   }
 
@@ -96,7 +98,7 @@ class RecordOrchestratorSamTest extends TestBase {
                 0, "intentional failure for unit test")); // 0 indicates a failed connection
     assertThrows(
         RestException.class,
-        () -> recordOrchestratorService.validateAndPermissions(COLLECTION, VERSION),
+        () -> recordOrchestratorService.validateAndPermissions(COLLECTION_UUID, VERSION),
         "validateAndPermissions should throw if caller does not have write permission in Sam");
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
@@ -1,5 +1,6 @@
 package org.databiosphere.workspacedataservice.service;
 
+import static java.util.UUID.randomUUID;
 import static org.databiosphere.workspacedataservice.service.RecordUtils.VERSION;
 import static org.databiosphere.workspacedataservice.service.RecordUtils.validateVersion;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -53,7 +54,8 @@ class RecordOrchestratorServiceTest extends TestBase {
   @Autowired private CollectionDao collectionDao;
   @Autowired private RecordOrchestratorService recordOrchestratorService;
 
-  private static final UUID COLLECTION = UUID.fromString(HARDCODED_WORKSPACE_ID);
+  private static final UUID COLLECTION_UUID = randomUUID();
+  private static final CollectionId COLLECTION_ID = CollectionId.of(COLLECTION_UUID);
   private static final RecordType TEST_TYPE = RecordType.valueOf("test");
 
   private static final String RECORD_ID = "aNewRecord";
@@ -63,14 +65,14 @@ class RecordOrchestratorServiceTest extends TestBase {
 
   @BeforeEach
   void setUp() {
-    if (!collectionDao.collectionSchemaExists(CollectionId.of(COLLECTION))) {
-      collectionDao.createSchema(COLLECTION);
+    if (!collectionDao.collectionSchemaExists(COLLECTION_ID)) {
+      collectionDao.createSchema(COLLECTION_ID);
     }
   }
 
   @AfterEach
   void tearDown() {
-    collectionDao.dropSchema(COLLECTION);
+    collectionDao.dropSchema(COLLECTION_UUID);
   }
 
   @Test
@@ -85,7 +87,7 @@ class RecordOrchestratorServiceTest extends TestBase {
 
     RecordResponse resp =
         recordOrchestratorService.updateSingleRecord(
-            COLLECTION, VERSION, TEST_TYPE, RECORD_ID, updateRequest);
+            COLLECTION_UUID, VERSION, TEST_TYPE, RECORD_ID, updateRequest);
 
     assertEquals(RECORD_ID, resp.recordId());
 
@@ -106,7 +108,7 @@ class RecordOrchestratorServiceTest extends TestBase {
 
     RecordQueryResponse resp =
         recordOrchestratorService.queryForRecords(
-            COLLECTION, TEST_TYPE, VERSION, new SearchRequest());
+            COLLECTION_UUID, TEST_TYPE, VERSION, new SearchRequest());
 
     testContainsRecord(RECORD_ID, TEST_KEY, TEST_VAL, resp.records());
     testContainsRecord(secondRecord, TEST_KEY, secondVal, resp.records());
@@ -130,7 +132,12 @@ class RecordOrchestratorServiceTest extends TestBase {
     // Act
     ResponseEntity<RecordResponse> response =
         recordOrchestratorService.upsertSingleRecord(
-            COLLECTION, VERSION, TEST_TYPE, RECORD_ID, Optional.of(PRIMARY_KEY), recordRequest);
+            COLLECTION_UUID,
+            VERSION,
+            TEST_TYPE,
+            RECORD_ID,
+            Optional.of(PRIMARY_KEY),
+            recordRequest);
 
     // Assert
     assertEquals(HttpStatus.CREATED, response.getStatusCode());
@@ -148,7 +155,7 @@ class RecordOrchestratorServiceTest extends TestBase {
         ConflictingPrimaryKeysException.class,
         () ->
             recordOrchestratorService.upsertSingleRecord(
-                COLLECTION, VERSION, TEST_TYPE, RECORD_ID, primaryKey, recordRequest),
+                COLLECTION_UUID, VERSION, TEST_TYPE, RECORD_ID, primaryKey, recordRequest),
         "upsertSingleRecord should have thrown an error");
   }
 
@@ -162,7 +169,7 @@ class RecordOrchestratorServiceTest extends TestBase {
     // Act
     ResponseEntity<RecordResponse> response =
         recordOrchestratorService.upsertSingleRecord(
-            COLLECTION, VERSION, TEST_TYPE, RECORD_ID, Optional.empty(), recordRequest);
+            COLLECTION_UUID, VERSION, TEST_TYPE, RECORD_ID, Optional.empty(), recordRequest);
 
     // Assert
     assertEquals(HttpStatus.CREATED, response.getStatusCode());
@@ -180,7 +187,7 @@ class RecordOrchestratorServiceTest extends TestBase {
         ConflictingPrimaryKeysException.class,
         () ->
             recordOrchestratorService.upsertSingleRecord(
-                COLLECTION, VERSION, TEST_TYPE, RECORD_ID, Optional.empty(), recordRequest),
+                COLLECTION_UUID, VERSION, TEST_TYPE, RECORD_ID, Optional.empty(), recordRequest),
         "upsertSingleRecord should have thrown an error");
   }
 
@@ -188,7 +195,7 @@ class RecordOrchestratorServiceTest extends TestBase {
   void upsertExistingRecordWithMatchingPrimaryKey() {
     // Arrange
     recordOrchestratorService.upsertSingleRecord(
-        COLLECTION,
+        COLLECTION_UUID,
         VERSION,
         TEST_TYPE,
         RECORD_ID,
@@ -202,7 +209,7 @@ class RecordOrchestratorServiceTest extends TestBase {
     Optional<String> primaryKey = Optional.of(PRIMARY_KEY);
     ResponseEntity<RecordResponse> response =
         recordOrchestratorService.upsertSingleRecord(
-            COLLECTION, VERSION, TEST_TYPE, RECORD_ID, primaryKey, recordRequest);
+            COLLECTION_UUID, VERSION, TEST_TYPE, RECORD_ID, primaryKey, recordRequest);
 
     // Assert
     assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -213,7 +220,7 @@ class RecordOrchestratorServiceTest extends TestBase {
   void upsertExistingRecordWithDifferentPrimaryKey(boolean primaryKeyInQuery) {
     // Arrange
     recordOrchestratorService.upsertSingleRecord(
-        COLLECTION,
+        COLLECTION_UUID,
         VERSION,
         TEST_TYPE,
         RECORD_ID,
@@ -229,7 +236,7 @@ class RecordOrchestratorServiceTest extends TestBase {
         ConflictingPrimaryKeysException.class,
         () ->
             recordOrchestratorService.upsertSingleRecord(
-                COLLECTION, VERSION, TEST_TYPE, RECORD_ID, primaryKey, recordRequest),
+                COLLECTION_UUID, VERSION, TEST_TYPE, RECORD_ID, primaryKey, recordRequest),
         "upsertSingleRecord should have thrown an error");
   }
 
@@ -237,7 +244,7 @@ class RecordOrchestratorServiceTest extends TestBase {
   void updateRecordWithMatchingPrimaryKey() {
     // Arrange
     recordOrchestratorService.upsertSingleRecord(
-        COLLECTION,
+        COLLECTION_UUID,
         VERSION,
         TEST_TYPE,
         RECORD_ID,
@@ -250,7 +257,7 @@ class RecordOrchestratorServiceTest extends TestBase {
     // Act
     RecordResponse response =
         recordOrchestratorService.updateSingleRecord(
-            COLLECTION, VERSION, TEST_TYPE, RECORD_ID, recordRequest);
+            COLLECTION_UUID, VERSION, TEST_TYPE, RECORD_ID, recordRequest);
 
     // Assert
     assertEquals(RECORD_ID, response.recordId());
@@ -260,7 +267,7 @@ class RecordOrchestratorServiceTest extends TestBase {
   void updateRecordWithDifferentPrimaryKey() {
     // Arrange
     recordOrchestratorService.upsertSingleRecord(
-        COLLECTION,
+        COLLECTION_UUID,
         VERSION,
         TEST_TYPE,
         RECORD_ID,
@@ -275,7 +282,7 @@ class RecordOrchestratorServiceTest extends TestBase {
         ConflictingPrimaryKeysException.class,
         () ->
             recordOrchestratorService.updateSingleRecord(
-                COLLECTION, VERSION, TEST_TYPE, RECORD_ID, recordRequest),
+                COLLECTION_UUID, VERSION, TEST_TYPE, RECORD_ID, recordRequest),
         "updateSingleRecord should have thrown an error");
   }
 
@@ -283,7 +290,7 @@ class RecordOrchestratorServiceTest extends TestBase {
   void deleteSingleRecord() {
     testCreateRecord(RECORD_ID, TEST_KEY, TEST_VAL);
 
-    recordOrchestratorService.deleteSingleRecord(COLLECTION, VERSION, TEST_TYPE, RECORD_ID);
+    recordOrchestratorService.deleteSingleRecord(COLLECTION_UUID, VERSION, TEST_TYPE, RECORD_ID);
 
     assertThrows(
         MissingObjectException.class,
@@ -295,11 +302,11 @@ class RecordOrchestratorServiceTest extends TestBase {
   void deleteRecordType() {
     testCreateRecord(RECORD_ID, TEST_KEY, TEST_VAL);
 
-    recordOrchestratorService.deleteRecordType(COLLECTION, VERSION, TEST_TYPE);
+    recordOrchestratorService.deleteRecordType(COLLECTION_UUID, VERSION, TEST_TYPE);
 
     assertThrows(
         MissingObjectException.class,
-        () -> recordOrchestratorService.describeRecordType(COLLECTION, VERSION, TEST_TYPE),
+        () -> recordOrchestratorService.describeRecordType(COLLECTION_UUID, VERSION, TEST_TYPE),
         "describeRecordType should have thrown an error");
   }
 
@@ -309,7 +316,8 @@ class RecordOrchestratorServiceTest extends TestBase {
     createRecordWithAttributes(new String[] {"attr1", "attr2"});
 
     // Act
-    recordOrchestratorService.renameAttribute(COLLECTION, VERSION, TEST_TYPE, "attr2", "attr3");
+    recordOrchestratorService.renameAttribute(
+        COLLECTION_UUID, VERSION, TEST_TYPE, "attr2", "attr3");
 
     // Assert
     assertAttributes(Set.of("id", "attr1", "attr3"));
@@ -327,7 +335,7 @@ class RecordOrchestratorServiceTest extends TestBase {
             ValidationException.class,
             () ->
                 recordOrchestratorService.renameAttribute(
-                    COLLECTION, VERSION, TEST_TYPE, "id", "newId"),
+                    COLLECTION_UUID, VERSION, TEST_TYPE, "id", "newId"),
             "renameAttribute should have thrown an error");
     assertEquals("Unable to rename primary key attribute", e.getMessage());
     assertAttributes(Set.of("id", "attr1", "attr2"));
@@ -344,7 +352,7 @@ class RecordOrchestratorServiceTest extends TestBase {
             MissingObjectException.class,
             () ->
                 recordOrchestratorService.renameAttribute(
-                    COLLECTION, VERSION, TEST_TYPE, "doesNotExist", "attr3"),
+                    COLLECTION_UUID, VERSION, TEST_TYPE, "doesNotExist", "attr3"),
             "renameAttribute should have thrown an error");
     assertEquals(
         "Attribute does not exist or you do not have permission to see it", e.getMessage());
@@ -362,7 +370,7 @@ class RecordOrchestratorServiceTest extends TestBase {
             ConflictException.class,
             () ->
                 recordOrchestratorService.renameAttribute(
-                    COLLECTION, VERSION, TEST_TYPE, "attr1", "attr2"),
+                    COLLECTION_UUID, VERSION, TEST_TYPE, "attr1", "attr2"),
             "renameAttribute should have thrown an error");
     assertEquals("Attribute already exists", e.getMessage());
     assertAttributes(Set.of("id", "attr1", "attr2"));
@@ -392,7 +400,7 @@ class RecordOrchestratorServiceTest extends TestBase {
         RecordAttributes.empty().putAttribute(attributeName, attributeValue);
     RecordRequest recordRequest = new RecordRequest(recordAttributes);
     recordOrchestratorService.upsertSingleRecord(
-        COLLECTION, VERSION, TEST_TYPE, RECORD_ID, Optional.of(PRIMARY_KEY), recordRequest);
+        COLLECTION_UUID, VERSION, TEST_TYPE, RECORD_ID, Optional.of(PRIMARY_KEY), recordRequest);
 
     assertAttributeDataType(
         attributeName,
@@ -401,7 +409,7 @@ class RecordOrchestratorServiceTest extends TestBase {
 
     // Act
     recordOrchestratorService.updateAttributeDataType(
-        COLLECTION, VERSION, TEST_TYPE, attributeName, newDataType.name());
+        COLLECTION_UUID, VERSION, TEST_TYPE, attributeName, newDataType.name());
 
     // Assert
     assertAttributeDataType(
@@ -778,7 +786,7 @@ class RecordOrchestratorServiceTest extends TestBase {
             ValidationException.class,
             () ->
                 recordOrchestratorService.updateAttributeDataType(
-                    COLLECTION, VERSION, TEST_TYPE, PRIMARY_KEY, "NUMBER"),
+                    COLLECTION_UUID, VERSION, TEST_TYPE, PRIMARY_KEY, "NUMBER"),
             "updateAttributeDataType should have thrown an error");
     assertEquals("Unable to update primary key attribute", e.getMessage());
   }
@@ -794,7 +802,7 @@ class RecordOrchestratorServiceTest extends TestBase {
             ValidationException.class,
             () ->
                 recordOrchestratorService.updateAttributeDataType(
-                    COLLECTION, VERSION, TEST_TYPE, "attr1", "INVALID_DATA_TYPE"),
+                    COLLECTION_UUID, VERSION, TEST_TYPE, "attr1", "INVALID_DATA_TYPE"),
             "updateAttributeDataType should have thrown an error");
     assertEquals("Invalid datatype", e.getMessage());
   }
@@ -807,7 +815,7 @@ class RecordOrchestratorServiceTest extends TestBase {
         RecordAttributes.empty().putAttribute(attributeName, List.of("foo", "bar", "baz"));
     RecordRequest recordRequest = new RecordRequest(recordAttributes);
     recordOrchestratorService.upsertSingleRecord(
-        COLLECTION, VERSION, TEST_TYPE, RECORD_ID, Optional.of(PRIMARY_KEY), recordRequest);
+        COLLECTION_UUID, VERSION, TEST_TYPE, RECORD_ID, Optional.of(PRIMARY_KEY), recordRequest);
 
     assertAttributeDataType(
         attributeName,
@@ -820,7 +828,7 @@ class RecordOrchestratorServiceTest extends TestBase {
             ValidationException.class,
             () ->
                 recordOrchestratorService.updateAttributeDataType(
-                    COLLECTION, VERSION, TEST_TYPE, attributeName, "STRING"),
+                    COLLECTION_UUID, VERSION, TEST_TYPE, attributeName, "STRING"),
             "updateAttributeDataType should have thrown an error");
     assertEquals("Unable to convert array type to scalar type", e.getMessage());
   }
@@ -834,13 +842,13 @@ class RecordOrchestratorServiceTest extends TestBase {
         RecordAttributes.empty().putAttribute(attributeName, "123");
     RecordRequest recordOneRequest = new RecordRequest(recordOneAttributes);
     recordOrchestratorService.upsertSingleRecord(
-        COLLECTION, VERSION, TEST_TYPE, "row_1", Optional.of(PRIMARY_KEY), recordOneRequest);
+        COLLECTION_UUID, VERSION, TEST_TYPE, "row_1", Optional.of(PRIMARY_KEY), recordOneRequest);
 
     RecordAttributes recordTwoAttributes =
         RecordAttributes.empty().putAttribute(attributeName, "foo");
     RecordRequest recordTwoRequest = new RecordRequest(recordTwoAttributes);
     recordOrchestratorService.upsertSingleRecord(
-        COLLECTION, VERSION, TEST_TYPE, "row_2", Optional.of(PRIMARY_KEY), recordTwoRequest);
+        COLLECTION_UUID, VERSION, TEST_TYPE, "row_2", Optional.of(PRIMARY_KEY), recordTwoRequest);
 
     assertAttributeDataType(
         attributeName, DataTypeMapping.STRING, "expected initial attribute data type to be STRING");
@@ -851,7 +859,7 @@ class RecordOrchestratorServiceTest extends TestBase {
             ConflictException.class,
             () ->
                 recordOrchestratorService.updateAttributeDataType(
-                    COLLECTION, VERSION, TEST_TYPE, attributeName, "NUMBER"),
+                    COLLECTION_UUID, VERSION, TEST_TYPE, attributeName, "NUMBER"),
             "updateAttributeDataType should have thrown an error");
 
     assertEquals(
@@ -877,7 +885,7 @@ class RecordOrchestratorServiceTest extends TestBase {
         RecordAttributes.empty().putAttribute(attributeName, attributeValue);
     RecordRequest recordRequest = new RecordRequest(recordAttributes);
     recordOrchestratorService.upsertSingleRecord(
-        COLLECTION, VERSION, TEST_TYPE, RECORD_ID, Optional.of(PRIMARY_KEY), recordRequest);
+        COLLECTION_UUID, VERSION, TEST_TYPE, RECORD_ID, Optional.of(PRIMARY_KEY), recordRequest);
 
     // Act/Assert
     ConflictException e =
@@ -885,7 +893,7 @@ class RecordOrchestratorServiceTest extends TestBase {
             ConflictException.class,
             () ->
                 recordOrchestratorService.updateAttributeDataType(
-                    COLLECTION, VERSION, TEST_TYPE, attributeName, newDataType.name()),
+                    COLLECTION_UUID, VERSION, TEST_TYPE, attributeName, newDataType.name()),
             "updateAttributeDataType should have thrown an error");
 
     assertEquals(
@@ -910,7 +918,7 @@ class RecordOrchestratorServiceTest extends TestBase {
         RecordAttributes.empty().putAttribute(attributeName, attributeValue);
     RecordRequest recordRequest = new RecordRequest(recordAttributes);
     recordOrchestratorService.upsertSingleRecord(
-        COLLECTION, VERSION, TEST_TYPE, RECORD_ID, Optional.of(PRIMARY_KEY), recordRequest);
+        COLLECTION_UUID, VERSION, TEST_TYPE, RECORD_ID, Optional.of(PRIMARY_KEY), recordRequest);
     assertAttributeDataType(
         attributeName,
         expectedInitialDataType,
@@ -922,7 +930,7 @@ class RecordOrchestratorServiceTest extends TestBase {
             ValidationException.class,
             () ->
                 recordOrchestratorService.updateAttributeDataType(
-                    COLLECTION, VERSION, TEST_TYPE, attributeName, newDataType.name()),
+                    COLLECTION_UUID, VERSION, TEST_TYPE, attributeName, newDataType.name()),
             "updateAttributeDataType should have thrown an error");
 
     assertEquals(
@@ -947,7 +955,7 @@ class RecordOrchestratorServiceTest extends TestBase {
     createRecordWithAttributes(new String[] {"attr1", "attr2"});
 
     // Act
-    recordOrchestratorService.deleteAttribute(COLLECTION, VERSION, TEST_TYPE, "attr2");
+    recordOrchestratorService.deleteAttribute(COLLECTION_UUID, VERSION, TEST_TYPE, "attr2");
 
     // Assert
     assertAttributes(Set.of("id", "attr1"));
@@ -962,7 +970,9 @@ class RecordOrchestratorServiceTest extends TestBase {
     ValidationException e =
         assertThrows(
             ValidationException.class,
-            () -> recordOrchestratorService.deleteAttribute(COLLECTION, VERSION, TEST_TYPE, "id"),
+            () ->
+                recordOrchestratorService.deleteAttribute(
+                    COLLECTION_UUID, VERSION, TEST_TYPE, "id"),
             "deleteAttribute should have thrown an error");
     assertEquals("Unable to delete primary key attribute", e.getMessage());
     assertAttributes(Set.of("id", "attr1", "attr2"));
@@ -979,7 +989,7 @@ class RecordOrchestratorServiceTest extends TestBase {
             MissingObjectException.class,
             () ->
                 recordOrchestratorService.deleteAttribute(
-                    COLLECTION, VERSION, TEST_TYPE, "doesnotexist"),
+                    COLLECTION_UUID, VERSION, TEST_TYPE, "doesnotexist"),
             "deleteAttribute should have thrown an error");
     assertEquals(
         "Attribute does not exist or you do not have permission to see it", e.getMessage());
@@ -995,7 +1005,12 @@ class RecordOrchestratorServiceTest extends TestBase {
 
     ResponseEntity<RecordResponse> response =
         recordOrchestratorService.upsertSingleRecord(
-            COLLECTION, VERSION, TEST_TYPE, RECORD_ID, Optional.of(PRIMARY_KEY), recordRequest);
+            COLLECTION_UUID,
+            VERSION,
+            TEST_TYPE,
+            RECORD_ID,
+            Optional.of(PRIMARY_KEY),
+            recordRequest);
 
     Set<String> expectedAttributes = Stream.of(attributeNames).collect(Collectors.toSet());
     expectedAttributes.add(PRIMARY_KEY);
@@ -1005,7 +1020,7 @@ class RecordOrchestratorServiceTest extends TestBase {
 
   private void assertAttributes(Set<String> expectedAttributeNames) {
     RecordTypeSchema schema =
-        recordOrchestratorService.describeRecordType(COLLECTION, VERSION, TEST_TYPE);
+        recordOrchestratorService.describeRecordType(COLLECTION_UUID, VERSION, TEST_TYPE);
     Set<String> actualAttributeNames =
         Set.copyOf(schema.attributes().stream().map(AttributeSchema::name).toList());
     assertEquals(expectedAttributeNames, actualAttributeNames);
@@ -1018,7 +1033,7 @@ class RecordOrchestratorServiceTest extends TestBase {
     testCreateRecord("third", TEST_KEY, "a third");
 
     RecordTypeSchema schema =
-        recordOrchestratorService.describeRecordType(COLLECTION, VERSION, TEST_TYPE);
+        recordOrchestratorService.describeRecordType(COLLECTION_UUID, VERSION, TEST_TYPE);
 
     assertEquals(TEST_TYPE, schema.name());
     assertEquals(3, schema.count());
@@ -1034,7 +1049,7 @@ class RecordOrchestratorServiceTest extends TestBase {
     testCreateRecord("fourth", TEST_KEY, "a fourth", typeTwo);
 
     List<RecordTypeSchema> schemas =
-        recordOrchestratorService.describeAllRecordTypes(COLLECTION, VERSION);
+        recordOrchestratorService.describeAllRecordTypes(COLLECTION_UUID, VERSION);
 
     assert (schemas.stream()
         .anyMatch(schema -> schema.name().equals(TEST_TYPE) && schema.count() == 3));
@@ -1066,14 +1081,14 @@ class RecordOrchestratorServiceTest extends TestBase {
 
     ResponseEntity<RecordResponse> response =
         recordOrchestratorService.upsertSingleRecord(
-            COLLECTION, VERSION, newRecordType, newRecordId, Optional.empty(), recordRequest);
+            COLLECTION_UUID, VERSION, newRecordType, newRecordId, Optional.empty(), recordRequest);
 
     assertEquals(newRecordId, response.getBody().recordId());
   }
 
   private void testGetRecord(String newRecordId, String testKey, String testVal) {
     RecordResponse recordResponse =
-        recordOrchestratorService.getSingleRecord(COLLECTION, VERSION, TEST_TYPE, newRecordId);
+        recordOrchestratorService.getSingleRecord(COLLECTION_UUID, VERSION, TEST_TYPE, newRecordId);
     assertEquals(testVal, recordResponse.recordAttributes().getAttributeValue(testKey));
   }
 
@@ -1094,7 +1109,7 @@ class RecordOrchestratorServiceTest extends TestBase {
   private void assertAttributeDataType(
       String attributeName, DataTypeMapping dataType, String message) {
     RecordTypeSchema recordTypeSchema =
-        recordOrchestratorService.describeRecordType(COLLECTION, VERSION, TEST_TYPE);
+        recordOrchestratorService.describeRecordType(COLLECTION_UUID, VERSION, TEST_TYPE);
     AttributeSchema attributeSchema = recordTypeSchema.getAttributeSchema(attributeName);
     assertEquals(dataType.name(), attributeSchema.datatype(), message);
   }
@@ -1102,7 +1117,7 @@ class RecordOrchestratorServiceTest extends TestBase {
   private void assertAttributeValue(
       String recordId, String attributeName, Object expectedValue, String message) {
     RecordResponse record =
-        recordOrchestratorService.getSingleRecord(COLLECTION, VERSION, TEST_TYPE, recordId);
+        recordOrchestratorService.getSingleRecord(COLLECTION_UUID, VERSION, TEST_TYPE, recordId);
     Object attributeValue = record.recordAttributes().getAttributeValue(attributeName);
 
     if (expectedValue instanceof Object[]) {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerBeanTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerBeanTest.java
@@ -89,7 +89,7 @@ class CollectionInitializerBeanTest extends TestBase {
     // collection does not exist
     assertFalse(collectionDao.collectionSchemaExists(collectionIdMatchingWorkspaceId()));
     // create the collection outside the initializer
-    collectionDao.createSchema(collectionUuidMatchingWorkspaceId());
+    collectionDao.createSchema(collectionIdMatchingWorkspaceId());
     assertTrue(collectionDao.collectionSchemaExists(collectionIdMatchingWorkspaceId()));
     // now run the initializer
     getBean().initializeCollection();
@@ -130,7 +130,7 @@ class CollectionInitializerBeanTest extends TestBase {
   // exists.
   void cloneWithCloneTableAndCollectionExist() {
     // start with collection and clone entry
-    collectionDao.createSchema(collectionUuidMatchingWorkspaceId());
+    collectionDao.createSchema(collectionIdMatchingWorkspaceId());
     cloneDao.createCloneEntry(randomUUID(), sourceWorkspaceId);
     // enter clone mode
     boolean cleanExit = getBean().initCloneMode(sourceWorkspaceId);
@@ -184,10 +184,6 @@ class CollectionInitializerBeanTest extends TestBase {
 
   private CollectionId collectionIdMatchingWorkspaceId() {
     return CollectionId.of(workspaceId.id());
-  }
-
-  private UUID collectionUuidMatchingWorkspaceId() {
-    return workspaceId.id();
   }
 
   private CollectionInitializerBean getBean() {


### PR DESCRIPTION
Change signature of `CollectionDao#createSchema` to use `CollectionId`
instead of `UUID`.