### PR TITLE
AJ-1782: remove override for aircompressor, now that parquet updated

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -152,9 +152,6 @@ dependencies {
         implementation('org.codehaus.jettison:jettison:1.5.4') {
             because("CVE-2022-40149, CVE-2022-40150, CVE-2022-45685, CVE-2022-45693, CVE-2023-1436")
         }
-        implementation('io.airlift:aircompressor:0.27') {
-            because("CVE-2024-36114")
-        }
     }
 }
 


### PR DESCRIPTION
The new parquet libraries in #831 eliminate the need for an `aircompressor` override.

From the build scan for this PR:
![Screenshot 17-06-2024 at 09 28](https://github.com/DataBiosphere/terra-workspace-data-service/assets/6041577/b3cd1ee8-1ec1-49dd-9a1b-77e41ae117bc)

