### PR TITLE
AJ-1782: remove unnecessary dependency constraints

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -146,12 +146,6 @@ dependencies {
         implementation('org.apache.commons:commons-configuration2:2.11.0') {
             because("CVE-2024-29131, CVE-2024-29133")
         }
-        implementation('org.xerial.snappy:snappy-java:1.1.10.5') {
-            because("CVE-2023-34453, CVE-2023-34454, CVE-2023-34455, CVE-2023-43642")
-        }
-        implementation('org.codehaus.jettison:jettison:1.5.4') {
-            because("CVE-2022-40149, CVE-2022-40150, CVE-2022-45685, CVE-2022-45693, CVE-2023-1436")
-        }
     }
 }
 


### PR DESCRIPTION
I'm not entirely sure when these constraints became unnecessary, but they are redundant. The versions specified in the (now deleted) constraints are the versions already in use. Discovered while testing #839.

From the [build scan](https://gradle.com/s/gb6xhyr6spqyg) for this PR:
![Screenshot 21-06-2024 at 10 56](https://github.com/DataBiosphere/terra-workspace-data-service/assets/6041577/3b0fae7b-10a0-4622-bc12-3d19fc0ea724)
![Screenshot 21-06-2024 at 10 56 (1)](https://github.com/DataBiosphere/terra-workspace-data-service/assets/6041577/0229e801-6592-4c01-9069-f1c0a54effe4)

