### PR TITLE
AJ-1782: update to spring boot 3.3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
 plugins {
-    id 'org.springframework.boot' version '3.3.0' apply false
+    id 'org.springframework.boot' version '3.3.1' apply false
     id 'io.spring.dependency-management' version '1.1.5' apply false
     id 'com.google.cloud.tools.jib' version '3.2.1' apply false
     id "org.sonarqube" version "5.0.0.4638" apply false


### PR DESCRIPTION
Spring Boot 3.3.1 is now available: https://spring.io/blog/2024/06/20/spring-boot-3-3-1-available-now

I reviewed the release notes and didn't see anything that needs attention.