### PR TITLE
AJ-1924: validation for collection names

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -60,6 +60,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-quartz'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation "io.micrometer.prometheus:prometheus-rsocket-spring:$prometheus_rsocket_version"
     implementation 'org.springframework.integration:spring-integration-jdbc'

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/GlobalExceptionHandler.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthenticationMaskableException;
 import org.databiosphere.workspacedataservice.service.model.exception.MissingObjectException;
@@ -17,12 +18,15 @@ import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
+import org.springframework.lang.Nullable;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import org.springframework.web.util.BindErrorUtils;
 
 @ControllerAdvice
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
@@ -51,7 +55,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
   @NotNull
   @Override
   protected ResponseEntity<Object> createResponseEntity(
-      Object body,
+      @Nullable Object body,
       @NotNull HttpHeaders headers,
       @NotNull HttpStatusCode statusCode,
       @NotNull WebRequest request) {
@@ -95,6 +99,38 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
   }
 
   /**
+   * @param ex the exception in question
+   * @param headers the response headers
+   * @param status the response status
+   * @param request the request
+   * @return the desired response
+   */
+  @Override
+  protected ResponseEntity<Object> handleMethodArgumentNotValid(
+      MethodArgumentNotValidException ex,
+      HttpHeaders headers,
+      HttpStatusCode status,
+      WebRequest request) {
+
+    // extract nicely-formatted error messages from the exception
+    String allErrors = BindErrorUtils.resolveAndJoin(ex.getAllErrors());
+
+    // extract request path from the request
+    String path = "";
+    if (request instanceof ServletWebRequest servletWebRequest) {
+      path = servletWebRequest.getRequest().getRequestURI();
+    }
+
+    // extract title
+    String title = Objects.requireNonNullElse(ex.getBody().getDetail(), status.toString());
+
+    // build response body
+    Object responseBody = buildBody(status.value(), title, allErrors, path);
+
+    return createResponseEntity(responseBody, headers, status, request);
+  }
+
+  /**
    * Handler for AuthenticationMaskableException. Rewrites the response to be a 404, using the same
    * message that MissingObjectException would produce. This prevents auth exceptions from leaking
    * existence/non-existence of resources.
@@ -115,17 +151,29 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
   // helper method for @ExceptionHandlers to build the response payload
   private ResponseEntity<Map<String, Object>> generateResponse(
       HttpStatus httpStatus, String errorMessage, HttpServletRequest servletRequest) {
-    Map<String, Object> errorBody = new LinkedHashMap<>();
-
-    errorBody.put(TIMESTAMP, new Date());
-    errorBody.put(STATUS, httpStatus.value());
-    errorBody.put(ERROR, httpStatus.getReasonPhrase());
-    errorBody.put(MESSAGE, errorMessage);
-    errorBody.put(PATH, servletRequest.getRequestURI());
+    Map<String, Object> errorBody =
+        buildBody(
+            httpStatus.value(),
+            httpStatus.getReasonPhrase(),
+            errorMessage,
+            servletRequest.getRequestURI());
 
     return ResponseEntity.status(httpStatus)
         .contentType(MediaType.APPLICATION_JSON)
         .body(errorBody);
+  }
+
+  // generate a response compatible with the ErrorResponse model
+  private Map<String, Object> buildBody(int statusCode, String error, String message, String path) {
+    Map<String, Object> errorBody = new LinkedHashMap<>();
+
+    errorBody.put(TIMESTAMP, new Date());
+    errorBody.put(STATUS, statusCode);
+    errorBody.put(ERROR, error);
+    errorBody.put(MESSAGE, message);
+    errorBody.put(PATH, path);
+
+    return errorBody;
   }
 
   @VisibleForTesting

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/GlobalExceptionHandler.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/GlobalExceptionHandler.java
@@ -109,7 +109,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
   protected ResponseEntity<Object> handleMethodArgumentNotValid(
       MethodArgumentNotValidException ex,
       HttpHeaders headers,
-      HttpStatusCode status,
+      @NotNull HttpStatusCode status,
       WebRequest request) {
 
     // extract nicely-formatted error messages from the exception

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/CollectionService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/CollectionService.java
@@ -98,7 +98,6 @@ public class CollectionService {
         throw new AuthenticationMaskableException(WORKSPACE);
       }
     }
-    // TODO: validate name against the CollectionServerModel.getName() pattern
 
     // if user did not specify an id, generate one
     CollectionId collectionId;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/CollectionControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/CollectionControllerMockMvcTest.java
@@ -35,7 +35,6 @@ import org.databiosphere.workspacedataservice.shared.model.WdsCollection;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.mockito.stubbing.OngoingStubbing;
@@ -49,6 +48,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 
 @ActiveProfiles(profiles = {"mock-sam"})
 @DirtiesContext
@@ -245,7 +245,6 @@ class CollectionControllerMockMvcTest extends MockMvcTestBase {
     assertCollectionExists(workspaceId, collectionId, name, description);
   }
 
-  @Disabled("for a future PR")
   @Test
   void createCollectionInvalidName() throws Exception {
     WorkspaceId workspaceId = WorkspaceId.of(UUID.randomUUID());
@@ -270,9 +269,11 @@ class CollectionControllerMockMvcTest extends MockMvcTestBase {
             .andReturn();
 
     // verify error message
-    assertInstanceOf(ConflictException.class, mvcResult.getResolvedException());
-    assertEquals(
-        "Collection with this id already exists", mvcResult.getResolvedException().getMessage());
+    assertInstanceOf(MethodArgumentNotValidException.class, mvcResult.getResolvedException());
+
+    ErrorResponse errorResponse =
+        objectMapper.readValue(mvcResult.getResponse().getContentAsString(), ErrorResponse.class);
+    assertEquals("name: must match \"[a-zA-Z0-9-_]{1,128}\"", errorResponse.getMessage());
 
     // new collection should not have been created
     assertCollectionDoesNotExist(collectionId);


### PR DESCRIPTION
Follow-on PR to #858. Introduces validation for collection names.

We are quite likely to use collection names in URLs in the future. While url-encoding is certainly possible, it feels ok right now to limit collection names to alphanumeric/dash/underscore only.

Instead of writing a custom validation to do this, I'm relying on `spring-boot-starter-validation` and `openapi-generator`. The workflow here is:
1. Define the validation constraint in the OpenAPI spec, [here](https://github.com/DataBiosphere/terra-workspace-data-service/blob/26fda06444c1eb0c421c538f4c84eb8b43f00194/service/src/main/resources/static/swagger/apis-v1.yaml#L309)
2. `openapi-generator` uses this constraint to generate a `@Pattern` annotation on its model, as seen [here](https://github.com/DataBiosphere/terra-workspace-data-service/blob/26fda06444c1eb0c421c538f4c84eb8b43f00194/service/src/main/java/org/databiosphere/workspacedataservice/generated/CollectionServerModel.java#L74)
3. `openapi-generator` marks its API stub as `@Validated` [here](https://github.com/DataBiosphere/terra-workspace-data-service/blob/26fda06444c1eb0c421c538f4c84eb8b43f00194/service/src/main/java/org/databiosphere/workspacedataservice/generated/CollectionApi.java#L37), and marks the request body with `@Valid` [here](https://github.com/DataBiosphere/terra-workspace-data-service/blob/26fda06444c1eb0c421c538f4c84eb8b43f00194/service/src/main/java/org/databiosphere/workspacedataservice/generated/CollectionApi.java#L76)
4. The presence of `spring-boot-starter-validation` in the classpath automatically invokes validation for the API, as configured by `@Pattern`, `@Validated`, and `@Valid`; Spring throws a `MethodArgumentNotValidException` if the user inputs bad data
5. The `handleMethodArgumentNotValid` override in our pre-existing `@ControllerAdvice` `GlobalExceptionHandler` massages the `MethodArgumentNotValidException` into a somewhat-nicer error message to the end user

The resultant error message is still somewhat engineer-oriented, in that it exposes the regex:
![Screenshot 24-07-2024 at 09 07](https://github.com/user-attachments/assets/2eef2702-69e0-4b24-b948-aff35d56a5d0)
```json
{
  "timestamp": "2024-07-24T12:57:34.045+00:00",
  "status": 400,
  "error": "Invalid request content.",
  "message": "name: must match \"[a-zA-Z0-9-_]{1,128}\"",
  "path": "/collections/v1/b95017ef-d0c9-4baf-9a1b-a9e692c37bce"
}
```

But the flip side is that by including `spring-boot-starter-validation` and having generic handling for `MethodArgumentNotValidException`, we gain built-in validation for all other APIs and can easily add more validation in the future