### PR TITLE
AJ-1953: filter-by-column supports file, boolean datatypes

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/search/QueryParser.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/search/QueryParser.java
@@ -82,8 +82,19 @@ public class QueryParser {
           clauses.add(":" + paramName + " = ANY(" + quote(column) + ")");
           values.put(paramName, parseNumericValue(value));
           break;
+
+          /* TODO AJ-1954: support
+              NULL, EMPTY_ARRAY,
+              BOOLEAN, ARRAY_OF_BOOLEAN,
+              FILE, ARRAY_OF_FILE,
+              DATE, ARRAY_OF_DATE,
+              DATE_TIME, ARRAY_OF_DATE_TIME,
+              RELATION, ARRAY_OF_RELATION,
+              JSON, ARRAY_OF_JSON
+          */
         default:
-          throw new InvalidQueryException("Column specified in query must be a string type");
+          throw new InvalidQueryException(
+              "Column specified in query is of an unsupported datatype");
       }
 
       return new WhereClausePart(clauses, values);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/search/QueryParser.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/search/QueryParser.java
@@ -3,6 +3,9 @@ package org.databiosphere.workspacedataservice.search;
 import static org.databiosphere.workspacedataservice.dao.SqlUtils.quote;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -92,11 +95,29 @@ public class QueryParser {
           clauses.add(":" + paramName + " = ANY(" + quote(column) + ")");
           values.put(paramName, strictParseBoolean(value));
           break;
+        case DATE:
+          // "mycolumn" = '1981-02-12'
+          clauses.add(quote(column) + " = :" + paramName);
+          values.put(paramName, parseDate(value));
+          break;
+        case ARRAY_OF_DATE:
+          // '1981-02-12' = ANY("mycolumn")
+          clauses.add(":" + paramName + " = ANY(" + quote(column) + ")");
+          values.put(paramName, parseDate(value));
+          break;
+        case DATE_TIME:
+          // "mycolumn" = '1981-02-12'
+          clauses.add(quote(column) + " = :" + paramName);
+          values.put(paramName, parseDateTime(value));
+          break;
+        case ARRAY_OF_DATE_TIME:
+          // '1981-02-12' = ANY("mycolumn")
+          clauses.add(":" + paramName + " = ANY(" + quote(column) + ")");
+          values.put(paramName, parseDateTime(value));
+          break;
 
           /* TODO AJ-1954: support
               NULL, EMPTY_ARRAY, (uncommon)
-              DATE, ARRAY_OF_DATE,
-              DATE_TIME, ARRAY_OF_DATE_TIME,
               RELATION, ARRAY_OF_RELATION,
               JSON, ARRAY_OF_JSON
           */
@@ -108,6 +129,24 @@ public class QueryParser {
       return new WhereClausePart(clauses, values);
     } else {
       throw new InvalidQueryException();
+    }
+  }
+
+  private LocalDate parseDate(String value) {
+    try {
+      return LocalDate.parse(value, DateTimeFormatter.ISO_LOCAL_DATE);
+    } catch (Exception e) {
+      throw new InvalidQueryException(
+          "Query value for date column must be a valid ISO date string");
+    }
+  }
+
+  private LocalDateTime parseDateTime(String value) {
+    try {
+      return LocalDateTime.parse(value, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+    } catch (Exception e) {
+      throw new InvalidQueryException(
+          "Query value for datetime column must be a valid ISO datetime string");
     }
   }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/search/QueryParser.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/search/QueryParser.java
@@ -62,12 +62,12 @@ public class QueryParser {
 
       // based on the datatype of the column, build relevant SQL
       switch (datatype) {
-        case STRING:
+        case STRING, FILE:
           // LOWER("mycolumn") = 'mysearchterm'
           clauses.add("LOWER(" + quote(column) + ") = :" + paramName);
           values.put(paramName, value.toLowerCase());
           break;
-        case ARRAY_OF_STRING:
+        case ARRAY_OF_STRING, ARRAY_OF_FILE:
           // 'mysearchterm' ILIKE ANY("mycolumn")
           clauses.add(":" + paramName + " ILIKE ANY(" + quote(column) + ")");
           values.put(paramName, value.toLowerCase());
@@ -86,7 +86,6 @@ public class QueryParser {
           /* TODO AJ-1954: support
               NULL, EMPTY_ARRAY,
               BOOLEAN, ARRAY_OF_BOOLEAN,
-              FILE, ARRAY_OF_FILE,
               DATE, ARRAY_OF_DATE,
               DATE_TIME, ARRAY_OF_DATE_TIME,
               RELATION, ARRAY_OF_RELATION,

--- a/service/src/main/java/org/databiosphere/workspacedataservice/search/QueryParser.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/search/QueryParser.java
@@ -106,12 +106,12 @@ public class QueryParser {
           values.put(paramName, parseDate(value));
           break;
         case DATE_TIME:
-          // "mycolumn" = '1981-02-12'
+          // "mycolumn" = '1981-02-12 19:00:00'
           clauses.add(quote(column) + " = :" + paramName);
           values.put(paramName, parseDateTime(value));
           break;
         case ARRAY_OF_DATE_TIME:
-          // '1981-02-12' = ANY("mycolumn")
+          // '1981-02-12 19:00:00' = ANY("mycolumn")
           clauses.add(":" + paramName + " = ANY(" + quote(column) + ")");
           values.put(paramName, parseDateTime(value));
           break;
@@ -132,6 +132,7 @@ public class QueryParser {
     }
   }
 
+  // parse string into LocalDate; throw InvalidQueryException if unparsable
   private LocalDate parseDate(String value) {
     try {
       return LocalDate.parse(value, DateTimeFormatter.ISO_LOCAL_DATE);
@@ -141,6 +142,7 @@ public class QueryParser {
     }
   }
 
+  // parse string into LocalDateTime; throw InvalidQueryException if unparsable
   private LocalDateTime parseDateTime(String value) {
     try {
       return LocalDateTime.parse(value, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
@@ -150,6 +152,8 @@ public class QueryParser {
     }
   }
 
+  // parse string into boolean, supporting only "true" or "false" strings, case-insensitive.
+  // throw InvalidQueryException if unparsable
   private boolean strictParseBoolean(String value) {
     // could use DataTypeInferer.isValidBoolean here instead, but that requires spring beans
     if ("true".equalsIgnoreCase(value)) {
@@ -162,6 +166,7 @@ public class QueryParser {
         "Query value for boolean column must be either 'true' or 'false'");
   }
 
+  // parse string into Double; throw InvalidQueryException if unparsable
   private Double parseNumericValue(String value) {
     BigDecimal parsedNumber;
     try {
@@ -172,6 +177,7 @@ public class QueryParser {
     return parsedNumber.doubleValue();
   }
 
+  // validate the column on which we are filtering
   private void validateColumnName(String columnName) {
     // The Lucene query parser requires a default column name to parse a query. If the end user
     // has not specified a column, the query parser will use the default column name. In our case,

--- a/service/src/test/java/org/databiosphere/workspacedataservice/search/QueryParserTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/search/QueryParserTest.java
@@ -13,6 +13,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 class QueryParserTest {
 
+  // ========== STRING and array thereof
+
   private static Stream<Arguments> stringTerms() {
     return Stream.of(
         Arguments.of("foo", "foo"),
@@ -34,10 +36,22 @@ class QueryParserTest {
   @ParameterizedTest(name = "Valid query `column1:{0}`")
   @MethodSource("stringTerms")
   void parseSingleStringColumnTerm(String queryTerm, String expectedResult) {
+    scalarStringTestImpl(queryTerm, expectedResult, DataTypeMapping.STRING);
+  }
+
+  // test expected parsing for a single array-of-string column and its filter term
+  @ParameterizedTest(name = "Valid query `column1:{0}`")
+  @MethodSource("stringTerms")
+  void parseSingleArrayOfStringColumnTerm(String queryTerm, String expectedResult) {
+    arrayStringTestImpl(queryTerm, expectedResult, DataTypeMapping.ARRAY_OF_STRING);
+  }
+
+  // helper for testing scalar strings; reused for scalar files
+  private void scalarStringTestImpl(
+      String queryTerm, String expectedResult, DataTypeMapping dataType) {
     String query = "column1:" + queryTerm;
 
-    WhereClausePart actual =
-        new QueryParser(Map.of("column1", DataTypeMapping.STRING)).parse(query);
+    WhereClausePart actual = new QueryParser(Map.of("column1", dataType)).parse(query);
 
     WhereClausePart expected =
         new WhereClausePart(
@@ -47,14 +61,12 @@ class QueryParserTest {
     assertEquals(expected, actual);
   }
 
-  // test expected parsing for a single array-of-string column and its filter term
-  @ParameterizedTest(name = "Valid query `column1:{0}`")
-  @MethodSource("stringTerms")
-  void parseSingleArrayOfStringColumnTerm(String queryTerm, String expectedResult) {
+  // helper for testing array of strings; reused for array of files
+  private void arrayStringTestImpl(
+      String queryTerm, String expectedResult, DataTypeMapping dataType) {
     String query = "column1:" + queryTerm;
 
-    WhereClausePart actual =
-        new QueryParser(Map.of("column1", DataTypeMapping.ARRAY_OF_STRING)).parse(query);
+    WhereClausePart actual = new QueryParser(Map.of("column1", dataType)).parse(query);
 
     WhereClausePart expected =
         new WhereClausePart(
@@ -63,6 +75,36 @@ class QueryParserTest {
 
     assertEquals(expected, actual);
   }
+
+  // ========== FILE and array thereof
+  private static Stream<Arguments> fileTerms() {
+    return Stream.of(
+        Arguments.of(
+            "\"https\\://lz1a2b345c67def8a91234bc.blob.core.windows.net/sc-7ad51c5d-eb4c-4685-bffe-62b861f7753f/file.bam\"",
+            "https://lz1a2b345c67def8a91234bc.blob.core.windows.net/sc-7ad51c5d-eb4c-4685-bffe-62b861f7753f/file.bam"),
+        Arguments.of(
+            "\"drs\\://example.org/dg.4503/cc32d93d-a73c-4d2c-a061-26c0410e74fa\"",
+            "drs://example.org/dg.4503/cc32d93d-a73c-4d2c-a061-26c0410e74fa"),
+        Arguments.of(
+            "\"https\\://teststorageaccount.blob.core.windows.net/testcontainer/file\"",
+            "https://teststorageaccount.blob.core.windows.net/testcontainer/file"));
+  }
+
+  // test expected parsing for a single string column and its filter term
+  @ParameterizedTest(name = "Valid query `column1:{0}`")
+  @MethodSource("fileTerms")
+  void parseSingleFileColumnTerm(String queryTerm, String expectedResult) {
+    scalarStringTestImpl(queryTerm, expectedResult, DataTypeMapping.FILE);
+  }
+
+  // test expected parsing for a single array-of-string column and its filter term
+  @ParameterizedTest(name = "Valid query `column1:{0}`")
+  @MethodSource("fileTerms")
+  void parseSingleArrayOfFileColumnTerm(String queryTerm, String expectedResult) {
+    arrayStringTestImpl(queryTerm, expectedResult, DataTypeMapping.ARRAY_OF_FILE);
+  }
+
+  // ========== NUMBER and array thereof
 
   private static Stream<Arguments> numberTerms() {
     return Stream.of(

--- a/service/src/test/java/org/databiosphere/workspacedataservice/search/QueryParserTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/search/QueryParserTest.java
@@ -149,6 +149,50 @@ class QueryParserTest {
     assertEquals(expected, actual);
   }
 
+  // ========== BOOLEAN and array thereof
+
+  private static Stream<Arguments> booleanTerms() {
+    return Stream.of(
+        Arguments.of("true", true),
+        Arguments.of("True", true),
+        Arguments.of("TRUE", true),
+        Arguments.of("false", false),
+        Arguments.of("False", false),
+        Arguments.of("FALSE", false));
+  }
+
+  // test expected parsing for a single number column and its filter term
+  @ParameterizedTest(name = "Valid query `column1:{0}`")
+  @MethodSource("booleanTerms")
+  void parseSingleBooleanColumnTerm(String queryTerm, boolean expectedResult) {
+    String query = "column1:" + queryTerm;
+
+    WhereClausePart actual =
+        new QueryParser(Map.of("column1", DataTypeMapping.BOOLEAN)).parse(query);
+
+    WhereClausePart expected =
+        new WhereClausePart(
+            List.of("\"column1\" = :filterquery0"), Map.of("filterquery0", expectedResult));
+
+    assertEquals(expected, actual);
+  }
+
+  // test expected parsing for a single array-of-number column and its filter term
+  @ParameterizedTest(name = "Valid query `column1:{0}`")
+  @MethodSource("booleanTerms")
+  void parseSingleArrayOfBooleanColumnTerm(String queryTerm, boolean expectedResult) {
+    String query = "column1:" + queryTerm;
+
+    WhereClausePart actual =
+        new QueryParser(Map.of("column1", DataTypeMapping.ARRAY_OF_BOOLEAN)).parse(query);
+
+    WhereClausePart expected =
+        new WhereClausePart(
+            List.of(":filterquery0 = ANY(\"column1\")"), Map.of("filterquery0", expectedResult));
+
+    assertEquals(expected, actual);
+  }
+
   private static Stream<String> invalidQuerySyntax() {
     return Stream.of(
         // ranges

--- a/service/src/test/java/org/databiosphere/workspacedataservice/search/QueryParserTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/search/QueryParserTest.java
@@ -3,6 +3,8 @@ package org.databiosphere.workspacedataservice.search;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -80,13 +82,13 @@ class QueryParserTest {
   private static Stream<Arguments> fileTerms() {
     return Stream.of(
         Arguments.of(
-            "\"https\\://lz1a2b345c67def8a91234bc.blob.core.windows.net/sc-7ad51c5d-eb4c-4685-bffe-62b861f7753f/file.bam\"",
+            "\"https://lz1a2b345c67def8a91234bc.blob.core.windows.net/sc-7ad51c5d-eb4c-4685-bffe-62b861f7753f/file.bam\"",
             "https://lz1a2b345c67def8a91234bc.blob.core.windows.net/sc-7ad51c5d-eb4c-4685-bffe-62b861f7753f/file.bam"),
         Arguments.of(
-            "\"drs\\://example.org/dg.4503/cc32d93d-a73c-4d2c-a061-26c0410e74fa\"",
+            "\"drs://example.org/dg.4503/cc32d93d-a73c-4d2c-a061-26c0410e74fa\"",
             "drs://example.org/dg.4503/cc32d93d-a73c-4d2c-a061-26c0410e74fa"),
         Arguments.of(
-            "\"https\\://teststorageaccount.blob.core.windows.net/testcontainer/file\"",
+            "\"https://teststorageaccount.blob.core.windows.net/testcontainer/file\"",
             "https://teststorageaccount.blob.core.windows.net/testcontainer/file"));
   }
 
@@ -161,7 +163,7 @@ class QueryParserTest {
         Arguments.of("FALSE", false));
   }
 
-  // test expected parsing for a single number column and its filter term
+  // test expected parsing for a single boolean column and its filter term
   @ParameterizedTest(name = "Valid query `column1:{0}`")
   @MethodSource("booleanTerms")
   void parseSingleBooleanColumnTerm(String queryTerm, boolean expectedResult) {
@@ -177,7 +179,7 @@ class QueryParserTest {
     assertEquals(expected, actual);
   }
 
-  // test expected parsing for a single array-of-number column and its filter term
+  // test expected parsing for a single array-of-boolean column and its filter term
   @ParameterizedTest(name = "Valid query `column1:{0}`")
   @MethodSource("booleanTerms")
   void parseSingleArrayOfBooleanColumnTerm(String queryTerm, boolean expectedResult) {
@@ -185,6 +187,85 @@ class QueryParserTest {
 
     WhereClausePart actual =
         new QueryParser(Map.of("column1", DataTypeMapping.ARRAY_OF_BOOLEAN)).parse(query);
+
+    WhereClausePart expected =
+        new WhereClausePart(
+            List.of(":filterquery0 = ANY(\"column1\")"), Map.of("filterquery0", expectedResult));
+
+    assertEquals(expected, actual);
+  }
+
+  // ========== DATE and array thereof
+
+  private static Stream<Arguments> dateTerms() {
+    return Stream.of(
+        Arguments.of("1979-06-25", LocalDate.of(1979, 6, 25)),
+        Arguments.of("1981-02-12", LocalDate.of(1981, 2, 12)));
+  }
+
+  // test expected parsing for a single date column and its filter term
+  @ParameterizedTest(name = "Valid query `column1:{0}`")
+  @MethodSource("dateTerms")
+  void parseSingleDateColumnTerm(String queryTerm, LocalDate expectedResult) {
+    String query = "column1:" + queryTerm;
+
+    WhereClausePart actual = new QueryParser(Map.of("column1", DataTypeMapping.DATE)).parse(query);
+
+    WhereClausePart expected =
+        new WhereClausePart(
+            List.of("\"column1\" = :filterquery0"), Map.of("filterquery0", expectedResult));
+
+    assertEquals(expected, actual);
+  }
+
+  // test expected parsing for a single array-of-date column and its filter term
+  @ParameterizedTest(name = "Valid query `column1:{0}`")
+  @MethodSource("dateTerms")
+  void parseSingleArrayOfDateColumnTerm(String queryTerm, LocalDate expectedResult) {
+    String query = "column1:" + queryTerm;
+
+    WhereClausePart actual =
+        new QueryParser(Map.of("column1", DataTypeMapping.ARRAY_OF_DATE)).parse(query);
+
+    WhereClausePart expected =
+        new WhereClausePart(
+            List.of(":filterquery0 = ANY(\"column1\")"), Map.of("filterquery0", expectedResult));
+
+    assertEquals(expected, actual);
+  }
+
+  // ========== DATETIME and array thereof
+
+  private static Stream<Arguments> datetimeTerms() {
+    return Stream.of(
+        Arguments.of("\"2024-08-13T19:00:00\"", LocalDateTime.of(2024, 8, 13, 19, 0)),
+        Arguments.of("\"2024-08-08T14:00:00\"", LocalDateTime.of(2024, 8, 8, 14, 0)));
+  }
+
+  // test expected parsing for a single datetime column and its filter term
+  @ParameterizedTest(name = "Valid query `column1:{0}`")
+  @MethodSource("datetimeTerms")
+  void parseSingleDatetimeColumnTerm(String queryTerm, LocalDateTime expectedResult) {
+    String query = "column1:" + queryTerm;
+
+    WhereClausePart actual =
+        new QueryParser(Map.of("column1", DataTypeMapping.DATE_TIME)).parse(query);
+
+    WhereClausePart expected =
+        new WhereClausePart(
+            List.of("\"column1\" = :filterquery0"), Map.of("filterquery0", expectedResult));
+
+    assertEquals(expected, actual);
+  }
+
+  // test expected parsing for a single array-of-datetime column and its filter term
+  @ParameterizedTest(name = "Valid query `column1:{0}`")
+  @MethodSource("datetimeTerms")
+  void parseSingleArrayOfDatetimeColumnTerm(String queryTerm, LocalDateTime expectedResult) {
+    String query = "column1:" + queryTerm;
+
+    WhereClausePart actual =
+        new QueryParser(Map.of("column1", DataTypeMapping.ARRAY_OF_DATE_TIME)).parse(query);
 
     WhereClausePart expected =
         new WhereClausePart(

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceFilterQueryTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceFilterQueryTest.java
@@ -138,7 +138,7 @@ class RecordOrchestratorServiceFilterQueryTest extends TestBase {
   @ParameterizedTest(name = "file filter for value <{0}>")
   @MethodSource("fileArguments")
   void fileColumn(String criteria, List<String> expectedIds) {
-    performTest("str", DataTypeMapping.STRING, criteria, expectedIds);
+    performTest("file", DataTypeMapping.FILE, criteria, expectedIds);
   }
 
   // ===== ARRAY_OF_FILE column
@@ -155,7 +155,7 @@ class RecordOrchestratorServiceFilterQueryTest extends TestBase {
   @ParameterizedTest(name = "array_of_file filter for value <{0}>")
   @MethodSource("arrayOfFileArguments")
   void arrayOfFileColumn(String criteria, List<String> expectedIds) {
-    performTest("arrstr", DataTypeMapping.ARRAY_OF_STRING, criteria, expectedIds);
+    performTest("arrfile", DataTypeMapping.ARRAY_OF_FILE, criteria, expectedIds);
   }
 
   // ===== NUMBER column

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceFilterQueryTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceFilterQueryTest.java
@@ -128,10 +128,10 @@ class RecordOrchestratorServiceFilterQueryTest extends TestBase {
   private static Stream<Arguments> fileArguments() {
     return Stream.of(
         Arguments.of(
-            "\"drs\\://example.org/dg.4503/cc32d93d-a73c-4d2c-a061-26c0410e74fa\"",
+            "\"drs://example.org/dg.4503/cc32d93d-a73c-4d2c-a061-26c0410e74fa\"",
             List.of("1", "2")),
         Arguments.of(
-            "\"https\\://teststorageaccount.blob.core.windows.net/testcontainer/file\"",
+            "\"https://teststorageaccount.blob.core.windows.net/testcontainer/file\"",
             List.of("3")));
   }
 
@@ -145,10 +145,10 @@ class RecordOrchestratorServiceFilterQueryTest extends TestBase {
   private static Stream<Arguments> arrayOfFileArguments() {
     return Stream.of(
         Arguments.of(
-            "\"drs\\://example.org/dg.4503/cc32d93d-a73c-4d2c-a061-26c0410e74fa\"",
+            "\"drs://example.org/dg.4503/cc32d93d-a73c-4d2c-a061-26c0410e74fa\"",
             List.of("1", "2")),
         Arguments.of(
-            "\"https\\://teststorageaccount.blob.core.windows.net/testcontainer/file\"",
+            "\"https://teststorageaccount.blob.core.windows.net/testcontainer/file\"",
             List.of("2", "3")));
   }
 
@@ -216,6 +216,59 @@ class RecordOrchestratorServiceFilterQueryTest extends TestBase {
   @MethodSource("arrayOfBooleanArguments")
   void arrayOfBooleanColumn(String criteria, List<String> expectedIds) {
     performTest("arrbool", DataTypeMapping.ARRAY_OF_BOOLEAN, criteria, expectedIds);
+  }
+
+  // ===== DATE column
+  private static Stream<Arguments> dateArguments() {
+    return Stream.of(
+        Arguments.of("1979-06-25", List.of("1", "2")), Arguments.of("1981-02-12", List.of("3")));
+  }
+
+  @ParameterizedTest(name = "date filter for value <{0}>")
+  @MethodSource("dateArguments")
+  void dateColumn(String criteria, List<String> expectedIds) {
+    performTest("date", DataTypeMapping.DATE, criteria, expectedIds);
+  }
+
+  // ===== ARRAY_OF_DATE column
+  private static Stream<Arguments> arrayOfDateArguments() {
+    return Stream.of(
+        Arguments.of("1971-11-12", List.of("1", "2")),
+        Arguments.of("1977-01-21", List.of("2", "3")));
+  }
+
+  @ParameterizedTest(name = "array_of_date filter for value <{0}>")
+  @MethodSource("arrayOfDateArguments")
+  void arrayOfDateColumn(String criteria, List<String> expectedIds) {
+    performTest("arrdate", DataTypeMapping.ARRAY_OF_DATE, criteria, expectedIds);
+  }
+
+  // ===== DATETIME column
+  private static Stream<Arguments> datetimeArguments() {
+    return Stream.of(
+        Arguments.of("\"2024-08-13T19:00:00\"", List.of("1")),
+        Arguments.of("\"2024-08-12T18:00:00\"", List.of("2")),
+        Arguments.of("\"2024-08-11T17:00:00\"", List.of("3")));
+  }
+
+  @ParameterizedTest(name = "datetime filter for value <{0}>")
+  @MethodSource("datetimeArguments")
+  void datetimeColumn(String criteria, List<String> expectedIds) {
+    performTest("datetime", DataTypeMapping.DATE_TIME, criteria, expectedIds);
+  }
+
+  // ===== ARRAY_OF_DATETIME column
+  private static Stream<Arguments> arrayOfDatetimeArguments() {
+    return Stream.of(
+        Arguments.of("\"2024-08-10T16:00:00\"", List.of("1")),
+        Arguments.of("\"2024-08-09T15:00:00\"", List.of("2")),
+        Arguments.of("\"2024-08-08T14:00:00\"", List.of("3")));
+  }
+
+  @ParameterizedTest(name = "array_of_datetime filter for value <{0}>")
+  @MethodSource("arrayOfDatetimeArguments")
+  void arrayOfDatetimeColumn(String criteria, List<String> expectedIds) {
+    performTest("arrdatetime", DataTypeMapping.ARRAY_OF_DATE_TIME, criteria, expectedIds);
   }
 
   // the test implementation for all tests above

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceFilterQueryTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceFilterQueryTest.java
@@ -188,6 +188,36 @@ class RecordOrchestratorServiceFilterQueryTest extends TestBase {
     performTest("arrnum", DataTypeMapping.ARRAY_OF_NUMBER, criteria, expectedIds);
   }
 
+  // ===== BOOLEAN column
+  private static Stream<Arguments> booleanArguments() {
+    return Stream.of(
+        Arguments.of("true", List.of("1", "2")),
+        Arguments.of("TRUE", List.of("1", "2")),
+        Arguments.of("false", List.of("3")),
+        Arguments.of("FALSE", List.of("3")));
+  }
+
+  @ParameterizedTest(name = "boolean filter for value <{0}>")
+  @MethodSource("booleanArguments")
+  void booleanColumn(String criteria, List<String> expectedIds) {
+    performTest("bool", DataTypeMapping.BOOLEAN, criteria, expectedIds);
+  }
+
+  // ===== ARRAY_OF_BOOLEAN column
+  private static Stream<Arguments> arrayOfBooleanArguments() {
+    return Stream.of(
+        Arguments.of("true", List.of("1", "2")),
+        Arguments.of("TRUE", List.of("1", "2")),
+        Arguments.of("false", List.of("2", "3")),
+        Arguments.of("FALSE", List.of("2", "3")));
+  }
+
+  @ParameterizedTest(name = "array_of_boolean filter for value <{0}>")
+  @MethodSource("arrayOfBooleanArguments")
+  void arrayOfBooleanColumn(String criteria, List<String> expectedIds) {
+    performTest("arrbool", DataTypeMapping.ARRAY_OF_BOOLEAN, criteria, expectedIds);
+  }
+
   // the test implementation for all tests above
   private void performTest(
       String columnName, DataTypeMapping datatype, String criteria, List<String> expectedIds) {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceFilterQueryTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceFilterQueryTest.java
@@ -124,6 +124,40 @@ class RecordOrchestratorServiceFilterQueryTest extends TestBase {
     performTest("arrstr", DataTypeMapping.ARRAY_OF_STRING, criteria, expectedIds);
   }
 
+  // ===== FILE column
+  private static Stream<Arguments> fileArguments() {
+    return Stream.of(
+        Arguments.of(
+            "\"drs\\://example.org/dg.4503/cc32d93d-a73c-4d2c-a061-26c0410e74fa\"",
+            List.of("1", "2")),
+        Arguments.of(
+            "\"https\\://teststorageaccount.blob.core.windows.net/testcontainer/file\"",
+            List.of("3")));
+  }
+
+  @ParameterizedTest(name = "file filter for value <{0}>")
+  @MethodSource("fileArguments")
+  void fileColumn(String criteria, List<String> expectedIds) {
+    performTest("str", DataTypeMapping.STRING, criteria, expectedIds);
+  }
+
+  // ===== ARRAY_OF_FILE column
+  private static Stream<Arguments> arrayOfFileArguments() {
+    return Stream.of(
+        Arguments.of(
+            "\"drs\\://example.org/dg.4503/cc32d93d-a73c-4d2c-a061-26c0410e74fa\"",
+            List.of("1", "2")),
+        Arguments.of(
+            "\"https\\://teststorageaccount.blob.core.windows.net/testcontainer/file\"",
+            List.of("2", "3")));
+  }
+
+  @ParameterizedTest(name = "array_of_file filter for value <{0}>")
+  @MethodSource("arrayOfFileArguments")
+  void arrayOfFileColumn(String criteria, List<String> expectedIds) {
+    performTest("arrstr", DataTypeMapping.ARRAY_OF_STRING, criteria, expectedIds);
+  }
+
   // ===== NUMBER column
   private static Stream<Arguments> numberArguments() {
     return Stream.of(

--- a/service/src/test/resources/searchfilter/testdata.tsv
+++ b/service/src/test/resources/searchfilter/testdata.tsv
@@ -1,4 +1,4 @@
-test_id	str	arrstr	num	arrnum
-1	hello world	["hello", "world", "how", "are", "you"]	42	[31,41,59]
-2	Hello World	["Hello", "World"]	42	[31,41]
-3	goodbye	["ONE", "TWO", "THREE"]	-1.23	[1,2,3]
+test_id	str	arrstr	num	arrnum	file	arrfile
+1	hello world	["hello", "world", "how", "are", "you"]	42	[31,41,59]	drs://example.org/dg.4503/cc32d93d-a73c-4d2c-a061-26c0410e74fa	[drs://example.org/dg.4503/cc32d93d-a73c-4d2c-a061-26c0410e74fa]
+2	Hello World	["Hello", "World"]	42	[31,41]	drs://example.org/dg.4503/cc32d93d-a73c-4d2c-a061-26c0410e74fa	[https://teststorageaccount.blob.core.windows.net/testcontainer/file, drs://example.org/dg.4503/cc32d93d-a73c-4d2c-a061-26c0410e74fa]
+3	goodbye	["ONE", "TWO", "THREE"]	-1.23	[1,2,3]	https://teststorageaccount.blob.core.windows.net/testcontainer/file	[https://teststorageaccount.blob.core.windows.net/testcontainer/file]

--- a/service/src/test/resources/searchfilter/testdata.tsv
+++ b/service/src/test/resources/searchfilter/testdata.tsv
@@ -1,4 +1,4 @@
 test_id	str	arrstr	num	arrnum	file	arrfile
-1	hello world	["hello", "world", "how", "are", "you"]	42	[31,41,59]	drs://example.org/dg.4503/cc32d93d-a73c-4d2c-a061-26c0410e74fa	[drs://example.org/dg.4503/cc32d93d-a73c-4d2c-a061-26c0410e74fa]
-2	Hello World	["Hello", "World"]	42	[31,41]	drs://example.org/dg.4503/cc32d93d-a73c-4d2c-a061-26c0410e74fa	[https://teststorageaccount.blob.core.windows.net/testcontainer/file, drs://example.org/dg.4503/cc32d93d-a73c-4d2c-a061-26c0410e74fa]
-3	goodbye	["ONE", "TWO", "THREE"]	-1.23	[1,2,3]	https://teststorageaccount.blob.core.windows.net/testcontainer/file	[https://teststorageaccount.blob.core.windows.net/testcontainer/file]
+1	hello world	["hello", "world", "how", "are", "you"]	42	[31,41,59]	drs://example.org/dg.4503/cc32d93d-a73c-4d2c-a061-26c0410e74fa	["drs://example.org/dg.4503/cc32d93d-a73c-4d2c-a061-26c0410e74fa"]
+2	Hello World	["Hello", "World"]	42	[31,41]	drs://example.org/dg.4503/cc32d93d-a73c-4d2c-a061-26c0410e74fa	["https://teststorageaccount.blob.core.windows.net/testcontainer/file", "drs://example.org/dg.4503/cc32d93d-a73c-4d2c-a061-26c0410e74fa"]
+3	goodbye	["ONE", "TWO", "THREE"]	-1.23	[1,2,3]	https://teststorageaccount.blob.core.windows.net/testcontainer/file	["https://teststorageaccount.blob.core.windows.net/testcontainer/file"]

--- a/service/src/test/resources/searchfilter/testdata.tsv
+++ b/service/src/test/resources/searchfilter/testdata.tsv
@@ -1,4 +1,4 @@
-test_id	str	arrstr	num	arrnum	file	arrfile
-1	hello world	["hello", "world", "how", "are", "you"]	42	[31,41,59]	drs://example.org/dg.4503/cc32d93d-a73c-4d2c-a061-26c0410e74fa	["drs://example.org/dg.4503/cc32d93d-a73c-4d2c-a061-26c0410e74fa"]
-2	Hello World	["Hello", "World"]	42	[31,41]	drs://example.org/dg.4503/cc32d93d-a73c-4d2c-a061-26c0410e74fa	["https://teststorageaccount.blob.core.windows.net/testcontainer/file", "drs://example.org/dg.4503/cc32d93d-a73c-4d2c-a061-26c0410e74fa"]
-3	goodbye	["ONE", "TWO", "THREE"]	-1.23	[1,2,3]	https://teststorageaccount.blob.core.windows.net/testcontainer/file	["https://teststorageaccount.blob.core.windows.net/testcontainer/file"]
+test_id	str	arrstr	num	arrnum	bool	arrbool	file	arrfile
+1	hello world	["hello", "world", "how", "are", "you"]	42	[31,41,59]	true	[true, true]	drs://example.org/dg.4503/cc32d93d-a73c-4d2c-a061-26c0410e74fa	["drs://example.org/dg.4503/cc32d93d-a73c-4d2c-a061-26c0410e74fa"]
+2	Hello World	["Hello", "World"]	42	[31,41]	true	[true,false]	drs://example.org/dg.4503/cc32d93d-a73c-4d2c-a061-26c0410e74fa	["https://teststorageaccount.blob.core.windows.net/testcontainer/file", "drs://example.org/dg.4503/cc32d93d-a73c-4d2c-a061-26c0410e74fa"]
+3	goodbye	["ONE", "TWO", "THREE"]	-1.23	[1,2,3]	false	[false,false]	https://teststorageaccount.blob.core.windows.net/testcontainer/file	["https://teststorageaccount.blob.core.windows.net/testcontainer/file"]

--- a/service/src/test/resources/searchfilter/testdata.tsv
+++ b/service/src/test/resources/searchfilter/testdata.tsv
@@ -1,4 +1,4 @@
-test_id	str	arrstr	num	arrnum	bool	arrbool	file	arrfile
-1	hello world	["hello", "world", "how", "are", "you"]	42	[31,41,59]	true	[true, true]	drs://example.org/dg.4503/cc32d93d-a73c-4d2c-a061-26c0410e74fa	["drs://example.org/dg.4503/cc32d93d-a73c-4d2c-a061-26c0410e74fa"]
-2	Hello World	["Hello", "World"]	42	[31,41]	true	[true,false]	drs://example.org/dg.4503/cc32d93d-a73c-4d2c-a061-26c0410e74fa	["https://teststorageaccount.blob.core.windows.net/testcontainer/file", "drs://example.org/dg.4503/cc32d93d-a73c-4d2c-a061-26c0410e74fa"]
-3	goodbye	["ONE", "TWO", "THREE"]	-1.23	[1,2,3]	false	[false,false]	https://teststorageaccount.blob.core.windows.net/testcontainer/file	["https://teststorageaccount.blob.core.windows.net/testcontainer/file"]
+test_id	str	arrstr	num	arrnum	bool	arrbool	date	arrdate	datetime	arrdatetime	file	arrfile
+1	hello world	["hello", "world", "how", "are", "you"]	42	[31,41,59]	true	[true, true]	1979-06-25	["1971-11-12"]	"2024-08-13T19:00:00"	["2024-08-10T16:00:00"]	drs://example.org/dg.4503/cc32d93d-a73c-4d2c-a061-26c0410e74fa	["drs://example.org/dg.4503/cc32d93d-a73c-4d2c-a061-26c0410e74fa"]
+2	Hello World	["Hello", "World"]	42	[31,41]	true	[true,false]	1979-06-25	["1971-11-12", "1977-01-21"]	"2024-08-12T18:00:00"	["2024-08-09T15:00:00"]	drs://example.org/dg.4503/cc32d93d-a73c-4d2c-a061-26c0410e74fa	["https://teststorageaccount.blob.core.windows.net/testcontainer/file", "drs://example.org/dg.4503/cc32d93d-a73c-4d2c-a061-26c0410e74fa"]
+3	goodbye	["ONE", "TWO", "THREE"]	-1.23	[1,2,3]	false	[false,false]	1981-02-12	["1977-01-21"]	"2024-08-11T17:00:00"	["2024-08-08T14:00:00"]	https://teststorageaccount.blob.core.windows.net/testcontainer/file	["https://teststorageaccount.blob.core.windows.net/testcontainer/file"]


### PR DESCRIPTION
the filter-by-column feature now supports additional datatypes:
* file / array_of_file
* boolean / array_of_boolean
* date / array_of_date
* datetime / array_of_datetime

still outstanding to support: null, empty_array, relation/array_of_relation, json/array_of_json
