### PR TITLE
AJ-1897: upgrade app insights to 3.5.3, exclude javax from hadoop

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -48,7 +48,7 @@ dependencies {
 
     // Azure libraries
     // do not upgrade app insights past 3.5.1 until AJ-1897 is resolved
-    implementation 'com.microsoft.azure:applicationinsights-runtime-attach:3.5.1'
+    implementation 'com.microsoft.azure:applicationinsights-runtime-attach:3.5.3'
     implementation 'com.azure:azure-storage-blob:12.26.1'
     implementation 'com.azure:azure-identity-extensions:1.1.17' // postgres password plugin
 
@@ -106,6 +106,7 @@ dependencies {
         exclude(group: 'org.slf4j')
         exclude(group: 'io.netty')
         exclude(group: 'org.mortbay.jetty')
+        exclude(group: 'javax.servlet') // conflicts with applicationinsights among others
         exclude(group: 'javax.servlet.jsp')
         exclude(group: 'com.sun.jersey')
         exclude(group: 'com.sun.xml.bind')


### PR DESCRIPTION
Upgrade `applicationinsights-runtime-attach` to 3.5.3, primarily to incorporate their fix:
> Remove _APPRESOURCEPREVIEW_ custom metric as it is still in preview

as noted in https://github.com/microsoft/ApplicationInsights-Java/releases. See https://github.com/DataBiosphere/terra-workspace-data-service/pull/833 for more details on that fix.

Upgrading to 3.5.3 on its own caused a regression in which http requests to WDS were not being recorded in app insights. I tracked this down to a conflict with `javax.servlet` transitive dependencies. We don't want `javax` in our codebase anyway, so I excluded those transitive dependencies from the hadoop libraries which pull them in.

