### PR TITLE
AJ-1957: remove unused batch-write-record-sink property

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/config/DataImportProperties.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/config/DataImportProperties.java
@@ -12,7 +12,6 @@ import org.springframework.lang.Nullable;
 
 /** Properties that dictate how data import processes should behave. */
 public class DataImportProperties {
-  private RecordSinkMode batchWriteRecordSink;
   private String rawlsBucketName;
   private boolean succeedOnCompletion;
   private boolean enableTdrPermissionSync = false;
@@ -23,15 +22,6 @@ public class DataImportProperties {
   private String statusUpdatesSubscription;
   private List<ImportSourceConfig> sources;
   private boolean shouldAddImportMetadata = false;
-
-  /** Where to write records after import, options are defined by {@link RecordSinkMode} */
-  public RecordSinkMode getBatchWriteRecordSink() {
-    return batchWriteRecordSink;
-  }
-
-  void setBatchWriteRecordSink(String batchWriteRecordSink) {
-    this.batchWriteRecordSink = RecordSinkMode.fromValue(batchWriteRecordSink);
-  }
 
   /** Where to write Rawls JSON files after import. */
   @Nullable

--- a/service/src/main/resources/application-control-plane.yml
+++ b/service/src/main/resources/application-control-plane.yml
@@ -9,7 +9,6 @@ twds:
     enforce-collections-match-workspace-id: false
   data-import:
     add-import-metadata: true
-    batch-write-record-sink: "rawls"
     succeed-on-completion: false
     # Name of the Google Cloud Storage bucket where JSON files are uploaded for import and sent to
     # Rawls for upserting.

--- a/service/src/main/resources/application-data-plane.yml
+++ b/service/src/main/resources/application-data-plane.yml
@@ -8,7 +8,6 @@ twds:
     # Should this WDS deployment require collections to belong to the workspace with $WORKSPACE_ID?
     enforce-collections-match-workspace-id: true
   data-import:
-    batch-write-record-sink: "wds"
     succeed-on-completion: true
 
 spring:

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -138,7 +138,6 @@ twds:
     require-env-workspace: true
     enforce-collections-match-workspace-id: true
   data-import:
-    batch-write-record-sink: "wds"
     allowed-hosts:
       - anvil\.gi\.ucsc\.edu
       - .*\.singlecell\.gi\.ucsc\.edu,

--- a/service/src/test/java/org/databiosphere/workspacedataservice/config/TwdsPropertiesControlPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/config/TwdsPropertiesControlPlaneTest.java
@@ -1,11 +1,9 @@
 package org.databiosphere.workspacedataservice.config;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.databiosphere.workspacedataservice.config.DataImportProperties.RecordSinkMode;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -31,11 +29,6 @@ class TwdsPropertiesControlPlaneTest {
   @Test
   void nonNullDataImport() {
     assertNotNull(twdsProperties.dataImportProperties());
-  }
-
-  @Test
-  void batchWriteRecordSink() {
-    assertEquals(RecordSinkMode.RAWLS, dataImportProperties.getBatchWriteRecordSink());
   }
 
   @Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/config/TwdsPropertiesDataPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/config/TwdsPropertiesDataPlaneTest.java
@@ -1,12 +1,10 @@
 package org.databiosphere.workspacedataservice.config;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.databiosphere.workspacedataservice.common.TestBase;
-import org.databiosphere.workspacedataservice.config.DataImportProperties.RecordSinkMode;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -25,11 +23,6 @@ class TwdsPropertiesDataPlaneTest extends TestBase {
   @Test
   void nonNullDataImport() {
     assertNotNull(twdsProperties.dataImportProperties());
-  }
-
-  @Test
-  void batchWriteRecordSink() {
-    assertEquals(RecordSinkMode.WDS, dataImportProperties.getBatchWriteRecordSink());
   }
 
   @Test


### PR DESCRIPTION
This property was unused except in tests. Let's delete it.