### PR TITLE
AJ-1782: remove bouncycastle bcprov-jdk15on transitive dependency

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -148,6 +148,9 @@ dependencies {
         implementation('org.codehaus.jettison:jettison:1.5.4') {
             because("CVE-2022-40149, CVE-2022-40150, CVE-2022-45685, CVE-2022-45693, CVE-2023-1436")
         }
+        implementation('org.bouncycastle:bcprov-jdk15on:1.78.1') {
+            because("CVE-2024-30172, CVE-2024-30171, CVE-2024-29857, CVE-2023-33201")
+        }
     }
 }
 

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -112,6 +112,7 @@ dependencies {
         exclude(group: 'org.apache.zookeeper')
         exclude(group: 'org.apache.kerby')
         exclude(group: 'com.google.protobuf')
+        exclude(group: 'org.bouncycastle')
     }
     implementation "org.apache.hadoop:hadoop-common:$hadoop_version", withoutHadoopExcludes
     implementation "org.apache.hadoop:hadoop-mapreduce-client-core:$hadoop_version", withoutHadoopExcludes
@@ -147,9 +148,6 @@ dependencies {
         }
         implementation('org.codehaus.jettison:jettison:1.5.4') {
             because("CVE-2022-40149, CVE-2022-40150, CVE-2022-45685, CVE-2022-45693, CVE-2023-1436")
-        }
-        implementation('org.bouncycastle:bcprov-jdk15on:1.78.1') {
-            because("CVE-2024-30172, CVE-2024-30171, CVE-2024-29857, CVE-2023-33201")
         }
     }
 }


### PR DESCRIPTION
removes the `bcprov-jdk15on` transitive dependency from the hadoop libraries to address:
* CVE-2024-30172
* CVE-2024-30171
* CVE-2024-29857
* CVE-2023-33201

Validated in my BEE by importing a PFB and a large TSV.