### PR TITLE
AJ-1660: mock-sam cleanup

### DIFF
--- a/service/src/integrationTest/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerCloneTest.java
+++ b/service/src/integrationTest/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerCloneTest.java
@@ -45,7 +45,7 @@ import org.springframework.test.context.TestPropertySource;
 
 // "local" profile prevents CollectionInitializerBean from running at Spring startup;
 // that way, we can run it when we want to inside our tests.
-@ActiveProfiles({"mock-storage", "local-cors", "mock-sam", "local", "data-plane"})
+@ActiveProfiles({"mock-storage", "local-cors", "local", "data-plane"})
 @TestPropertySource(
     properties = {
       // source id must match value in WDS-integrationTest-LocalFileStorage-input.sql

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorService.java
@@ -89,7 +89,7 @@ public class RecordOrchestratorService { // TODO give me a better name
       RecordType recordType,
       String recordId,
       RecordRequest recordRequest) {
-    validateAndPermissions(collectionId, version);
+    validateCollectionAndVersion(collectionId, version);
     checkRecordTypeExists(collectionId, recordType);
     RecordResponse response =
         recordService.updateSingleRecord(collectionId, recordType, recordId, recordRequest);
@@ -98,8 +98,7 @@ public class RecordOrchestratorService { // TODO give me a better name
     return response;
   }
 
-  // TODO AJ-1660: rename this method; it no longer checks permissions
-  public void validateAndPermissions(UUID collectionId, String version) {
+  public void validateCollectionAndVersion(UUID collectionId, String version) {
     validateVersion(version);
     collectionService.validateCollection(collectionId);
   }
@@ -125,7 +124,7 @@ public class RecordOrchestratorService { // TODO give me a better name
       Optional<String> primaryKey,
       MultipartFile records)
       throws IOException, DataImportException {
-    validateAndPermissions(collectionId, version);
+    validateCollectionAndVersion(collectionId, version);
     if (recordDao.recordTypeExists(collectionId, recordType)) {
       primaryKey =
           Optional.of(recordService.validatePrimaryKey(collectionId, recordType, primaryKey));
@@ -225,7 +224,7 @@ public class RecordOrchestratorService { // TODO give me a better name
       String recordId,
       Optional<String> primaryKey,
       RecordRequest recordRequest) {
-    validateAndPermissions(collectionId, version);
+    validateCollectionAndVersion(collectionId, version);
     ResponseEntity<RecordResponse> response =
         recordService.upsertSingleRecord(
             collectionId, recordType, recordId, primaryKey, recordRequest);
@@ -242,7 +241,7 @@ public class RecordOrchestratorService { // TODO give me a better name
 
   public boolean deleteSingleRecord(
       UUID collectionId, String version, RecordType recordType, String recordId) {
-    validateAndPermissions(collectionId, version);
+    validateCollectionAndVersion(collectionId, version);
     checkRecordTypeExists(collectionId, recordType);
     boolean response = recordService.deleteSingleRecord(collectionId, recordType, recordId);
     activityLogger.saveEventForCurrentUser(
@@ -251,7 +250,7 @@ public class RecordOrchestratorService { // TODO give me a better name
   }
 
   public void deleteRecordType(UUID collectionId, String version, RecordType recordType) {
-    validateAndPermissions(collectionId, version);
+    validateCollectionAndVersion(collectionId, version);
     checkRecordTypeExists(collectionId, recordType);
     recordService.deleteRecordType(collectionId, recordType);
     activityLogger.saveEventForCurrentUser(
@@ -264,7 +263,7 @@ public class RecordOrchestratorService { // TODO give me a better name
       RecordType recordType,
       String attribute,
       String newAttributeName) {
-    validateAndPermissions(collectionId, version);
+    validateCollectionAndVersion(collectionId, version);
     checkRecordTypeExists(collectionId, recordType);
     validateRenameAttribute(collectionId, recordType, attribute, newAttributeName);
     recordService.renameAttribute(collectionId, recordType, attribute, newAttributeName);
@@ -297,7 +296,7 @@ public class RecordOrchestratorService { // TODO give me a better name
       RecordType recordType,
       String attribute,
       String newDataType) {
-    validateAndPermissions(collectionId, version);
+    validateCollectionAndVersion(collectionId, version);
     checkRecordTypeExists(collectionId, recordType);
     RecordTypeSchema schema = getSchemaDescription(collectionId, recordType);
     if (schema.isPrimaryKey(attribute)) {
@@ -325,7 +324,7 @@ public class RecordOrchestratorService { // TODO give me a better name
 
   public void deleteAttribute(
       UUID collectionId, String version, RecordType recordType, String attribute) {
-    validateAndPermissions(collectionId, version);
+    validateCollectionAndVersion(collectionId, version);
     checkRecordTypeExists(collectionId, recordType);
     validateDeleteAttribute(collectionId, recordType, attribute);
     recordService.deleteAttribute(collectionId, recordType, attribute);
@@ -370,7 +369,7 @@ public class RecordOrchestratorService { // TODO give me a better name
       Optional<String> primaryKey,
       InputStream is)
       throws DataImportException {
-    validateAndPermissions(collectionId, version);
+    validateCollectionAndVersion(collectionId, version);
     if (recordDao.recordTypeExists(collectionId, recordType)) {
       recordService.validatePrimaryKey(collectionId, recordType, primaryKey);
     }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/ActivityEventBuilderTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/ActivityEventBuilderTest.java
@@ -27,11 +27,9 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.context.request.RequestContextHolder;
 
-@ActiveProfiles(profiles = "mock-sam")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @SpringBootTest
 @AutoConfigureMockMvc

--- a/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/LogStatementTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/LogStatementTest.java
@@ -32,17 +32,17 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.web.multipart.MultipartFile;
 
-@ActiveProfiles(profiles = {"mock-sam"})
 @SpringBootTest
 @ExtendWith(OutputCaptureExtension.class)
 @TestPropertySource(
     properties = {
       "twds.tenancy.enforce-collections-match-workspace-id=false", // TODO(AJ-1682): get rid of this
     })
+@DirtiesContext
 class LogStatementTest extends TestBase {
 
   private final String VERSION = "v0.2";

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobTest.java
@@ -53,11 +53,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.core.io.Resource;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ActiveProfiles;
 
 @DirtiesContext
 @SpringBootTest
-@ActiveProfiles("mock-sam")
 class PfbQuartzJobTest extends TestBase {
   @MockBean JobDao jobDao;
   @MockBean WorkspaceManagerDao wsmDao;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobTest.java
@@ -82,11 +82,9 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.Resource;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ActiveProfiles;
 
 @DirtiesContext
 @SpringBootTest
-@ActiveProfiles(profiles = {"mock-sam"})
 @Import(MockInstantSourceConfig.class)
 class TdrManifestQuartzJobTest extends TestBase {
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceGetWorkspaceIdTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceGetWorkspaceIdTest.java
@@ -22,10 +22,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ActiveProfiles;
 
 /** Tests for CollectionService.getWorkspaceId() */
-@ActiveProfiles(profiles = {"mock-sam"})
 @DirtiesContext
 @SpringBootTest
 class CollectionServiceGetWorkspaceIdTest extends TestBase {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceTest.java
@@ -17,7 +17,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
-@ActiveProfiles(profiles = {"mock-sam", "mock-collection-dao"})
+@ActiveProfiles(profiles = {"mock-collection-dao"})
 @DirtiesContext
 @SpringBootTest
 class CollectionServiceTest extends TestBase {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceControlPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceControlPlaneTest.java
@@ -47,9 +47,9 @@ class ImportServiceControlPlaneTest {
   private final ImportRequestServerModel importRequest =
       new ImportRequestServerModel(PFB, importUri);
 
-  /* Collection does not exist, user has access */
+  /* Collection does not exist, which is expected in the control plane */
   @Test
-  void hasWritePermission() {
+  void virtualCollection() {
     // ARRANGE
     CollectionId collectionId = CollectionId.of(UUID.randomUUID());
     // collection dao says the collection does not exist

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceDataPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceDataPlaneTest.java
@@ -3,8 +3,6 @@ package org.databiosphere.workspacedataservice.service;
 import static org.databiosphere.workspacedataservice.generated.ImportRequestServerModel.TypeEnum.PFB;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.net.URI;
@@ -13,15 +11,11 @@ import org.databiosphere.workspacedataservice.annotations.SingleTenant;
 import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.dao.CollectionDao;
 import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
-import org.databiosphere.workspacedataservice.sam.MockSamAuthorizationDao;
-import org.databiosphere.workspacedataservice.sam.SamAuthorizationDao;
-import org.databiosphere.workspacedataservice.sam.SamAuthorizationDaoFactory;
 import org.databiosphere.workspacedataservice.service.model.exception.CollectionException;
 import org.databiosphere.workspacedataservice.service.model.exception.MissingObjectException;
 import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.junit.jupiter.api.Test;
-import org.mockito.stubbing.OngoingStubbing;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -42,8 +36,6 @@ class ImportServiceDataPlaneTest extends TestBase {
   @Autowired ImportService importService;
   @Autowired @SingleTenant WorkspaceId workspaceId;
   @MockBean CollectionDao collectionDao;
-  @MockBean SamAuthorizationDaoFactory samAuthorizationDaoFactory;
-  private final SamAuthorizationDao samAuthorizationDao = spy(MockSamAuthorizationDao.allowAll());
 
   private final URI importUri =
       URI.create("https://teststorageaccount.blob.core.windows.net/testcontainer/file");
@@ -52,16 +44,13 @@ class ImportServiceDataPlaneTest extends TestBase {
 
   private final CollectionId collectionId = CollectionId.of(UUID.randomUUID());
 
-  /* collection exists, workspace matches env var, user has write permission */
+  /* collection exists, workspace matches env var */
   @Test
-  void userHasWritePermission() {
+  void singleTenantWorkspaceId() {
     // ARRANGE
     // collection dao says the collection exists and returns the expected workspace id
     when(collectionDao.collectionSchemaExists(collectionId)).thenReturn(true);
     when(collectionDao.getWorkspaceId(collectionId)).thenReturn(workspaceId);
-    // sam dao says the user has write permission
-    stubWriteWorkspacePermission(workspaceId).thenReturn(true);
-    stubReadWorkspacePermission(workspaceId).thenReturn(true);
 
     // ACT/ASSERT
     // extract the UUID here so the lambda below has only one invocation possibly throwing a runtime
@@ -79,8 +68,6 @@ class ImportServiceDataPlaneTest extends TestBase {
     // collection dao says the collection exists and returns an unexpected workspace id
     when(collectionDao.collectionSchemaExists(collectionId)).thenReturn(true);
     when(collectionDao.getWorkspaceId(collectionId)).thenReturn(nonMatchingWorkspaceId);
-    // sam dao says the user has write permission
-    stubWriteWorkspacePermission(nonMatchingWorkspaceId).thenReturn(true);
 
     // ACT/ASSERT
     // extract the UUID here so the lambda below has only one invocation possibly throwing a runtime
@@ -108,20 +95,5 @@ class ImportServiceDataPlaneTest extends TestBase {
     assertThrows(
         MissingObjectException.class,
         () -> importService.createImport(collectionUuid, importRequest));
-
-    verifyNoInteractions(samAuthorizationDaoFactory);
-    verifyNoInteractions(samAuthorizationDao);
-  }
-
-  private OngoingStubbing<Boolean> stubWriteWorkspacePermission(WorkspaceId workspaceId) {
-    when(samAuthorizationDaoFactory.getSamAuthorizationDao(workspaceId))
-        .thenReturn(samAuthorizationDao);
-    return when(samAuthorizationDao.hasWriteWorkspacePermission());
-  }
-
-  private OngoingStubbing<Boolean> stubReadWorkspacePermission(WorkspaceId workspaceId) {
-    when(samAuthorizationDaoFactory.getSamAuthorizationDao(workspaceId))
-        .thenReturn(samAuthorizationDao);
-    return when(samAuthorizationDao.hasReadWorkspacePermission());
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceTest.java
@@ -61,7 +61,7 @@ import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
-@ActiveProfiles(profiles = {"mock-sam", "mock-collection-dao"})
+@ActiveProfiles(profiles = {"mock-collection-dao"})
 @DirtiesContext
 @SpringBootTest
 class ImportServiceTest extends TestBase {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
@@ -45,10 +45,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.server.ResponseStatusException;
 
-@ActiveProfiles(profiles = {"mock-sam"})
 @SpringBootTest
 class RecordOrchestratorServiceTest extends TestBase {
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordServiceTest.java
@@ -27,11 +27,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @DirtiesContext
-@ActiveProfiles(profiles = {"mock-sam"})
 @WithTestObservationRegistry
 class RecordServiceTest extends TestBase {
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerBeanTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerBeanTest.java
@@ -40,8 +40,7 @@ import org.springframework.test.context.ActiveProfiles;
   "mock-backup-dao",
   "mock-restore-dao",
   "mock-clone-dao",
-  "local-cors",
-  "mock-sam"
+  "local-cors"
 })
 @DirtiesContext
 @SpringBootTest

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvErrorMessageTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvErrorMessageTest.java
@@ -22,16 +22,16 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 
-@ActiveProfiles(profiles = "mock-sam")
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestPropertySource(
     properties = {
       "twds.tenancy.enforce-collections-match-workspace-id=false", // TODO(AJ-1682): get rid of this
     })
+@DirtiesContext
 class TsvErrorMessageTest extends TestBase {
 
   @Autowired CollectionService collectionService;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/workspacemanager/WorkspaceManagerDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/workspacemanager/WorkspaceManagerDaoTest.java
@@ -36,9 +36,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.lang.Nullable;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ActiveProfiles;
 
-@ActiveProfiles(profiles = "mock-sam")
 @SpringBootTest
 @DirtiesContext
 class WorkspaceManagerDaoTest extends TestBase {


### PR DESCRIPTION
follow-on to #871 

* rename `validateAndPermissions()` method which no longer checks permissions
* remove usages of the `mock-sam` profile in tests where it is no longer needed
* add `@DirtiesContext` to a few tests that I noticed needed it while I was adjusting tests
* rename a few test methods to reflect that they no longer test permissions