### PR TITLE
AJ-1924: update-collection v1 API

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/CollectionController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/CollectionController.java
@@ -96,7 +96,9 @@ public class CollectionController implements CollectionApi {
   @Override
   public ResponseEntity<CollectionServerModel> updateCollectionV1(
       UUID workspaceId, UUID collectionId, CollectionServerModel collectionServerModel) {
-    // TODO: implement
-    return CollectionApi.super.updateCollectionV1(workspaceId, collectionId, collectionServerModel);
+    CollectionServerModel coll =
+        collectionService.update(
+            WorkspaceId.of(workspaceId), CollectionId.of(collectionId), collectionServerModel);
+    return new ResponseEntity<>(coll, HttpStatus.OK);
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/CollectionService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/CollectionService.java
@@ -244,6 +244,15 @@ public class CollectionService {
             .find(workspaceId, collectionId)
             .orElseThrow(() -> new MissingObjectException(COLLECTION));
 
+    // optimization: if the request doesn't change anything, don't bother writing to the db
+    if (found.name().equals(collectionServerModel.getName())
+        && found.description().equals(collectionServerModel.getDescription())) {
+      // make sure this response has an id
+      CollectionServerModel response = new CollectionServerModel(found.name(), found.description());
+      response.id(found.collectionId().id());
+      return response;
+    }
+
     // update the found object with the supplied name and description
     WdsCollection updateRequest =
         new WdsCollection(

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/CollectionService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/CollectionService.java
@@ -203,6 +203,13 @@ public class CollectionService {
         .toList();
   }
 
+  /**
+   * Retrieve a single collection by its workspaceId and collectionId.
+   *
+   * @param workspaceId the workspace containing the collection to be retrieved
+   * @param collectionId id of the collection to be retrieved
+   * @return the collection
+   */
   public CollectionServerModel get(WorkspaceId workspaceId, CollectionId collectionId) {
     // verify permission to read collections
     if (!canListCollections(workspaceId)) {
@@ -224,6 +231,16 @@ public class CollectionService {
     return serverModel;
   }
 
+  /**
+   * Updates the name and/or description for a collection. Updates to the collection's id or
+   * workspaceId are not allowed.
+   *
+   * @param workspaceId the workspace containing the collection to be updated
+   * @param collectionId id of the collection to be updated
+   * @param collectionServerModel object containing the updated name and description. Collection id
+   *     is optional in this object. If specified, it must match the collectionId argument.
+   * @return the updated collection
+   */
   public CollectionServerModel update(
       WorkspaceId workspaceId,
       CollectionId collectionId,

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/CollectionService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/CollectionService.java
@@ -412,6 +412,8 @@ public class CollectionService {
         user -> user.deleted().collection().withUuid(collectionUuid));
   }
 
+  // ============================== helpers ==============================
+
   public void validateCollection(UUID collectionId) {
     // if this deployment allows virtual collections, there is nothing to validate
     if (tenancyProperties.getAllowVirtualCollections()) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/CollectionService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/CollectionService.java
@@ -3,6 +3,7 @@ package org.databiosphere.workspacedataservice.service;
 import static org.databiosphere.workspacedataservice.dao.SqlUtils.quote;
 import static org.databiosphere.workspacedataservice.service.RecordUtils.validateVersion;
 
+import bio.terra.common.db.WriteTransaction;
 import java.util.List;
 import java.util.Objects;
 import java.util.Spliterator;
@@ -86,6 +87,7 @@ public class CollectionService {
    * @param collectionServerModel the collection definition
    * @return the created collection
    */
+  @WriteTransaction
   public CollectionServerModel save(
       WorkspaceId workspaceId, CollectionServerModel collectionServerModel) {
 
@@ -133,6 +135,7 @@ public class CollectionService {
    * @param workspaceId the workspace containing the collection to be deleted
    * @param collectionId id of the collection to be deleted
    */
+  @WriteTransaction
   public void delete(WorkspaceId workspaceId, CollectionId collectionId) {
 
     // check that the current user has permission to delete the collection

--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -365,8 +365,8 @@ paths:
   ##############################
   /instances/{v}:
     get:
-      summary: List instances
-      description: List all instances in this server.
+      summary: This API will be deleted on or after August 25, 2024.
+      description: Use GET /collections/v1/{workspaceId} instead.
       operationId: listWDSInstances
       deprecated: true
       tags:
@@ -385,8 +385,8 @@ paths:
                   format: uuid
   /instances/{v}/{instanceid}:
     post:
-      summary: Create an instance
-      description: Create an instance with the given UUID.
+      summary: This API will be deleted on or after August 25, 2024.
+      description: Use POST /collections/v1/{workspaceId} instead.
       operationId: createWDSInstance
       deprecated: true
       security:
@@ -406,11 +406,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
     delete:
-      summary: Delete an instance
-      description: |
-        Delete the instance with the given UUID. This API is liable to change.
-
-        THIS WILL DELETE ALL DATA WITHIN THE INSTANCE. Be certain this is what you want to do.
+      summary: This API will be deleted on or after August 25, 2024.
+      description: Use DELETE /collections/v1/{workspaceId}/{collectionId} instead.
       operationId: deleteWDSInstance
       deprecated: true
       security:

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/CollectionControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/CollectionControllerMockMvcTest.java
@@ -1624,14 +1624,13 @@ class CollectionControllerMockMvcTest extends MockMvcTestBase {
     stubWriteWorkspacePermission(workspaceId).thenReturn(true);
 
     // attempt to update the collection, but don't specify any changes
-    MvcResult mvcResult =
-        mockMvc
-            .perform(
-                put("/collections/v1/{workspaceId}/{collectionId}", workspaceId, collectionId)
-                    .content(toJson(collectionServerModel))
-                    .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andReturn();
+    mockMvc
+        .perform(
+            put("/collections/v1/{workspaceId}/{collectionId}", workspaceId, collectionId)
+                .content(toJson(collectionServerModel))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andReturn();
 
     // collection should not be updated (collection should exist with original name/description)
     assertCollectionExists(

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/CollectionControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/CollectionControllerMockMvcTest.java
@@ -1283,10 +1283,16 @@ class CollectionControllerMockMvcTest extends MockMvcTestBase {
             .andExpect(status().isNotFound())
             .andReturn();
 
-    assertInstanceOf(AuthorizationException.class, mvcResult.getResolvedException());
+    // verify error message
+    AuthenticationMaskableException actual =
+        assertInstanceOf(AuthenticationMaskableException.class, mvcResult.getResolvedException());
+    assertEquals("Workspace", actual.getObjectType());
+
+    ErrorResponse errorResponse =
+        objectMapper.readValue(mvcResult.getResponse().getContentAsString(), ErrorResponse.class);
     assertEquals(
-        "403 FORBIDDEN \"Caller does not have permission to update collection.\"",
-        mvcResult.getResolvedException().getMessage());
+        "Workspace does not exist or you do not have permission to see it",
+        errorResponse.getMessage());
 
     // collection should not exist
     assertCollectionDoesNotExist(collectionId);
@@ -1540,7 +1546,7 @@ class CollectionControllerMockMvcTest extends MockMvcTestBase {
                         collectionServerModelTwo.getId())
                     .content(toJson(updateRequest))
                     .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isForbidden())
+            .andExpect(status().isNotFound())
             .andReturn();
 
     // verify error message


### PR DESCRIPTION
In this PR:
* Implementation and test coverage for the update-collection v1 collection API. This is the last unimplemented v1 collection API!
* Update summary/description for the deprecated v0.2 instance APIs in the OpenAPI spec
* add `@WriteTransaction` annotation for save/delete methods

Runtime code changes are relatively small, but there's a lot of lines of test coverage.
