### PR TITLE
AJ-1729: record number of snapshots considered and linked for imports

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJob.java
@@ -26,6 +26,7 @@ import org.databiosphere.workspacedataservice.config.DataImportProperties;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.dataimport.ImportDetails;
 import org.databiosphere.workspacedataservice.dataimport.ImportDetailsRetriever;
+import org.databiosphere.workspacedataservice.dataimport.snapshotsupport.SnapshotLinkResult;
 import org.databiosphere.workspacedataservice.dataimport.snapshotsupport.SnapshotSupport;
 import org.databiosphere.workspacedataservice.dataimport.snapshotsupport.SnapshotSupportFactory;
 import org.databiosphere.workspacedataservice.jobexec.JobDataMapReader;
@@ -228,7 +229,18 @@ public class PfbQuartzJob extends QuartzJob {
   protected void linkSnapshots(Set<UUID> snapshotIds, WorkspaceId workspaceId) {
     // list existing snapshots linked to this workspace
     SnapshotSupport snapshotSupport = snapshotSupportFactory.buildSnapshotSupport(workspaceId);
-    snapshotSupport.linkSnapshots(snapshotIds);
+    SnapshotLinkResult snapshotLinkResult = snapshotSupport.linkSnapshots(snapshotIds);
+
+    // record metrics
+    importMetrics
+        .snapshotsConsideredDistributionSummary()
+        .distributionSummary()
+        .record(snapshotLinkResult.numSnapshotsConsidered());
+
+    importMetrics
+        .snapshotsLinkedDistributionSummary()
+        .distributionSummary()
+        .record(snapshotLinkResult.numSnapshotsLinked());
   }
 
   @Nullable

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/snapshotsupport/SnapshotLinkResult.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/snapshotsupport/SnapshotLinkResult.java
@@ -1,0 +1,3 @@
+package org.databiosphere.workspacedataservice.dataimport.snapshotsupport;
+
+public record SnapshotLinkResult(int numSnapshotsConsidered, int numSnapshotsLinked) {}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/snapshotsupport/SnapshotSupport.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/snapshotsupport/SnapshotSupport.java
@@ -76,7 +76,7 @@ public abstract class SnapshotSupport {
    *
    * @param snapshotIds the list of snapshot ids to create or verify references.
    */
-  public void linkSnapshots(Set<UUID> snapshotIds) {
+  public SnapshotLinkResult linkSnapshots(Set<UUID> snapshotIds) {
     // list existing snapshots linked to this workspace
     Set<UUID> existingSnapshotIds = Set.copyOf(existingPolicySnapshotIds(/* pageSize= */ 50));
     // find the snapshots that are not already linked to this workspace
@@ -89,13 +89,17 @@ public abstract class SnapshotSupport {
         newSnapshotIds.size());
 
     // pass snapshotIds to underlying client to link
+    int successfulLinks = 0;
     for (UUID uuid : newSnapshotIds) {
       try {
         linkSnapshot(uuid);
+        successfulLinks++;
       } catch (RestException re) {
         throw new DataImportException("Error processing data import: " + re.getMessage(), re);
       }
     }
+
+    return new SnapshotLinkResult(snapshotIds.size(), successfulLinks);
   }
 
   /**

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJob.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJob.java
@@ -46,6 +46,7 @@ import org.databiosphere.workspacedataservice.dataimport.FileDownloadHelper;
 import org.databiosphere.workspacedataservice.dataimport.ImportDetails;
 import org.databiosphere.workspacedataservice.dataimport.ImportDetailsRetriever;
 import org.databiosphere.workspacedataservice.dataimport.ImportJobInput;
+import org.databiosphere.workspacedataservice.dataimport.snapshotsupport.SnapshotLinkResult;
 import org.databiosphere.workspacedataservice.dataimport.snapshotsupport.SnapshotSupport;
 import org.databiosphere.workspacedataservice.dataimport.snapshotsupport.SnapshotSupportFactory;
 import org.databiosphere.workspacedataservice.jobexec.JobDataMapReader;
@@ -482,7 +483,18 @@ public class TdrManifestQuartzJob extends QuartzJob {
     // list existing snapshots linked to this workspace
     SnapshotSupport snapshotSupport = snapshotSupportFactory.buildSnapshotSupport(workspaceId);
     // TODO AJ-1673: don't use the env-var workspaceId here
-    snapshotSupport.linkSnapshots(snapshotIds);
+    SnapshotLinkResult snapshotLinkResult = snapshotSupport.linkSnapshots(snapshotIds);
+
+    // record metrics
+    importMetrics
+        .snapshotsConsideredDistributionSummary()
+        .distributionSummary()
+        .record(snapshotLinkResult.numSnapshotsConsidered());
+
+    importMetrics
+        .snapshotsLinkedDistributionSummary()
+        .distributionSummary()
+        .record(snapshotLinkResult.numSnapshotsLinked());
   }
 
   /**

--- a/service/src/main/java/org/databiosphere/workspacedataservice/metrics/ImportMetrics.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/metrics/ImportMetrics.java
@@ -9,4 +9,7 @@ import org.springframework.stereotype.Component;
  *     import
  */
 @Component
-public record ImportMetrics(RecordUpsertDistributionSummary recordUpsertDistributionSummary) {}
+public record ImportMetrics(
+    RecordUpsertDistributionSummary recordUpsertDistributionSummary,
+    SnapshotsConsideredDistributionSummary snapshotsConsideredDistributionSummary,
+    SnapshotsLinkedDistributionSummary snapshotsLinkedDistributionSummary) {}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/metrics/MetricsConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/metrics/MetricsConfig.java
@@ -75,4 +75,32 @@ public class MetricsConfig {
 
     return new RecordUpsertDistributionSummary(distributionSummary);
   }
+
+  // central definition for the wds.import.snapshotsLinked distribution summary
+  @Bean
+  SnapshotsLinkedDistributionSummary snapshotsLinkedDistributionSummary(
+      MeterRegistry meterRegistry) {
+    DistributionSummary distributionSummary =
+        DistributionSummary.builder("wds.import.snapshotsLinked")
+            .baseUnit("snapshots")
+            .description("Number of snapshots actually linked by an import job")
+            .publishPercentiles(0.25, 0.5, 0.75, 0.95, 0.99)
+            .register(meterRegistry);
+
+    return new SnapshotsLinkedDistributionSummary(distributionSummary);
+  }
+
+  // central definition for the wds.import.snapshotsConsidered distribution summary
+  @Bean
+  SnapshotsConsideredDistributionSummary snapshotsConsideredDistributionSummary(
+      MeterRegistry meterRegistry) {
+    DistributionSummary distributionSummary =
+        DistributionSummary.builder("wds.import.snapshotsConsidered")
+            .baseUnit("snapshots")
+            .description("Number of snapshots mentioned by an import source")
+            .publishPercentiles(0.25, 0.5, 0.75, 0.95, 0.99)
+            .register(meterRegistry);
+
+    return new SnapshotsConsideredDistributionSummary(distributionSummary);
+  }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/metrics/SnapshotsConsideredDistributionSummary.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/metrics/SnapshotsConsideredDistributionSummary.java
@@ -1,0 +1,6 @@
+package org.databiosphere.workspacedataservice.metrics;
+
+import io.micrometer.core.instrument.DistributionSummary;
+
+/** Wrapper for distribution summary of number of snapshots within a PFB or other import source */
+public record SnapshotsConsideredDistributionSummary(DistributionSummary distributionSummary) {}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/metrics/SnapshotsLinkedDistributionSummary.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/metrics/SnapshotsLinkedDistributionSummary.java
@@ -1,0 +1,6 @@
+package org.databiosphere.workspacedataservice.metrics;
+
+import io.micrometer.core.instrument.DistributionSummary;
+
+/** Wrapper for distribution summary of number of snapshots actually linked by an import job */
+public record SnapshotsLinkedDistributionSummary(DistributionSummary distributionSummary) {}


### PR DESCRIPTION
New Prometheus metrics for:
* number of snapshots found in a PFB during import (or in a TDR manifest, which will always be 1)
* number of snapshots actually linked to a workspace during import
