### PR TITLE
AJ-1660: security for all non-public APIs in OpenAPI spec

### DIFF
--- a/service/src/main/resources/static/swagger/apis-v1.yaml
+++ b/service/src/main/resources/static/swagger/apis-v1.yaml
@@ -11,6 +11,9 @@ info:
   title: Workspace Data Service
   version: v1
 
+security:
+  - bearerAuth: [ ]
+
 tags:
   # Tags should be listed in the order they should appear in the UI
   - name: Import
@@ -31,8 +34,6 @@ paths:
       summary: Import from a file
       description: Imports records from the specified URL.
       operationId: importV1
-      security:
-        - bearerAuth: [ ]
       tags:
         - Import
       parameters:
@@ -76,8 +77,6 @@ paths:
     get:
       summary: Get status of a long-running job.
       operationId: jobStatusV1
-      security:
-        - bearerAuth: [ ]
       tags:
         - Job
       parameters:
@@ -104,8 +103,6 @@ paths:
     get:
       summary: Get all jobs with a certain status under a particular instance.
       operationId: jobsInInstanceV1
-      security:
-        - bearerAuth: [ ]
       tags:
         - Job
       parameters:
@@ -137,8 +134,6 @@ paths:
     get:
       summary: List all collections in this workspace.
       operationId: listCollectionsV1
-      security:
-        - bearerAuth: [ ]
       tags:
         - Collection
       parameters:
@@ -158,8 +153,6 @@ paths:
         If collection id is specified in the request body, it must be a valid UUID.
         If omitted, the system will generate an id.
       operationId: createCollectionV1
-      security:
-        - bearerAuth: [ ]
       tags:
         - Collection
       parameters:
@@ -182,8 +175,6 @@ paths:
     get:
       summary: Retrieve a single collection.
       operationId: getCollectionV1
-      security:
-        - bearerAuth: [ ]
       tags:
         - Collection
       parameters:
@@ -202,8 +193,6 @@ paths:
         Collection id is optional in the request body. If specified, it must match the collection id
         specified in the url.
       operationId: updateCollectionV1
-      security:
-        - bearerAuth: [ ]
       tags:
         - Collection
       parameters:
@@ -226,8 +215,6 @@ paths:
     delete:
       summary: Delete the specified collection.
       operationId: deleteCollectionV1
-      security:
-        - bearerAuth: [ ]
       tags:
         - Collection
       parameters:
@@ -246,6 +233,7 @@ paths:
       operationId: capabilities
       tags:
         - Capabilities
+      security: [ ]
       responses:
         200:
           description: key-value pairs describing capabilities

--- a/service/src/main/resources/static/swagger/cwds-api-docs.yaml
+++ b/service/src/main/resources/static/swagger/cwds-api-docs.yaml
@@ -11,6 +11,9 @@ info:
     name: BSD
     url: https://opensource.org/licenses/BSD-3-Clause
 
+security:
+  - bearerAuth: [ ]
+
 tags:
   # Tags should be listed in the order they should appear in the UI
   - name: Import

--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -17,6 +17,9 @@ info:
 servers:
   - url: /
 
+security:
+  - bearerAuth: [ ]
+
 tags:
   # Tags should be listed in the order they should appear in the UI
   - name: Cloning
@@ -55,8 +58,6 @@ paths:
         $ref: '#/components/requestBodies/BackupRestoreRequestBody'
       summary: Create a backup of all WDS data
       operationId: createBackup
-      security:
-        - bearerAuth: [ ]
       responses:
         200:
           description: Successfully initiated the backup process
@@ -73,8 +74,6 @@ paths:
         - $ref: '#/components/parameters/trackingIdPathParam'
       summary: Check status of a WDS data backup
       operationId: getBackupStatus
-      security:
-        - bearerAuth: [ ]
       responses:
         200:
           description: Returns backup status
@@ -90,8 +89,6 @@ paths:
         - $ref: '#/components/parameters/versionPathParam'
       summary: Check status of a WDS data clone
       operationId: getCloneStatus
-      security:
-        - bearerAuth: [ ]
       responses:
         200:
           description: Returns clone status
@@ -108,8 +105,6 @@ paths:
       summary: Batch write records
       description: Perform a batch of upsert / delete operations on multiple records
       operationId: batchWriteRecords
-      security:
-        - bearerAuth: [ ]
       tags:
         - Records
       parameters:
@@ -155,8 +150,6 @@ paths:
         the attributes in the request body.
         TODO: add a query parameter to allow/disallow overwriting existing records?
       operationId: createOrReplaceRecord
-      security:
-        - bearerAuth: [ ]
       tags:
         - Records
       parameters:
@@ -181,8 +174,6 @@ paths:
     patch:
       summary: Update record
       operationId: updateRecord
-      security:
-        - bearerAuth: [ ]
       description: |
         Updates the record of the specified type and id.
         Any attributes included in the request body will be created or overwritten.
@@ -216,8 +207,6 @@ paths:
       summary: Delete record
       description: Deletes the record at the specified type and id.
       operationId: deleteRecord
-      security:
-        - bearerAuth: [ ]
       tags:
         - Records
       parameters:
@@ -297,8 +286,6 @@ paths:
       tags:
         - Records
       operationId: uploadTSV
-      security:
-        - bearerAuth: [ ]
       parameters:
         - $ref: '#/components/parameters/instanceIdPathParam'
         - $ref: '#/components/parameters/versionPathParam'
@@ -389,8 +376,6 @@ paths:
       description: Use POST /collections/v1/{workspaceId} instead.
       operationId: createWDSInstance
       deprecated: true
-      security:
-        - bearerAuth: [ ]
       tags:
         - Instances
       parameters:
@@ -410,8 +395,6 @@ paths:
       description: Use DELETE /collections/v1/{workspaceId}/{collectionId} instead.
       operationId: deleteWDSInstance
       deprecated: true
-      security:
-        - bearerAuth: [ ]
       tags:
         - Instances
       parameters:
@@ -485,8 +468,6 @@ paths:
       summary: Delete record type
       description: Delete record type. All records of this type will be deleted.
       operationId: deleteRecordType
-      security:
-        - bearerAuth: [ ]
       tags:
         - Schema
       parameters:
@@ -503,8 +484,6 @@ paths:
       summary: Update an attribute
       description: Update an attribute. All records of this type will be updated.
       operationId: updateAttribute
-      security:
-        - bearerAuth: [ ]
       tags:
         - Schema
       parameters:
@@ -539,8 +518,6 @@ paths:
       summary: Delete attribute from record type
       description: Delete attribute from record type. This attribute will be removed from all records of this type.
       operationId: deleteAttribute
-      security:
-        - bearerAuth: [ ]
       tags:
         - Schema
       parameters:
@@ -573,6 +550,7 @@ paths:
       operationId: statusGet
       tags:
         - General WDS Information
+      security: [ ]
       responses:
         200:
           $ref: '#/components/responses/StatusResponseBody'
@@ -582,6 +560,7 @@ paths:
       operationId: versionGet
       tags:
         - General WDS Information
+      security: [ ]
       responses:
         200:
           $ref: '#/components/responses/VersionResponseBody'


### PR DESCRIPTION
part of AJ-1660 but does not complete that ticket.

This turns on bearer security for all APIs in our OpenAPI specs, except for /version, /status, and /capabilities.

It does so by setting a global security setting, then overriding those three public APIs to have no security. This is a bit of a refactor.

To test this, I:
* ran WDS locally and observed the swagger-ui pages
* built and published a snapshot version of the java client from this PR ([here](https://broadinstitute.jfrog.io/ui/native/libs-snapshot-local/org/databiosphere/workspacedataservice-client-okhttp-jakarta/0.13.5-SNAPSHOT/)), then ran unit tests in CBAS using this updated client
* see that Python client tests are passing as part of the checks on this PR

For follow-on PR(s): enforce security in the Java layer for all APIs.