### PR TITLE
AJ-1898: stop app insights from instrumenting liveness and readiness probes

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -47,7 +47,8 @@ dependencies {
     implementation 'org.zalando:logbook-spring-boot-starter:3.9.0'
 
     // Azure libraries
-    implementation 'com.microsoft.azure:applicationinsights-runtime-attach:3.4.19'
+    // do not upgrade app insights past 3.5.1 until AJ-1897 is resolved
+    implementation 'com.microsoft.azure:applicationinsights-runtime-attach:3.5.1'
     implementation 'com.azure:azure-storage-blob:12.26.1'
     implementation 'com.azure:azure-identity-extensions:1.1.16' // postgres password plugin
 

--- a/service/src/main/resources/applicationinsights.json
+++ b/service/src/main/resources/applicationinsights.json
@@ -2,5 +2,31 @@
   "customDimensions": {
     "workspaceId": "${WORKSPACE_ID}",
     "service.version": "${RELEASE_NAME}"
+  },
+  "sampling": {
+    "overrides": [
+      {
+        "telemetryType": "request",
+        "attributes": [
+          {
+            "key": "url.path",
+            "value": "/status/liveness",
+            "matchType": "strict"
+          }
+        ],
+        "percentage": 0
+      },
+      {
+        "telemetryType": "request",
+        "attributes": [
+          {
+            "key": "url.path",
+            "value": "/status/readiness",
+            "matchType": "strict"
+          }
+        ],
+        "percentage": 0
+      }
+    ]
   }
 }

--- a/service/src/main/resources/applicationinsights.json
+++ b/service/src/main/resources/applicationinsights.json
@@ -4,7 +4,6 @@
     "service.version": "${RELEASE_NAME}"
   },
   "sampling": {
-    "requestsPerSecond": 5.0,
     "overrides": [
       {
         "telemetryType": "request",

--- a/service/src/main/resources/applicationinsights.json
+++ b/service/src/main/resources/applicationinsights.json
@@ -4,6 +4,7 @@
     "service.version": "${RELEASE_NAME}"
   },
   "sampling": {
+    "requestsPerSecond": 5.0,
     "overrides": [
       {
         "telemetryType": "request",


### PR DESCRIPTION
See https://learn.microsoft.com/en-us/azure/azure-monitor/app/java-standalone-sampling-overrides#example-suppress-collecting-telemetry-for-health-checks for explanation of the config changes in this PR.

This will reduce our Log Analytics ingestion cost by ignoring liveness/readiness probes.

This PR upgrades the app insights library to 3.5.1:
* greater than or equal to 3.5.0 so [sampling overrides are GA](https://github.com/microsoft/ApplicationInsights-Java/releases/tag/3.5.0)
* less than 3.5.2 because of https://broadworkbench.atlassian.net/browse/AJ-1897

I deployed the code in this PR to a test workspace. Here's a visualization of the results in Log Analytics:

`AppRequests` table:
![Screenshot 24-06-2024 at 10 18](https://github.com/DataBiosphere/terra-workspace-data-service/assets/6041577/5ad4b0cc-1475-4e5f-88b0-705c1f720ed9)

`AppDependencies` table:
![Screenshot 24-06-2024 at 10 19](https://github.com/DataBiosphere/terra-workspace-data-service/assets/6041577/daf86404-61d2-46b3-8b79-c9dc109b5ef1)
