### PR TITLE
AJ-1943 Remove v0.2 Instance APIs

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.annotations.DeploymentMode.DataPlane;
-import org.databiosphere.workspacedataservice.generated.CollectionServerModel;
 import org.databiosphere.workspacedataservice.service.CollectionService;
 import org.databiosphere.workspacedataservice.service.PermissionService;
 import org.databiosphere.workspacedataservice.service.RecordOrchestratorService;
@@ -134,42 +133,6 @@ public class RecordController {
     permissionService.requireWritePermission(CollectionId.of(instanceId));
     return recordOrchestratorService.upsertSingleRecord(
         instanceId, version, recordType, recordId, primaryKey, recordRequest);
-  }
-
-  /**
-   * @deprecated Use {@link CollectionController#listCollectionsV1(UUID)} instead.
-   */
-  @Deprecated(forRemoval = true, since = "v0.14.0")
-  @GetMapping("/instances/{version}")
-  public ResponseEntity<List<UUID>> listInstances(@PathVariable("version") String version) {
-    permissionService.requireReadPermissionSingleTenant();
-    List<UUID> schemaList = collectionService.listCollections(version);
-    return new ResponseEntity<>(schemaList, HttpStatus.OK);
-  }
-
-  /**
-   * @deprecated Use {@link CollectionController#createCollectionV1(UUID, CollectionServerModel)}
-   *     instead.
-   */
-  @Deprecated(forRemoval = true, since = "v0.14.0")
-  @PostMapping("/instances/{version}/{instanceId}")
-  public ResponseEntity<String> createInstance(
-      @PathVariable("instanceId") UUID instanceId, @PathVariable("version") String version) {
-    permissionService.requireWritePermissionSingleTenant();
-    collectionService.createCollection(instanceId, version);
-    return new ResponseEntity<>(HttpStatus.CREATED);
-  }
-
-  /**
-   * @deprecated Use {@link CollectionController#deleteCollectionV1(UUID, UUID)} instead.
-   */
-  @Deprecated(forRemoval = true, since = "v0.14.0")
-  @DeleteMapping("/instances/{version}/{instanceId}")
-  public ResponseEntity<String> deleteInstance(
-      @PathVariable("instanceId") UUID instanceId, @PathVariable("version") String version) {
-    permissionService.requireWritePermissionSingleTenant();
-    collectionService.deleteCollection(instanceId, version);
-    return new ResponseEntity<>(HttpStatus.OK);
   }
 
   @DeleteMapping("/{instanceId}/records/{version}/{recordType}/{recordId}")

--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/RecordController.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.annotations.DeploymentMode.DataPlane;
-import org.databiosphere.workspacedataservice.service.CollectionService;
 import org.databiosphere.workspacedataservice.service.PermissionService;
 import org.databiosphere.workspacedataservice.service.RecordOrchestratorService;
 import org.databiosphere.workspacedataservice.service.model.AttributeSchema;
@@ -42,15 +41,11 @@ import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBo
 @RestController
 public class RecordController {
 
-  private final CollectionService collectionService;
   private final RecordOrchestratorService recordOrchestratorService;
   private final PermissionService permissionService;
 
   public RecordController(
-      CollectionService collectionService,
-      RecordOrchestratorService recordOrchestratorService,
-      PermissionService permissionService) {
-    this.collectionService = collectionService;
+      RecordOrchestratorService recordOrchestratorService, PermissionService permissionService) {
     this.recordOrchestratorService = recordOrchestratorService;
     this.permissionService = permissionService;
   }

--- a/service/src/main/resources/static/swagger/openapi-docs.yaml
+++ b/service/src/main/resources/static/swagger/openapi-docs.yaml
@@ -32,8 +32,6 @@ tags:
     description: Job APIs
   - name: Collection
     description: Collection APIs
-  - name: Instances
-    description: Instance APIs
   - name: Schema
     description: Schema Manipulation APIs (coming soon)
   - name: Workspace
@@ -348,69 +346,6 @@ paths:
     $ref: 'apis-v1.yaml#/paths/~1collections~1v1~1{workspaceId}'
   /collections/v1/{workspaceId}/{collectionId}:
     $ref: 'apis-v1.yaml#/paths/~1collections~1v1~1{workspaceId}~1{collectionId}'
-
-  ##############################
-  # Instances APIs
-  ##############################
-  /instances/{v}:
-    get:
-      summary: This API will be deleted on or after August 25, 2024.
-      description: Use GET /collections/v1/{workspaceId} instead.
-      operationId: listWDSInstances
-      deprecated: true
-      tags:
-        - Instances
-      parameters:
-        - $ref: '#/components/parameters/versionPathParam'
-      responses:
-        200:
-          description: Success
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: string
-                  format: uuid
-  /instances/{v}/{instanceid}:
-    post:
-      summary: This API will be deleted on or after August 25, 2024.
-      description: Use POST /collections/v1/{workspaceId} instead.
-      operationId: createWDSInstance
-      deprecated: true
-      tags:
-        - Instances
-      parameters:
-        - $ref: '#/components/parameters/instanceIdPathParam'
-        - $ref: '#/components/parameters/versionPathParam'
-      responses:
-        201:
-          description: Success
-        409:
-          description: Conflict - schema already exists.
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-    delete:
-      summary: This API will be deleted on or after August 25, 2024.
-      description: Use DELETE /collections/v1/{workspaceId}/{collectionId} instead.
-      operationId: deleteWDSInstance
-      deprecated: true
-      tags:
-        - Instances
-      parameters:
-        - $ref: '#/components/parameters/instanceIdPathParam'
-        - $ref: '#/components/parameters/versionPathParam'
-      responses:
-        200:
-          description: Success
-        404:
-          description: Not Found - instance does not exist.
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
 
   ##############################
   # Schema APIs

--- a/service/src/test/java/org/databiosphere/workspacedataservice/GeneratedClientTests.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/GeneratedClientTests.java
@@ -11,12 +11,14 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.databiosphere.workspacedata.api.CollectionApi;
 import org.databiosphere.workspacedata.api.GeneralWdsInformationApi;
 import org.databiosphere.workspacedata.api.RecordsApi;
 import org.databiosphere.workspacedata.api.SchemaApi;
 import org.databiosphere.workspacedata.client.ApiClient;
 import org.databiosphere.workspacedata.client.ApiException;
+import org.databiosphere.workspacedata.model.Collection;
 import org.databiosphere.workspacedata.model.CollectionRequest;
 import org.databiosphere.workspacedata.model.RecordAttributes;
 import org.databiosphere.workspacedata.model.RecordQueryResponse;
@@ -51,8 +53,7 @@ class GeneratedClientTests extends TestBase {
   @LocalServerPort int port;
 
   @Autowired TwdsProperties twdsProperties;
-  private final UUID workspaceId = twdsProperties.workspaceId().id();
-  private final UUID collectionId = UUID.randomUUID();
+  private UUID collectionId;
   private final String version = "v0.2";
 
   @BeforeEach
@@ -60,13 +61,14 @@ class GeneratedClientTests extends TestBase {
     apiClient = new ApiClient();
     apiClient.setBasePath("http://localhost:" + port);
     CollectionRequest collectionRequest = new CollectionRequest();
-    collectionRequest.setName("default");
-    createNewCollection(collectionRequest, workspaceId);
+    collectionRequest.setName(RandomStringUtils.randomAlphabetic(16));
+    collectionRequest.setDescription("description");
+    collectionId = createNewCollection(collectionRequest, twdsProperties.workspaceId().id());
   }
 
   @AfterEach
   void afterEach() throws ApiException {
-    deleteCollection(workspaceId, collectionId);
+    deleteCollection(twdsProperties.workspaceId().id(), collectionId);
   }
 
   @Test
@@ -308,10 +310,11 @@ class GeneratedClientTests extends TestBase {
     assertThat(recordAttributes).containsEntry("greeting", "hello").containsEntry("double", -2.287);
   }
 
-  private void createNewCollection(CollectionRequest collectionRequest, UUID workspaceId)
+  private UUID createNewCollection(CollectionRequest collectionRequest, UUID workspaceId)
       throws ApiException {
     CollectionApi collectionApi = new CollectionApi(apiClient);
-    collectionApi.createCollectionV1(collectionRequest, workspaceId);
+    Collection createdCollection = collectionApi.createCollectionV1(collectionRequest, workspaceId);
+    return createdCollection.getId();
   }
 
   private void deleteCollection(UUID workspaceId, UUID collectionId) throws ApiException {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/GeneratedClientTests.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/GeneratedClientTests.java
@@ -31,6 +31,7 @@ import org.databiosphere.workspacedata.model.StatusResponse;
 import org.databiosphere.workspacedata.model.TsvUploadResponse;
 import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.config.TwdsProperties;
+import org.databiosphere.workspacedataservice.service.CollectionService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,6 +41,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.lang.Nullable;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
@@ -56,6 +58,9 @@ class GeneratedClientTests extends TestBase {
   private UUID collectionId;
   private final String version = "v0.2";
 
+  @Autowired CollectionService collectionService;
+  @Autowired NamedParameterJdbcTemplate namedTemplate;
+
   @BeforeEach
   void init() throws ApiException {
     apiClient = new ApiClient();
@@ -67,8 +72,8 @@ class GeneratedClientTests extends TestBase {
   }
 
   @AfterEach
-  void afterEach() throws ApiException {
-    deleteCollection(twdsProperties.workspaceId().id(), collectionId);
+  void afterEach() {
+    TestUtils.cleanAllCollections(collectionService, namedTemplate);
   }
 
   @Test
@@ -315,10 +320,5 @@ class GeneratedClientTests extends TestBase {
     CollectionApi collectionApi = new CollectionApi(apiClient);
     Collection createdCollection = collectionApi.createCollectionV1(collectionRequest, workspaceId);
     return createdCollection.getId();
-  }
-
-  private void deleteCollection(UUID workspaceId, UUID collectionId) throws ApiException {
-    CollectionApi collectionApi = new CollectionApi(apiClient);
-    collectionApi.deleteCollectionV1(workspaceId, collectionId);
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/GeneratedClientTests.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/GeneratedClientTests.java
@@ -11,12 +11,13 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.apache.commons.io.FileUtils;
+import org.databiosphere.workspacedata.api.CollectionApi;
 import org.databiosphere.workspacedata.api.GeneralWdsInformationApi;
-import org.databiosphere.workspacedata.api.InstancesApi;
 import org.databiosphere.workspacedata.api.RecordsApi;
 import org.databiosphere.workspacedata.api.SchemaApi;
 import org.databiosphere.workspacedata.client.ApiClient;
 import org.databiosphere.workspacedata.client.ApiException;
+import org.databiosphere.workspacedata.model.CollectionRequest;
 import org.databiosphere.workspacedata.model.RecordAttributes;
 import org.databiosphere.workspacedata.model.RecordQueryResponse;
 import org.databiosphere.workspacedata.model.RecordRequest;
@@ -27,12 +28,14 @@ import org.databiosphere.workspacedata.model.SearchRequest;
 import org.databiosphere.workspacedata.model.StatusResponse;
 import org.databiosphere.workspacedata.model.TsvUploadResponse;
 import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.config.TwdsProperties;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.lang.Nullable;
@@ -47,6 +50,8 @@ class GeneratedClientTests extends TestBase {
   private ApiClient apiClient;
   @LocalServerPort int port;
 
+  @Autowired TwdsProperties twdsProperties;
+  private final UUID workspaceId = twdsProperties.workspaceId().id();
   private final UUID collectionId = UUID.randomUUID();
   private final String version = "v0.2";
 
@@ -54,12 +59,14 @@ class GeneratedClientTests extends TestBase {
   void init() throws ApiException {
     apiClient = new ApiClient();
     apiClient.setBasePath("http://localhost:" + port);
-    createNewCollection(collectionId);
+    CollectionRequest collectionRequest = new CollectionRequest();
+    collectionRequest.setName("default");
+    createNewCollection(collectionRequest, workspaceId);
   }
 
   @AfterEach
   void afterEach() throws ApiException {
-    deleteCollection(collectionId);
+    deleteCollection(workspaceId, collectionId);
   }
 
   @Test
@@ -301,13 +308,14 @@ class GeneratedClientTests extends TestBase {
     assertThat(recordAttributes).containsEntry("greeting", "hello").containsEntry("double", -2.287);
   }
 
-  private void createNewCollection(UUID collectionId) throws ApiException {
-    InstancesApi instancesApi = new InstancesApi(apiClient);
-    instancesApi.createWDSInstance(collectionId.toString(), version);
+  private void createNewCollection(CollectionRequest collectionRequest, UUID workspaceId)
+      throws ApiException {
+    CollectionApi collectionApi = new CollectionApi(apiClient);
+    collectionApi.createCollectionV1(collectionRequest, workspaceId);
   }
 
-  private void deleteCollection(UUID collection) throws ApiException {
-    InstancesApi instancesApi = new InstancesApi(apiClient);
-    instancesApi.deleteWDSInstance(collection.toString(), version);
+  private void deleteCollection(UUID workspaceId, UUID collectionId) throws ApiException {
+    CollectionApi collectionApi = new CollectionApi(apiClient);
+    collectionApi.deleteCollectionV1(workspaceId, collectionId);
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/TestUtils.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/TestUtils.java
@@ -1,5 +1,7 @@
 package org.databiosphere.workspacedataservice;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.LocalDate;
@@ -7,8 +9,10 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
+import org.databiosphere.workspacedataservice.generated.CollectionServerModel;
 import org.databiosphere.workspacedataservice.service.CollectionService;
 import org.databiosphere.workspacedataservice.service.RelationUtils;
 import org.databiosphere.workspacedataservice.shared.model.CollectionId;
@@ -197,5 +201,13 @@ public class TestUtils {
             "2016-06-06T12:00:01",
             "1991-05-15T12:00:01")
         .get(seed % 8);
+  }
+
+  public static UUID getCollectionId(ObjectMapper objectMapper, String responseBody)
+      throws JsonProcessingException {
+    CollectionServerModel created =
+        objectMapper.readValue(responseBody, CollectionServerModel.class);
+
+    return created.getId();
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/AllControllersPermissionsTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/AllControllersPermissionsTest.java
@@ -256,24 +256,7 @@ class AllControllersPermissionsTest extends MockMvcTestBase {
             named(
                 "GET /backup/v0.2/{trackingId}",
                 get("/backup/v0.2/{trackingId}", UUID.randomUUID()))),
-        arguments(named("GET /clone/v0.2", get("/clone/v0.2"))),
-        // Instances
-        arguments(named("GET /instances/v0.2", get("/instances/v0.2"))));
-  }
-
-  // these single-tenant APIs require write permission. When single-tenant APIs are fully retired,
-  // this method and any tests that use it should be deleted.
-  private static Stream<Arguments> singleTenantWriteApis() {
-    return Stream.of(
-        // Instances
-        arguments(
-            named(
-                "POST /instances/v0.2/{instanceid}",
-                post("/instances/v0.2/{instanceid}", UUID.randomUUID()))),
-        arguments(
-            named(
-                "DELETE /instances/v0.2/{instanceid}",
-                delete("/instances/v0.2/{instanceid}", collectionId))));
+        arguments(named("GET /clone/v0.2", get("/clone/v0.2"))));
   }
 
   // ========== write API tests
@@ -319,30 +302,6 @@ class AllControllersPermissionsTest extends MockMvcTestBase {
   @MethodSource("readOnlyApis")
   void readApiNoPermission(MockHttpServletRequestBuilder request) throws Exception {
     userNoPermissions(workspaceId);
-    requestShouldBeMaskedNotFound(request);
-  }
-
-  // ========== single-tenant write API tests
-
-  @ParameterizedTest(name = "single-tenant write API {0} succeeds with write permission")
-  @MethodSource("singleTenantWriteApis")
-  void singleTenantWriteApiWritePermission(MockHttpServletRequestBuilder request) throws Exception {
-    userCanWrite(twdsProperties.workspaceId());
-    requestShouldSucceed(request);
-  }
-
-  @ParameterizedTest(name = "single-tenant write API {0} is forbidden with read-only permission")
-  @MethodSource("singleTenantWriteApis")
-  void singleTenantWriteApiReadOnlyPermission(MockHttpServletRequestBuilder request)
-      throws Exception {
-    userCanRead(twdsProperties.workspaceId());
-    requestShouldBeForbidden(request);
-  }
-
-  @ParameterizedTest(name = "single-tenant write API {0} is not found with no permission")
-  @MethodSource("singleTenantWriteApis")
-  void singleTenantWriteApiNoPermission(MockHttpServletRequestBuilder request) throws Exception {
-    userNoPermissions(twdsProperties.workspaceId());
     requestShouldBeMaskedNotFound(request);
   }
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/ConcurrentDataTypeChangesTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/ConcurrentDataTypeChangesTest.java
@@ -14,8 +14,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.config.TwdsProperties;
-import org.databiosphere.workspacedataservice.generated.CollectionServerModel;
-import org.databiosphere.workspacedataservice.shared.model.CollectionId;
+import org.databiosphere.workspacedataservice.generated.CollectionRequestServerModel;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
 import org.databiosphere.workspacedataservice.shared.model.RecordRequest;
 import org.databiosphere.workspacedataservice.shared.model.RecordResponse;
@@ -51,12 +50,11 @@ class ConcurrentDataTypeChangesTest extends TestBase {
 
   @BeforeEach
   void setUp() throws JsonProcessingException {
-    CollectionId collectionId = CollectionId.of(UUID.randomUUID());
     String name = "test-name";
     String description = "test-description";
 
-    CollectionServerModel collectionServerModel = new CollectionServerModel(name, description);
-    collectionServerModel.id(collectionId.id());
+    CollectionRequestServerModel collectionRequestServerModel =
+        new CollectionRequestServerModel(name, description);
 
     ObjectMapper objectMapper = new ObjectMapper();
 
@@ -66,7 +64,8 @@ class ConcurrentDataTypeChangesTest extends TestBase {
         restTemplate.exchange(
             "/collections/v1/{workspaceId}",
             HttpMethod.POST,
-            new HttpEntity<>(objectMapper.writeValueAsString(collectionServerModel), headers),
+            new HttpEntity<>(
+                objectMapper.writeValueAsString(collectionRequestServerModel), headers),
             String.class,
             twdsProperties.workspaceId().id());
     assertEquals(HttpStatus.CREATED, response.getStatusCode());

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/ConcurrentDataTypeChangesTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/ConcurrentDataTypeChangesTest.java
@@ -4,14 +4,15 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import org.databiosphere.workspacedataservice.TestUtils;
 import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.config.TwdsProperties;
 import org.databiosphere.workspacedataservice.generated.CollectionRequestServerModel;
@@ -70,9 +71,8 @@ class ConcurrentDataTypeChangesTest extends TestBase {
             twdsProperties.workspaceId().id());
     assertEquals(HttpStatus.CREATED, response.getStatusCode());
 
-    JsonNode jsonNode = objectMapper.readTree(response.getBody());
-
-    instanceId = UUID.fromString(jsonNode.get("id").asText());
+    instanceId =
+        TestUtils.getCollectionId(objectMapper, Objects.requireNonNull(response.getBody()));
   }
 
   @AfterEach

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
@@ -23,10 +23,9 @@ import java.util.function.Supplier;
 import org.databiosphere.workspacedata.model.ErrorResponse;
 import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.config.TwdsProperties;
-import org.databiosphere.workspacedataservice.generated.CollectionServerModel;
+import org.databiosphere.workspacedataservice.generated.CollectionRequestServerModel;
 import org.databiosphere.workspacedataservice.service.RelationUtils;
 import org.databiosphere.workspacedataservice.shared.model.BatchOperation;
-import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.databiosphere.workspacedataservice.shared.model.OperationType;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
@@ -76,12 +75,11 @@ class FullStackRecordControllerTest extends TestBase {
 
   @BeforeEach
   void setUp() throws JsonProcessingException {
-    CollectionId collectionId = CollectionId.of(UUID.randomUUID());
     String name = "test-name";
     String description = "test-description";
 
-    CollectionServerModel collectionServerModel = new CollectionServerModel(name, description);
-    collectionServerModel.id(collectionId.id());
+    CollectionRequestServerModel collectionRequestServerModel =
+        new CollectionRequestServerModel(name, description);
 
     ObjectMapper objectMapper = new ObjectMapper();
 
@@ -91,7 +89,8 @@ class FullStackRecordControllerTest extends TestBase {
         restTemplate.exchange(
             "/collections/v1/{workspaceId}",
             HttpMethod.POST,
-            new HttpEntity<>(objectMapper.writeValueAsString(collectionServerModel), headers),
+            new HttpEntity<>(
+                objectMapper.writeValueAsString(collectionRequestServerModel), headers),
             String.class,
             twdsProperties.workspaceId().id());
     assertEquals(HttpStatus.CREATED, response.getStatusCode());

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -18,9 +17,11 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Supplier;
 import org.databiosphere.workspacedata.model.ErrorResponse;
+import org.databiosphere.workspacedataservice.TestUtils;
 import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.config.TwdsProperties;
 import org.databiosphere.workspacedataservice.generated.CollectionRequestServerModel;
@@ -95,9 +96,8 @@ class FullStackRecordControllerTest extends TestBase {
             twdsProperties.workspaceId().id());
     assertEquals(HttpStatus.CREATED, response.getStatusCode());
 
-    JsonNode jsonNode = objectMapper.readTree(response.getBody());
-
-    instanceId = UUID.fromString(jsonNode.get("id").asText());
+    instanceId =
+        TestUtils.getCollectionId(objectMapper, Objects.requireNonNull(response.getBody()));
   }
 
   @AfterEach

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -89,10 +88,8 @@ class RecordControllerMockMvcTest extends MockMvcTestBase {
             .andExpect(status().isCreated())
             .andReturn();
 
-    String responseContent = mvcResult.getResponse().getContentAsString();
-    JsonNode jsonNode = objectMapper.readTree(responseContent);
-
-    instanceId = UUID.fromString(jsonNode.get("id").asText());
+    instanceId =
+        TestUtils.getCollectionId(objectMapper, mvcResult.getResponse().getContentAsString());
   }
 
   @AfterEach

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -8,6 +8,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -20,7 +22,9 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.databiosphere.workspacedataservice.TestUtils;
+import org.databiosphere.workspacedataservice.config.TwdsProperties;
 import org.databiosphere.workspacedataservice.dao.TestDao;
+import org.databiosphere.workspacedataservice.generated.CollectionServerModel;
 import org.databiosphere.workspacedataservice.service.RelationUtils;
 import org.databiosphere.workspacedataservice.service.model.AttributeSchema;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
@@ -29,6 +33,7 @@ import org.databiosphere.workspacedataservice.service.model.exception.InvalidNam
 import org.databiosphere.workspacedataservice.service.model.exception.InvalidRelationException;
 import org.databiosphere.workspacedataservice.service.model.exception.MissingObjectException;
 import org.databiosphere.workspacedataservice.shared.model.BatchOperation;
+import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.databiosphere.workspacedataservice.shared.model.OperationType;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
@@ -36,7 +41,6 @@ import org.databiosphere.workspacedataservice.shared.model.RecordQueryResponse;
 import org.databiosphere.workspacedataservice.shared.model.RecordRequest;
 import org.databiosphere.workspacedataservice.shared.model.RecordResponse;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -61,82 +65,50 @@ class RecordControllerMockMvcTest extends MockMvcTestBase {
 
   private static final String versionId = "v0.2";
 
+  @Autowired private TwdsProperties twdsProperties;
+
   @Autowired TestDao testDao;
 
   @BeforeEach
   void setUp() throws Exception {
-    instanceId = UUID.randomUUID();
-    mockMvc
-        .perform(post("/instances/{v}/{instanceid}", versionId, instanceId).content(""))
-        .andExpect(status().isCreated());
+    CollectionId collectionId = CollectionId.of(UUID.randomUUID());
+    String name = "test-name";
+    String description = "test-description";
+
+    CollectionServerModel collectionServerModel = new CollectionServerModel(name, description);
+    collectionServerModel.id(collectionId.id());
+
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    MvcResult mvcResult =
+        mockMvc
+            .perform(
+                post("/collections/v1/{workspaceId}", twdsProperties.workspaceId().id())
+                    .content(objectMapper.writeValueAsString(collectionServerModel))
+                    .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isCreated())
+            .andReturn();
+
+    String responseContent = mvcResult.getResponse().getContentAsString();
+    JsonNode jsonNode = objectMapper.readTree(responseContent);
+
+    instanceId = UUID.fromString(jsonNode.get("id").asText());
   }
 
   @AfterEach
   void tearDown() {
     try {
       mockMvc
-          .perform(delete("/instances/{v}/{instanceid}", versionId, instanceId).content(""))
+          .perform(
+              delete(
+                      "/collections/v1/{workspaceId}/{instanceid}",
+                      twdsProperties.workspaceId().id(),
+                      instanceId)
+                  .content(""))
           .andExpect(status().isOk());
     } catch (Throwable t) {
       // noop - if we fail to delete the instance, don't fail the test
     }
-  }
-
-  @AfterAll
-  void deleteAllInstances() throws Exception {
-    MvcResult response = mockMvc.perform(get("/instances/{v}", versionId)).andReturn();
-    UUID[] allInstances = fromJson(response, UUID[].class);
-    for (UUID id : allInstances) {
-      mockMvc.perform(delete("/instances/{v}/{instanceid}", versionId, id).content(""));
-    }
-  }
-
-  @Test
-  @Transactional
-  void createInstanceAndTryToCreateAgain() throws Exception {
-    UUID uuid = UUID.randomUUID();
-    mockMvc
-        .perform(post("/instances/{version}/{instanceId}", versionId, uuid))
-        .andExpect(status().isCreated());
-    mockMvc
-        .perform(post("/instances/{version}/{instanceId}", versionId, uuid))
-        .andExpect(status().isConflict());
-  }
-
-  @Test
-  void listInstances() throws Exception {
-    // get initial instance list
-    MvcResult initialResult =
-        mockMvc
-            .perform(get("/instances/{version}", versionId))
-            .andExpect(status().isOk())
-            .andReturn();
-    UUID[] initialInstances = fromJson(initialResult, UUID[].class);
-    // create new uuid; new uuid should not be in our initial instance list
-    UUID uuid = UUID.randomUUID();
-    assertFalse(
-        Arrays.asList(initialInstances).contains(uuid),
-        "initial instance list should not contain brand new UUID");
-    // create a new instance from the new uuid
-    mockMvc
-        .perform(post("/instances/{version}/{instanceId}", versionId, uuid))
-        .andExpect(status().isCreated());
-    // get instance list again
-    MvcResult afterCreationResult =
-        mockMvc
-            .perform(get("/instances/{version}", versionId))
-            .andExpect(status().isOk())
-            .andReturn();
-    UUID[] afterCreationInstances = fromJson(afterCreationResult, UUID[].class);
-    // new uuid should be in our initial instance list
-    assertTrue(
-        Arrays.asList(afterCreationInstances).contains(uuid),
-        "after-creation instance list should contain brand new UUID");
-
-    assertEquals(
-        initialInstances.length + 1,
-        afterCreationInstances.length,
-        "size of after-creation list should be equal to the initial size plus one");
   }
 
   @Test
@@ -200,32 +172,6 @@ class RecordControllerMockMvcTest extends MockMvcTestBase {
 
   @Test
   @Transactional
-  void deleteInstance() throws Exception {
-    UUID uuid = UUID.randomUUID();
-    // delete nonexistent instance should 404
-    mockMvc
-        .perform(delete("/instances/{version}/{instanceId}", versionId, uuid))
-        .andExpect(status().isNotFound());
-    // creating the instance should 201
-    mockMvc
-        .perform(post("/instances/{version}/{instanceId}", versionId, uuid))
-        .andExpect(status().isCreated());
-    // delete existing instance should 200
-    mockMvc
-        .perform(delete("/instances/{version}/{instanceId}", versionId, uuid))
-        .andExpect(status().isOk());
-    // deleting again should 404
-    mockMvc
-        .perform(delete("/instances/{version}/{instanceId}", versionId, uuid))
-        .andExpect(status().isNotFound());
-    // creating again should 201
-    mockMvc
-        .perform(post("/instances/{version}/{instanceId}", versionId, uuid))
-        .andExpect(status().isCreated());
-  }
-
-  @Test
-  @Transactional
   void deleteInstanceContainingData() throws Exception {
     RecordAttributes attributes = new RecordAttributes(Map.of("foo", "bar", "num", 123));
     // create "to" record, which will be the target of a relation
@@ -253,10 +199,14 @@ class RecordControllerMockMvcTest extends MockMvcTestBase {
                 .content(toJson(new RecordRequest(attributes2)))
                 .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isCreated());
-    // delete existing instance should 200
+    // delete existing collection should 204
     mockMvc
-        .perform(delete("/instances/{version}/{instanceId}", versionId, instanceId))
-        .andExpect(status().isOk());
+        .perform(
+            delete(
+                "/collections/v1/{workspaceId}/{instanceId}",
+                twdsProperties.workspaceId().id(),
+                instanceId))
+        .andExpect(status().isNoContent());
   }
 
   @Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
@@ -21,8 +21,12 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Stream;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.config.TwdsProperties;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
+import org.databiosphere.workspacedataservice.generated.CollectionRequestServerModel;
+import org.databiosphere.workspacedataservice.generated.CollectionServerModel;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
 import org.databiosphere.workspacedataservice.shared.model.BatchResponse;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
@@ -62,6 +66,7 @@ class TsvDownloadTest extends TestBase {
   @Autowired private TestRestTemplate restTemplate;
 
   @Autowired private RecordController recordController;
+  @Autowired private CollectionController collectionController;
   @Autowired private RecordDao recordDao;
   @Autowired private ObjectMapper mapper;
   private String version;
@@ -69,16 +74,23 @@ class TsvDownloadTest extends TestBase {
 
   @Autowired private ObjectReader tsvReader;
 
+  @Autowired TwdsProperties twdsProperties;
+
   @BeforeEach
   void init() {
     version = "v0.2";
-    collectionId = UUID.randomUUID();
-    recordController.createInstance(collectionId, version);
+    CollectionRequestServerModel collectionRequestServerModel = new CollectionRequestServerModel();
+    collectionRequestServerModel.setName(RandomStringUtils.randomAlphabetic(16));
+    collectionRequestServerModel.setDescription("description");
+    ResponseEntity<CollectionServerModel> createdCollection =
+        collectionController.createCollectionV1(
+            twdsProperties.workspaceId().id(), collectionRequestServerModel);
+    collectionId = Objects.requireNonNull(createdCollection.getBody()).getId();
   }
 
   @AfterEach
   void tearDown() {
-    recordController.deleteInstance(collectionId, version);
+    collectionController.deleteCollectionV1(twdsProperties.workspaceId().id(), collectionId);
   }
 
   @ParameterizedTest(name = "PK name {0} should be honored")

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
@@ -22,11 +22,13 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.databiosphere.workspacedataservice.TestUtils;
 import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.config.TwdsProperties;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.databiosphere.workspacedataservice.generated.CollectionRequestServerModel;
 import org.databiosphere.workspacedataservice.generated.CollectionServerModel;
+import org.databiosphere.workspacedataservice.service.CollectionService;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
 import org.databiosphere.workspacedataservice.shared.model.BatchResponse;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
@@ -53,6 +55,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
@@ -76,6 +79,9 @@ class TsvDownloadTest extends TestBase {
 
   @Autowired TwdsProperties twdsProperties;
 
+  @Autowired CollectionService collectionService;
+  @Autowired NamedParameterJdbcTemplate namedTemplate;
+
   @BeforeEach
   void init() {
     version = "v0.2";
@@ -90,7 +96,7 @@ class TsvDownloadTest extends TestBase {
 
   @AfterEach
   void tearDown() {
-    collectionController.deleteCollectionV1(twdsProperties.workspaceId().id(), collectionId);
+    TestUtils.cleanAllCollections(collectionService, namedTemplate);
   }
 
   @ParameterizedTest(name = "PK name {0} should be honored")

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvInputFormatsTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvInputFormatsTest.java
@@ -5,7 +5,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.math.BigDecimal;
 import java.util.Arrays;
@@ -13,6 +12,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.databiosphere.workspacedataservice.TestUtils;
 import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.config.TwdsProperties;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
@@ -72,10 +72,8 @@ class TsvInputFormatsTest extends TestBase {
             .andExpect(status().isCreated())
             .andReturn();
 
-    String responseContent = mvcResult.getResponse().getContentAsString();
-    JsonNode jsonNode = objectMapper.readTree(responseContent);
-
-    instanceId = UUID.fromString(jsonNode.get("id").asText());
+    instanceId =
+        TestUtils.getCollectionId(objectMapper, mvcResult.getResponse().getContentAsString());
   }
 
   @AfterEach

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvInputFormatsTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvInputFormatsTest.java
@@ -16,8 +16,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.config.TwdsProperties;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
-import org.databiosphere.workspacedataservice.generated.CollectionServerModel;
-import org.databiosphere.workspacedataservice.shared.model.CollectionId;
+import org.databiosphere.workspacedataservice.generated.CollectionRequestServerModel;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 import org.databiosphere.workspacedataservice.shared.model.attributes.JsonAttribute;
@@ -56,12 +55,11 @@ class TsvInputFormatsTest extends TestBase {
 
   @BeforeEach
   void setUp() throws Exception {
-    CollectionId collectionId = CollectionId.of(UUID.randomUUID());
     String name = "test-name";
     String description = "test-description";
 
-    CollectionServerModel collectionServerModel = new CollectionServerModel(name, description);
-    collectionServerModel.id(collectionId.id());
+    CollectionRequestServerModel collectionRequestServerModel =
+        new CollectionRequestServerModel(name, description);
 
     ObjectMapper objectMapper = new ObjectMapper();
 
@@ -69,7 +67,7 @@ class TsvInputFormatsTest extends TestBase {
         mockMvc
             .perform(
                 post("/collections/v1/{workspaceId}", twdsProperties.workspaceId().id())
-                    .content(objectMapper.writeValueAsString(collectionServerModel))
+                    .content(objectMapper.writeValueAsString(collectionRequestServerModel))
                     .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isCreated())
             .andReturn();

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/NoCacheFilterTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/NoCacheFilterTest.java
@@ -4,14 +4,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.databiosphere.workspacedataservice.TestUtils.generateRandomAttributes;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.text.StringSubstitutor;
+import org.databiosphere.workspacedataservice.TestUtils;
 import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.config.TwdsProperties;
 import org.databiosphere.workspacedataservice.generated.CollectionRequestServerModel;
@@ -129,9 +130,9 @@ class NoCacheFilterTest extends TestBase {
             twdsProperties.workspaceId().id());
     assertEquals(HttpStatus.CREATED, createInstanceResponse.getStatusCode());
 
-    JsonNode jsonNode = objectMapper.readTree(createInstanceResponse.getBody());
-
-    instanceId = UUID.fromString(jsonNode.get("id").asText());
+    instanceId =
+        TestUtils.getCollectionId(
+            objectMapper, Objects.requireNonNull(createInstanceResponse.getBody()));
 
     // Create a record
     RecordAttributes attributes = generateRandomAttributes();

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/NoCacheFilterTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/NoCacheFilterTest.java
@@ -43,7 +43,7 @@ class NoCacheFilterTest extends TestBase {
 
   @Autowired private TestRestTemplate restTemplate;
 
-  private UUID instanceId = UUID.randomUUID();
+  private UUID instanceId;
 
   @ParameterizedTest(name = "Responses from {0} should not be cached")
   @ValueSource(

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/NoCacheFilterTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/NoCacheFilterTest.java
@@ -14,8 +14,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.text.StringSubstitutor;
 import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.config.TwdsProperties;
-import org.databiosphere.workspacedataservice.generated.CollectionServerModel;
-import org.databiosphere.workspacedataservice.shared.model.CollectionId;
+import org.databiosphere.workspacedataservice.generated.CollectionRequestServerModel;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
 import org.databiosphere.workspacedataservice.shared.model.RecordRequest;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -108,12 +107,11 @@ class NoCacheFilterTest extends TestBase {
   }
 
   private void createInstanceAndUploadRecord(String recordType, String recordId) throws Exception {
-    CollectionId collectionId = CollectionId.of(UUID.randomUUID());
     String name = RandomStringUtils.randomAlphabetic(16);
     String description = "test-description";
 
-    CollectionServerModel collectionServerModel = new CollectionServerModel(name, description);
-    collectionServerModel.id(collectionId.id());
+    CollectionRequestServerModel collectionRequestServerModel =
+        new CollectionRequestServerModel(name, description);
 
     ObjectMapper objectMapper = new ObjectMapper();
 
@@ -125,7 +123,8 @@ class NoCacheFilterTest extends TestBase {
         restTemplate.exchange(
             "/collections/v1/{workspaceId}",
             HttpMethod.POST,
-            new HttpEntity<>(objectMapper.writeValueAsString(collectionServerModel), headers),
+            new HttpEntity<>(
+                objectMapper.writeValueAsString(collectionRequestServerModel), headers),
             String.class,
             twdsProperties.workspaceId().id());
     assertEquals(HttpStatus.CREATED, createInstanceResponse.getStatusCode());

--- a/service/src/test/python/test.py
+++ b/service/src/test/python/test.py
@@ -7,6 +7,7 @@ from datetime import date, datetime
 import random
 import csv
 import time
+import os
 
 # generate records for testing
 def generate_record():
@@ -97,10 +98,9 @@ class WdsTests(TestCase):
     records_client = wds_client.RecordsApi(api_client)
     generalInfo_client = wds_client.GeneralWDSInformationApi(api_client)
     schema_client = wds_client.SchemaApi(api_client)
-    instance_client = wds_client.InstancesApi(api_client)
     import_client = wds_client.ImportApi(api_client)
     job_client = wds_client.JobApi(api_client)
-    current_workspaceId = instance_client.list_wds_instances(version)[0]
+    current_workspaceId = os.environ['WORKSPACE_ID']
 
     local_server_host = 'http://localhost:9889'
 


### PR DESCRIPTION
**Summary**

This PR removes the outdated v0.2 instance APIs from our swagger page. These APIs are deprecated, and we’ve moved to newer v1 Collection APIs.

**Changes**

- Deleted all v0.2 Instance API endpoints.
- Removed or updated tests related to v0.2 Instance APIs.

**Testing**

- Verified the system builds and passes all tests.
- Manually checked that no code still references the removed v0.2 Instance APIs.

**Next Steps**

- Monitor for any issues after deployment.
- Notify relevant teams about the change.
- Follow-up https://broadworkbench.atlassian.net/browse/AJ-1942


![Removed Instance v0 2 Apis](https://github.com/user-attachments/assets/3b89e3c2-d560-457a-987e-d44bbadd7b0d)

