### PR TITLE
AJ-1782: update azure-identity-extensions to 1.1.17

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     // do not upgrade app insights past 3.5.1 until AJ-1897 is resolved
     implementation 'com.microsoft.azure:applicationinsights-runtime-attach:3.5.1'
     implementation 'com.azure:azure-storage-blob:12.26.1'
-    implementation 'com.azure:azure-identity-extensions:1.1.16' // postgres password plugin
+    implementation 'com.azure:azure-identity-extensions:1.1.17' // postgres password plugin
 
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'


### PR DESCRIPTION
Update azure-identity-extensions to 1.1.17, which transitively updates its dependencies.

This should resolve:
* https://github.com/DataBiosphere/terra-workspace-data-service/security/dependabot/92
* https://github.com/DataBiosphere/terra-workspace-data-service/security/dependabot/94