### PR TITLE
AJ-1238: filter by column enhancements

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -51,7 +51,6 @@ import org.databiosphere.workspacedataservice.service.model.exception.ConflictEx
 import org.databiosphere.workspacedataservice.service.model.exception.InvalidRelationException;
 import org.databiosphere.workspacedataservice.service.model.exception.MissingObjectException;
 import org.databiosphere.workspacedataservice.service.model.exception.SerializationException;
-import org.databiosphere.workspacedataservice.service.model.exception.ValidationException;
 import org.databiosphere.workspacedataservice.shared.model.AttributeComparator;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
@@ -320,18 +319,7 @@ public class RecordDao {
     // if this query has specified filter.query, populate the where clause and bind params
     Optional<String> filterQuery = searchFilter.flatMap(SearchFilter::query);
     if (filterQuery.isPresent()) {
-      WhereClausePart queryPart = new QueryParser().parse(filterQuery.get());
-      for (String column : queryPart.columns()) {
-        if (!schema.containsKey(column)) {
-          throw new ValidationException(
-              "Column specified in query does not exist in this record type");
-        }
-        var datatype = schema.get(column);
-        if (!DataTypeMapping.STRING.equals(datatype)) {
-          throw new ValidationException("Column specified in query must be a string type");
-        }
-      }
-
+      WhereClausePart queryPart = new QueryParser(schema).parse(filterQuery.get());
       clauses.addAll(queryPart.clauses());
       sqlParams.addValues(queryPart.values());
     }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/search/QueryParser.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/search/QueryParser.java
@@ -46,8 +46,8 @@ public class QueryParser {
 
       // bind parameter names have syntax limitations, so we use an artificial one
       var paramName = "filterquery0";
-      clauses.add(quote(column) + " = :" + paramName);
-      values.put(paramName, value);
+      clauses.add("LOWER(" + quote(column) + ") = :" + paramName);
+      values.put(paramName, value.toLowerCase());
       columns.add(column);
 
       return new WhereClausePart(clauses, values, columns);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/search/QueryParser.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/search/QueryParser.java
@@ -12,7 +12,6 @@ import org.apache.lucene.queryparser.flexible.core.nodes.FieldQueryNode;
 import org.apache.lucene.queryparser.flexible.core.nodes.QueryNode;
 import org.apache.lucene.queryparser.flexible.standard.parser.StandardSyntaxParser;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
-import org.databiosphere.workspacedataservice.service.model.exception.ValidationException;
 
 public class QueryParser {
 
@@ -73,12 +72,13 @@ public class QueryParser {
     }
     // does this column exist in the record type?
     if (!schema.containsKey(columnName)) {
-      throw new ValidationException("Column specified in query does not exist in this record type");
+      throw new InvalidQueryException(
+          "Column specified in query does not exist in this record type");
     }
     // is this column of a datatype we currently support?
     var datatype = schema.get(columnName);
     if (!DataTypeMapping.STRING.equals(datatype)) {
-      throw new ValidationException("Column specified in query must be a string type");
+      throw new InvalidQueryException("Column specified in query must be a string type");
     }
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/search/WhereClausePart.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/search/WhereClausePart.java
@@ -3,4 +3,4 @@ package org.databiosphere.workspacedataservice.search;
 import java.util.List;
 import java.util.Map;
 
-public record WhereClausePart(List<String> clauses, Map<String, ?> values, List<String> columns) {}
+public record WhereClausePart(List<String> clauses, Map<String, ?> values) {}

--- a/service/src/main/resources/capabilities.json
+++ b/service/src/main/resources/capabilities.json
@@ -5,5 +5,6 @@
   "edit.deleteAttribute": true,
   "edit.renameAttribute": true,
   "search.filter.ids": true,
-  "search.filter.bycolumn": true
+  "search.filter.query": true,
+  "search.filter.query.column.exact": true
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoWhereClauseTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoWhereClauseTest.java
@@ -64,8 +64,19 @@ class RecordDaoWhereClauseTest {
     WhereClause actual =
         RecordDao.generateQueryWhereClause(
             "my-pk-col", Map.of("col1", DataTypeMapping.STRING), Optional.of(searchFilter));
-    assertEquals(" where \"col1\" = :filterquery0", actual.sql());
+    assertEquals(" where LOWER(\"col1\") = :filterquery0", actual.sql());
     assertEquals(Map.of("filterquery0", "col1value"), actual.params().getValues());
+  }
+
+  @Test
+  void oneColumnCaseInsensitive() {
+    SearchFilter searchFilter = new SearchFilter(Optional.empty(), Optional.of("col1:UPPER"));
+
+    WhereClause actual =
+        RecordDao.generateQueryWhereClause(
+            "my-pk-col", Map.of("col1", DataTypeMapping.STRING), Optional.of(searchFilter));
+    assertEquals(" where LOWER(\"col1\") = :filterquery0", actual.sql());
+    assertEquals(Map.of("filterquery0", "upper"), actual.params().getValues());
   }
 
   @Disabled("we don't support multiple columns yet")

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoWhereClauseTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoWhereClauseTest.java
@@ -14,6 +14,11 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests for RecordDao.generateQueryWhereClause() These tests don't require any Spring context, so
  * it's nice to have them in their own class
+ *
+ * <p>See also org.databiosphere.workspacedataservice.search.QueryParserTest. QueryParserTest has
+ * detailed tests for the filter.query portion of the where clause, and we don't need to replicate
+ * those here. Here, we should be testing the interactions between filter.query and filter.ids, as
+ * well as any other higher-level logic.
  */
 class RecordDaoWhereClauseTest {
 
@@ -48,7 +53,7 @@ class RecordDaoWhereClauseTest {
   }
 
   @Test
-  void emptyColumnFilters() {
+  void emptyFilterQuery() {
     SearchFilter searchFilter = new SearchFilter(Optional.empty(), Optional.of(""));
 
     WhereClause actual =
@@ -58,7 +63,7 @@ class RecordDaoWhereClauseTest {
   }
 
   @Test
-  void oneColumnFilter() {
+  void oneColumnFilterQuery() {
     SearchFilter searchFilter = new SearchFilter(Optional.empty(), Optional.of("col1:col1value"));
 
     WhereClause actual =
@@ -69,35 +74,22 @@ class RecordDaoWhereClauseTest {
   }
 
   @Test
-  void oneColumnCaseInsensitive() {
-    SearchFilter searchFilter = new SearchFilter(Optional.empty(), Optional.of("col1:UPPER"));
+  void idsAndOneColumnFilterQuery() {
+    List<String> ids = List.of("one", "two", "three");
+    SearchFilter searchFilter = new SearchFilter(Optional.of(ids), Optional.of("col1:col1value"));
 
     WhereClause actual =
         RecordDao.generateQueryWhereClause(
             "my-pk-col", Map.of("col1", DataTypeMapping.STRING), Optional.of(searchFilter));
-    assertEquals(" where LOWER(\"col1\") = :filterquery0", actual.sql());
-    assertEquals(Map.of("filterquery0", "upper"), actual.params().getValues());
+    assertEquals(
+        " where \"my-pk-col\" in (:filterIds) and LOWER(\"col1\") = :filterquery0", actual.sql());
+    assertEquals(
+        Map.of("filterIds", ids, "filterquery0", "col1value"), actual.params().getValues());
   }
 
   @Disabled("we don't support multiple columns yet")
   @Test
-  void multipleColumnFilters() {
-    SearchFilter searchFilter =
-        new SearchFilter(
-            Optional.empty(), Optional.of("col1:col1value AND col2:col2value AND col3:col3value"));
-
-    WhereClause actual =
-        RecordDao.generateQueryWhereClause("my-pk-col", Map.of(), Optional.of(searchFilter));
-    assertEquals(
-        " where \"col1\" = :filter0 and \"col2\" = :filter1 and \"col3\" = :filter2", actual.sql());
-    assertEquals(
-        Map.of("filter0", "col1value", "filter1", "col2value", "filter2", "col3value"),
-        actual.params().getValues());
-  }
-
-  @Disabled("we don't support multiple columns yet")
-  @Test
-  void idsAndColumnFilters() {
+  void idsAndMultipleColumnFiltersQuery() {
     List<String> ids = List.of("one", "two", "three");
     SearchFilter searchFilter =
         new SearchFilter(

--- a/service/src/test/java/org/databiosphere/workspacedataservice/search/QueryParserTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/search/QueryParserTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 class QueryParserTest {
 
-  private static Stream<Arguments> singleColumnTerms() {
+  private static Stream<Arguments> stringTerms() {
     return Stream.of(
         Arguments.of("foo", "foo"),
         // Lucene query syntax uses * and ? as wildcards
@@ -30,10 +30,10 @@ class QueryParserTest {
         Arguments.of("42", "42"));
   }
 
-  // test expected parsing for a single column and its filter term
+  // test expected parsing for a single string column and its filter term
   @ParameterizedTest(name = "Valid query `column1:{0}`")
-  @MethodSource("singleColumnTerms")
-  void parseSingleColumnTerm(String queryTerm, String expectedResult) {
+  @MethodSource("stringTerms")
+  void parseSingleStringColumnTerm(String queryTerm, String expectedResult) {
     String query = "column1:" + queryTerm;
 
     WhereClausePart actual =
@@ -43,6 +43,66 @@ class QueryParserTest {
         new WhereClausePart(
             List.of("LOWER(\"column1\") = :filterquery0"),
             Map.of("filterquery0", expectedResult.toLowerCase()));
+
+    assertEquals(expected, actual);
+  }
+
+  // test expected parsing for a single array-of-string column and its filter term
+  @ParameterizedTest(name = "Valid query `column1:{0}`")
+  @MethodSource("stringTerms")
+  void parseSingleArrayOfStringColumnTerm(String queryTerm, String expectedResult) {
+    String query = "column1:" + queryTerm;
+
+    WhereClausePart actual =
+        new QueryParser(Map.of("column1", DataTypeMapping.ARRAY_OF_STRING)).parse(query);
+
+    WhereClausePart expected =
+        new WhereClausePart(
+            List.of(":filterquery0 ILIKE ANY(\"column1\")"),
+            Map.of("filterquery0", expectedResult.toLowerCase()));
+
+    assertEquals(expected, actual);
+  }
+
+  private static Stream<Arguments> numberTerms() {
+    return Stream.of(
+        Arguments.of("1", 1d),
+        Arguments.of("1.23", 1.23d),
+        Arguments.of(Double.toString(Double.MAX_VALUE), Double.MAX_VALUE),
+        Arguments.of(Double.toString(Double.MIN_VALUE), Double.MIN_VALUE),
+        // negative numbers require escaping the dash; a bare dash is shorthand for NOT:
+        // https://lucene.apache.org/core/2_9_4/queryparsersyntax.html#Escaping%20Special%20Characters
+        Arguments.of("\\-1.23", -1.23d));
+  }
+
+  // test expected parsing for a single number column and its filter term
+  @ParameterizedTest(name = "Valid query `column1:{0}`")
+  @MethodSource("numberTerms")
+  void parseSingleNumberColumnTerm(String queryTerm, Double expectedResult) {
+    String query = "column1:" + queryTerm;
+
+    WhereClausePart actual =
+        new QueryParser(Map.of("column1", DataTypeMapping.NUMBER)).parse(query);
+
+    WhereClausePart expected =
+        new WhereClausePart(
+            List.of("\"column1\" = :filterquery0"), Map.of("filterquery0", expectedResult));
+
+    assertEquals(expected, actual);
+  }
+
+  // test expected parsing for a single array-of-number column and its filter term
+  @ParameterizedTest(name = "Valid query `column1:{0}`")
+  @MethodSource("numberTerms")
+  void parseSingleArrayOfNumberColumnTerm(String queryTerm, Double expectedResult) {
+    String query = "column1:" + queryTerm;
+
+    WhereClausePart actual =
+        new QueryParser(Map.of("column1", DataTypeMapping.ARRAY_OF_NUMBER)).parse(query);
+
+    WhereClausePart expected =
+        new WhereClausePart(
+            List.of(":filterquery0 = ANY(\"column1\")"), Map.of("filterquery0", expectedResult));
 
     assertEquals(expected, actual);
   }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/search/QueryParserTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/search/QueryParserTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
+import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -35,13 +36,13 @@ class QueryParserTest {
   void parseSingleColumnTerm(String queryTerm, String expectedResult) {
     String query = "column1:" + queryTerm;
 
-    WhereClausePart actual = new QueryParser().parse(query);
+    WhereClausePart actual =
+        new QueryParser(Map.of("column1", DataTypeMapping.STRING)).parse(query);
 
     WhereClausePart expected =
         new WhereClausePart(
-            List.of("\"column1\" = :filterquery0"),
-            Map.of("filterquery0", expectedResult),
-            List.of("column1"));
+            List.of("LOWER(\"column1\") = :filterquery0"),
+            Map.of("filterquery0", expectedResult.toLowerCase()));
 
     assertEquals(expected, actual);
   }
@@ -61,7 +62,7 @@ class QueryParserTest {
   @ParameterizedTest(name = "Invalid query `{0}`")
   @MethodSource("invalidQuerySyntax")
   void parseInvalidQueries(String query) {
-    QueryParser queryParser = new QueryParser();
+    QueryParser queryParser = new QueryParser(Map.of("column1", DataTypeMapping.STRING));
     assertThrows(InvalidQueryException.class, () -> queryParser.parse(query));
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceFilterQueryTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceFilterQueryTest.java
@@ -18,9 +18,9 @@ import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.config.TwdsProperties;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.databiosphere.workspacedataservice.generated.CollectionServerModel;
+import org.databiosphere.workspacedataservice.search.InvalidQueryException;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
 import org.databiosphere.workspacedataservice.service.model.RelationCollection;
-import org.databiosphere.workspacedataservice.service.model.exception.ValidationException;
 import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
 import org.databiosphere.workspacedataservice.shared.model.RecordQueryResponse;
@@ -137,9 +137,9 @@ class RecordOrchestratorServiceFilterQueryTest extends TestBase {
     SearchRequest searchRequest = new SearchRequest();
     searchRequest.setFilter(Optional.of(searchFilter));
 
-    ValidationException validationException =
+    InvalidQueryException validationException =
         assertThrows(
-            ValidationException.class,
+            InvalidQueryException.class,
             () ->
                 recordOrchestratorService.queryForRecords(
                     COLLECTION_UUID, TEST_TYPE, VERSION, searchRequest));

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceFilterQueryTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceFilterQueryTest.java
@@ -117,8 +117,8 @@ class RecordOrchestratorServiceFilterQueryTest extends TestBase {
     insertFillerRecords(3, criteria, controlValueSupplier);
     filterAndExpect(1, findOne, searchRequest);
 
-    // insert two more findable records, then filter; should return 3
-    List<String> findTwo = insertFindableRecords(2, criteria);
+    // insert two more findable records, with the criteria uppercased, then filter; should return 3
+    List<String> findTwo = insertFindableRecords(2, criteria.toUpperCase());
     List<String> findOneAndTwo = Stream.concat(findOne.stream(), findTwo.stream()).toList();
     filterAndExpect(3, findOneAndTwo, searchRequest);
   }

--- a/service/src/test/resources/searchfilter/README.md
+++ b/service/src/test/resources/searchfilter/README.md
@@ -1,0 +1,2 @@
+data for use in RecordOrchestratorServiceFilterQueryTest, which tests
+the filter capabilities of the queryRecords API

--- a/service/src/test/resources/searchfilter/testdata.tsv
+++ b/service/src/test/resources/searchfilter/testdata.tsv
@@ -1,0 +1,4 @@
+test_id	str	arrstr	num	arrnum
+1	hello world	["hello", "world", "how", "are", "you"]	42	[31,41,59]
+2	Hello World	["Hello", "World"]	42	[31,41]
+3	goodbye	["ONE", "TWO", "THREE"]	-1.23	[1,2,3]


### PR DESCRIPTION
Followup to #868 

* report more detailed capabilities so the UI can distinguish individual query features
* filter-by-column is now case-insensitive
* support filtering on array_of_string, number, and array_of_number columns

Still todo:
1. Support boolean, file, relation, date, etc columns
2. It is exact-match only, not substring match or natural language search.
4. It works on a single column only; you can't search for e.g. "column1:foo AND column2:bar".
5. Users cannot search for null
6. The `totalRecords` value in the response of the `queryRecords` API may be considered incorrect. It returns the count of records for the specified record type _ignoring_ any filtering. So, if your filter only finds 1 record out of 100 samples, `totalRecords` will still return 100. 

