### PR TITLE
AJ-1868: update aircompressor transitive dep

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -148,6 +148,9 @@ dependencies {
         implementation('org.codehaus.jettison:jettison:1.5.4') {
             because("CVE-2022-40149, CVE-2022-40150, CVE-2022-45685, CVE-2022-45693, CVE-2023-1436")
         }
+        implementation('io.airlift:aircompressor:0.27') {
+            because("CVE-2024-36114")
+        }
     }
 }
 


### PR DESCRIPTION
Updates `aircompressor` transitive dependency to address CVE-2024-36114