### PR TITLE
AJ-1857: PFB/Parquet maps and records should not be stringified twice

### DIFF
--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbRecordConverterTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbRecordConverterTest.java
@@ -7,6 +7,7 @@ import static org.databiosphere.workspacedataservice.dataimport.pfb.PfbTestUtils
 import static org.databiosphere.workspacedataservice.dataimport.pfb.PfbTestUtils.RELATION_ARRAY_SCHEMA;
 import static org.databiosphere.workspacedataservice.dataimport.pfb.PfbTestUtils.RELATION_SCHEMA;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -29,6 +30,7 @@ import org.databiosphere.workspacedataservice.recordsource.RecordSource.ImportMo
 import org.databiosphere.workspacedataservice.service.JsonConfig;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
+import org.databiosphere.workspacedataservice.shared.model.attributes.JsonAttribute;
 import org.databiosphere.workspacedataservice.shared.model.attributes.RelationAttribute;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -181,15 +183,17 @@ class PfbRecordConverterTest extends TestBase {
         actual.getAttributeValue("arrayOfNumbers"));
     assertEquals(List.of("one", "two", "three"), actual.getAttributeValue("arrayOfStrings"));
     assertEquals(List.of("enumValue2", "enumValue1"), actual.getAttributeValue("arrayOfEnums"));
-    assertEqualsJsonString(
+
+    // json attributes use the JsonAttribute wrapper class
+    assertEqualsJsonAttribute(
         "{\"one\":1,\"two\":2,\"three\":3}", actual.getAttributeValue("mapOfNumbers"));
-    assertEqualsJsonString(
+    assertEqualsJsonAttribute(
         "{\"one\":\"one\",\"two\":\"two\",\"three\":\"three\"}",
         actual.getAttributeValue("mapOfStrings"));
-    assertEqualsJsonString(
+    assertEqualsJsonAttribute(
         "{\"one\":\"enumValue1\",\"two\":\"enumValue2\"}", actual.getAttributeValue("mapOfEnums"));
-    assertEqualsJsonString(
-        "{\"embeddedLong\":123,\"embeddedString\":\"embeddedString\"}",
+    assertEqualsJsonAttribute(
+        "{\"embeddedLong\":123,\"embeddedString\":\"embeddedString\"})",
         actual.getAttributeValue("embeddedObject"));
   }
 
@@ -326,11 +330,11 @@ class PfbRecordConverterTest extends TestBase {
         Arguments.of("noconversion", "noconversion"));
   }
 
-  private void assertEqualsJsonString(String expectedJsonString, Object actualValue) {
-    assertThat(actualValue).isInstanceOf(String.class);
-
+  private void assertEqualsJsonAttribute(String expectedJsonString, Object actualValue) {
+    // json attributes use the JsonAttribute wrapper class
+    JsonAttribute actual = assertInstanceOf(JsonAttribute.class, actualValue);
     try {
-      JsonNode actualJson = normalizeJson(actualValue.toString());
+      JsonNode actualJson = normalizeJson(actual.jsonValue().toString());
       JsonNode expectedJson = normalizeJson(expectedJsonString);
       assertThat(actualJson).isEqualTo(expectedJson);
     } catch (JsonProcessingException e) {


### PR DESCRIPTION
The import in question from HCA contains some attributes which are, at the Avro level, `Array`s of `GenericData$Record`.

In `AvroRecordConverter`, we properly detect these types and serialize them to json.

However, we store that serialized json inside a `String`. Later, when `RawlsRecordSink` puts that string inside an `AddListMember` `Op` and that `Op` is serialized into file (i.e. written to a bucket), the `Op`'s serialization notices all the double quotes within the string and escapes them. Thus, the carefully-serialized json is escaped and loses its json-ness.

The end result causes fatal errors for the HCA import:
* it expected to store an array of json objects, with each object being of a legal size
* instead, it tries to store a single escaped string that concatenates all objects, and this single string is over the legal size

The solution in this PR is, in `AvroRecordConverter`, to store the serialized json in a `JsonAttribute` instead of in a `String`. `JsonAttribute` has defines its own json serializer, so it bypasses the escaping.

### The written JSON, after this PR. Note that the "newMember" value is an OBJECT:
```
{"op":"AddListMember" ... "newMember":{"inputs":[{"input_id":"550e8400-e29b-41d4-a716-446655440000","input_type":"cell_suspension"}],"link_type":
```

### The written JSON, before this PR. Note that the "newMember" value is an STRING, containing an escaped version of the object:
```
{"op":"AddListMember" ... "newMember":"{\"inputs\": [{\"input_id\": \"550e8400-e29b-41d4-a716-446655440000\", \"input_type\": \"cell_suspension\"}], \"link_type\":
```


# Screenshots

## GCP, `main` branch
_importing the HCA PFB causes an error:_
![azure-main-error](https://github.com/DataBiosphere/terra-workspace-data-service/assets/6041577/4bba80ff-722e-4268-853b-b621dde264c6)
_when viewing the table, elements in the `pfb:links` column look ok; but note there are only 853 rows in the links table due to the import error_
![gcp-main-2](https://github.com/DataBiosphere/terra-workspace-data-service/assets/6041577/c2d6bd1f-7248-4a9b-9ad2-071efdffec2a)
_but when viewing their details, you can see they are escaped json strings:_
![gcp-main](https://github.com/DataBiosphere/terra-workspace-data-service/assets/6041577/8ef34285-6766-4b92-91fa-d78fb2bc66b2)

## GCP, this PR
_when viewing the table, elements in the `pfb:links` column show as objects. Note that all 1029 rows of the links table imported:_
![gcp-branch-2](https://github.com/DataBiosphere/terra-workspace-data-service/assets/6041577/608f653d-2180-49d3-a693-5dba075d8802)
_when viewing their details, you can see the object data:_
![gcp-branch](https://github.com/DataBiosphere/terra-workspace-data-service/assets/6041577/6f63b6fc-97c6-443c-aaf0-874dad9cf5e3)

## Azure, `main` branch
_when viewing the table, elements in the `contributors` column look ok. Note that I had to use a different table for Azure/main because I can't even get the `links` table to load_
![azure-main-2](https://github.com/DataBiosphere/terra-workspace-data-service/assets/6041577/34f762e7-c673-4021-a457-56f367775ab2)
_but when viewing their details, you can see they are escaped json strings:_
![azure-main](https://github.com/DataBiosphere/terra-workspace-data-service/assets/6041577/f307cf59-8ca8-4d0b-8dbe-ac300cd28d14)

## Azure, this PR
_when viewing the table, elements in the `links` column show as objects:_
![azure-branch-2](https://github.com/DataBiosphere/terra-workspace-data-service/assets/6041577/60a16fef-fcb0-4c7a-9b93-84a2a2eae96a)
_when viewing their details, you can see the object data:_
![azure-branch](https://github.com/DataBiosphere/terra-workspace-data-service/assets/6041577/7c6aa5c4-9501-43a7-b303-214969542eb0)




