### PR TITLE
AJ-1782: update app insights library

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     implementation 'org.zalando:logbook-spring-boot-starter:3.9.0'
 
     // Azure libraries
-    implementation 'com.microsoft.azure:applicationinsights-runtime-attach:3.4.19'
+    implementation 'com.microsoft.azure:applicationinsights-runtime-attach:3.5.3'
     implementation 'com.azure:azure-storage-blob:12.26.1'
     implementation 'com.azure:azure-identity-extensions:1.1.16' // postgres password plugin
 


### PR DESCRIPTION
Updates `https://github.com/microsoft/ApplicationInsights-Java/releases` from 3.4.19 to 3.5.3.

See release notes at https://github.com/microsoft/ApplicationInsights-Java/releases.

The most exciting change in 3.5.3 (imho) is:
> Remove _APPRESOURCEPREVIEW_ custom metric as it is still in preview

If this works as expected, those metrics will shave off ~7% of our total metrics ingestion, leading to reduced Log Analytics ingestion cost.