### PR TITLE
Revert "AJ-1782: update app insights library"

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     implementation 'org.zalando:logbook-spring-boot-starter:3.9.0'
 
     // Azure libraries
-    implementation 'com.microsoft.azure:applicationinsights-runtime-attach:3.5.3'
+    implementation 'com.microsoft.azure:applicationinsights-runtime-attach:3.4.19'
     implementation 'com.azure:azure-storage-blob:12.26.1'
     implementation 'com.azure:azure-identity-extensions:1.1.16' // postgres password plugin
 


### PR DESCRIPTION
Reverts DataBiosphere/terra-workspace-data-service#833

While #833 worked as expected w/r/t reducing `_APPRESOURCEPREVIEW_` metrics, it also seems to have a regression in that it stops recording http requests into the `AppRequests` table. I'd like to revert the update until I have a chance to investigate that.