### PR TITLE
AJ-1945: allow explicit sorting on primary key column

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
@@ -202,7 +202,7 @@ public class RecordOrchestratorService { // TODO give me a better name
     }
     if (searchRequest.getSortAttribute() != null
         && !recordDao
-            .getExistingTableSchemaLessPrimaryKey(collectionId, recordType)
+            .getExistingTableSchema(collectionId, recordType)
             .containsKey(searchRequest.getSortAttribute())) {
       throw new MissingObjectException("Requested sort attribute");
     }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
@@ -33,6 +33,7 @@ import org.databiosphere.workspacedataservice.shared.model.RecordRequest;
 import org.databiosphere.workspacedataservice.shared.model.RecordResponse;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 import org.databiosphere.workspacedataservice.shared.model.SearchRequest;
+import org.databiosphere.workspacedataservice.shared.model.SortDirection;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -114,6 +115,94 @@ class RecordOrchestratorServiceTest extends TestBase {
     testContainsRecord(secondRecord, TEST_KEY, secondVal, resp.records());
     testContainsRecord(thirdRecord, TEST_KEY, thirdVal, resp.records());
     assertEquals(3, resp.totalRecords());
+  }
+
+  @Test
+  void sortAscending() {
+    // insert records out of any order to ensure native db order doesn't give false positives
+    testCreateRecord("two", TEST_KEY, "value2");
+    testCreateRecord("three", TEST_KEY, "value3");
+    testCreateRecord("one", TEST_KEY, "value1");
+
+    SearchRequest searchRequest = new SearchRequest();
+    searchRequest.setSortAttribute(TEST_KEY);
+    searchRequest.setSort(SortDirection.ASC);
+
+    RecordQueryResponse resp =
+        recordOrchestratorService.queryForRecords(
+            COLLECTION_UUID, TEST_TYPE, VERSION, searchRequest);
+
+    assertEquals(3, resp.totalRecords());
+
+    // extract actual ids, in order, from the response
+    List<String> actualIds = resp.records().stream().map(RecordResponse::recordId).toList();
+    assertEquals(List.of("one", "two", "three"), actualIds);
+  }
+
+  @Test
+  void sortDescending() {
+    // insert records out of any order to ensure native db order doesn't give false positives
+    testCreateRecord("two", TEST_KEY, "value2");
+    testCreateRecord("three", TEST_KEY, "value3");
+    testCreateRecord("one", TEST_KEY, "value1");
+
+    SearchRequest searchRequest = new SearchRequest();
+    searchRequest.setSortAttribute(TEST_KEY);
+    searchRequest.setSort(SortDirection.DESC);
+
+    RecordQueryResponse resp =
+        recordOrchestratorService.queryForRecords(
+            COLLECTION_UUID, TEST_TYPE, VERSION, searchRequest);
+
+    assertEquals(3, resp.totalRecords());
+
+    // extract actual ids, in order, from the response
+    List<String> actualIds = resp.records().stream().map(RecordResponse::recordId).toList();
+    assertEquals(List.of("three", "two", "one"), actualIds);
+  }
+
+  @Test
+  void sortPrimaryKeyImplicit() {
+    // insert records out of any order to ensure native db order doesn't give false positives
+    testCreateRecord("two", TEST_KEY, "value2");
+    testCreateRecord("three", TEST_KEY, "value3");
+    testCreateRecord("one", TEST_KEY, "value1");
+
+    SearchRequest searchRequest = new SearchRequest();
+    // omitting the sort attribute will implicitly sort by primary key
+    searchRequest.setSort(SortDirection.DESC);
+
+    RecordQueryResponse resp =
+        recordOrchestratorService.queryForRecords(
+            COLLECTION_UUID, TEST_TYPE, VERSION, searchRequest);
+
+    assertEquals(3, resp.totalRecords());
+
+    // extract actual ids, in order, from the response
+    List<String> actualIds = resp.records().stream().map(RecordResponse::recordId).toList();
+    assertEquals(List.of("two", "three", "one"), actualIds); // descending alpha sort on pk
+  }
+
+  @Test
+  void sortPrimaryKeyExplicit() {
+    // insert records out of any order to ensure native db order doesn't give false positives
+    testCreateRecord("two", TEST_KEY, "value2");
+    testCreateRecord("three", TEST_KEY, "value3");
+    testCreateRecord("one", TEST_KEY, "value1");
+
+    SearchRequest searchRequest = new SearchRequest();
+    searchRequest.setSortAttribute("sys_wds"); // default primary key name for testCreateRecord()
+    searchRequest.setSort(SortDirection.DESC);
+
+    RecordQueryResponse resp =
+        recordOrchestratorService.queryForRecords(
+            COLLECTION_UUID, TEST_TYPE, VERSION, searchRequest);
+
+    assertEquals(3, resp.totalRecords());
+
+    // extract actual ids, in order, from the response
+    List<String> actualIds = resp.records().stream().map(RecordResponse::recordId).toList();
+    assertEquals(List.of("two", "three", "one"), actualIds); // descending alpha sort on pk
   }
 
   @Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
@@ -191,7 +191,7 @@ class RecordOrchestratorServiceTest extends TestBase {
     testCreateRecord("one", TEST_KEY, "value1");
 
     SearchRequest searchRequest = new SearchRequest();
-    searchRequest.setSortAttribute("sys_wds"); // default primary key name for testCreateRecord()
+    searchRequest.setSortAttribute("sys_name"); // default primary key name for testCreateRecord()
     searchRequest.setSort(SortDirection.DESC);
 
     RecordQueryResponse resp =

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
@@ -121,8 +121,8 @@ class RecordOrchestratorServiceTest extends TestBase {
   void sortAscending() {
     // insert records out of any order to ensure native db order doesn't give false positives
     testCreateRecord("two", TEST_KEY, "value2");
-    testCreateRecord("three", TEST_KEY, "value3");
     testCreateRecord("one", TEST_KEY, "value1");
+    testCreateRecord("three", TEST_KEY, "value3");
 
     SearchRequest searchRequest = new SearchRequest();
     searchRequest.setSortAttribute(TEST_KEY);
@@ -143,8 +143,8 @@ class RecordOrchestratorServiceTest extends TestBase {
   void sortDescending() {
     // insert records out of any order to ensure native db order doesn't give false positives
     testCreateRecord("two", TEST_KEY, "value2");
-    testCreateRecord("three", TEST_KEY, "value3");
     testCreateRecord("one", TEST_KEY, "value1");
+    testCreateRecord("three", TEST_KEY, "value3");
 
     SearchRequest searchRequest = new SearchRequest();
     searchRequest.setSortAttribute(TEST_KEY);
@@ -165,8 +165,8 @@ class RecordOrchestratorServiceTest extends TestBase {
   void sortPrimaryKeyImplicit() {
     // insert records out of any order to ensure native db order doesn't give false positives
     testCreateRecord("two", TEST_KEY, "value2");
-    testCreateRecord("three", TEST_KEY, "value3");
     testCreateRecord("one", TEST_KEY, "value1");
+    testCreateRecord("three", TEST_KEY, "value3");
 
     SearchRequest searchRequest = new SearchRequest();
     // omitting the sort attribute will implicitly sort by primary key
@@ -187,8 +187,8 @@ class RecordOrchestratorServiceTest extends TestBase {
   void sortPrimaryKeyExplicit() {
     // insert records out of any order to ensure native db order doesn't give false positives
     testCreateRecord("two", TEST_KEY, "value2");
-    testCreateRecord("three", TEST_KEY, "value3");
     testCreateRecord("one", TEST_KEY, "value1");
+    testCreateRecord("three", TEST_KEY, "value3");
 
     SearchRequest searchRequest = new SearchRequest();
     searchRequest.setSortAttribute("sys_name"); // default primary key name for testCreateRecord()


### PR DESCRIPTION
Before this PR:
* you could sort by the primary key column by omitting the `sortAttribute` field entirely from the API request payload. Omitting the field caused WDS to impose a default sort attribute, which was the primary key
* sorting by primary key worked in Terra UI, because Terra UI would omit the `sortAttribute` field
* you got an error if you included the `sortAttribute` field and its value was the primary key column.

After this PR:
* you can set the `sortAttribute` field to the primary key column
* omitting the `sortAttribute` field works as before
* Terra UI works as before

This PR is related to #868 - I found this issue while working on that other PR, and the change in this PR helps that other one.
