### PR TITLE
AJ-1682: Remove `enforce-collections-match-workspace-id` test overrides

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/CollectionService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/CollectionService.java
@@ -384,9 +384,8 @@ public class CollectionService {
       }
     }
 
-    // safety check: if we found a workspace id in the db, it indicates we are in a data-plane
-    // single-tenant WDS. Verify the workspace matches the $WORKSPACE_ID env var.
-    // we must remove this check in a future multi-tenant WDS.
+    // safety check: if we are running as a single-tenant WDS, verify the workspace matches the
+    // $WORKSPACE_ID env var.
     if (tenancyProperties.getEnforceCollectionsMatchWorkspaceId()
         && rowWorkspaceId != null
         && !rowWorkspaceId.equals(workspaceId)) {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/LogStatementTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/LogStatementTest.java
@@ -33,15 +33,10 @@ import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.web.multipart.MultipartFile;
 
 @SpringBootTest
 @ExtendWith(OutputCaptureExtension.class)
-@TestPropertySource(
-    properties = {
-      "twds.tenancy.enforce-collections-match-workspace-id=false", // TODO(AJ-1682): get rid of this
-    })
 @DirtiesContext
 class LogStatementTest extends TestBase {
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/CollectionControllerMockMvcSingleTenantTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/CollectionControllerMockMvcSingleTenantTest.java
@@ -49,10 +49,7 @@ import org.springframework.test.web.servlet.MvcResult;
 @ActiveProfiles(profiles = {"mock-sam"})
 @DirtiesContext
 @TestPropertySource(
-    properties = {
-      "twds.tenancy.enforce-collections-match-workspace-id=true",
-      "twds.instance.workspace-id=45f90f59-f83d-453f-961a-480ec740df9f"
-    })
+    properties = {"twds.instance.workspace-id=45f90f59-f83d-453f-961a-480ec740df9f"})
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class CollectionControllerMockMvcSingleTenantTest extends MockMvcTestBase {
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/CollectionControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/CollectionControllerMockMvcTest.java
@@ -57,6 +57,8 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 
 @ActiveProfiles(profiles = {"mock-sam"})
 @DirtiesContext
+// this class explicitly tests multi-tenancy, so it ensures that
+// `enforce-collections-match-workspace-id` is turned off
 @TestPropertySource(properties = {"twds.tenancy.enforce-collections-match-workspace-id=false"})
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class CollectionControllerMockMvcTest extends MockMvcTestBase {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvErrorMessageTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvErrorMessageTest.java
@@ -23,14 +23,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@TestPropertySource(
-    properties = {
-      "twds.tenancy.enforce-collections-match-workspace-id=false", // TODO(AJ-1682): get rid of this
-    })
 @DirtiesContext
 class TsvErrorMessageTest extends TestBase {
 


### PR DESCRIPTION
See https://broadworkbench.atlassian.net/browse/AJ-1682. The A/C for that ticket is to remove `enforce-collections-match-workspace-id` entirely. I don't think that's the right thing to do; I think it's good and fine to leave that config flag in place.

That config flag is only used, via `TenancyProperties`, in two places:
1. When saving a new collection, [here](https://github.com/DataBiosphere/terra-workspace-data-service/blob/76d9479887c5f10b670e4aeb39afdfb238f99f36/service/src/main/java/org/databiosphere/workspacedataservice/service/CollectionService.java#L87-L91).
2. When retrieving the workspaceId for a collection, [here](https://github.com/DataBiosphere/terra-workspace-data-service/blob/76d9479887c5f10b670e4aeb39afdfb238f99f36/service/src/main/java/org/databiosphere/workspacedataservice/service/CollectionService.java#L390-L402).

Those seem like minimally-invasive usages, and useful as long as we think we may want to support single-tenant deployments.

I _have_ removed all but one override of that config flag from tests. We still have one override in `CollectionControllerMockMvcTest`; I've added a code comment to that class to explain.