### PR TITLE
AJ-1957: bean to determine Rawls vs WDS data tables

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/protecteddatasupport/RawlsProtectedDataSupport.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/protecteddatasupport/RawlsProtectedDataSupport.java
@@ -17,6 +17,7 @@ public class RawlsProtectedDataSupport implements ProtectedDataSupport {
     this.rawlsClient = rawlsClient;
   }
 
+  // TODO AJ-1957: move into WorkspaceService?
   public boolean workspaceSupportsProtectedDataPolicy(WorkspaceId workspaceId) {
     RawlsWorkspaceDetails workspaceDetails = rawlsClient.getWorkspaceDetails(workspaceId.id());
     WorkspaceType workspaceType = workspaceDetails.workspace().workspaceType();

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/WorkspaceService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/WorkspaceService.java
@@ -10,6 +10,8 @@ import org.databiosphere.workspacedataservice.shared.model.job.Job;
 import org.databiosphere.workspacedataservice.shared.model.job.JobInput;
 import org.databiosphere.workspacedataservice.shared.model.job.JobResult;
 import org.databiosphere.workspacedataservice.shared.model.job.JobType;
+import org.databiosphere.workspacedataservice.workspace.DataTableTypeInspector;
+import org.databiosphere.workspacedataservice.workspace.WorkspaceDataTableType;
 import org.databiosphere.workspacedataservice.workspace.WorkspaceInitJobInput;
 import org.databiosphere.workspacedataservice.workspace.WorkspaceInitJobResult;
 import org.slf4j.Logger;
@@ -22,10 +24,19 @@ public class WorkspaceService {
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
   private final JobDao jobDao;
   private final CollectionService collectionService;
+  private final DataTableTypeInspector dataTableTypeInspector;
 
-  public WorkspaceService(JobDao jobDao, CollectionService collectionService) {
+  public WorkspaceService(
+      JobDao jobDao,
+      CollectionService collectionService,
+      DataTableTypeInspector dataTableTypeInspector) {
     this.jobDao = jobDao;
     this.collectionService = collectionService;
+    this.dataTableTypeInspector = dataTableTypeInspector;
+  }
+
+  public WorkspaceDataTableType getDataTableType(WorkspaceId workspaceId) {
+    return dataTableTypeInspector.getWorkspaceDataTableType(workspaceId);
   }
 
   /**

--- a/service/src/main/java/org/databiosphere/workspacedataservice/workspace/DataTableTypeInspector.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/workspace/DataTableTypeInspector.java
@@ -1,0 +1,14 @@
+package org.databiosphere.workspacedataservice.workspace;
+
+import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
+
+/** Inspects a workspace and decides what type of data table (WDS, RAWLS) this workspace uses. */
+public interface DataTableTypeInspector {
+  /**
+   * Determine the type of data tables that the given workspace uses.
+   *
+   * @param workspaceId the workspace to check
+   * @return whether the workspace should use WDS-powered or Rawls-powered data tables
+   */
+  WorkspaceDataTableType getWorkspaceDataTableType(WorkspaceId workspaceId);
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/workspace/DataTableTypeInspectorConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/workspace/DataTableTypeInspectorConfig.java
@@ -1,5 +1,7 @@
 package org.databiosphere.workspacedataservice.workspace;
 
+import static org.databiosphere.workspacedataservice.annotations.DeploymentMode.*;
+
 import org.databiosphere.workspacedataservice.rawls.RawlsClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -8,7 +10,14 @@ import org.springframework.context.annotation.Configuration;
 public class DataTableTypeInspectorConfig {
 
   @Bean
-  DataTableTypeInspector dataTableTypeInspector(RawlsClient rawlsClient) {
+  @ControlPlane
+  DataTableTypeInspector rawlsDataTableTypeInspector(RawlsClient rawlsClient) {
     return new RawlsDataTableTypeInspector(rawlsClient);
+  }
+
+  @Bean
+  @DataPlane
+  DataTableTypeInspector wdsDataTableTypeInspector() {
+    return new WdsDataTableTypeInspector();
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/workspace/DataTableTypeInspectorConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/workspace/DataTableTypeInspectorConfig.java
@@ -1,0 +1,14 @@
+package org.databiosphere.workspacedataservice.workspace;
+
+import org.databiosphere.workspacedataservice.rawls.RawlsClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class DataTableTypeInspectorConfig {
+
+  @Bean
+  DataTableTypeInspector dataTableTypeInspector(RawlsClient rawlsClient) {
+    return new RawlsDataTableTypeInspector(rawlsClient);
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/workspace/RawlsDataTableTypeInspector.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/workspace/RawlsDataTableTypeInspector.java
@@ -23,10 +23,10 @@ public class RawlsDataTableTypeInspector implements DataTableTypeInspector {
   @Override
   public WorkspaceDataTableType getWorkspaceDataTableType(WorkspaceId workspaceId) {
     RawlsWorkspaceDetails details = rawlsClient.getWorkspaceDetails(workspaceId.id());
-    if (RawlsWorkspaceDetails.RawlsWorkspace.WorkspaceType.MC.equals(
-        details.workspace().workspaceType())) {
-      return WorkspaceDataTableType.WDS;
-    }
-    return WorkspaceDataTableType.RAWLS;
+
+    return switch (details.workspace().workspaceType()) {
+      case MC -> WorkspaceDataTableType.WDS;
+      case RAWLS -> WorkspaceDataTableType.RAWLS;
+    };
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/workspace/RawlsDataTableTypeInspector.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/workspace/RawlsDataTableTypeInspector.java
@@ -1,0 +1,32 @@
+package org.databiosphere.workspacedataservice.workspace;
+
+import org.databiosphere.workspacedataservice.rawls.RawlsClient;
+import org.databiosphere.workspacedataservice.rawls.RawlsWorkspaceDetails;
+import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
+
+public class RawlsDataTableTypeInspector implements DataTableTypeInspector {
+
+  private final RawlsClient rawlsClient;
+
+  public RawlsDataTableTypeInspector(RawlsClient rawlsClient) {
+    this.rawlsClient = rawlsClient;
+  }
+
+  /**
+   * Determine the type of data tables that the given workspace uses, by making a REST request to
+   * Rawls. If Rawls says this is an MC workspace, this method will say the workspace is powered by
+   * WDS. Else, this method will say the workspace is powered by Rawls Entity Service.
+   *
+   * @param workspaceId the workspace to check
+   * @return whether the workspace should use WDS-powered or Rawls-powered data tables
+   */
+  @Override
+  public WorkspaceDataTableType getWorkspaceDataTableType(WorkspaceId workspaceId) {
+    RawlsWorkspaceDetails details = rawlsClient.getWorkspaceDetails(workspaceId.id());
+    if (RawlsWorkspaceDetails.RawlsWorkspace.WorkspaceType.MC.equals(
+        details.workspace().workspaceType())) {
+      return WorkspaceDataTableType.WDS;
+    }
+    return WorkspaceDataTableType.RAWLS;
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/workspace/WdsDataTableTypeInspector.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/workspace/WdsDataTableTypeInspector.java
@@ -1,0 +1,19 @@
+package org.databiosphere.workspacedataservice.workspace;
+
+import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
+
+public class WdsDataTableTypeInspector implements DataTableTypeInspector {
+
+  /**
+   * Always returns WDS. This implementation of DataTableTypeInspector is used in the data plane,
+   * which has no Rawls client. By nature, if this WDS is running in the data plane, its data tables
+   * are powered by WDS.
+   *
+   * @param workspaceId the workspace to check
+   * @return whether the workspace should use WDS-powered or Rawls-powered data tables
+   */
+  @Override
+  public WorkspaceDataTableType getWorkspaceDataTableType(WorkspaceId workspaceId) {
+    return WorkspaceDataTableType.WDS;
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/workspace/WorkspaceDataTableType.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/workspace/WorkspaceDataTableType.java
@@ -1,0 +1,8 @@
+package org.databiosphere.workspacedataservice.workspace;
+
+public enum WorkspaceDataTableType {
+  // data tables powered by Rawls Entity Service; nothing persisted in WDS
+  RAWLS,
+  // data tables powered by WDS; persisted to WDS's Postgres
+  WDS
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/annotations/AnnotatedApisTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/annotations/AnnotatedApisTest.java
@@ -16,6 +16,8 @@ import org.databiosphere.workspacedataservice.recordsink.RecordSinkFactory;
 import org.databiosphere.workspacedataservice.recordsink.WdsRecordSinkFactory;
 import org.databiosphere.workspacedataservice.service.DataTypeInferer;
 import org.databiosphere.workspacedataservice.service.RecordService;
+import org.databiosphere.workspacedataservice.workspace.DataTableTypeInspector;
+import org.databiosphere.workspacedataservice.workspace.WdsDataTableTypeInspector;
 import org.databiosphere.workspacedataservice.workspacemanager.WorkspaceManagerDao;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -65,6 +67,12 @@ class AnnotatedApisTest extends TestBase {
     @Bean("overrideProtectedDataSupport")
     ProtectedDataSupport overrideProtectedDataSupport(WorkspaceManagerDao wsmDao) {
       return new WsmProtectedDataSupport(wsmDao);
+    }
+
+    @Primary
+    @Bean("overrideDataTableTypeInspector")
+    DataTableTypeInspector overrideDataTableTypeInspector() {
+      return new WdsDataTableTypeInspector();
     }
   }
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/WorkspaceServiceControlPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/WorkspaceServiceControlPlaneTest.java
@@ -17,10 +17,20 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 
+@ActiveProfiles(profiles = {"control-plane"})
 @DirtiesContext
 @SpringBootTest
-class WorkspaceServiceTest {
+@TestPropertySource(
+    properties = {
+      // turn off pubsub autoconfiguration for tests
+      "spring.cloud.gcp.pubsub.enabled=false",
+      // Rawls url must be valid, else context initialization (Spring startup) will fail
+      "rawlsUrl=https://localhost/"
+    })
+class WorkspaceServiceControlPlaneTest {
 
   @MockBean RawlsClient rawlsClient;
   @Autowired WorkspaceService workspaceService;
@@ -36,7 +46,7 @@ class WorkspaceServiceTest {
 
   @ParameterizedTest(name = "workspace type `{0}` should use `{1}` data tables")
   @MethodSource("workspaceTypeArguments")
-  void mcWorkspace(
+  void dataTableType(
       RawlsWorkspaceDetails.RawlsWorkspace.WorkspaceType workspaceType,
       WorkspaceDataTableType dataTableType) {
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/WorkspaceServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/WorkspaceServiceTest.java
@@ -1,0 +1,54 @@
+package org.databiosphere.workspacedataservice.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.databiosphere.workspacedataservice.rawls.RawlsClient;
+import org.databiosphere.workspacedataservice.rawls.RawlsWorkspaceDetails;
+import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
+import org.databiosphere.workspacedataservice.workspace.WorkspaceDataTableType;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.annotation.DirtiesContext;
+
+@DirtiesContext
+@SpringBootTest
+class WorkspaceServiceTest {
+
+  @MockBean RawlsClient rawlsClient;
+  @Autowired WorkspaceService workspaceService;
+
+  static Stream<Arguments> workspaceTypeArguments() {
+    return Stream.of(
+        Arguments.of(
+            RawlsWorkspaceDetails.RawlsWorkspace.WorkspaceType.MC, WorkspaceDataTableType.WDS),
+        Arguments.of(
+            RawlsWorkspaceDetails.RawlsWorkspace.WorkspaceType.RAWLS,
+            WorkspaceDataTableType.RAWLS));
+  }
+
+  @ParameterizedTest(name = "workspace type `{0}` should use `{1}` data tables")
+  @MethodSource("workspaceTypeArguments")
+  void mcWorkspace(
+      RawlsWorkspaceDetails.RawlsWorkspace.WorkspaceType workspaceType,
+      WorkspaceDataTableType dataTableType) {
+
+    WorkspaceId workspaceId = WorkspaceId.of(UUID.randomUUID());
+    RawlsWorkspaceDetails.RawlsWorkspace rawlsWorkspace =
+        new RawlsWorkspaceDetails.RawlsWorkspace("bucketName", workspaceType);
+    RawlsWorkspaceDetails rawlsWorkspaceDetails =
+        new RawlsWorkspaceDetails(rawlsWorkspace, List.of());
+
+    when(rawlsClient.getWorkspaceDetails(workspaceId.id())).thenReturn(rawlsWorkspaceDetails);
+
+    WorkspaceDataTableType actual = workspaceService.getDataTableType(workspaceId);
+    assertEquals(dataTableType, actual);
+  }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/workspace/RawlsDataTableTypeInspectorTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/workspace/RawlsDataTableTypeInspectorTest.java
@@ -1,0 +1,45 @@
+package org.databiosphere.workspacedataservice.workspace;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.databiosphere.workspacedataservice.rawls.RawlsClient;
+import org.databiosphere.workspacedataservice.rawls.RawlsWorkspaceDetails;
+import org.databiosphere.workspacedataservice.rawls.RawlsWorkspaceDetails.RawlsWorkspace;
+import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+
+// note: we don't need @SpringBootTest, so we omit it to keep tests as light as possible
+class RawlsDataTableTypeInspectorTest {
+
+  static Stream<Arguments> workspaceTypeArguments() {
+    return Stream.of(
+        Arguments.of(RawlsWorkspace.WorkspaceType.MC, WorkspaceDataTableType.WDS),
+        Arguments.of(RawlsWorkspace.WorkspaceType.RAWLS, WorkspaceDataTableType.RAWLS));
+  }
+
+  @ParameterizedTest(name = "workspace type `{0}` should use `{1}` data tables")
+  @MethodSource("workspaceTypeArguments")
+  void mcWorkspace(
+      RawlsWorkspace.WorkspaceType workspaceType, WorkspaceDataTableType dataTableType) {
+
+    RawlsClient mockRawlsClient = Mockito.mock(RawlsClient.class);
+
+    WorkspaceId workspaceId = WorkspaceId.of(UUID.randomUUID());
+    RawlsWorkspace rawlsWorkspace = new RawlsWorkspace("bucketName", workspaceType);
+    RawlsWorkspaceDetails rawlsWorkspaceDetails =
+        new RawlsWorkspaceDetails(rawlsWorkspace, List.of());
+
+    when(mockRawlsClient.getWorkspaceDetails(workspaceId.id())).thenReturn(rawlsWorkspaceDetails);
+
+    RawlsDataTableTypeInspector inspector = new RawlsDataTableTypeInspector(mockRawlsClient);
+    WorkspaceDataTableType actual = inspector.getWorkspaceDataTableType(workspaceId);
+    assertEquals(dataTableType, actual);
+  }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/workspace/RawlsDataTableTypeInspectorTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/workspace/RawlsDataTableTypeInspectorTest.java
@@ -26,7 +26,7 @@ class RawlsDataTableTypeInspectorTest {
 
   @ParameterizedTest(name = "workspace type `{0}` should use `{1}` data tables")
   @MethodSource("workspaceTypeArguments")
-  void mcWorkspace(
+  void dataTableType(
       RawlsWorkspace.WorkspaceType workspaceType, WorkspaceDataTableType dataTableType) {
 
     RawlsClient mockRawlsClient = Mockito.mock(RawlsClient.class);


### PR DESCRIPTION
Part of AJ-1957 but does not complete that ticket.

This PR adds a method `WorkspaceService.getDataTableType(WorkspaceId workspaceId)` which returns, for any given workspace id, whether that workspace should be powered by WDS data tables or Rawls Entity Service data tables.

This method is currently unused in this PR. It is a prerequisite for completing the rest of AJ-1957, and future PRs will take advantage of it.

The logic to determine the data table type is quite simple: make a request to Rawls to describe the workspace. If the workspace is of type `MC`, it uses WDS data tables. If the workspace is of type `RAWLS`, it uses Rawls Entity Service data tables.

The implementation of this logic is fairly abstracted, via a `DataTableTypeInspector` interface and a `RawlsDataTableTypeInspector` bean. I've abstracted it this much because I believe we will be changing this logic in the near future, as we start to migrate GCP workspaces to WDS and possibly even as the Workspaces team starts migrating GCP workspaces to use WSM.