### PR TITLE
AJ-1971: remove CollectionDao.listCollectionSchemas()

### DIFF
--- a/service/src/integrationTest/java/org/databiosphere/workspacedataservice/service/BackupRestoreServiceFailureIntegrationTest.java
+++ b/service/src/integrationTest/java/org/databiosphere/workspacedataservice/service/BackupRestoreServiceFailureIntegrationTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.IntegrationServiceTestBase;
-import org.databiosphere.workspacedataservice.dao.CollectionDao;
 import org.databiosphere.workspacedataservice.shared.model.BackupRestoreRequest;
 import org.databiosphere.workspacedataservice.shared.model.RestoreResponse;
 import org.databiosphere.workspacedataservice.shared.model.job.Job;
@@ -35,7 +34,7 @@ import org.springframework.test.context.TestPropertySource;
     })
 class BackupRestoreServiceFailureIntegrationTest extends IntegrationServiceTestBase {
   @Autowired private BackupRestoreService backupRestoreService;
-  @Autowired CollectionDao collectionDao;
+  @Autowired CollectionService collectionService;
   @Autowired NamedParameterJdbcTemplate namedTemplate;
 
   @Value("${twds.instance.source-workspace-id}")
@@ -44,7 +43,7 @@ class BackupRestoreServiceFailureIntegrationTest extends IntegrationServiceTestB
   // ensure we clean up the db after our tests
   @AfterEach
   void cleanUp() {
-    cleanDb(collectionDao, namedTemplate);
+    cleanDb(collectionService, namedTemplate);
   }
 
   @Test

--- a/service/src/integrationTest/java/org/databiosphere/workspacedataservice/service/BackupServiceIntegrationTest.java
+++ b/service/src/integrationTest/java/org/databiosphere/workspacedataservice/service/BackupServiceIntegrationTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.IntegrationServiceTestBase;
 import org.databiosphere.workspacedataservice.dao.BackupRestoreDao;
-import org.databiosphere.workspacedataservice.dao.CollectionDao;
 import org.databiosphere.workspacedataservice.shared.model.BackupResponse;
 import org.databiosphere.workspacedataservice.shared.model.BackupRestoreRequest;
 import org.databiosphere.workspacedataservice.shared.model.job.JobStatus;
@@ -32,13 +31,13 @@ import org.springframework.test.context.TestPropertySource;
 class BackupServiceIntegrationTest extends IntegrationServiceTestBase {
   @Autowired private BackupRestoreService backupRestoreService;
   @Autowired private BackupRestoreDao<BackupResponse> backupDao;
-  @Autowired CollectionDao collectionDao;
+  @Autowired CollectionService collectionService;
   @Autowired NamedParameterJdbcTemplate namedTemplate;
 
   // ensure we clean up the db after our tests
   @AfterEach
   void cleanUp() {
-    cleanDb(collectionDao, namedTemplate);
+    cleanDb(collectionService, namedTemplate);
   }
 
   @Test

--- a/service/src/integrationTest/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerCloneTest.java
+++ b/service/src/integrationTest/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerCloneTest.java
@@ -159,7 +159,10 @@ class CollectionInitializerCloneTest extends IntegrationServiceTestBase {
     // default collection should exist, with a single table named "thing" in it
     // the "thing" table is defined in WDS-integrationTest-LocalFileStorage-input.sql.
     UUID workspaceUuid = workspaceId.id();
-    List<CollectionId> actualCollections = collectionDao.listCollectionSchemas();
+    List<CollectionId> actualCollections =
+        collectionService.list(workspaceId).stream()
+            .map(coll -> CollectionId.of(coll.getId()))
+            .toList();
     assertEquals(List.of(CollectionId.of(workspaceUuid)), actualCollections);
     List<RecordType> actualTypes = recordDao.getAllRecordTypes(workspaceUuid);
     assertEquals(List.of(RecordType.valueOf("thing")), actualTypes);

--- a/service/src/integrationTest/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerCloneTest.java
+++ b/service/src/integrationTest/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerCloneTest.java
@@ -20,6 +20,7 @@ import org.databiosphere.workspacedataservice.dao.CloneDao;
 import org.databiosphere.workspacedataservice.dao.CollectionDao;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.databiosphere.workspacedataservice.leonardo.LeonardoDao;
+import org.databiosphere.workspacedataservice.service.CollectionService;
 import org.databiosphere.workspacedataservice.shared.model.CloneResponse;
 import org.databiosphere.workspacedataservice.shared.model.CloneStatus;
 import org.databiosphere.workspacedataservice.shared.model.CollectionId;
@@ -58,7 +59,7 @@ class CollectionInitializerCloneTest extends IntegrationServiceTestBase {
 
   // standard beans
   @Autowired CollectionInitializerBean collectionInitializerBean;
-  @Autowired CollectionDao collectionDao;
+  @Autowired CollectionService collectionService;
   @Autowired RecordDao recordDao;
   @Autowired CloneDao cloneDao;
   @Autowired NamedParameterJdbcTemplate namedTemplate;
@@ -81,7 +82,7 @@ class CollectionInitializerCloneTest extends IntegrationServiceTestBase {
   // ensure we clean up the db after our tests
   @AfterEach
   void cleanUp() {
-    cleanDb(collectionDao, namedTemplate);
+    cleanDb(collectionService, namedTemplate);
   }
 
   /*

--- a/service/src/integrationTest/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerCloneTest.java
+++ b/service/src/integrationTest/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerCloneTest.java
@@ -17,6 +17,7 @@ import org.databiosphere.workspacedata.model.BackupResponse;
 import org.databiosphere.workspacedataservice.IntegrationServiceTestBase;
 import org.databiosphere.workspacedataservice.annotations.SingleTenant;
 import org.databiosphere.workspacedataservice.dao.CloneDao;
+import org.databiosphere.workspacedataservice.dao.CollectionDao;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.databiosphere.workspacedataservice.leonardo.LeonardoDao;
 import org.databiosphere.workspacedataservice.service.CollectionService;
@@ -58,6 +59,7 @@ class CollectionInitializerCloneTest extends IntegrationServiceTestBase {
 
   // standard beans
   @Autowired CollectionInitializerBean collectionInitializerBean;
+  @Autowired CollectionDao collectionDao;
   @Autowired CollectionService collectionService;
   @Autowired RecordDao recordDao;
   @Autowired CloneDao cloneDao;

--- a/service/src/integrationTest/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerCloneTest.java
+++ b/service/src/integrationTest/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerCloneTest.java
@@ -17,7 +17,6 @@ import org.databiosphere.workspacedata.model.BackupResponse;
 import org.databiosphere.workspacedataservice.IntegrationServiceTestBase;
 import org.databiosphere.workspacedataservice.annotations.SingleTenant;
 import org.databiosphere.workspacedataservice.dao.CloneDao;
-import org.databiosphere.workspacedataservice.dao.CollectionDao;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.databiosphere.workspacedataservice.leonardo.LeonardoDao;
 import org.databiosphere.workspacedataservice.service.CollectionService;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/CollectionDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/CollectionDao.java
@@ -5,13 +5,18 @@ import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 
 @Deprecated(forRemoval = true, since = "v0.18.0")
 public interface CollectionDao {
+  // 23 usages
   boolean collectionSchemaExists(CollectionId collectionId);
 
+  // 13 usages
   void createSchema(CollectionId collectionId);
 
+  // 6 usages
   void dropSchema(CollectionId collectionId);
 
+  // 1 usage
   void alterSchema(CollectionId oldCollectionId, CollectionId newCollectionId);
 
+  // 14 usages
   WorkspaceId getWorkspaceId(CollectionId collectionId);
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/CollectionDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/CollectionDao.java
@@ -4,6 +4,7 @@ import java.util.List;
 import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 
+@Deprecated(forRemoval = true, since = "v0.18.0")
 public interface CollectionDao {
   boolean collectionSchemaExists(CollectionId collectionId);
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/CollectionDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/CollectionDao.java
@@ -1,14 +1,11 @@
 package org.databiosphere.workspacedataservice.dao;
 
-import java.util.List;
 import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 
 @Deprecated(forRemoval = true, since = "v0.18.0")
 public interface CollectionDao {
   boolean collectionSchemaExists(CollectionId collectionId);
-
-  List<CollectionId> listCollectionSchemas();
 
   void createSchema(CollectionId collectionId);
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresCollectionDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresCollectionDao.java
@@ -4,7 +4,6 @@ import static org.databiosphere.workspacedataservice.dao.SqlUtils.quote;
 import static org.databiosphere.workspacedataservice.service.CollectionService.NAME_DEFAULT;
 
 import bio.terra.common.db.WriteTransaction;
-import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.annotations.SingleTenant;
@@ -45,16 +44,6 @@ public class PostgresCollectionDao implements CollectionDao {
             "select exists(select from sys_wds.collection WHERE id = :collectionId)",
             new MapSqlParameterSource("collectionId", collectionId.id()),
             Boolean.class));
-  }
-
-  @Override
-  public List<CollectionId> listCollectionSchemas() {
-    return namedTemplate
-        .getJdbcTemplate()
-        .queryForList("select id from sys_wds.collection order by id", UUID.class)
-        .stream()
-        .map(CollectionId::of)
-        .toList();
   }
 
   @Override

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/BackupRestoreService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/BackupRestoreService.java
@@ -12,9 +12,11 @@ import org.apache.commons.lang3.StringUtils;
 import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
 import org.databiosphere.workspacedataservice.annotations.DeploymentMode.DataPlane;
 import org.databiosphere.workspacedataservice.annotations.SingleTenant;
+import org.databiosphere.workspacedataservice.config.TwdsProperties;
 import org.databiosphere.workspacedataservice.dao.BackupRestoreDao;
 import org.databiosphere.workspacedataservice.dao.CloneDao;
 import org.databiosphere.workspacedataservice.dao.CollectionDao;
+import org.databiosphere.workspacedataservice.dao.CollectionRepository;
 import org.databiosphere.workspacedataservice.process.LocalProcessLauncher;
 import org.databiosphere.workspacedataservice.service.model.exception.LaunchProcessException;
 import org.databiosphere.workspacedataservice.service.model.exception.MissingObjectException;
@@ -23,6 +25,7 @@ import org.databiosphere.workspacedataservice.shared.model.BackupRestoreRequest;
 import org.databiosphere.workspacedataservice.shared.model.CloneResponse;
 import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.databiosphere.workspacedataservice.shared.model.RestoreResponse;
+import org.databiosphere.workspacedataservice.shared.model.WdsCollection;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.databiosphere.workspacedataservice.shared.model.job.Job;
 import org.databiosphere.workspacedataservice.shared.model.job.JobInput;
@@ -45,6 +48,8 @@ public class BackupRestoreService {
   private final CloneDao cloneDao;
   private final BackUpFileStorage storage;
   private final CollectionDao collectionDao;
+  private final CollectionRepository collectionRepository;
+  private final TwdsProperties twdsProperties;
   private final NamedParameterJdbcTemplate namedTemplate;
   private final ActivityLogger activityLogger;
   private final WorkspaceId workspaceId;
@@ -84,6 +89,8 @@ public class BackupRestoreService {
       CollectionDao collectionDao,
       BackUpFileStorage backUpFileStorage,
       CloneDao cloneDao,
+      CollectionRepository collectionRepository,
+      TwdsProperties twdsProperties,
       NamedParameterJdbcTemplate namedTemplate,
       ActivityLogger activityLogger,
       @SingleTenant WorkspaceId workspaceId) {
@@ -92,6 +99,8 @@ public class BackupRestoreService {
     this.collectionDao = collectionDao;
     this.cloneDao = cloneDao;
     this.storage = backUpFileStorage;
+    this.collectionRepository = collectionRepository;
+    this.twdsProperties = twdsProperties;
     this.namedTemplate = namedTemplate;
     this.activityLogger = activityLogger;
     this.workspaceId = workspaceId;
@@ -257,8 +266,9 @@ public class BackupRestoreService {
       command.put(pgDumpPath, null);
       command.put("-b", null);
       // Grab all workspace collections/schemas in wds
-      for (CollectionId id : collectionDao.listCollectionSchemas()) {
-        command.put("-n", id.toString());
+      for (WdsCollection collection :
+          collectionRepository.findByWorkspace(twdsProperties.workspaceId())) {
+        command.put("-n", collection.collectionId().toString());
       }
     } else {
       command.put(psqlPath, null);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/BackupRestoreService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/BackupRestoreService.java
@@ -43,15 +43,15 @@ import org.springframework.stereotype.Service;
 @Service
 @DataPlane
 public class BackupRestoreService {
+  private final ActivityLogger activityLogger;
+  private final BackUpFileStorage storage;
   private final BackupRestoreDao<BackupResponse> backupDao;
   private final BackupRestoreDao<RestoreResponse> restoreDao;
   private final CloneDao cloneDao;
-  private final BackUpFileStorage storage;
   private final CollectionDao collectionDao;
   private final CollectionRepository collectionRepository;
-  private final TwdsProperties twdsProperties;
   private final NamedParameterJdbcTemplate namedTemplate;
-  private final ActivityLogger activityLogger;
+  private final TwdsProperties twdsProperties;
   private final WorkspaceId workspaceId;
 
   private static final Logger LOGGER = LoggerFactory.getLogger(BackupRestoreService.class);
@@ -84,25 +84,25 @@ public class BackupRestoreService {
   private boolean useAzureIdentity;
 
   public BackupRestoreService(
+      ActivityLogger activityLogger,
+      BackUpFileStorage storage,
       BackupRestoreDao<BackupResponse> backupDao,
       BackupRestoreDao<RestoreResponse> restoreDao,
-      CollectionDao collectionDao,
-      BackUpFileStorage backUpFileStorage,
       CloneDao cloneDao,
+      CollectionDao collectionDao,
       CollectionRepository collectionRepository,
-      TwdsProperties twdsProperties,
       NamedParameterJdbcTemplate namedTemplate,
-      ActivityLogger activityLogger,
-      @SingleTenant WorkspaceId workspaceId) {
+      TwdsProperties twdsProperties,
+      WorkspaceId workspaceId) {
+    this.activityLogger = activityLogger;
+    this.storage = storage;
     this.backupDao = backupDao;
     this.restoreDao = restoreDao;
-    this.collectionDao = collectionDao;
     this.cloneDao = cloneDao;
-    this.storage = backUpFileStorage;
+    this.collectionDao = collectionDao;
     this.collectionRepository = collectionRepository;
-    this.twdsProperties = twdsProperties;
     this.namedTemplate = namedTemplate;
-    this.activityLogger = activityLogger;
+    this.twdsProperties = twdsProperties;
     this.workspaceId = workspaceId;
   }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/BackupRestoreService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/BackupRestoreService.java
@@ -11,7 +11,6 @@ import java.util.*;
 import org.apache.commons.lang3.StringUtils;
 import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
 import org.databiosphere.workspacedataservice.annotations.DeploymentMode.DataPlane;
-import org.databiosphere.workspacedataservice.annotations.SingleTenant;
 import org.databiosphere.workspacedataservice.config.TwdsProperties;
 import org.databiosphere.workspacedataservice.dao.BackupRestoreDao;
 import org.databiosphere.workspacedataservice.dao.CloneDao;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/MockCollectionDao.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/MockCollectionDao.java
@@ -1,7 +1,6 @@
 package org.databiosphere.workspacedataservice.dao;
 
 import java.sql.SQLException;
-import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import org.databiosphere.workspacedataservice.shared.model.CollectionId;
@@ -22,11 +21,6 @@ public class MockCollectionDao implements CollectionDao {
   @Override
   public boolean collectionSchemaExists(CollectionId collectionId) {
     return collections.contains(collectionId);
-  }
-
-  @Override
-  public List<CollectionId> listCollectionSchemas() {
-    return collections.stream().toList();
   }
 
   @Override

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/PostgresCollectionDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/PostgresCollectionDaoTest.java
@@ -4,11 +4,13 @@ import static java.util.UUID.randomUUID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import org.databiosphere.workspacedataservice.TestUtils;
 import org.databiosphere.workspacedataservice.annotations.SingleTenant;
 import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.config.TwdsProperties;
+import org.databiosphere.workspacedataservice.service.CollectionService;
 import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.junit.jupiter.api.AfterAll;
@@ -27,22 +29,22 @@ import org.springframework.test.annotation.DirtiesContext;
 class PostgresCollectionDaoTest extends TestBase {
 
   @Autowired CollectionDao collectionDao;
+  @Autowired CollectionService collectionService;
   @Autowired NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+  @Autowired TwdsProperties twdsProperties;
   @Autowired @SingleTenant WorkspaceId workspaceId;
 
   // clean up all collections before each test to ensure tests start from a clean slate
   @BeforeEach
   void beforeEach() {
-    List<CollectionId> allCollections = collectionDao.listCollectionSchemas();
-    allCollections.forEach(collectionId -> collectionDao.dropSchema(collectionId));
+    TestUtils.cleanAllCollections(collectionService, namedParameterJdbcTemplate);
   }
 
   // clean up all collections after all tests to ensure tests in other files start from a clean
   // slate
   @AfterAll
   void afterAll() {
-    List<CollectionId> allCollections = collectionDao.listCollectionSchemas();
-    allCollections.forEach(collectionId -> collectionDao.dropSchema(collectionId));
+    TestUtils.cleanAllCollections(collectionService, namedParameterJdbcTemplate);
   }
 
   // is this test set up correctly?
@@ -59,7 +61,7 @@ class PostgresCollectionDaoTest extends TestBase {
   // do we populate all db columns correctly?
   @Test
   void insertPopulatesAllColumns() {
-    assertEquals(0, collectionDao.listCollectionSchemas().size());
+    assertEquals(0, collectionService.list(twdsProperties.workspaceId()).size());
 
     CollectionId collectionId = CollectionId.of(randomUUID());
     UUID collectionUuid = collectionId.id();
@@ -81,7 +83,7 @@ class PostgresCollectionDaoTest extends TestBase {
   // do we populate all db columns correctly?
   @Test
   void defaultPopulatesAllColumns() {
-    assertEquals(0, collectionDao.listCollectionSchemas().size());
+    assertEquals(0, collectionService.list(twdsProperties.workspaceId()).size());
 
     UUID collectionUuid = workspaceId.id();
     CollectionId collectionId = CollectionId.of(collectionUuid);

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceTest.java
@@ -3,9 +3,9 @@ package org.databiosphere.workspacedataservice.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.databiosphere.workspacedataservice.TestUtils;
 import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.config.TwdsProperties;
-import org.databiosphere.workspacedataservice.dao.CollectionDao;
 import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.junit.jupiter.api.AfterEach;
@@ -13,33 +13,22 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ActiveProfiles;
 
-@ActiveProfiles(profiles = {"mock-collection-dao"})
 @DirtiesContext
 @SpringBootTest
 class CollectionServiceTest extends TestBase {
 
   @Autowired private CollectionService collectionService;
-  @Autowired private CollectionDao collectionDao;
+  @Autowired private NamedParameterJdbcTemplate namedTemplate;
   @Autowired private TwdsProperties twdsProperties;
 
   @BeforeEach
   @AfterEach
   void dropCollectionSchemas() {
-    // Delete all collections (v0.2)
-    collectionDao
-        .listCollectionSchemas()
-        .forEach(collection -> collectionDao.dropSchema(collection));
-    // Delete all collections in this workspace (v1)
-    WorkspaceId workspaceId = twdsProperties.workspaceId();
-    collectionService
-        .list(workspaceId)
-        .forEach(
-            collection -> {
-              collectionService.delete(workspaceId, CollectionId.of(collection.getId()));
-            });
+    // Delete all collections
+    TestUtils.cleanAllCollections(collectionService, namedTemplate);
   }
 
   @Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerBeanTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerBeanTest.java
@@ -15,7 +15,6 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.locks.Lock;
 import org.databiosphere.workspacedataservice.TestUtils;
-import org.databiosphere.workspacedataservice.annotations.SingleTenant;
 import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.config.TwdsProperties;
 import org.databiosphere.workspacedataservice.dao.*;
@@ -54,8 +53,6 @@ class CollectionInitializerBeanTest extends TestBase {
   @MockBean JdbcLockRegistry registry;
   @SpyBean CollectionDao collectionDao;
   @SpyBean CloneDao cloneDao;
-
-  @Autowired @SingleTenant WorkspaceId workspaceIdXXX;
 
   // sourceWorkspaceId when we need one
   final WorkspaceId sourceWorkspaceId = WorkspaceId.of(randomUUID());


### PR DESCRIPTION
More multi-tenancy changes in service of AJ-1971. This one removes the `CollectionDao.listCollectionSchemas()` method, which was not multi-tenant-safe.

I'll be removing `CollectionDao` piece by piece across a few PRs, to prevent any one PR from getting too big.