### PR TITLE
AJ-1941: collection id is always auto-generated on creation

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/CollectionController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/CollectionController.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.annotations.DeploymentMode.DataPlane;
 import org.databiosphere.workspacedataservice.generated.CollectionApi;
+import org.databiosphere.workspacedataservice.generated.CollectionRequestServerModel;
 import org.databiosphere.workspacedataservice.generated.CollectionServerModel;
 import org.databiosphere.workspacedataservice.service.CollectionService;
 import org.databiosphere.workspacedataservice.service.PermissionService;
@@ -36,15 +37,15 @@ public class CollectionController implements CollectionApi {
    * id.
    *
    * @param workspaceId Workspace id (required)
-   * @param collectionServerModel The collection to create (required)
+   * @param collectionRequestServerModel The collection to create (required)
    * @return The collection just created. (status code 201)
    */
   @Override
   public ResponseEntity<CollectionServerModel> createCollectionV1(
-      UUID workspaceId, CollectionServerModel collectionServerModel) {
+      UUID workspaceId, CollectionRequestServerModel collectionRequestServerModel) {
     permissionService.requireWritePermission(WorkspaceId.of(workspaceId));
     CollectionServerModel coll =
-        collectionService.save(WorkspaceId.of(workspaceId), collectionServerModel);
+        collectionService.save(WorkspaceId.of(workspaceId), collectionRequestServerModel);
     return new ResponseEntity<>(coll, HttpStatus.CREATED);
   }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/CollectionController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/CollectionController.java
@@ -94,8 +94,6 @@ public class CollectionController implements CollectionApi {
 
   /**
    * PUT /collections/v1/{workspaceId}/{collectionId} : Update the specified collection.
-   * WdsCollection id is optional in the request body. If specified, it must match the collection id
-   * specified in the url.
    *
    * @param workspaceId Workspace id (required)
    * @param collectionId WdsCollection id (required)

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/CollectionController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/CollectionController.java
@@ -99,16 +99,20 @@ public class CollectionController implements CollectionApi {
    *
    * @param workspaceId Workspace id (required)
    * @param collectionId WdsCollection id (required)
-   * @param collectionServerModel The collection to update (required)
+   * @param collectionRequestServerModel The collection to update (required)
    * @return The collection just updated. (status code 200)
    */
   @Override
   public ResponseEntity<CollectionServerModel> updateCollectionV1(
-      UUID workspaceId, UUID collectionId, CollectionServerModel collectionServerModel) {
+      UUID workspaceId,
+      UUID collectionId,
+      CollectionRequestServerModel collectionRequestServerModel) {
     permissionService.requireWritePermission(WorkspaceId.of(workspaceId));
     CollectionServerModel coll =
         collectionService.update(
-            WorkspaceId.of(workspaceId), CollectionId.of(collectionId), collectionServerModel);
+            WorkspaceId.of(workspaceId),
+            CollectionId.of(collectionId),
+            collectionRequestServerModel);
     return new ResponseEntity<>(coll, HttpStatus.OK);
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/generated/CollectionApi.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/generated/CollectionApi.java
@@ -5,6 +5,7 @@
  */
 package org.databiosphere.workspacedataservice.generated;
 
+import org.databiosphere.workspacedataservice.generated.CollectionRequestServerModel;
 import org.databiosphere.workspacedataservice.generated.CollectionServerModel;
 import java.util.UUID;
 import io.swagger.v3.oas.annotations.ExternalDocumentation;
@@ -47,7 +48,7 @@ public interface CollectionApi {
      * If collection id is specified in the request body, it will be ignored; ids are auto-generated. 
      *
      * @param workspaceId Workspace id (required)
-     * @param collectionServerModel The collection to create (required)
+     * @param collectionRequestServerModel The collection to create (required)
      * @return The collection just created. (status code 201)
      */
     @Operation(
@@ -73,7 +74,7 @@ public interface CollectionApi {
     
     default ResponseEntity<CollectionServerModel> createCollectionV1(
         @Parameter(name = "workspaceId", description = "Workspace id", required = true, in = ParameterIn.PATH) @PathVariable("workspaceId") UUID workspaceId,
-        @Parameter(name = "CollectionServerModel", description = "The collection to create", required = true) @Valid @RequestBody CollectionServerModel collectionServerModel
+        @Parameter(name = "CollectionRequestServerModel", description = "The collection to create", required = true) @Valid @RequestBody CollectionRequestServerModel collectionRequestServerModel
     ) {
         return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/generated/CollectionApi.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/generated/CollectionApi.java
@@ -45,7 +45,6 @@ public interface CollectionApi {
 
     /**
      * POST /collections/v1/{workspaceId} : Create a collection in this workspace.
-     * If collection id is specified in the request body, it will be ignored; ids are auto-generated. 
      *
      * @param workspaceId Workspace id (required)
      * @param collectionRequestServerModel The collection to create (required)
@@ -54,7 +53,6 @@ public interface CollectionApi {
     @Operation(
         operationId = "createCollectionV1",
         summary = "Create a collection in this workspace.",
-        description = "If collection id is specified in the request body, it will be ignored; ids are auto-generated. ",
         tags = { "Collection" },
         responses = {
             @ApiResponse(responseCode = "201", description = "The collection just created.", content = {
@@ -183,17 +181,15 @@ public interface CollectionApi {
 
     /**
      * PUT /collections/v1/{workspaceId}/{collectionId} : Update the specified collection.
-     * Collection id is optional in the request body. If specified, it must match the collection id specified in the url. 
      *
      * @param workspaceId Workspace id (required)
      * @param collectionId Collection id (required)
-     * @param collectionServerModel The collection to update (required)
+     * @param collectionRequestServerModel The collection to update (required)
      * @return The collection just updated. (status code 200)
      */
     @Operation(
         operationId = "updateCollectionV1",
         summary = "Update the specified collection.",
-        description = "Collection id is optional in the request body. If specified, it must match the collection id specified in the url. ",
         tags = { "Collection" },
         responses = {
             @ApiResponse(responseCode = "200", description = "The collection just updated.", content = {
@@ -214,7 +210,7 @@ public interface CollectionApi {
     default ResponseEntity<CollectionServerModel> updateCollectionV1(
         @Parameter(name = "workspaceId", description = "Workspace id", required = true, in = ParameterIn.PATH) @PathVariable("workspaceId") UUID workspaceId,
         @Parameter(name = "collectionId", description = "Collection id", required = true, in = ParameterIn.PATH) @PathVariable("collectionId") UUID collectionId,
-        @Parameter(name = "CollectionServerModel", description = "The collection to update", required = true) @Valid @RequestBody CollectionServerModel collectionServerModel
+        @Parameter(name = "CollectionRequestServerModel", description = "The collection to update", required = true) @Valid @RequestBody CollectionRequestServerModel collectionRequestServerModel
     ) {
         return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/generated/CollectionApi.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/generated/CollectionApi.java
@@ -44,7 +44,7 @@ public interface CollectionApi {
 
     /**
      * POST /collections/v1/{workspaceId} : Create a collection in this workspace.
-     * If collection id is specified in the request body, it must be a valid UUID. If omitted, the system will generate an id. 
+     * If collection id is specified in the request body, it will be ignored; ids are auto-generated. 
      *
      * @param workspaceId Workspace id (required)
      * @param collectionServerModel The collection to create (required)
@@ -53,7 +53,7 @@ public interface CollectionApi {
     @Operation(
         operationId = "createCollectionV1",
         summary = "Create a collection in this workspace.",
-        description = "If collection id is specified in the request body, it must be a valid UUID. If omitted, the system will generate an id. ",
+        description = "If collection id is specified in the request body, it will be ignored; ids are auto-generated. ",
         tags = { "Collection" },
         responses = {
             @ApiResponse(responseCode = "201", description = "The collection just created.", content = {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/generated/CollectionRequestServerModel.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/generated/CollectionRequestServerModel.java
@@ -1,0 +1,121 @@
+package org.databiosphere.workspacedataservice.generated;
+
+import java.net.URI;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import org.openapitools.jackson.nullable.JsonNullable;
+import java.time.OffsetDateTime;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+import jakarta.annotation.Generated;
+
+/**
+ * CollectionRequestServerModel
+ */
+
+@JsonTypeName("CollectionRequest")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.7.0")
+public class CollectionRequestServerModel {
+
+  private String name;
+
+  private String description;
+
+  public CollectionRequestServerModel() {
+    super();
+  }
+
+  /**
+   * Constructor with only required parameters
+   */
+  public CollectionRequestServerModel(String name, String description) {
+    this.name = name;
+    this.description = description;
+  }
+
+  public CollectionRequestServerModel name(String name) {
+    this.name = name;
+    return this;
+  }
+
+  /**
+   * Letters, numbers, dash and underscore only. Max 128 characters.
+   * @return name
+   */
+  @NotNull @Pattern(regexp = "[a-zA-Z0-9-_]{1,128}") 
+  @Schema(name = "name", description = "Letters, numbers, dash and underscore only. Max 128 characters.", requiredMode = Schema.RequiredMode.REQUIRED)
+  @JsonProperty("name")
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public CollectionRequestServerModel description(String description) {
+    this.description = description;
+    return this;
+  }
+
+  /**
+   * Get description
+   * @return description
+   */
+  @NotNull 
+  @Schema(name = "description", requiredMode = Schema.RequiredMode.REQUIRED)
+  @JsonProperty("description")
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    CollectionRequestServerModel collectionRequest = (CollectionRequestServerModel) o;
+    return Objects.equals(this.name, collectionRequest.name) &&
+        Objects.equals(this.description, collectionRequest.description);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, description);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class CollectionRequestServerModel {\n");
+    sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("    description: ").append(toIndentedString(description)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/CollectionService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/CollectionService.java
@@ -90,7 +90,7 @@ public class CollectionService {
       throw new ValidationException("Cannot create collection in this workspace.");
     }
 
-    // always generate the collection id; ignore anything specified by the caller
+    // generate a collection id
     CollectionId collectionId = CollectionId.of(UUID.randomUUID());
 
     // translate CollectionServerModel to WdsCollection

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/CollectionService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/CollectionService.java
@@ -192,21 +192,15 @@ public class CollectionService {
    *
    * @param workspaceId the workspace containing the collection to be updated
    * @param collectionId id of the collection to be updated
-   * @param collectionServerModel object containing the updated name and description. Collection id
-   *     is optional in this object. If specified, it must match the collectionId argument.
+   * @param collectionRequestServerModel object containing the updated name and description.
+   *     Collection id is optional in this object. If specified, it must match the collectionId
+   *     argument.
    * @return the updated collection
    */
   public CollectionServerModel update(
       WorkspaceId workspaceId,
       CollectionId collectionId,
-      CollectionServerModel collectionServerModel) {
-
-    // if collection id is specified in the CollectionServerModel, ensure it matches
-    if (collectionServerModel.getId() != null
-        && !collectionServerModel.getId().equals(collectionId.id())) {
-      throw new ValidationException(
-          "Collection id in request body does not match collection id in URL. You can omit the collection id from the request body.");
-    }
+      CollectionRequestServerModel collectionRequestServerModel) {
 
     // retrieve the collection; throw if collection not found
     WdsCollection found =
@@ -215,8 +209,8 @@ public class CollectionService {
             .orElseThrow(() -> new MissingObjectException(COLLECTION));
 
     // optimization: if the request doesn't change anything, don't bother writing to the db
-    if (found.name().equals(collectionServerModel.getName())
-        && found.description().equals(collectionServerModel.getDescription())) {
+    if (found.name().equals(collectionRequestServerModel.getName())
+        && found.description().equals(collectionRequestServerModel.getDescription())) {
       // make sure this response has an id
       CollectionServerModel response = new CollectionServerModel(found.name(), found.description());
       response.id(found.collectionId().id());
@@ -228,8 +222,8 @@ public class CollectionService {
         new WdsCollection(
             found.workspaceId(),
             found.collectionId(),
-            collectionServerModel.getName(),
-            collectionServerModel.getDescription());
+            collectionRequestServerModel.getName(),
+            collectionRequestServerModel.getDescription());
 
     // save, handle exceptions, and translate to the response model
     CollectionServerModel response = saveAndHandleExceptions(updateRequest);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/CollectionService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/CollectionService.java
@@ -193,8 +193,6 @@ public class CollectionService {
    * @param workspaceId the workspace containing the collection to be updated
    * @param collectionId id of the collection to be updated
    * @param collectionRequestServerModel object containing the updated name and description.
-   *     Collection id is optional in this object. If specified, it must match the collectionId
-   *     argument.
    * @return the updated collection
    */
   public CollectionServerModel update(

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/CollectionService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/CollectionService.java
@@ -16,6 +16,7 @@ import org.databiosphere.workspacedataservice.annotations.SingleTenant;
 import org.databiosphere.workspacedataservice.config.TenancyProperties;
 import org.databiosphere.workspacedataservice.dao.CollectionDao;
 import org.databiosphere.workspacedataservice.dao.CollectionRepository;
+import org.databiosphere.workspacedataservice.generated.CollectionRequestServerModel;
 import org.databiosphere.workspacedataservice.generated.CollectionServerModel;
 import org.databiosphere.workspacedataservice.service.model.exception.CollectionException;
 import org.databiosphere.workspacedataservice.service.model.exception.ConflictException;
@@ -76,12 +77,12 @@ public class CollectionService {
    * Insert a new collection
    *
    * @param workspaceId the workspace to contain this collection
-   * @param collectionServerModel the collection definition
+   * @param collectionRequestServerModel the collection definition
    * @return the created collection
    */
   @WriteTransaction
   public CollectionServerModel save(
-      WorkspaceId workspaceId, CollectionServerModel collectionServerModel) {
+      WorkspaceId workspaceId, CollectionRequestServerModel collectionRequestServerModel) {
 
     // if WDS is running in single-tenant mode, ensure the specified workspace matches
     if (tenancyProperties.getEnforceCollectionsMatchWorkspaceId()
@@ -97,8 +98,8 @@ public class CollectionService {
         new WdsCollectionCreateRequest(
             workspaceId,
             collectionId,
-            collectionServerModel.getName(),
-            collectionServerModel.getDescription());
+            collectionRequestServerModel.getName(),
+            collectionRequestServerModel.getDescription());
 
     // save, handle exceptions, and translate to the response model
     CollectionServerModel response = saveAndHandleExceptions(wdsCollectionRequest);
@@ -294,7 +295,7 @@ public class CollectionService {
   }
 
   /**
-   * @deprecated Use {@link #save(WorkspaceId, CollectionServerModel)} instead.
+   * @deprecated Use {@link #save(WorkspaceId, CollectionRequestServerModel)} instead.
    */
   @Deprecated(forRemoval = true, since = "v0.14.0")
   public void createCollection(UUID collectionId, String version) {
@@ -310,7 +311,7 @@ public class CollectionService {
   }
 
   /**
-   * @deprecated Use {@link #save(WorkspaceId, CollectionServerModel)} instead.
+   * @deprecated Use {@link #save(WorkspaceId, CollectionRequestServerModel)} instead.
    */
   @Deprecated(forRemoval = true, since = "v0.14.0")
   public void createCollection(WorkspaceId workspaceId, CollectionId collectionId, String version) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/CollectionService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/CollectionService.java
@@ -89,13 +89,9 @@ public class CollectionService {
       throw new ValidationException("Cannot create collection in this workspace.");
     }
 
-    // if user did not specify an id, generate one
-    CollectionId collectionId;
-    if (collectionServerModel.getId() != null) {
-      collectionId = CollectionId.of(collectionServerModel.getId());
-    } else {
-      collectionId = CollectionId.of(UUID.randomUUID());
-    }
+    // always generate the collection id; ignore anything specified by the caller
+    CollectionId collectionId = CollectionId.of(UUID.randomUUID());
+
     // translate CollectionServerModel to WdsCollection
     WdsCollection wdsCollectionRequest =
         new WdsCollectionCreateRequest(

--- a/service/src/main/resources/static/swagger/apis-v1.yaml
+++ b/service/src/main/resources/static/swagger/apis-v1.yaml
@@ -150,8 +150,8 @@ paths:
     post:
       summary: Create a collection in this workspace.
       description: |
-        If collection id is specified in the request body, it must be a valid UUID.
-        If omitted, the system will generate an id.
+        If collection id is specified in the request body, it will be ignored; ids are
+        auto-generated.
       operationId: createCollectionV1
       tags:
         - Collection

--- a/service/src/main/resources/static/swagger/apis-v1.yaml
+++ b/service/src/main/resources/static/swagger/apis-v1.yaml
@@ -149,9 +149,6 @@ paths:
                   $ref: '#/components/schemas/Collection'
     post:
       summary: Create a collection in this workspace.
-      description: |
-        If collection id is specified in the request body, it will be ignored; ids are
-        auto-generated.
       operationId: createCollectionV1
       tags:
         - Collection
@@ -189,9 +186,6 @@ paths:
                 $ref: '#/components/schemas/Collection'
     put:
       summary: Update the specified collection.
-      description: |
-        Collection id is optional in the request body. If specified, it must match the collection id
-        specified in the url.
       operationId: updateCollectionV1
       tags:
         - Collection
@@ -204,7 +198,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Collection'
+              $ref: '#/components/schemas/CollectionRequest'
       responses:
         200:
           description: The collection just updated.

--- a/service/src/main/resources/static/swagger/apis-v1.yaml
+++ b/service/src/main/resources/static/swagger/apis-v1.yaml
@@ -163,7 +163,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Collection'
+              $ref: '#/components/schemas/CollectionRequest'
       responses:
         201:
           description: The collection just created.
@@ -303,6 +303,21 @@ components:
         - description
       example:
         id: 00112233-4455-6677-8899-aabbccddeeff
+        name: my-collection-name
+        description: This is a human-readable description for the collection.
+    CollectionRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          pattern: '[a-zA-Z0-9-_]{1,128}'
+          description: Letters, numbers, dash and underscore only. Max 128 characters.
+        description:
+          type: string
+      required:
+        - name
+        - description
+      example:
         name: my-collection-name
         description: This is a human-readable description for the collection.
     GenericJob:

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/CollectionControllerMockMvcSingleTenantTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/CollectionControllerMockMvcSingleTenantTest.java
@@ -3,6 +3,7 @@ package org.databiosphere.workspacedataservice.controller;
 import static org.databiosphere.workspacedataservice.dao.SqlUtils.quote;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.spy;
@@ -116,12 +117,15 @@ class CollectionControllerMockMvcSingleTenantTest extends MockMvcTestBase {
             mvcResult.getResponse().getContentAsString(), CollectionServerModel.class);
 
     assertNotNull(actualResponse);
-    assertEquals(collectionId.id(), actualResponse.getId(), "incorrect collection id");
+    assertNotEquals(
+        collectionId.id(),
+        actualResponse.getId(),
+        "Collection id in create request should be ignored");
     assertEquals(name, actualResponse.getName(), "incorrect collection name");
     assertEquals(description, actualResponse.getDescription(), "incorrect collection description");
 
     // the collection should exist in the db
-    assertCollectionExists(workspaceId, collectionId, name, description);
+    assertCollectionExists(workspaceId, CollectionId.of(actualResponse.getId()), name, description);
   }
 
   @Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceFilterQueryTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceFilterQueryTest.java
@@ -16,6 +16,7 @@ import java.util.stream.Stream;
 import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.config.TwdsProperties;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
+import org.databiosphere.workspacedataservice.generated.CollectionRequestServerModel;
 import org.databiosphere.workspacedataservice.generated.CollectionServerModel;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
 import org.databiosphere.workspacedataservice.service.model.RelationCollection;
@@ -72,8 +73,8 @@ class RecordOrchestratorServiceFilterQueryTest extends TestBase {
     // delete all existing collections
     cleanupAll();
     // create our collection
-    CollectionServerModel coll =
-        new CollectionServerModel(
+    CollectionRequestServerModel coll =
+        new CollectionRequestServerModel(
             "unit-test", "RecordOrchestratorServiceFilterQueryTest unit test collection");
 
     CollectionServerModel actual = collectionService.save(twdsProperties.workspaceId(), coll);


### PR DESCRIPTION
1. Do not allow callers to specify a collection id when creating a new collection.
2. Do not allow callers to specify a collection id when updating an existing collection. We already ignored such an id, but our OpenApi spec made it look possible.

At the implementation layer, starting in the OpenApi spec `apis-v1.yaml`, this PR changes from using the `Collection/CollectionServerModel` model to a new `CollectionRequest/CollectionRequestServerModel`. The latter does not include an id.

This model change cascades down through the controller, the service, and a bunch of tests. It also allows for removing some business logic around ids and the tests for that logic.

Note that this change does NOT affect our current state of creating a default collection where collectionId=workspaceId on startup. That uses an internal code path.

