### PR TITLE
AJ-1808: don't publish messages to Rawls if import translation fails

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJob.java
@@ -121,6 +121,8 @@ public class PfbQuartzJob extends QuartzJob {
       //   group its merged results under import mode; most notably, relations will be double
       //   counted
       result.merge(withPfbStream(uri, stream -> importTables(stream, recordSink, RELATIONS)));
+      // complete the RecordSink
+      recordSink.success();
     } catch (DataImportException e) {
       throw new PfbImportException(e.getMessage(), e);
     }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJob.java
@@ -199,6 +199,8 @@ public class TdrManifestQuartzJob extends QuartzJob {
       if (options.syncPermissions() && isTdrPermissionSyncingEnabled) {
         syncPermissions(details.workspaceId(), snapshotId);
       }
+      // complete the RecordSink
+      recordSink.success();
     } catch (Exception e) {
       throw new TdrManifestImportException(e.getMessage(), e);
     } finally {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RecordSink.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RecordSink.java
@@ -44,12 +44,20 @@ public interface RecordSink extends AutoCloseable {
   void deleteBatch(RecordType recordType, List<Record> records) throws DataImportException;
 
   /**
-   * Callback invoked at the end of a series of batches operations with the result. Implementers can
-   * commit changes, clean up resources, publish results, etc.
+   * Callback always invoked at the end of a series of batch operations. This should execute any
+   * code to run on both success and failure, such as closing open files.
    *
    * @throws DataImportException if an error occurs while closing the sink
    */
   default void close() throws DataImportException {
     // no-op
   }
+
+  /**
+   * Method manually invoked by callers to indicate success of all batch operations. This should
+   * execute any code to run only on success, such as sending events to other systems.
+   *
+   * @throws DataImportException if an error occurs while closing the sink
+   */
+  void success() throws DataImportException;
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RecordSink.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RecordSink.java
@@ -57,7 +57,7 @@ public interface RecordSink extends AutoCloseable {
    * Method manually invoked by callers to indicate success of all batch operations. This should
    * execute any code to run only on success, such as sending events to other systems.
    *
-   * @throws DataImportException if an error occurs while closing the sink
+   * @throws DataImportException subclasses should throw this on any error in their implementations
    */
   void success() throws DataImportException;
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/WdsRecordSink.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/WdsRecordSink.java
@@ -6,6 +6,7 @@ import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.databiosphere.workspacedataservice.service.DataTypeInferer;
 import org.databiosphere.workspacedataservice.service.RecordService;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
+import org.databiosphere.workspacedataservice.service.model.exception.DataImportException;
 import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
@@ -68,5 +69,10 @@ public class WdsRecordSink implements RecordSink {
   @Override
   public void deleteBatch(RecordType recordType, List<Record> records) {
     recordDao.batchDelete(collectionId.id(), recordType, records);
+  }
+
+  @Override
+  public void success() throws DataImportException {
+    // noop
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkTest.java
@@ -59,7 +59,6 @@ import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.databiosphere.workspacedataservice.shared.model.attributes.RelationAttribute;
 import org.databiosphere.workspacedataservice.storage.GcsStorage;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -354,7 +353,6 @@ class RawlsRecordSinkTest extends TestBase {
     assertThat(pubSubMessageCaptor.getValue()).isEqualTo(expectedMessage);
   }
 
-  @Disabled("AJ-1808: Don't publish to Rawls on failure.")
   @Test
   void doesNotSendPubSubOnFailure() throws IOException {
     // Arrange
@@ -405,6 +403,7 @@ class RawlsRecordSinkTest extends TestBase {
           recordList,
           /* primaryKey= */ "name" // currently ignored
           );
+      recordSink.success();
     }
 
     // Assert


### PR DESCRIPTION
Before this PR, cWDS would always publish a "start import" pub/sub message to Rawls, even if the import failed early in the process and there was nothing for Rawls to import.

Now, `RecordSink` has a new `success()` method, which the PFB and TDR jobs call as their last step, and pub/sub publishing is contained in that method. The rawlsjson import job already did the right thing w/r/t publishing.

In previous discussion with Josh, we talked about fancy ways to set callback handlers on the RecordSink, or to automatically detect success vs. failure. After getting into the code, that seemed like overkill, and this approach feels pragmatic.

I considered also adding a `failure(Exception e)` method on `RecordSink` to flesh out its API, but … there's nothing to do there, so I ignored it.