### PR TITLE
AJ-1854 add concurrency groups to GH workflows

### DIFF
--- a/.github/workflows/build-and-integration-test.yml
+++ b/.github/workflows/build-and-integration-test.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [ '**' ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ '**' ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,8 +1,8 @@
 name: Build and Test
 
 on:
-  push:
-    paths-ignore: [ '*.md' ]
+  # push:
+  #   paths-ignore: [ '*.md' ]
   pull_request:
     branches: [ '**' ]
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,8 +1,6 @@
 name: Build and Test
 
 on:
-  # push:
-  #   paths-ignore: [ '*.md' ]
   pull_request:
     branches: [ '**' ]
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -3,9 +3,11 @@ name: Build and Test
 on:
   pull_request:
     branches: [ '**' ]
+  push:
+    branches: main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,7 +5,7 @@ on:
     branches: [ '**' ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/publish-pacts.yml
+++ b/.github/workflows/publish-pacts.yml
@@ -9,6 +9,10 @@ on:
       - main
     paths-ignore: [ '**.md' ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 env:
   WDS_RUN_ID: ${{ github.event.repository.name }}-${{ github.run_id }}
   PUBLISH_CONTRACT_RUN_NAME: 'publish-contracts-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}'


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1854

Adds concurrency groups to 3 workflows that run for pull requests.  
Reviewer, please verify that the [github.head_ref](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context) is the appropriate group name.  In the case of `publish_pacts.yaml`, this could be blank (if it's on `push` instead of `pull_request`), in which case I use `github.ref`.  (Or should I remove it from running on `push` as well?) 
Updates `build-and-test.yaml` to only run on `pull_request`, not also `push`. 
Todo:
[ ] Update GHA structure diagram to reflect this change.

Verified that concurrent runs were cancelled - I received emails alerting me to cancelled runs as I was committing to this PR.

Reminder:

#### Releasing WDS ####
PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag-and-publish.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 

#### Keeping Docs Up To Date ####
If you make changes to the github actions or workflows, particularly when they are run or which other workflows they call, please update [the GHA wiki page](https://github.com/DataBiosphere/terra-workspace-data-service/wiki/GHA-structure-in-WDS) to stay up to date.
