### PR TITLE
AJ-1909: createOrModifyRecordType should consider primary key

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/WdsRecordSink.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/WdsRecordSink.java
@@ -51,7 +51,7 @@ public class WdsRecordSink implements RecordSink {
           collectionId.id(),
           recordType,
           schema,
-          recordDao.getExistingTableSchemaLessPrimaryKey(collectionId.id(), recordType),
+          recordDao.getExistingTableSchema(collectionId.id(), recordType),
           records);
     }
     return schema;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobMultipleBatchTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobMultipleBatchTest.java
@@ -84,8 +84,10 @@ class TdrManifestQuartzJobMultipleBatchTest extends TestBase {
     collectionService.deleteCollection(collectionId, "v0.2");
   }
 
-  // this test targets AJ-1909, which concerns a SQL exception thrown when importing.
-  // the import will fail if the exception is present. This test verifies the import succeeds,
+  // This test targets AJ-1909, which concerns a SQL exception thrown when importing, wherein
+  // we retried to re-add the primary key column a second time. The second attempt would fail
+  // because the column already existed.
+  // The import will fail if the exception is present. This test verifies the import succeeds,
   // and doesn't verify too much else about the import results.
   @Test
   @Tag(SLOW)

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobMultipleBatchTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobMultipleBatchTest.java
@@ -1,0 +1,124 @@
+package org.databiosphere.workspacedataservice.dataimport.tdr;
+
+import static org.databiosphere.workspacedataservice.TestTags.SLOW;
+import static org.databiosphere.workspacedataservice.dataimport.tdr.TdrManifestTestUtils.stubJobContext;
+import static org.databiosphere.workspacedataservice.generated.ImportRequestServerModel.TypeEnum.TDRMANIFEST;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.when;
+
+import bio.terra.workspace.model.ResourceList;
+import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.dataimport.ImportValidator;
+import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
+import org.databiosphere.workspacedataservice.service.CollectionService;
+import org.databiosphere.workspacedataservice.service.ImportService;
+import org.databiosphere.workspacedataservice.service.RecordOrchestratorService;
+import org.databiosphere.workspacedataservice.service.model.RecordTypeSchema;
+import org.databiosphere.workspacedataservice.shared.model.CollectionId;
+import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
+import org.databiosphere.workspacedataservice.workspacemanager.WorkspaceManagerDao;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.core.io.Resource;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * Tests for TdrManifest import that execute "end-to-end" and involve multiple batches. These tests
+ * ensure multiple batches by setting twds.write.batch.size very low.
+ *
+ * <p>See also TdrManifestQuartzJobE2ETest for additional test coverage.
+ *
+ * <p>Notably stubbed out: the parquet files referenced in the manifests come from the classpath (as
+ * indicated by a "classpath:" prefix) rather than being fetched from a remote URL. This is made
+ * possible by using TdrTestSupport.buildTdrManifestQuartzJob() which creates a special
+ * TdrManifestQuartzJob that knows how to fetch from the classpath.
+ */
+@ActiveProfiles(profiles = {"mock-sam", "noop-scheduler-dao"})
+@DirtiesContext
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {"twds.write.batch.size=2"})
+class TdrManifestQuartzJobMultipleBatchTest extends TestBase {
+  @Autowired private RecordOrchestratorService recordOrchestratorService;
+  @Autowired private ImportService importService;
+  @Autowired private CollectionService collectionService;
+  @Autowired private TdrTestSupport testSupport;
+
+  // Mock ImportValidator to allow importing test data from a file:// URL.
+  @MockBean ImportValidator importValidator;
+  @MockBean WorkspaceManagerDao wsmDao;
+
+  @Value("classpath:tdrmanifest/with-entity-reference-lists.json")
+  Resource withEntityReferenceListsResource;
+
+  UUID collectionId;
+
+  @BeforeEach
+  void beforeEach() {
+    collectionId = UUID.randomUUID();
+    collectionService.createCollection(
+        WorkspaceId.of(collectionId), CollectionId.of(collectionId), "v0.2");
+  }
+
+  @AfterEach
+  void afterEach() {
+    collectionService.deleteCollection(collectionId, "v0.2");
+  }
+
+  // this test targets AJ-1909, which concerns a SQL exception thrown when importing.
+  // the import will fail if the exception is present. This test verifies the import succeeds,
+  // and doesn't verify too much else about the import results.
+  @Test
+  @Tag(SLOW)
+  void defaultPrimaryKey() throws IOException, JobExecutionException {
+    var importResource = withEntityReferenceListsResource;
+
+    var importRequest = new ImportRequestServerModel(TDRMANIFEST, importResource.getURI());
+
+    // because we have a mock scheduler dao, this won't trigger Quartz
+    var genericJobServerModel = importService.createImport(collectionId, importRequest);
+
+    UUID jobId = genericJobServerModel.getJobId();
+    JobExecutionContext mockContext = stubJobContext(jobId, importResource, collectionId);
+
+    // WSM should report no snapshots already linked to this workspace
+    when(wsmDao.enumerateDataRepoSnapshotReferences(any(), anyInt(), anyInt()))
+        .thenReturn(new ResourceList());
+
+    testSupport.buildTdrManifestQuartzJob().execute(mockContext);
+
+    List<RecordTypeSchema> allTypes =
+        recordOrchestratorService.describeAllRecordTypes(collectionId, "v0.2");
+
+    Map<String, Integer> actualCounts =
+        allTypes.stream()
+            .collect(
+                Collectors.toMap(
+                    recordTypeSchema -> recordTypeSchema.name().getName(),
+                    RecordTypeSchema::count));
+
+    Map<String, Integer> expectedCounts =
+        new ImmutableMap.Builder<String, Integer>().put("sample", 5).put("person", 3).build();
+
+    assertEquals(expectedCounts, actualCounts);
+  }
+}


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1909

The error occurred when importing a table that has > 5000 rows - i.e. across multiple batches. Our batch size is set to 5000.

This fixes the error and adds a unit test to verify behavior across batches.

Related to #796.