### PR TITLE
[Needs ticket] Fix bee-retry name in e2e test

### DIFF
--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -8,7 +8,6 @@ env:
   BEE_NAME: 'wds-${{ github.run_id }}-${{ github.run_attempt}}-dev'
   TOKEN: '${{ secrets.BROADBOT_TOKEN }}'
   ATTACH_BP_TO_LZ_RUN_NAME: 'attach-billing-project-to-landing-zone-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}'
-  RUN_NAME_SUFFIX: ${{ github.event.repository.name }}-${{ github.run_id }}-${{github.run_attempt }}
 jobs:
   init-github-context:
     runs-on: ubuntu-latest
@@ -52,7 +51,7 @@ jobs:
         if: steps.FirstAttemptCreateBee.outcome == 'failure'
         uses: ./.github/actions/create-bee
         with:
-          bee_name: ${{ env.BEE_NAME }}
+          bee_name: ${{ env.BEE_NAME }}-2
           token: ${{ env.TOKEN }}
 
   attach-landing-zone-to-bee-workflow:


### PR DESCRIPTION
Recently when we had create-bee failures in our e2e test, I noticed that the retry failed with a [different error](https://github.com/broadinstitute/terra-github-workflows/actions/runs/9989978977/job/27609700090) than the original failure:  "duplicate key value violates unique constraint \"environments_name_unique\"".  It looks like the retry uses the same bee-name, which I'm guessing is the cause of the failure, if the first attempt got far enough to create something with the same name.  
Incidentally, it seems like we never use `RUN_NAME_SUFFIX`; its value is just a subset of `ATTACH_BP_TO_LZ_RUN_NAME`, so I also deleted that line.

Question for reviewers:
Will the addition of these two characters make the bee name too long or otherwise incorrect?  I seem to recall some failures with bee names not conforming to some expected format or length.

Reminder:

#### Releasing WDS ####
PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag-and-publish.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 

#### Keeping Docs Up To Date ####
If you make changes to the github actions or workflows, particularly when they are run or which other workflows they call, please update [the GHA wiki page](https://github.com/DataBiosphere/terra-workspace-data-service/wiki/GHA-structure-in-WDS) to stay up to date.
