### PR TITLE
AJ-1952: POC of SQL-based cloning

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -77,6 +77,7 @@ dependencies {
     implementation 'jakarta.ws.rs:jakarta.ws.rs-api'
     implementation 'com.google.mug:mug:8.0'
     implementation 'org.apache.lucene:lucene-queryparser:9.11.1'
+    implementation 'org.jgrapht:jgrapht-core:1.5.2' // for topological graph sorting
 
     // required by openapi-generated models and api interfaces
     implementation 'jakarta.validation:jakarta.validation-api'

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/CloningService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/CloningService.java
@@ -3,12 +3,15 @@ package org.databiosphere.workspacedataservice.service;
 import static org.databiosphere.workspacedataservice.service.model.ReservedNames.RESERVED_NAME_PREFIX;
 
 import bio.terra.common.db.WriteTransaction;
-import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.commons.collections4.IteratorUtils;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.databiosphere.workspacedataservice.generated.CollectionRequestServerModel;
@@ -16,6 +19,7 @@ import org.databiosphere.workspacedataservice.generated.CollectionServerModel;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
 import org.databiosphere.workspacedataservice.service.model.Relation;
 import org.databiosphere.workspacedataservice.service.model.RelationCollection;
+import org.databiosphere.workspacedataservice.service.model.exception.CloningException;
 import org.databiosphere.workspacedataservice.shared.model.DefaultCollectionCreationResult;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
@@ -50,8 +54,88 @@ public class CloningService {
   public DefaultCollectionCreationResult clone(
       WorkspaceId sourceWorkspaceId, WorkspaceId targetWorkspaceId) {
 
+    /*
+     pseudocode:
+         1. for each collection in the source,
+         2. create a corresponding collection the target
+         3. build a dependency graph of the collection's tables and their foreign keys.
+         4. for each table, in dependency order, create the table schemas.
+         5. for each table, copy data.
+    */
+
+    // check if the target workspace already contains any collections
+    if (!collectionService.list(targetWorkspaceId).isEmpty()) {
+      // TODO AJ-1952: find a better exception to throw; this should be a 400 bad request, not a 500
+      //   internal server error
+      throw new CloningException("Cannot clone into this workspace; it is not empty.");
+    }
+
+    // TODO AJ-1952: turn down logging throughout; it's pretty verbose for now
     logger.info(
-        "Starting clone from workspace {} to workspace {}", sourceWorkspaceId, targetWorkspaceId);
+        "Starting clone from source workspace {} to target workspace {}",
+        sourceWorkspaceId,
+        targetWorkspaceId);
+
+    // create the collections in the target workspace and calculate the source->target id mapping
+    Map<UUID, UUID> collectionMapping =
+        copyCollectionDefinitions(sourceWorkspaceId, targetWorkspaceId);
+
+    // for each source collection in the source workspace
+    collectionMapping.forEach(
+        (sourceCollectionId, targetCollectionId) -> {
+          logger.info("... processing source collection {}", sourceCollectionId);
+
+          // build the dependency graph of tables in this collection, so we know what order to copy
+          // them
+          List<String> tableOrder = getTableOrder(sourceCollectionId);
+
+          // create the table schemas for each table. For this step, we skip the "sys_" join tables;
+          // those will
+          // be created automatically when we create the tables they support.
+          logger.info("... creating table schemas for target collection {}", targetCollectionId);
+          tableOrder.stream()
+              .filter(tableName -> !tableName.startsWith(RESERVED_NAME_PREFIX))
+              .forEach(
+                  tableName -> {
+                    copyRecordType(
+                        RecordType.valueOf(tableName), sourceCollectionId, targetCollectionId);
+                  });
+          logger.info(
+              "... all table schemas created successfully for target collection {}",
+              targetCollectionId);
+
+          // now, copy the data from table to table, including the "sys_" join tables.
+          logger.info("... copying table data for target collection {}", targetCollectionId);
+          tableOrder.forEach(
+              tableName -> {
+                copyTableData(tableName, sourceCollectionId, targetCollectionId);
+              });
+          logger.info(
+              "... all table data copied successfully for target collection {}",
+              targetCollectionId);
+        });
+
+    // TODO AJ-1952: populate this better, it should have more info like number of
+    //   collections/tables/rows copied
+    DefaultCollectionCreationResult result =
+        new DefaultCollectionCreationResult(true, new CollectionServerModel("clone", "clone"));
+
+    return result;
+  }
+
+  /**
+   * Copies the collection definitions - without any tables or data - from one collection to
+   * another.
+   *
+   * @param sourceWorkspaceId workspace from which to copy collections
+   * @param targetWorkspaceId workspace into which to copy collections
+   * @return map of source collection id -> target collection id
+   */
+  Map<UUID, UUID> copyCollectionDefinitions(
+      WorkspaceId sourceWorkspaceId, WorkspaceId targetWorkspaceId) {
+
+    // init the return object
+    Map<UUID, UUID> result = new HashMap<>();
 
     // get the list of all collections in the source workspace
     List<CollectionServerModel> sourceCollections = collectionService.list(sourceWorkspaceId);
@@ -62,7 +146,7 @@ public class CloningService {
           UUID sourceCollectionId = sourceCollection.getId();
           UUID targetCollectionId;
 
-          logger.info("... processing source collection {}", sourceCollectionId);
+          logger.info("... copying source collection {}", sourceCollectionId);
 
           // create a corresponding collection in the target workspace
           if (sourceWorkspaceId.id().equals(sourceCollection.getId())) {
@@ -85,104 +169,103 @@ public class CloningService {
                 collectionService.save(targetWorkspaceId, collectionRequest);
             targetCollectionId = creationResult.getId();
           }
+
+          result.put(sourceCollectionId, targetCollectionId);
           logger.info(
               "... source collection {} will clone to target collection {}",
               sourceCollectionId,
               targetCollectionId);
-
-          //    list all source db tables in the source collection
-          List<String> tableNames = getTableNames(sourceCollection.getId());
-          //    list all foreign keys in the source collection
-          List<ForeignKeyEdge> foreignKeys = getForeignKeys(sourceCollection.getId());
-          // instantiate a graph, which will allow us to traverse tables in the proper order.
-          // when cloning tables, we need to insert foreign key targets before foreign key
-          // sources.
-          DirectedAcyclicGraph<String, DefaultEdge> graph =
-              new DirectedAcyclicGraph<>(DefaultEdge.class);
-          // add each table as a node in the graph
-          tableNames.forEach(graph::addVertex);
-          // add each foreign key as an edge in the graph
-          foreignKeys.forEach(
-              fkEdge -> {
-                logger.warn("adding edge from {} to {}", fkEdge.fromTable, fkEdge.toTable);
-                graph.addEdge(fkEdge.fromTable, fkEdge.toTable);
-              });
-
-          // TODO AJ-1952: what to do about cyclic table structures? One option is to disable FK
-          //   validation in Postgres, do the inserts, then turn FK validation back on.
-
-          // traverse the graph in REVERSE topological order. JGraphT's topological order is from
-          // the root node to the leaves; we need to insert leaf tables first so they exist
-          // before anything that has a foreign key to them. So, we reverse the topo order.
-          TopologicalOrderIterator<String, DefaultEdge> topologicalOrderIterator =
-              new TopologicalOrderIterator<>(graph);
-          List<String> topoOrder = IteratorUtils.toList(topologicalOrderIterator);
-          Collections.reverse(topoOrder);
-
-          topoOrder.forEach(
-              tableName -> {
-
-                // skip tables starting with "sys_". We needed those to build the DAG, but
-                // they will be created implicitly by copyRecordType.
-                if (!tableName.startsWith(RESERVED_NAME_PREFIX)) {
-                  logger.info("... processing table {}.{}", sourceCollectionId, tableName);
-
-                  copyRecordType(
-                      RecordType.valueOf(tableName), sourceCollectionId, targetCollectionId);
-
-                  // copy data from source to target
-                  // CREATE TABLE copy_table AS SELECT * FROM original_table;
-                  String copySql =
-                      "INSERT INTO \"%s\".\"%s\" SELECT * FROM \"%s\".\"%s\";"
-                          .formatted(targetCollectionId, tableName, sourceCollectionId, tableName);
-
-                  namedTemplate.update(copySql, Map.of());
-
-                  logger.info(
-                      "... successfully cloned to table {}.{}", targetCollectionId, tableName);
-                }
-              });
-
-          // TODO AJ-1952: finally, copy data for the sys_ join tables
-          topoOrder.forEach(
-              tableName -> {
-
-                // only starting with "sys_".
-                if (tableName.startsWith(RESERVED_NAME_PREFIX)) {
-                  logger.info("... processing table {}.{}", sourceCollectionId, tableName);
-
-                  // copy data from source to target
-                  // CREATE TABLE copy_table AS SELECT * FROM original_table;
-                  String copySql =
-                      "INSERT INTO \"%s\".\"%s\" SELECT * FROM \"%s\".\"%s\";"
-                          .formatted(targetCollectionId, tableName, sourceCollectionId, tableName);
-
-                  namedTemplate.update(copySql, Map.of());
-
-                  logger.info(
-                      "... successfully cloned to table {}.{}", targetCollectionId, tableName);
-                }
-              });
         });
-
-    // TODO AJ-1952: populate this better, it should have more info like number of
-    //   collections/tables/rows copied
-    DefaultCollectionCreationResult result =
-        new DefaultCollectionCreationResult(true, new CollectionServerModel("clone", "clone"));
 
     return result;
   }
 
   /**
-   * Postgres supports `CREATE TABLE foo (LIKE otherTable INCLUDING ALL)`, but that does NOT handle
-   * creating foreign keys ... which we need. So, we do this the long way by asking WDS to re-create
-   * the record type in the target based on info from the source.
+   * Calculates the order in which a collection's tables should be cloned. Since tables use foreign
+   * keys, we need to clone the "to" tables in a FK before the "from" tables.
+   *
+   * @param sourceCollectionId the collection to inspect
+   * @return a safe table order
+   */
+  List<String> getTableOrder(UUID sourceCollectionId) {
+    //    list all source db tables in the source collection
+    List<String> tableNames = getTableNames(sourceCollectionId);
+    //    list all foreign keys in the source collection
+    Set<ForeignKeyEdge> foreignKeys = getForeignKeys(sourceCollectionId);
+    // instantiate a graph, which will allow us to traverse tables in the proper order.
+    // when cloning tables, we need to insert foreign key targets before foreign key
+    // sources.
+    DirectedAcyclicGraph<String, DefaultEdge> graph = new DirectedAcyclicGraph<>(DefaultEdge.class);
+    // add each table as a node in the graph
+    tableNames.forEach(graph::addVertex);
+    // add each foreign key as an edge in the graph
+    foreignKeys.forEach(
+        fkEdge -> {
+          graph.addEdge(fkEdge.fromTable, fkEdge.toTable);
+        });
+
+    // TODO AJ-1952: what to do about cyclic table structures? One option is to disable FK
+    //   validation in Postgres, do the inserts, then turn FK validation back on.
+
+    // traverse the graph in REVERSE topological order. JGraphT's topological order is from
+    // the root node to the leaves; we need to insert leaf tables first so they exist
+    // before anything that has a foreign key to them. So, we reverse the topological order.
+    TopologicalOrderIterator<String, DefaultEdge> topologicalOrderIterator =
+        new TopologicalOrderIterator<>(graph);
+    List<String> tableOrder = IteratorUtils.toList(topologicalOrderIterator);
+    Collections.reverse(tableOrder);
+
+    // finally, move all the "sys_" tables to LAST. We intentionally didn't include these tables
+    // when adding edges
+    // above, so they aren't in the proper order. We know they should be last.
+    Map<Boolean, List<String>> tableGrouping =
+        tableOrder.stream()
+            .collect(
+                Collectors.groupingBy(tableName -> tableName.startsWith(RESERVED_NAME_PREFIX)));
+
+    List<String> userTables = tableGrouping.getOrDefault(false, List.of());
+    List<String> sysTables = tableGrouping.getOrDefault(true, List.of());
+
+    return Stream.concat(userTables.stream(), sysTables.stream()).toList();
+  }
+
+  /**
+   * Copies all row data for a given table from one collection to another collection.
+   *
+   * <p>Critically, this method uses an "INSERT INTO ... SELECT" sql statement to perform the copy.
+   * This means the row data is copied completely within Postgres, and avoids any bulk export and
+   * import - no need to pull the data from Postgres to Java and then push it back from Java to
+   * Postgres.
+   *
+   * @param tableName table to copy; this table must exist in both collections
+   * @param sourceCollectionId source from which to copy
+   * @param targetCollectionId target into which to copy
+   */
+  void copyTableData(String tableName, UUID sourceCollectionId, UUID targetCollectionId) {
+    // copy data from source to target
+    // CREATE TABLE copy_table AS SELECT * FROM original_table;
+    String copySql =
+        "INSERT INTO \"%s\".\"%s\" SELECT * FROM \"%s\".\"%s\";"
+            .formatted(targetCollectionId, tableName, sourceCollectionId, tableName);
+
+    namedTemplate.update(copySql, Map.of());
+
+    logger.info("... successfully cloned to table {}.{}", targetCollectionId, tableName);
+  }
+
+  /**
+   * Creates a copy of a given record type in a new collection.
+   *
+   * <p>Postgres supports `CREATE TABLE foo (LIKE otherTable INCLUDING ALL)`, but that does NOT
+   * handle creating foreign keys ... which we need. So, we do this the long way by asking WDS to
+   * re-create the record type in the target based on info from the source.
    *
    * @param recordType the record type to copy
    * @param sourceCollectionId collection being cloned
    * @param targetCollectionId destination into which the record type is copied
    */
   void copyRecordType(RecordType recordType, UUID sourceCollectionId, UUID targetCollectionId) {
+    logger.info("... creating table {}.{}", targetCollectionId, recordType);
     // get the existing WDS information from the source table
     Map<String, DataTypeMapping> tableSchema =
         recordDao.getExistingTableSchema(sourceCollectionId, recordType);
@@ -196,10 +279,17 @@ public class CloningService {
     // create the record type in the target
     recordDao.createRecordType(
         targetCollectionId, tableSchema, recordType, relationCollection, primaryKey);
+    logger.info("... table {}.{} created.", targetCollectionId, recordType);
   }
 
-  // similar to RecordDao.getAllRecordTypes, but this method includes sys_ tables as well, since
-  // we need to clone the join tables for arrays of relations
+  /**
+   * Get all table names in a given collection. This is similar to RecordDao.getAllRecordTypes, but
+   * this method includes sys_ tables as well, since we need to clone the join tables for arrays of
+   * relations
+   *
+   * @param collectionId collection to inspect
+   * @return list of table names
+   */
   List<String> getTableNames(UUID collectionId) {
     return namedTemplate.queryForList(
         "select tablename from pg_tables WHERE schemaname = :workspaceSchema order by tablename",
@@ -208,21 +298,17 @@ public class CloningService {
   }
 
   /**
-   * Returns a map of FK target->FK source. In the graph we're foreign keys - graph edges - are
-   * added IN REVERSE. If a table "red" has a foreign key to table "green", we add an edge of
-   * green->red. This allows the topological graph sort to function in the order we need.
-   *
-   * <p>Similar to RecordDao.getRelationCols, but this method operates on all tables in the
-   * collection and only returns table information, not column information
+   * Returns a set of the "from" and "to" tables for all relations/all tables in this collection.
+   * Used to build a dependency graph of tables, so we know which tables to clone first.
    *
    * @param collectionId collection to inspect
-   * @return list of table-to-table relations
+   * @return set of table-to-table relations
    */
-  // TODO AJ-1952: directionality of the sys_ join tables is topologically incorrect! Need to use
-  //  higher-level constructs instead
-  List<ForeignKeyEdge> getForeignKeys(UUID collectionId) {
-
-    List<ForeignKeyEdge> fks = new ArrayList<>();
+  Set<ForeignKeyEdge> getForeignKeys(UUID collectionId) {
+    // TODO AJ-1952: if cloning is a performance bottleneck, this could definitely be optimized. It
+    //  currently makes multiple SQL queries per table; we could probably consolidate to 1-2 queries
+    //  for the whole collection.
+    Set<ForeignKeyEdge> fks = new HashSet<>();
 
     recordDao
         .getAllRecordTypes(collectionId)
@@ -242,17 +328,6 @@ public class CloningService {
             });
 
     return fks;
-
-    //    return namedTemplate.query(
-    //        "SELECT tc.table_name as from_table, ccu.table_name as to_table "
-    //            + "FROM information_schema.table_constraints tc "
-    //            + "JOIN information_schema.constraint_column_usage ccu "
-    //            + "ON ccu.constraint_name = tc.constraint_name AND ccu.table_schema =
-    // tc.table_schema "
-    //            + "WHERE tc.constraint_type = 'FOREIGN KEY' AND tc.table_schema = :collectionId",
-    //        Map.of("collectionId", collectionId.toString()),
-    //        (rs, rowNum) -> new ForeignKeyEdge(rs.getString("from_table"),
-    // rs.getString("to_table")));
   }
 
   // helper class for foreign keys

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/CloningService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/CloningService.java
@@ -1,13 +1,14 @@
 package org.databiosphere.workspacedataservice.service;
 
+import bio.terra.common.db.WriteTransaction;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import org.apache.commons.collections4.IteratorUtils;
 import org.databiosphere.workspacedataservice.generated.CollectionRequestServerModel;
 import org.databiosphere.workspacedataservice.generated.CollectionServerModel;
-import org.databiosphere.workspacedataservice.service.model.Relation;
 import org.databiosphere.workspacedataservice.shared.model.DefaultCollectionCreationResult;
-import org.databiosphere.workspacedataservice.shared.model.RecordType;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.jgrapht.graph.DefaultEdge;
 import org.jgrapht.graph.DirectedAcyclicGraph;
@@ -32,7 +33,7 @@ public class CloningService {
     this.namedTemplate = namedTemplate;
   }
 
-  @SuppressWarnings("UnstableApiUsage") // Guava's Graph feature is marked @Beta
+  @WriteTransaction
   public DefaultCollectionCreationResult clone(
       WorkspaceId sourceWorkspaceId, WorkspaceId targetWorkspaceId) {
 
@@ -62,7 +63,7 @@ public class CloningService {
             // this is a non-default collection in the source workspace; create a non-default
             // collection in the target workspace
             logger.info(
-                "... source collection is non-default; creating target collection '{}",
+                "... source collection is non-default; creating target collection '{}'",
                 sourceCollection.getName());
             CollectionRequestServerModel collectionRequest =
                 new CollectionRequestServerModel(
@@ -79,39 +80,56 @@ public class CloningService {
           //    list all source db tables in the source collection
           List<String> tableNames = getTableNames(sourceCollection.getId());
           //    list all foreign keys in the source collection
-          Map<String, String> foreignKeys = getForeignKeys(sourceCollection.getId());
+          List<ForeignKeyEdge> foreignKeys = getForeignKeys(sourceCollection.getId());
           // instantiate a graph, which will allow us to traverse tables in the proper order.
-          // when processing tables, we need to insert foreign key targets before foreign key
+          // when cloning tables, we need to insert foreign key targets before foreign key
           // sources.
           DirectedAcyclicGraph<String, DefaultEdge> graph =
               new DirectedAcyclicGraph<>(DefaultEdge.class);
           // add each table as a node in the graph
           tableNames.forEach(graph::addVertex);
           // add each foreign key as an edge in the graph
-          foreignKeys.forEach(graph::addEdge);
+          foreignKeys.forEach(fkEdge -> graph.addEdge(fkEdge.fromTable, fkEdge.toTable));
 
-          // traverse the graph in topological order
+          // TODO AJ-1952: what to do about cyclic table structures? One option is to disable FK
+          //   validation in Postgres, do the inserts, then turn FK validation back on.
+
+          // traverse the graph in REVERSE topological order. JGraphT's topological order is from
+          // the root node to the leaves; we need to insert leaf tables first so they exist
+          // before anything that has a foreign key to them. So, we reverse the topo order.
           TopologicalOrderIterator<String, DefaultEdge> topologicalOrderIterator =
               new TopologicalOrderIterator<>(graph);
+          List<String> topoOrder = IteratorUtils.toList(topologicalOrderIterator);
+          Collections.reverse(topoOrder);
 
-          while (topologicalOrderIterator.hasNext()) {
-            String tableName = topologicalOrderIterator.next();
+          topoOrder.forEach(
+              tableName -> {
+                logger.info("... processing table {}.{}", sourceCollectionId, tableName);
 
-            logger.info("... processing table {}.{}", sourceCollectionId, tableName);
+                // create table in target
+                // CREATE TABLE target_table (LIKE source_table INCLUDING ALL);
+                // TODO AJ-1952: this does NOT include foreign key constraints!
+                String createSql =
+                    "CREATE TABLE \"%s\".\"%s\" (LIKE \"%s\".\"%s\" INCLUDING ALL);"
+                        .formatted(targetCollectionId, tableName, sourceCollectionId, tableName);
 
-            // copy table from source to target
-            // CREATE TABLE copy_table AS SELECT * FROM original_table;
-            String sql =
-                "CREATE TABLE \"%s\".\"%s\" AS SELECT * FROM \"%s\".\"%s\""
-                    .formatted(targetCollectionId, tableName, sourceCollectionId, tableName);
+                namedTemplate.update(createSql, Map.of());
 
-            namedTemplate.update(sql, Map.of());
+                // copy data from source to target
+                // CREATE TABLE copy_table AS SELECT * FROM original_table;
+                String copySql =
+                    "INSERT INTO \"%s\".\"%s\" SELECT * FROM \"%s\".\"%s\";"
+                        .formatted(targetCollectionId, tableName, sourceCollectionId, tableName);
 
-            logger.info("... successfully cloned to table {}.{}", targetCollectionId, tableName);
-          }
+                namedTemplate.update(copySql, Map.of());
+
+                logger.info(
+                    "... successfully cloned to table {}.{}", targetCollectionId, tableName);
+              });
         });
 
-    // TODO AJ-1952: populate this better
+    // TODO AJ-1952: populate this better, it should have more info like number of
+    //   collections/tables/rows copied
     DefaultCollectionCreationResult result =
         new DefaultCollectionCreationResult(true, new CollectionServerModel("clone", "clone"));
 
@@ -120,7 +138,7 @@ public class CloningService {
 
   // similar to RecordDao.getAllRecordTypes, but this method includes sys_ tables as well, since
   // we need to clone the join tables for arrays of relations
-  private List<String> getTableNames(UUID collectionId) {
+  List<String> getTableNames(UUID collectionId) {
     return namedTemplate.queryForList(
         "select tablename from pg_tables WHERE schemaname = :workspaceSchema order by tablename",
         new MapSqlParameterSource("workspaceSchema", collectionId.toString()),
@@ -133,25 +151,22 @@ public class CloningService {
    * green->red. This allows the topological graph sort to function in the order we need.
    *
    * <p>Similar to RecordDao.getRelationCols, but this method operates on all tables in the
-   * collection
+   * collection and only returns table information, not column information
    *
-   * @param collectionId
-   * @return
+   * @param collectionId collection to inspect
+   * @return list of table-to-table relations
    */
   // TODO AJ-1952: implement
-  private Map<String, String> getForeignKeys(UUID collectionId) {
-    return Map.of();
+  List<ForeignKeyEdge> getForeignKeys(UUID collectionId) {
+    return namedTemplate.query(
+        "SELECT tc.table_name as from_table, ccu.table_name as to_table "
+            + "FROM information_schema.table_constraints tc "
+            + "JOIN information_schema.constraint_column_usage ccu "
+            + "ON ccu.constraint_name = tc.constraint_name AND ccu.table_schema = tc.table_schema "
+            + "WHERE tc.constraint_type = 'FOREIGN KEY' AND tc.table_schema = :collectionId",
+        Map.of("collectionId", collectionId.toString()),
+        (rs, rowNum) -> new ForeignKeyEdge(rs.getString("from_table"), rs.getString("to_table")));
   }
 
-  public List<Relation> getRelationCols(UUID collectionId, RecordType recordType) {
-    return namedTemplate.query(
-        "SELECT kcu.column_name, ccu.table_name FROM information_schema.table_constraints tc JOIN information_schema.key_column_usage kcu "
-            + "ON tc.constraint_name = kcu.constraint_name AND tc.table_schema = kcu.table_schema "
-            + "JOIN information_schema.constraint_column_usage ccu ON ccu.constraint_name = tc.constraint_name AND ccu.table_schema = tc.table_schema "
-            + "WHERE tc.constraint_type = 'FOREIGN KEY' AND tc.table_schema = :workspace AND tc.table_name= :tableName",
-        Map.of("workspace", collectionId.toString(), "tableName", recordType.getName()),
-        (rs, rowNum) ->
-            new Relation(
-                rs.getString("column_name"), RecordType.valueOf(rs.getString("table_name"))));
-  }
+  record ForeignKeyEdge(String fromTable, String toTable) {}
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/CloningService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/CloningService.java
@@ -1,0 +1,157 @@
+package org.databiosphere.workspacedataservice.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.databiosphere.workspacedataservice.generated.CollectionRequestServerModel;
+import org.databiosphere.workspacedataservice.generated.CollectionServerModel;
+import org.databiosphere.workspacedataservice.service.model.Relation;
+import org.databiosphere.workspacedataservice.shared.model.DefaultCollectionCreationResult;
+import org.databiosphere.workspacedataservice.shared.model.RecordType;
+import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.graph.DirectedAcyclicGraph;
+import org.jgrapht.traverse.TopologicalOrderIterator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CloningService {
+
+  private final CollectionService collectionService;
+  private final NamedParameterJdbcTemplate namedTemplate;
+
+  private static final Logger logger = LoggerFactory.getLogger(CloningService.class);
+
+  public CloningService(
+      CollectionService collectionService, NamedParameterJdbcTemplate namedTemplate) {
+    this.collectionService = collectionService;
+    this.namedTemplate = namedTemplate;
+  }
+
+  @SuppressWarnings("UnstableApiUsage") // Guava's Graph feature is marked @Beta
+  public DefaultCollectionCreationResult clone(
+      WorkspaceId sourceWorkspaceId, WorkspaceId targetWorkspaceId) {
+
+    logger.info(
+        "Starting clone from workspace {} to workspace {}", sourceWorkspaceId, targetWorkspaceId);
+
+    // get the list of all collections in the source workspace
+    List<CollectionServerModel> sourceCollections = collectionService.list(sourceWorkspaceId);
+
+    // for each source collection in the source workspace
+    sourceCollections.forEach(
+        sourceCollection -> {
+          UUID sourceCollectionId = sourceCollection.getId();
+          UUID targetCollectionId;
+
+          logger.info("... processing source collection {}", sourceCollectionId);
+
+          // create a corresponding collection in the target workspace
+          if (sourceWorkspaceId.id().equals(sourceCollection.getId())) {
+            // this is the default collection in the source workspace; create a default collection
+            // in the target workspace
+            logger.info("... source collection is default; creating target default");
+            DefaultCollectionCreationResult creationResult =
+                collectionService.createDefaultCollection(targetWorkspaceId);
+            targetCollectionId = creationResult.collectionServerModel().getId();
+          } else {
+            // this is a non-default collection in the source workspace; create a non-default
+            // collection in the target workspace
+            logger.info(
+                "... source collection is non-default; creating target collection '{}",
+                sourceCollection.getName());
+            CollectionRequestServerModel collectionRequest =
+                new CollectionRequestServerModel(
+                    sourceCollection.getName(), sourceCollection.getDescription());
+            CollectionServerModel creationResult =
+                collectionService.save(targetWorkspaceId, collectionRequest);
+            targetCollectionId = creationResult.getId();
+          }
+          logger.info(
+              "... source collection {} will clone to target collection {}",
+              sourceCollectionId,
+              targetCollectionId);
+
+          //    list all source db tables in the source collection
+          List<String> tableNames = getTableNames(sourceCollection.getId());
+          //    list all foreign keys in the source collection
+          Map<String, String> foreignKeys = getForeignKeys(sourceCollection.getId());
+          // instantiate a graph, which will allow us to traverse tables in the proper order.
+          // when processing tables, we need to insert foreign key targets before foreign key
+          // sources.
+          DirectedAcyclicGraph<String, DefaultEdge> graph =
+              new DirectedAcyclicGraph<>(DefaultEdge.class);
+          // add each table as a node in the graph
+          tableNames.forEach(graph::addVertex);
+          // add each foreign key as an edge in the graph
+          foreignKeys.forEach(graph::addEdge);
+
+          // traverse the graph in topological order
+          TopologicalOrderIterator<String, DefaultEdge> topologicalOrderIterator =
+              new TopologicalOrderIterator<>(graph);
+
+          while (topologicalOrderIterator.hasNext()) {
+            String tableName = topologicalOrderIterator.next();
+
+            logger.info("... processing table {}.{}", sourceCollectionId, tableName);
+
+            // copy table from source to target
+            // CREATE TABLE copy_table AS SELECT * FROM original_table;
+            String sql =
+                "CREATE TABLE \"%s\".\"%s\" AS SELECT * FROM \"%s\".\"%s\""
+                    .formatted(targetCollectionId, tableName, sourceCollectionId, tableName);
+
+            namedTemplate.update(sql, Map.of());
+
+            logger.info("... successfully cloned to table {}.{}", targetCollectionId, tableName);
+          }
+        });
+
+    // TODO AJ-1952: populate this better
+    DefaultCollectionCreationResult result =
+        new DefaultCollectionCreationResult(true, new CollectionServerModel("clone", "clone"));
+
+    return result;
+  }
+
+  // similar to RecordDao.getAllRecordTypes, but this method includes sys_ tables as well, since
+  // we need to clone the join tables for arrays of relations
+  private List<String> getTableNames(UUID collectionId) {
+    return namedTemplate.queryForList(
+        "select tablename from pg_tables WHERE schemaname = :workspaceSchema order by tablename",
+        new MapSqlParameterSource("workspaceSchema", collectionId.toString()),
+        String.class);
+  }
+
+  /**
+   * Returns a map of FK target->FK source. In the graph we're foreign keys - graph edges - are
+   * added IN REVERSE. If a table "red" has a foreign key to table "green", we add an edge of
+   * green->red. This allows the topological graph sort to function in the order we need.
+   *
+   * <p>Similar to RecordDao.getRelationCols, but this method operates on all tables in the
+   * collection
+   *
+   * @param collectionId
+   * @return
+   */
+  // TODO AJ-1952: implement
+  private Map<String, String> getForeignKeys(UUID collectionId) {
+    return Map.of();
+  }
+
+  public List<Relation> getRelationCols(UUID collectionId, RecordType recordType) {
+    return namedTemplate.query(
+        "SELECT kcu.column_name, ccu.table_name FROM information_schema.table_constraints tc JOIN information_schema.key_column_usage kcu "
+            + "ON tc.constraint_name = kcu.constraint_name AND tc.table_schema = kcu.table_schema "
+            + "JOIN information_schema.constraint_column_usage ccu ON ccu.constraint_name = tc.constraint_name AND ccu.table_schema = tc.table_schema "
+            + "WHERE tc.constraint_type = 'FOREIGN KEY' AND tc.table_schema = :workspace AND tc.table_name= :tableName",
+        Map.of("workspace", collectionId.toString(), "tableName", recordType.getName()),
+        (rs, rowNum) ->
+            new Relation(
+                rs.getString("column_name"), RecordType.valueOf(rs.getString("table_name"))));
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/CloningService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/CloningService.java
@@ -1,14 +1,23 @@
 package org.databiosphere.workspacedataservice.service;
 
+import static org.databiosphere.workspacedataservice.service.model.ReservedNames.RESERVED_NAME_PREFIX;
+
 import bio.terra.common.db.WriteTransaction;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import org.apache.commons.collections4.IteratorUtils;
+import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.databiosphere.workspacedataservice.generated.CollectionRequestServerModel;
 import org.databiosphere.workspacedataservice.generated.CollectionServerModel;
+import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
+import org.databiosphere.workspacedataservice.service.model.Relation;
+import org.databiosphere.workspacedataservice.service.model.RelationCollection;
 import org.databiosphere.workspacedataservice.shared.model.DefaultCollectionCreationResult;
+import org.databiosphere.workspacedataservice.shared.model.RecordType;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.jgrapht.graph.DefaultEdge;
 import org.jgrapht.graph.DirectedAcyclicGraph;
@@ -24,13 +33,17 @@ public class CloningService {
 
   private final CollectionService collectionService;
   private final NamedParameterJdbcTemplate namedTemplate;
+  private final RecordDao recordDao;
 
   private static final Logger logger = LoggerFactory.getLogger(CloningService.class);
 
   public CloningService(
-      CollectionService collectionService, NamedParameterJdbcTemplate namedTemplate) {
+      CollectionService collectionService,
+      NamedParameterJdbcTemplate namedTemplate,
+      RecordDao recordDao) {
     this.collectionService = collectionService;
     this.namedTemplate = namedTemplate;
+    this.recordDao = recordDao;
   }
 
   @WriteTransaction
@@ -89,7 +102,11 @@ public class CloningService {
           // add each table as a node in the graph
           tableNames.forEach(graph::addVertex);
           // add each foreign key as an edge in the graph
-          foreignKeys.forEach(fkEdge -> graph.addEdge(fkEdge.fromTable, fkEdge.toTable));
+          foreignKeys.forEach(
+              fkEdge -> {
+                logger.warn("adding edge from {} to {}", fkEdge.fromTable, fkEdge.toTable);
+                graph.addEdge(fkEdge.fromTable, fkEdge.toTable);
+              });
 
           // TODO AJ-1952: what to do about cyclic table structures? One option is to disable FK
           //   validation in Postgres, do the inserts, then turn FK validation back on.
@@ -104,27 +121,47 @@ public class CloningService {
 
           topoOrder.forEach(
               tableName -> {
-                logger.info("... processing table {}.{}", sourceCollectionId, tableName);
 
-                // create table in target
-                // CREATE TABLE target_table (LIKE source_table INCLUDING ALL);
-                // TODO AJ-1952: this does NOT include foreign key constraints!
-                String createSql =
-                    "CREATE TABLE \"%s\".\"%s\" (LIKE \"%s\".\"%s\" INCLUDING ALL);"
-                        .formatted(targetCollectionId, tableName, sourceCollectionId, tableName);
+                // skip tables starting with "sys_". We needed those to build the DAG, but
+                // they will be created implicitly by copyRecordType.
+                if (!tableName.startsWith(RESERVED_NAME_PREFIX)) {
+                  logger.info("... processing table {}.{}", sourceCollectionId, tableName);
 
-                namedTemplate.update(createSql, Map.of());
+                  copyRecordType(
+                      RecordType.valueOf(tableName), sourceCollectionId, targetCollectionId);
 
-                // copy data from source to target
-                // CREATE TABLE copy_table AS SELECT * FROM original_table;
-                String copySql =
-                    "INSERT INTO \"%s\".\"%s\" SELECT * FROM \"%s\".\"%s\";"
-                        .formatted(targetCollectionId, tableName, sourceCollectionId, tableName);
+                  // copy data from source to target
+                  // CREATE TABLE copy_table AS SELECT * FROM original_table;
+                  String copySql =
+                      "INSERT INTO \"%s\".\"%s\" SELECT * FROM \"%s\".\"%s\";"
+                          .formatted(targetCollectionId, tableName, sourceCollectionId, tableName);
 
-                namedTemplate.update(copySql, Map.of());
+                  namedTemplate.update(copySql, Map.of());
 
-                logger.info(
-                    "... successfully cloned to table {}.{}", targetCollectionId, tableName);
+                  logger.info(
+                      "... successfully cloned to table {}.{}", targetCollectionId, tableName);
+                }
+              });
+
+          // TODO AJ-1952: finally, copy data for the sys_ join tables
+          topoOrder.forEach(
+              tableName -> {
+
+                // only starting with "sys_".
+                if (tableName.startsWith(RESERVED_NAME_PREFIX)) {
+                  logger.info("... processing table {}.{}", sourceCollectionId, tableName);
+
+                  // copy data from source to target
+                  // CREATE TABLE copy_table AS SELECT * FROM original_table;
+                  String copySql =
+                      "INSERT INTO \"%s\".\"%s\" SELECT * FROM \"%s\".\"%s\";"
+                          .formatted(targetCollectionId, tableName, sourceCollectionId, tableName);
+
+                  namedTemplate.update(copySql, Map.of());
+
+                  logger.info(
+                      "... successfully cloned to table {}.{}", targetCollectionId, tableName);
+                }
               });
         });
 
@@ -134,6 +171,31 @@ public class CloningService {
         new DefaultCollectionCreationResult(true, new CollectionServerModel("clone", "clone"));
 
     return result;
+  }
+
+  /**
+   * Postgres supports `CREATE TABLE foo (LIKE otherTable INCLUDING ALL)`, but that does NOT handle
+   * creating foreign keys ... which we need. So, we do this the long way by asking WDS to re-create
+   * the record type in the target based on info from the source.
+   *
+   * @param recordType the record type to copy
+   * @param sourceCollectionId collection being cloned
+   * @param targetCollectionId destination into which the record type is copied
+   */
+  void copyRecordType(RecordType recordType, UUID sourceCollectionId, UUID targetCollectionId) {
+    // get the existing WDS information from the source table
+    Map<String, DataTypeMapping> tableSchema =
+        recordDao.getExistingTableSchema(sourceCollectionId, recordType);
+    String primaryKey = recordDao.getPrimaryKeyColumn(recordType, sourceCollectionId);
+    List<Relation> relations = recordDao.getRelationCols(sourceCollectionId, recordType);
+    List<Relation> relationArrays = recordDao.getRelationArrayCols(sourceCollectionId, recordType);
+
+    RelationCollection relationCollection =
+        new RelationCollection(Set.copyOf(relations), Set.copyOf(relationArrays));
+
+    // create the record type in the target
+    recordDao.createRecordType(
+        targetCollectionId, tableSchema, recordType, relationCollection, primaryKey);
   }
 
   // similar to RecordDao.getAllRecordTypes, but this method includes sys_ tables as well, since
@@ -156,17 +218,43 @@ public class CloningService {
    * @param collectionId collection to inspect
    * @return list of table-to-table relations
    */
-  // TODO AJ-1952: implement
+  // TODO AJ-1952: directionality of the sys_ join tables is topologically incorrect! Need to use
+  //  higher-level constructs instead
   List<ForeignKeyEdge> getForeignKeys(UUID collectionId) {
-    return namedTemplate.query(
-        "SELECT tc.table_name as from_table, ccu.table_name as to_table "
-            + "FROM information_schema.table_constraints tc "
-            + "JOIN information_schema.constraint_column_usage ccu "
-            + "ON ccu.constraint_name = tc.constraint_name AND ccu.table_schema = tc.table_schema "
-            + "WHERE tc.constraint_type = 'FOREIGN KEY' AND tc.table_schema = :collectionId",
-        Map.of("collectionId", collectionId.toString()),
-        (rs, rowNum) -> new ForeignKeyEdge(rs.getString("from_table"), rs.getString("to_table")));
+
+    List<ForeignKeyEdge> fks = new ArrayList<>();
+
+    recordDao
+        .getAllRecordTypes(collectionId)
+        .forEach(
+            recType -> {
+              List<Relation> relations = recordDao.getRelationCols(collectionId, recType);
+              List<Relation> relationArrays = recordDao.getRelationArrayCols(collectionId, recType);
+
+              relations.addAll(relationArrays);
+
+              relations.forEach(
+                  relation -> {
+                    fks.add(
+                        new ForeignKeyEdge(
+                            recType.getName(), relation.relationRecordType().getName()));
+                  });
+            });
+
+    return fks;
+
+    //    return namedTemplate.query(
+    //        "SELECT tc.table_name as from_table, ccu.table_name as to_table "
+    //            + "FROM information_schema.table_constraints tc "
+    //            + "JOIN information_schema.constraint_column_usage ccu "
+    //            + "ON ccu.constraint_name = tc.constraint_name AND ccu.table_schema =
+    // tc.table_schema "
+    //            + "WHERE tc.constraint_type = 'FOREIGN KEY' AND tc.table_schema = :collectionId",
+    //        Map.of("collectionId", collectionId.toString()),
+    //        (rs, rowNum) -> new ForeignKeyEdge(rs.getString("from_table"),
+    // rs.getString("to_table")));
   }
 
+  // helper class for foreign keys
   record ForeignKeyEdge(String fromTable, String toTable) {}
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/CloningServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/CloningServiceTest.java
@@ -1,0 +1,79 @@
+package org.databiosphere.workspacedataservice.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.databiosphere.workspacedataservice.TestUtils;
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.graph.DirectedAcyclicGraph;
+import org.jgrapht.traverse.TopologicalOrderIterator;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest
+@ActiveProfiles("control-plane")
+@TestPropertySource(
+    properties = {
+      // turn off pubsub autoconfiguration for tests
+      "spring.cloud.gcp.pubsub.enabled=false",
+      // Rawls url must be valid, else context initialization (Spring startup) will fail
+      "rawlsUrl=https://localhost/"
+    })
+@DirtiesContext
+public class CloningServiceTest {
+
+  @Autowired CollectionService collectionService;
+  @Autowired NamedParameterJdbcTemplate namedTemplate;
+  @Autowired RecordService recordService;
+  @Autowired WorkspaceService workspaceService;
+
+  @BeforeEach
+  @AfterEach
+  void cleanup() {}
+
+  @Test
+  void graphOrdering() {
+
+    List<String> tableNames = List.of("red", "green", "blue");
+    // foreign keys - graph edges - are added IN REVERSE. If a table "red" has a foreign key to
+    // table "green", we add an edge of green->red. This allows the topological graph sort to
+    // function in the order we need.
+    Map<String, String> foreignKeys = Map.of("green", "red");
+
+    // instantiate a graph, which will allow us to traverse tables in the proper order.
+    // when processing tables, we need to insert foreign key targets before foreign key
+    // sources.
+    DirectedAcyclicGraph<String, DefaultEdge> graph = new DirectedAcyclicGraph<>(DefaultEdge.class);
+
+    // add each table as a node in the graph
+    tableNames.forEach(graph::addVertex);
+    // add each foreign key as an edge in the graph
+    foreignKeys.forEach(graph::addEdge);
+
+    // traverse the graph in topological order
+    TopologicalOrderIterator<String, DefaultEdge> topologicalOrderIterator =
+        new TopologicalOrderIterator<>(graph);
+
+    // for the purpose of assertions, create a map of vertex->index in list
+    Map<String, Integer> vertexIndices = new HashMap<>();
+    int i = 0;
+    while (topologicalOrderIterator.hasNext()) {
+      String vertex = topologicalOrderIterator.next();
+      vertexIndices.put(vertex, i);
+      i++;
+    }
+
+    // expected ordering:
+    // there exists an edge green->red, so green must come before red
+    assertThat(vertexIndices.get("green")).isLessThan(vertexIndices.get("red"));
+  }
+}

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/CloningServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/CloningServiceTest.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import org.databiosphere.workspacedataservice.TestUtils;
 import org.databiosphere.workspacedataservice.generated.CollectionRequestServerModel;
 import org.databiosphere.workspacedataservice.generated.CollectionServerModel;
 import org.databiosphere.workspacedataservice.service.CloningService.ForeignKeyEdge;
@@ -54,7 +55,7 @@ public class CloningServiceTest {
   @BeforeEach
   @AfterEach
   void cleanup() {
-    //    TestUtils.cleanAllCollections(collectionService, namedTemplate);
+    TestUtils.cleanAllCollections(collectionService, namedTemplate);
   }
 
   // this tests the behavior of the JGraphT library. We don't need this test - I made it to help ME
@@ -181,13 +182,9 @@ public class CloningServiceTest {
 
     // we expect relations of:
     // blue->red
-    // sys_green_rel->green
-    // sys_green_rel->blue
+    // green->blue
     List<ForeignKeyEdge> expected =
-        List.of(
-            new ForeignKeyEdge("blue", "red"),
-            new ForeignKeyEdge("sys_green_rel", "green"),
-            new ForeignKeyEdge("sys_green_rel", "blue"));
+        List.of(new ForeignKeyEdge("blue", "red"), new ForeignKeyEdge("green", "blue"));
 
     assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
   }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/CloningServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/CloningServiceTest.java
@@ -1,11 +1,23 @@
 package org.databiosphere.workspacedataservice.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.databiosphere.workspacedataservice.TestUtils;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.databiosphere.workspacedataservice.generated.CollectionRequestServerModel;
+import org.databiosphere.workspacedataservice.generated.CollectionServerModel;
+import org.databiosphere.workspacedataservice.service.CloningService.ForeignKeyEdge;
+import org.databiosphere.workspacedataservice.shared.model.CollectionId;
+import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
+import org.databiosphere.workspacedataservice.shared.model.RecordRequest;
+import org.databiosphere.workspacedataservice.shared.model.RecordType;
+import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
+import org.databiosphere.workspacedataservice.shared.model.attributes.RelationAttribute;
 import org.jgrapht.graph.DefaultEdge;
 import org.jgrapht.graph.DirectedAcyclicGraph;
 import org.jgrapht.traverse.TopologicalOrderIterator;
@@ -25,12 +37,15 @@ import org.springframework.test.context.TestPropertySource;
     properties = {
       // turn off pubsub autoconfiguration for tests
       "spring.cloud.gcp.pubsub.enabled=false",
+      // disable virtual collections
+      "twds.tenancy.allow-virtual-collections=false",
       // Rawls url must be valid, else context initialization (Spring startup) will fail
       "rawlsUrl=https://localhost/"
     })
 @DirtiesContext
 public class CloningServiceTest {
 
+  @Autowired CloningService cloningService;
   @Autowired CollectionService collectionService;
   @Autowired NamedParameterJdbcTemplate namedTemplate;
   @Autowired RecordService recordService;
@@ -38,15 +53,16 @@ public class CloningServiceTest {
 
   @BeforeEach
   @AfterEach
-  void cleanup() {}
+  void cleanup() {
+    //    TestUtils.cleanAllCollections(collectionService, namedTemplate);
+  }
 
+  // this tests the behavior of the JGraphT library. We don't need this test - I made it to help ME
+  // understand how the library works!
   @Test
   void graphOrdering() {
 
     List<String> tableNames = List.of("red", "green", "blue");
-    // foreign keys - graph edges - are added IN REVERSE. If a table "red" has a foreign key to
-    // table "green", we add an edge of green->red. This allows the topological graph sort to
-    // function in the order we need.
     Map<String, String> foreignKeys = Map.of("green", "red");
 
     // instantiate a graph, which will allow us to traverse tables in the proper order.
@@ -75,5 +91,104 @@ public class CloningServiceTest {
     // expected ordering:
     // there exists an edge green->red, so green must come before red
     assertThat(vertexIndices.get("green")).isLessThan(vertexIndices.get("red"));
+  }
+
+  @Test
+  void getTableNamesTest() {
+    WorkspaceId workspaceId = WorkspaceId.of(UUID.randomUUID());
+    CollectionServerModel collection =
+        collectionService.save(workspaceId, new CollectionRequestServerModel("unit", "test"));
+    CollectionId collectionId = CollectionId.of(collection.getId());
+
+    RecordType red = RecordType.valueOf("red");
+    RecordType green = RecordType.valueOf("green");
+    RecordType blue = RecordType.valueOf("blue");
+
+    // create record type "red" and record "red-one"
+    recordService.upsertSingleRecord(
+        collectionId.id(),
+        red,
+        "red-one",
+        Optional.empty(),
+        new RecordRequest(RecordAttributes.empty()));
+
+    // create record type "blue" and record "blue-one" with a scalar relation to red
+    recordService.upsertSingleRecord(
+        collectionId.id(),
+        blue,
+        "blue-one",
+        Optional.empty(),
+        new RecordRequest(
+            new RecordAttributes(Map.of("rel", new RelationAttribute(red, "red-one")))));
+
+    // add table green, with an array of relations to blue
+    recordService.upsertSingleRecord(
+        collectionId.id(),
+        green,
+        "green-one",
+        Optional.empty(),
+        new RecordRequest(
+            new RecordAttributes(Map.of("rel", List.of(new RelationAttribute(blue, "blue-one"))))));
+
+    // list table names
+    List<String> actual = cloningService.getTableNames(collectionId.id());
+
+    // should be red, green, blue, and join table from green to blue
+    Set<String> expected = Set.of("red", "green", "blue", "sys_green_rel");
+
+    assertEquals(expected, Set.copyOf(actual));
+  }
+
+  @Test
+  void getForeignKeysTest() {
+    WorkspaceId workspaceId = WorkspaceId.of(UUID.randomUUID());
+    CollectionServerModel collection =
+        collectionService.save(workspaceId, new CollectionRequestServerModel("unit", "test"));
+    CollectionId collectionId = CollectionId.of(collection.getId());
+
+    RecordType red = RecordType.valueOf("red");
+    RecordType green = RecordType.valueOf("green");
+    RecordType blue = RecordType.valueOf("blue");
+
+    // create record type "red" and record "red-one"
+    recordService.upsertSingleRecord(
+        collectionId.id(),
+        red,
+        "red-one",
+        Optional.empty(),
+        new RecordRequest(RecordAttributes.empty()));
+
+    // create record type "blue" and record "blue-one" with a scalar relation to red
+    recordService.upsertSingleRecord(
+        collectionId.id(),
+        blue,
+        "blue-one",
+        Optional.empty(),
+        new RecordRequest(
+            new RecordAttributes(Map.of("rel", new RelationAttribute(red, "red-one")))));
+
+    // add table green, with an array of relations to blue
+    recordService.upsertSingleRecord(
+        collectionId.id(),
+        green,
+        "green-one",
+        Optional.empty(),
+        new RecordRequest(
+            new RecordAttributes(Map.of("rel", List.of(new RelationAttribute(blue, "blue-one"))))));
+
+    // list foreign keys
+    List<ForeignKeyEdge> actual = cloningService.getForeignKeys(collectionId.id());
+
+    // we expect relations of:
+    // blue->red
+    // sys_green_rel->green
+    // sys_green_rel->blue
+    List<ForeignKeyEdge> expected =
+        List.of(
+            new ForeignKeyEdge("blue", "red"),
+            new ForeignKeyEdge("sys_green_rel", "green"),
+            new ForeignKeyEdge("sys_green_rel", "blue"));
+
+    assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/CloningServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/CloningServiceTest.java
@@ -178,14 +178,14 @@ public class CloningServiceTest {
             new RecordAttributes(Map.of("rel", List.of(new RelationAttribute(blue, "blue-one"))))));
 
     // list foreign keys
-    List<ForeignKeyEdge> actual = cloningService.getForeignKeys(collectionId.id());
+    Set<ForeignKeyEdge> actual = cloningService.getForeignKeys(collectionId.id());
 
     // we expect relations of:
     // blue->red
     // green->blue
-    List<ForeignKeyEdge> expected =
-        List.of(new ForeignKeyEdge("blue", "red"), new ForeignKeyEdge("green", "blue"));
+    Set<ForeignKeyEdge> expected =
+        Set.of(new ForeignKeyEdge("blue", "red"), new ForeignKeyEdge("green", "blue"));
 
-    assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
+    assertEquals(expected, actual);
   }
 }


### PR DESCRIPTION
This is a _POC_ of SQL-based cloning; that is, it doesn't use `pg_dump`. Posting for feedback and consideration.

The main advantages I see of this approach over a `pg_dump` solution:
* data-copying is completely within postgres; we don't need to export and import every row to some other system
* we have full control over the implementation; it is extensible if we wanted to add features like only cloning selected tables

The main disadvantages I see as compared to a `pg_dump` solution:
* more code for us to maintain, since we are re-implementing some of `pg_dump`'s features
* not easily extensible to the data plane or any use cases where we're cloning between multiple cWDS databases

Because this is a POC, it's missing a lot of tests, polish, error-handling, etc. I've left `TODO AJ-1952` comments throughout the code, but I'm 100% certain I missed some cases.

The major outstanding issue I have not tackled in this POC is handling circular table references: for instance, table "red" has a relation to table "green", but table "green" also has a relation to table "red". I am curious how `pg_dump` handles this.

