### PR TITLE
AJ-1782: upgrade Python client to openapi-generator 7.7.0

### DIFF
--- a/.github/workflows/release-python-client.yml
+++ b/.github/workflows/release-python-client.yml
@@ -46,8 +46,8 @@ jobs:
       - name: Install openapi-generator-cli
         run: npm install @openapitools/openapi-generator-cli -g
 
-      - name: set version to 7.6.0
-        run: openapi-generator-cli version-manager set 7.6.0
+      - name: set version to 7.7.0
+        run: openapi-generator-cli version-manager set 7.7.0
 
       - name: Generate Python client
         run: |

--- a/docs/WDS Running Python tests locally.md
+++ b/docs/WDS Running Python tests locally.md
@@ -12,7 +12,7 @@ You may need to run tests locally to replicate and debug failures from the GitHu
 _You should only need to install prerequisites once._ Python tests require:
 
 * Python 3.8
-* openapi-generator 7.6.0
+* openapi-generator 7.7.0
 * pytest
 * optionally, a python virtual environment
 
@@ -32,7 +32,7 @@ Configure openapi-generator-cli to use the same version as the GitHub Action.
 Depending on your user permissions, sudo may be required to run these commands.
 
 ```bash
-openapi-generator-cli version-manager set 7.6.0
+openapi-generator-cli version-manager set 7.7.0
 ```
 
 At times, openapi-generator-cli won't set the right version even if the command above is run, so it
@@ -43,7 +43,7 @@ can be set. To see all available commands:
 openapi-generator-cli
 ```
 
-Run this command to see what versions are downloaded, if 7.6.0 is not, use arrow keys to navigate to
+Run this command to see what versions are downloaded, if 7.7.0 is not, use arrow keys to navigate to
 it and download it (or if already downloaded to use it).
 
 ```bash


### PR DESCRIPTION
https://github.com/DataBiosphere/terra-workspace-data-service/pull/847 upgraded our Java client to use openapi-generator 7.7.0. This PR upgrades the Python client to the same version to keep them in sync.

---

Reminder:

#### Releasing WDS ####
PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag-and-publish.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 

#### Keeping Docs Up To Date ####
If you make changes to the github actions or workflows, particularly when they are run or which other workflows they call, please update [the GHA wiki page](https://github.com/DataBiosphere/terra-workspace-data-service/wiki/GHA-structure-in-WDS) to stay up to date.
