### PR TITLE
POC pg_dump-based cloning

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/controller/WorkspaceController.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/controller/WorkspaceController.java
@@ -1,7 +1,6 @@
 package org.databiosphere.workspacedataservice.controller;
 
 import java.util.UUID;
-import org.databiosphere.workspacedataservice.annotations.DeploymentMode.DataPlane;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
 import org.databiosphere.workspacedataservice.generated.WorkspaceApi;
 import org.databiosphere.workspacedataservice.generated.WorkspaceInitServerModel;
@@ -12,7 +11,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
-@DataPlane
+// @DataPlane
 @RestController
 public class WorkspaceController implements WorkspaceApi {
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/CollectionDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/CollectionDao.java
@@ -7,7 +7,7 @@ import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 public interface CollectionDao {
   boolean collectionSchemaExists(CollectionId collectionId);
 
-  List<CollectionId> listCollectionSchemas();
+  List<CollectionId> listCollectionSchemas(WorkspaceId workspaceId);
 
   void createSchema(CollectionId collectionId);
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/CollectionService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/CollectionService.java
@@ -334,7 +334,7 @@ public class CollectionService {
   @Deprecated(forRemoval = true, since = "v0.14.0")
   public List<UUID> listCollections(String version) {
     validateVersion(version);
-    return collectionDao.listCollectionSchemas().stream().map(CollectionId::id).toList();
+    return collectionDao.listCollectionSchemas(workspaceId).stream().map(CollectionId::id).toList();
   }
 
   /**

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/ControlPlaneBackupRestoreService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/ControlPlaneBackupRestoreService.java
@@ -1,0 +1,321 @@
+package org.databiosphere.workspacedataservice.service;
+
+import static org.databiosphere.workspacedataservice.service.RecordUtils.validateVersion;
+
+import com.azure.identity.extensions.jdbc.postgresql.AzurePostgresqlAuthenticationPlugin;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import org.apache.commons.lang3.StringUtils;
+import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
+import org.databiosphere.workspacedataservice.annotations.DeploymentMode;
+import org.databiosphere.workspacedataservice.dao.BackupRestoreDao;
+import org.databiosphere.workspacedataservice.dao.CloneDao;
+import org.databiosphere.workspacedataservice.dao.CollectionDao;
+import org.databiosphere.workspacedataservice.process.LocalProcessLauncher;
+import org.databiosphere.workspacedataservice.service.model.exception.LaunchProcessException;
+import org.databiosphere.workspacedataservice.service.model.exception.MissingObjectException;
+import org.databiosphere.workspacedataservice.shared.model.BackupResponse;
+import org.databiosphere.workspacedataservice.shared.model.BackupRestoreRequest;
+import org.databiosphere.workspacedataservice.shared.model.CloneResponse;
+import org.databiosphere.workspacedataservice.shared.model.CollectionId;
+import org.databiosphere.workspacedataservice.shared.model.RestoreResponse;
+import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
+import org.databiosphere.workspacedataservice.shared.model.job.Job;
+import org.databiosphere.workspacedataservice.shared.model.job.JobInput;
+import org.databiosphere.workspacedataservice.shared.model.job.JobStatus;
+import org.databiosphere.workspacedataservice.storage.BackUpFileStorage;
+import org.postgresql.plugin.AuthenticationRequestType;
+import org.postgresql.util.PSQLException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@DeploymentMode.ControlPlane
+public class ControlPlaneBackupRestoreService {
+  private final BackupRestoreDao<BackupResponse> backupDao;
+  private final BackupRestoreDao<RestoreResponse> restoreDao;
+  private final CloneDao cloneDao;
+  private final BackUpFileStorage storage;
+  private final CollectionDao collectionDao;
+  private final NamedParameterJdbcTemplate namedTemplate;
+  private final ActivityLogger activityLogger;
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(ControlPlaneBackupRestoreService.class);
+
+  @Value("${twds.pg_dump.user:}")
+  private String dbUser;
+
+  @Value("${twds.pg_dump.dbName:}")
+  private String dbName;
+
+  @Value("${twds.pg_dump.password:}")
+  private String dbPassword;
+
+  @Value("${twds.pg_dump.port:}")
+  private String dbPort;
+
+  @Value("${twds.pg_dump.host:}")
+  private String dbHost;
+
+  @Value("${twds.pg_dump.path:}")
+  private String pgDumpPath;
+
+  @Value("${twds.pg_dump.psqlPath:}")
+  private String psqlPath;
+
+  @Value("${twds.pg_dump.useAzureIdentity:}")
+  private boolean useAzureIdentity;
+
+  public ControlPlaneBackupRestoreService(
+      BackupRestoreDao<BackupResponse> backupDao,
+      BackupRestoreDao<RestoreResponse> restoreDao,
+      CollectionDao collectionDao,
+      BackUpFileStorage backUpFileStorage,
+      CloneDao cloneDao,
+      NamedParameterJdbcTemplate namedTemplate,
+      ActivityLogger activityLogger) {
+    this.backupDao = backupDao;
+    this.restoreDao = restoreDao;
+    this.collectionDao = collectionDao;
+    this.cloneDao = cloneDao;
+    this.storage = backUpFileStorage;
+    this.namedTemplate = namedTemplate;
+    this.activityLogger = activityLogger;
+  }
+
+  public Job<JobInput, BackupResponse> checkBackupStatus(UUID trackingId) {
+    var backupJob = backupDao.getStatus(trackingId);
+
+    if (backupJob == null) {
+      throw new MissingObjectException("Backup job");
+    }
+
+    return backupJob;
+  }
+
+  public Job<JobInput, CloneResponse> checkCloneStatus() {
+    return cloneDao.getCloneStatus();
+  }
+
+  public Job<JobInput, BackupResponse> backupAzureWDS(
+      String version,
+      UUID trackingId,
+      BackupRestoreRequest backupRestoreRequest,
+      WorkspaceId sourceWorkspaceId) {
+    try {
+      validateVersion(version);
+
+      // if request did not specify which workspace asked for the backup, default to the current
+      // workspace
+      WorkspaceId requesterWorkspaceId =
+          WorkspaceId.of(backupRestoreRequest.requestingWorkspaceId());
+      //          backupRestoreRequest.requestingWorkspaceId() == null
+      //              ? workspaceId
+      //              : WorkspaceId.of(backupRestoreRequest.requestingWorkspaceId());
+
+      // create an entry to track progress of this backup
+      backupDao.createEntry(trackingId, backupRestoreRequest);
+
+      String blobName = generateBackupFilename(requesterWorkspaceId.toString());
+
+      List<String> commandList = generateCommandList(true, sourceWorkspaceId);
+      Map<String, String> envVars = Map.of("PGPASSWORD", determinePassword());
+
+      LocalProcessLauncher localProcessLauncher = new LocalProcessLauncher();
+      localProcessLauncher.launchProcess(commandList, envVars);
+
+      backupDao.updateStatus(trackingId, JobStatus.RUNNING);
+      LOGGER.info("Starting streaming backup to storage.");
+      storage.streamOutputToBlobStorage(
+          localProcessLauncher.getInputStream(), blobName, requesterWorkspaceId);
+      String error = checkForError(localProcessLauncher);
+
+      if (StringUtils.isNotBlank(error)) {
+        LOGGER.error("process error: {}", error);
+        backupDao.terminateToError(trackingId, error);
+      } else {
+        // if no errors happen and code reaches here, the backup has been completed successfully
+        backupDao.updateFilename(trackingId, blobName);
+        backupDao.updateStatus(trackingId, JobStatus.SUCCEEDED);
+        activityLogger.saveEventForCurrentUser(user -> user.created().backup().withId(blobName));
+      }
+    } catch (Exception ex) {
+      LOGGER.error("Process error: {}", ex.getMessage());
+      backupDao.terminateToError(trackingId, ex.getMessage());
+    }
+
+    return backupDao.getStatus(trackingId);
+  }
+
+  public Job<JobInput, RestoreResponse> restoreAzureWDS(
+      String version,
+      String backupFileName,
+      UUID trackingId,
+      String startupToken,
+      WorkspaceId sourceWorkspaceIdParam,
+      WorkspaceId requestingWorkspaceId) {
+    validateVersion(version);
+    boolean doCleanup = false;
+    try {
+      LOGGER.info("Starting restore. ");
+      logSearchPath("At beginning of restore");
+      // create an entry to track progress of this restore
+      restoreDao.createEntry(
+          trackingId,
+          new BackupRestoreRequest(
+              requestingWorkspaceId.id(), String.format("Restore from %s", backupFileName)));
+
+      // generate psql query
+      List<String> commandList = generateCommandList(false, sourceWorkspaceIdParam);
+      Map<String, String> envVars = Map.of("PGPASSWORD", determinePassword());
+
+      restoreDao.updateStatus(trackingId, JobStatus.RUNNING);
+      LocalProcessLauncher localProcessLauncher = new LocalProcessLauncher();
+      localProcessLauncher.launchProcess(commandList, envVars);
+
+      LOGGER.info("Grabbing data from the backup file. ");
+      // if we've reached this point, trigger cleanup of the backup file when the restore attempt is
+      // done
+      doCleanup = true;
+      // grab blob from storage
+      storage.streamInputFromBlobStorage(
+          localProcessLauncher.getOutputStream(),
+          backupFileName,
+          requestingWorkspaceId,
+          startupToken);
+
+      logSearchPath("Immediately after restore");
+
+      String error = checkForError(localProcessLauncher);
+      if (StringUtils.isNotBlank(error)) {
+        LOGGER.error("process error: {}", error);
+        restoreDao.terminateToError(trackingId, error);
+        return restoreDao.getStatus(trackingId);
+      }
+
+      /* TODO: insert rows in sys_wds.collection for all schemas we just inserted.
+         The following call to alterSchema only handles the default collection;
+         if the source had any additional collections, they will not be handled correctly.
+         If we insert rows here, we don't need the additional insert check in alterSchema.
+      */
+
+      // rename workspace schema from source to dest
+      //      collectionDao.alterSchema(
+      //          CollectionId.fromString(sourceWorkspaceIdParam.toString()),
+      //          CollectionId.of(requestingWorkspaceId.id()));
+
+      activityLogger.saveEventForCurrentUser(
+          user -> user.restored().backup().withId(backupFileName));
+      restoreDao.updateStatus(trackingId, JobStatus.SUCCEEDED);
+    } catch (LaunchProcessException | PSQLException | DataAccessException ex) {
+      LOGGER.error("process error: {}", ex.getMessage());
+      restoreDao.terminateToError(trackingId, ex.getMessage());
+    } finally {
+      // reset the Postgres search path. Restoring the pg_dump set the search path to empty.
+      namedTemplate.update("SET search_path TO DEFAULT;", Map.of());
+      logSearchPath("After resetting search path in finally block");
+      // clean up
+      if (doCleanup) {
+        try {
+          storage.deleteBlob(backupFileName, requestingWorkspaceId, startupToken);
+        } catch (Exception e) {
+          LOGGER.warn(
+              "Error cleaning up after restore. File '{}' was not deleted from storage container: {}",
+              backupFileName,
+              e.getMessage(),
+              e);
+        }
+      }
+    }
+    return restoreDao.getStatus(trackingId);
+  }
+
+  private void logSearchPath(String logPrefix) {
+    try {
+      String searchPath = namedTemplate.queryForObject("SHOW search_path;", Map.of(), String.class);
+      LOGGER.info("{}, the Postgres search path is: [{}]", logPrefix, searchPath);
+    } catch (Exception e) {
+      // don't fail if there is a problem with logging
+    }
+  }
+
+  private String determinePassword() throws PSQLException {
+    if (useAzureIdentity) {
+      return new String(
+          new AzurePostgresqlAuthenticationPlugin(new Properties())
+              .getPassword(AuthenticationRequestType.CLEARTEXT_PASSWORD));
+    } else {
+      return dbPassword;
+    }
+  }
+
+  // Same args, different command depending on whether we're doing backup or restore.
+  public List<String> generateCommandList(boolean isBackup, WorkspaceId sourceWorkspaceId) {
+    Map<String, String> command = new LinkedHashMap<>();
+    if (isBackup) {
+      command.put(pgDumpPath, null);
+      command.put("-b", null);
+      // Grab all workspace collections/schemas in wds
+      for (CollectionId id : collectionDao.listCollectionSchemas(sourceWorkspaceId)) {
+        command.put("-n", id.toString());
+      }
+    } else {
+      command.put(psqlPath, null);
+    }
+    command.put("-h", dbHost);
+    command.put("-p", dbPort);
+    command.put("-U", dbUser);
+    command.put("-d", dbName);
+
+    List<String> commandList = new ArrayList<>();
+    for (Map.Entry<String, String> entry : command.entrySet()) {
+      commandList.add(entry.getKey());
+      if (entry.getValue() != null) {
+        commandList.add(entry.getValue());
+      }
+    }
+    commandList.add("-v");
+    commandList.add("-w");
+
+    return commandList;
+  }
+
+  public String generateBackupFilename(String workspaceId) {
+    LocalDateTime now = LocalDateTime.now();
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss");
+    String timestamp = now.format(formatter);
+    //    return "wdsservice/cloning/backup/" + workspaceId + "-" + timestamp + ".sql";
+    return workspaceId + "-" + timestamp;
+  }
+
+  private String checkForError(LocalProcessLauncher localProcessLauncher) {
+    // materialize only the first 1024 bytes of the error stream to ensure we don't DoS ourselves
+    int errorLimit = 1024;
+
+    int exitCode = localProcessLauncher.waitForTerminate();
+    if (exitCode != 0) {
+      InputStream errorStream =
+          localProcessLauncher.getOutputForProcess(LocalProcessLauncher.Output.ERROR);
+      try {
+        String error = new String(errorStream.readNBytes(errorLimit)).trim();
+        LOGGER.error("process error: {}", error);
+        return error;
+      } catch (IOException e) {
+        LOGGER.warn(
+            "process failed with exit code {}, but encountered an exception reading the error output: {}",
+            exitCode,
+            e.getMessage());
+        return "Unknown error";
+      }
+    }
+    return "";
+  }
+}

--- a/service/src/main/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerBean.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerBean.java
@@ -10,7 +10,7 @@ import org.databiosphere.workspacedataservice.annotations.SingleTenant;
 import org.databiosphere.workspacedataservice.dao.CloneDao;
 import org.databiosphere.workspacedataservice.dao.CollectionDao;
 import org.databiosphere.workspacedataservice.leonardo.LeonardoDao;
-import org.databiosphere.workspacedataservice.service.BackupRestoreService;
+import org.databiosphere.workspacedataservice.service.ControlPlaneBackupRestoreService;
 import org.databiosphere.workspacedataservice.service.model.exception.CloningException;
 import org.databiosphere.workspacedataservice.service.model.exception.RestException;
 import org.databiosphere.workspacedataservice.shared.model.CloneResponse;
@@ -39,7 +39,7 @@ public class CollectionInitializerBean {
   private final CloneDao cloneDao;
   private final LockRegistry lockRegistry;
 
-  private final BackupRestoreService restoreService;
+  private final ControlPlaneBackupRestoreService restoreService;
   private final WorkspaceId workspaceId;
 
   @Nullable private final String sourceWorkspaceIdString;
@@ -63,7 +63,7 @@ public class CollectionInitializerBean {
       LeonardoDao leoDao,
       WorkspaceDataServiceDao wdsDao,
       CloneDao cloneDao,
-      BackupRestoreService restoreService,
+      ControlPlaneBackupRestoreService restoreService,
       LockRegistry lockRegistry,
       @SingleTenant WorkspaceId workspaceId,
       @Nullable String sourceWorkspaceIdString,

--- a/service/src/main/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerBean.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerBean.java
@@ -268,7 +268,13 @@ public class CollectionInitializerBean {
         backupFileName);
     cloneDao.updateCloneEntryStatus(cloneJobId, CloneStatus.RESTOREQUEUED);
     var restoreResponse =
-        restoreService.restoreAzureWDS("v0.2", backupFileName, cloneJobId, startupToken);
+        restoreService.restoreAzureWDS(
+            "v0.2",
+            backupFileName,
+            cloneJobId,
+            startupToken,
+            WorkspaceId.fromString(sourceWorkspaceIdString),
+            workspaceId);
     if (!restoreResponse.getStatus().equals(JobStatus.SUCCEEDED)) {
       LOGGER.error(
           "Something went wrong with restore: {}. Starting with empty default collection schema.",

--- a/service/src/main/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerConfig.java
@@ -5,7 +5,7 @@ import org.databiosphere.workspacedataservice.annotations.SingleTenant;
 import org.databiosphere.workspacedataservice.dao.CloneDao;
 import org.databiosphere.workspacedataservice.dao.CollectionDao;
 import org.databiosphere.workspacedataservice.leonardo.LeonardoDao;
-import org.databiosphere.workspacedataservice.service.BackupRestoreService;
+import org.databiosphere.workspacedataservice.service.ControlPlaneBackupRestoreService;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.databiosphere.workspacedataservice.sourcewds.WorkspaceDataServiceDao;
 import org.springframework.beans.factory.annotation.Value;
@@ -23,7 +23,7 @@ public class CollectionInitializerConfig {
       LeonardoDao leoDao,
       WorkspaceDataServiceDao wdsDao,
       CloneDao cloneDao,
-      BackupRestoreService restoreService,
+      ControlPlaneBackupRestoreService restoreService,
       LockRegistry lockRegistry,
       @SingleTenant WorkspaceId workspaceId,
       @Value("${twds.instance.source-workspace-id}") String sourceWorkspaceIdString,

--- a/service/src/main/java/org/databiosphere/workspacedataservice/storage/AzureBlobStorage.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/storage/AzureBlobStorage.java
@@ -1,24 +1,23 @@
 package org.databiosphere.workspacedataservice.storage;
 
-import com.azure.storage.blob.BlobContainerClient;
-import com.azure.storage.blob.BlobServiceClient;
-import com.azure.storage.blob.BlobServiceClientBuilder;
-import com.azure.storage.blob.models.BlobStorageException;
-import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 import org.databiosphere.workspacedataservice.service.model.exception.LaunchProcessException;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.databiosphere.workspacedataservice.workspacemanager.WorkspaceManagerDao;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.lang.Nullable;
 
 @Configuration
 public class AzureBlobStorage implements BackUpFileStorage {
@@ -31,6 +30,64 @@ public class AzureBlobStorage implements BackUpFileStorage {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AzureBlobStorage.class);
 
+  @Override
+  public void streamOutputToBlobStorage(
+      InputStream fromStream, String blobName, WorkspaceId workspaceId) {
+    File targetFile;
+    //    try {
+    File directory =
+        new File(
+            "/Users/bmorgan/dev/workbench/terra-workspace-data-service/service/src/integrationTest/resources");
+    //      targetFile = File.createTempFile("WDS-integrationTest-LocalFileStorage-", ".sql");
+    //      targetFile = File.createTempFile(blobName, ".sql", directory);
+    targetFile = new File("/home/" + blobName + ".sql");
+    //    } catch (IOException e) {
+    //      throw new RuntimeException(e);
+    //    }
+    try (OutputStream outStream = new FileOutputStream(targetFile)) {
+      try (BufferedReader bufferedReader =
+          new BufferedReader(new InputStreamReader(fromStream, StandardCharsets.UTF_8))) {
+        int line;
+        while ((line = bufferedReader.read()) != -1) {
+          outStream.write(line);
+        }
+      }
+    } catch (IOException ioEx) {
+      throw new LaunchProcessException("Error streaming output during local test", ioEx);
+    } finally {
+      try {
+        // clean up the temp file
+        //noinspection ResultOfMethodCallIgnored
+        //        targetFile.delete();
+      } catch (Exception e) {
+        // could not clean up the temp file; don't fail the test due to this.
+      }
+    }
+  }
+
+  @Override
+  public void streamInputFromBlobStorage(
+      OutputStream toStream, String blobName, WorkspaceId workspaceId, String authToken) {
+    File inputFile = new File("/home/" + blobName + ".sql");
+    try (InputStream inStream = new FileInputStream(inputFile)) {
+      try (BufferedWriter bufferedWriter =
+          new BufferedWriter(new OutputStreamWriter(toStream, StandardCharsets.UTF_8))) {
+        int line;
+        while ((line = Objects.requireNonNull(inStream).read()) != -1) {
+          bufferedWriter.write((line));
+        }
+      }
+    } catch (IOException ioEx) {
+      throw new LaunchProcessException("Error streaming input during local test", ioEx);
+    }
+  }
+
+  @Override
+  public void deleteBlob(String blobFile, WorkspaceId workspaceId, String authToken) {
+    // delete is handled in stream output for local set up
+  }
+}
+
   /*
   6/28/2023 - Terra's storage inside a billing project is organized as follows:
   by default a billing project gets a single blob storage azure resource
@@ -42,76 +99,76 @@ public class AzureBlobStorage implements BackUpFileStorage {
   backups will be stored inside the workspace container in a path determined by function GenerateBackupFilename
   which exists within BackupService.java.
    */
-  @Override
-  public void streamOutputToBlobStorage(
-      InputStream fromStream, String blobName, WorkspaceId workspaceId) {
-    LOGGER.info("Creating blob storage client. ");
-    BlobContainerClient blobContainerClient =
-        constructBlockBlobClient(workspaceId, /* authToken= */ null);
-    LOGGER.info("About to write to blob storage. ");
-    // https://learn.microsoft.com/en-us/java/api/overview/azure/storage-blob-readme?view=azure-java-stable#upload-a-blob-via-an-outputstream
-    try (OutputStreamWriter blobOS =
-        new OutputStreamWriter(
-            new BufferedOutputStream(
-                blobContainerClient
-                    .getBlobClient(blobName)
-                    .getBlockBlobClient()
-                    .getBlobOutputStream()),
-            StandardCharsets.UTF_8.newEncoder())) {
-      try (BufferedReader bufferedReader =
-          new BufferedReader(new InputStreamReader(fromStream, StandardCharsets.UTF_8))) {
-        int line;
-        while ((line = bufferedReader.read()) != -1) {
-          blobOS.write(line);
-        }
-      }
-    } catch (IOException ioEx) {
-      throw new LaunchProcessException("Error streaming output of child process", ioEx);
-    }
-  }
-
-  @Override
-  public void streamInputFromBlobStorage(
-      OutputStream toStream, String blobName, WorkspaceId workspaceId, String authToken) {
-    BlobContainerClient blobContainerClient = constructBlockBlobClient(workspaceId, authToken);
-    try (toStream) {
-      blobContainerClient.getBlobClient(blobName).downloadStream(toStream);
-    } catch (IOException ioEx) {
-      throw new LaunchProcessException("Error streaming input to child process", ioEx);
-    }
-  }
-
-  private BlobContainerClient constructBlockBlobClient(
-      WorkspaceId workspaceId, @Nullable String authToken) {
-    // get workspace blob storage endpoint and token
-    var blobstorageDetails = workspaceManagerDao.getBlobStorageUrl(workspaceId, authToken);
-
-    // the url we get from WSM already contains the token in it, so no need to specify sasToken
-    // separately
-    BlobServiceClient blobServiceClient =
-        new BlobServiceClientBuilder().endpoint(blobstorageDetails).buildClient();
-
-    try {
-      // the way storage containers are set up in a workspace are as follows:
-      // billing project gets a single azure storage account
-      // each workspace gets a container inside of that storage account to keep its data
-      return blobServiceClient.getBlobContainerClient("sc-" + workspaceId);
-    } catch (BlobStorageException e) {
-      // if the default workspace container doesn't exist, something went horribly wrong
-      LOGGER.error("Default storage container missing for workspace id {}", workspaceId);
-      throw (e);
-    }
-  }
-
-  @Override
-  public void deleteBlob(String blobFile, WorkspaceId workspaceId, String authToken) {
-    BlobContainerClient blobContainerClient = constructBlockBlobClient(workspaceId, authToken);
-    try {
-      var blobClient = blobContainerClient.getBlobClient(blobFile);
-      blobClient.delete();
-    } catch (BlobStorageException e) {
-      LOGGER.error("Failed to delete file with name {}. ", blobFile);
-      throw (e);
-    }
-  }
-}
+//  @Override
+//  public void streamOutputToBlobStorage(
+//      InputStream fromStream, String blobName, WorkspaceId workspaceId) {
+//    LOGGER.info("Creating blob storage client. ");
+//    BlobContainerClient blobContainerClient =
+//        constructBlockBlobClient(workspaceId, /* authToken= */ null);
+//    LOGGER.info("About to write to blob storage. ");
+//    //
+// https://learn.microsoft.com/en-us/java/api/overview/azure/storage-blob-readme?view=azure-java-stable#upload-a-blob-via-an-outputstream
+//    try (OutputStreamWriter blobOS =
+//        new OutputStreamWriter(
+//            new BufferedOutputStream(
+//                blobContainerClient
+//                    .getBlobClient(blobName)
+//                    .getBlockBlobClient()
+//                    .getBlobOutputStream()),
+//            StandardCharsets.UTF_8.newEncoder())) {
+//      try (BufferedReader bufferedReader =
+//          new BufferedReader(new InputStreamReader(fromStream, StandardCharsets.UTF_8))) {
+//        int line;
+//        while ((line = bufferedReader.read()) != -1) {
+//          blobOS.write(line);
+//        }
+//      }
+//    } catch (IOException ioEx) {
+//      throw new LaunchProcessException("Error streaming output of child process", ioEx);
+//    }
+//  }
+//
+//  @Override
+//  public void streamInputFromBlobStorage(
+//      OutputStream toStream, String blobName, WorkspaceId workspaceId, String authToken) {
+//    BlobContainerClient blobContainerClient = constructBlockBlobClient(workspaceId, authToken);
+//    try (toStream) {
+//      blobContainerClient.getBlobClient(blobName).downloadStream(toStream);
+//    } catch (IOException ioEx) {
+//      throw new LaunchProcessException("Error streaming input to child process", ioEx);
+//    }
+//  }
+//
+//  private BlobContainerClient constructBlockBlobClient(
+//      WorkspaceId workspaceId, @Nullable String authToken) {
+//    // get workspace blob storage endpoint and token
+//    var blobstorageDetails = workspaceManagerDao.getBlobStorageUrl(workspaceId, authToken);
+//
+//    // the url we get from WSM already contains the token in it, so no need to specify sasToken
+//    // separately
+//    BlobServiceClient blobServiceClient =
+//        new BlobServiceClientBuilder().endpoint(blobstorageDetails).buildClient();
+//
+//    try {
+//      // the way storage containers are set up in a workspace are as follows:
+//      // billing project gets a single azure storage account
+//      // each workspace gets a container inside of that storage account to keep its data
+//      return blobServiceClient.getBlobContainerClient("sc-" + workspaceId);
+//    } catch (BlobStorageException e) {
+//      // if the default workspace container doesn't exist, something went horribly wrong
+//      LOGGER.error("Default storage container missing for workspace id {}", workspaceId);
+//      throw (e);
+//    }
+//  }
+//
+//  @Override
+//  public void deleteBlob(String blobFile, WorkspaceId workspaceId, String authToken) {
+//    BlobContainerClient blobContainerClient = constructBlockBlobClient(workspaceId, authToken);
+//    try {
+//      var blobClient = blobContainerClient.getBlobClient(blobFile);
+//      blobClient.delete();
+//    } catch (BlobStorageException e) {
+//      LOGGER.error("Failed to delete file with name {}. ", blobFile);
+//      throw (e);
+//    }
+//  }

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -162,7 +162,7 @@ twds:
     password: ${env.wds.db.password}
     host: ${env.wds.db.host}
     # When running on Azure in k8s with workload identity set PGDUMP_USE_AZURE_IDENTITY to true
-    useAzureIdentity: ${PGDUMP_USE_AZURE_IDENTITY:true}
+    useAzureIdentity: ${PGDUMP_USE_AZURE_IDENTITY:false}
 
 # retry configuration for REST clients (Sam, WSM, TDR, Leo, etc)
 rest:

--- a/service/src/main/resources/static/swagger/cwds-api-docs.yaml
+++ b/service/src/main/resources/static/swagger/cwds-api-docs.yaml
@@ -20,6 +20,8 @@ tags:
     description: Import APIs
   - name: Job
     description: Job APIs
+  - name: Workspace
+    description: Workspace APIs
   - name: General WDS Information
     description: Information regarding versioning, health, info, etc. for WDS
 
@@ -43,6 +45,12 @@ paths:
     $ref: 'apis-v1.yaml#/paths/~1job~1v1~1{jobId}'
   /job/v1/instance/{instanceUuid}:
     $ref: 'apis-v1.yaml#/paths/~1job~1v1~1instance~1{instanceUuid}'
+
+  ##############################
+  # Workspace APIs
+  ##############################
+  /workspaces/v1/{workspaceId}:
+    $ref: 'apis-v1.yaml#/paths/~1workspaces~1v1~1{workspaceId}'
 
   ##############################
   # General WDS Information APIs

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/MockCollectionDao.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/MockCollectionDao.java
@@ -25,7 +25,7 @@ public class MockCollectionDao implements CollectionDao {
   }
 
   @Override
-  public List<CollectionId> listCollectionSchemas() {
+  public List<CollectionId> listCollectionSchemas(WorkspaceId workspaceId) {
     return collections.stream().toList();
   }
 


### PR DESCRIPTION
Extremely hacky POC of workspace cloning by using pre-existing `pg_dump` code, although with significant modifations:
- `CollectionDao.listCollectionSchemas` should take in a workspaceId and filter by it
- `PostgresCollectionDao.alterSchema` no longer checks for an environmental workspaceId - should this come in as a parameter instead?
- For ease of POC, created a new file `ControlPlaneBackupRestoreService` that copies from `BackupRestoreService` but with the needed changes.  Should be available in Control Plane, which requires passing sourceworkspaceId and workspaceId around instead of belonging to the class
- The `pg_dump` file is saved on the cWDS pod; since this doesn't use azure, I've turned off the `useAzureIdentity` property.  Where to save this file and how to make sure it is removed, as well as dealing with simultaneous clones, would need to be addressed.

Necessary changes not yet implemented in this POC: 
- update generateCommandList to allow multiple schemas (multiple `-n` parameters work with `pg_dump` just fine, only the code uses `-n` as a key in a hashmap so subsequent schemas overwrite previous ones)
- delete file after use
- rename new schemas - `pg_dump` would just load the same schemas that already exist; this might require editing the pg_dump file either as it's being written or afterwards.  As written, the POC creates a new collection matching the new workspaceId but no others and the new data is not actually in the new collection.

Modulo the changes that still need to be done, I've verified that this works in principle on my BEE.
Would require somewhat significant refactoring to accomplish with clean, non-hacky code.  