### PR TITLE
AJ-1948: enable previously-disabled tests

### DIFF
--- a/service/src/test/java/org/databiosphere/workspacedataservice/annotations/ControlPlaneDeploymentModeTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/annotations/ControlPlaneDeploymentModeTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.databiosphere.workspacedataservice.annotations.DeploymentMode.ControlPlane;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
@@ -22,7 +21,6 @@ class ControlPlaneDeploymentModeTest extends DeploymentModeTestBase {
     assertThrows(NoSuchBeanDefinitionException.class, () -> context.getBean(beanName));
   }
 
-  @Disabled("Test disabled until we have parameters in controlPlaneConditionalBeans")
   @ParameterizedTest(name = "{0} is enabled for DeploymentMode control-plane only")
   @MethodSource("controlPlaneConditionalBeans")
   void beansEnabledForControlPlaneOnly(String beanName) {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/annotations/DataPlaneDeploymentModeTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/annotations/DataPlaneDeploymentModeTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.databiosphere.workspacedataservice.annotations.DeploymentMode.DataPlane;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
@@ -21,7 +20,6 @@ class DataPlaneDeploymentModeTest extends DeploymentModeTestBase {
     assertNotNull(context.findAnnotationOnBean(beanName, DataPlane.class));
   }
 
-  @Disabled("Test disabled until we have parameters in controlPlaneConditionalBeans")
   @ParameterizedTest(name = "{0} is disabled for DeploymentMode data-plane")
   @MethodSource("controlPlaneConditionalBeans")
   void beansDisabledForDataPlane(String beanName) {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/annotations/DeploymentModeTestBase.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/annotations/DeploymentModeTestBase.java
@@ -29,10 +29,28 @@ class DeploymentModeTestBase extends TestBase {
   @Autowired protected ApplicationContext context;
 
   protected static Stream<String> dataPlaneConditionalBeans() {
-    return Stream.of("backupRestoreService", "collectionInitializer", "collectionInitializerBean");
+    return Stream.of(
+        "backupRestoreService",
+        "collectionInitializer",
+        "collectionInitializerBean",
+        "wsmProtectedDataSupport",
+        "wsmSnapshotSupportFactory",
+        "wdsRecordSinkFactory",
+        "capabilitiesController",
+        "cloningController",
+        "collectionController",
+        "recordController");
   }
 
   protected static Stream<String> controlPlaneConditionalBeans() {
-    return Stream.of();
+    return Stream.of(
+        "rawlsProtectedDataSupport",
+        "rawlsJsonQuartzJob",
+        "rawlsSnapshotSupportFactory",
+        "rawlsClientConfig",
+        "rawlsClient",
+        "rawlsApi",
+        "rawlsRestClient",
+        "rawlsRecordSinkFactory");
   }
 }


### PR DESCRIPTION
Quick maintenance/upkeep fix: I noticed we had two unit tests marked as `@Disabled`, because they kept showing up in my test reports. There's no need for these tests to be disabled. I enabled them, and fleshed out their corresponding argument providers.