### PR TITLE
AJ-1782: update commons-configuration2 transitive dependency

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -142,6 +142,9 @@ dependencies {
         implementation('org.apache.commons:commons-compress:1.26.2') {
             because("CVE-2023-42503")
         }
+        implementation('org.apache.commons:commons-configuration2:2.10.1') {
+            because("CVE-2024-29131, CVE-2024-29133")
+        }
         implementation('org.xerial.snappy:snappy-java:1.1.10.5') {
             because("CVE-2023-34453, CVE-2023-34454, CVE-2023-34455, CVE-2023-43642")
         }


### PR DESCRIPTION
Updates `commons-configuration2` transitive dependency to address:
* CVE-2024-29131
* CVE-2024-29133