### PR TITLE
AJ-1971: removing collection dao

### DIFF
--- a/service/src/integrationTest/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerCloneTest.java
+++ b/service/src/integrationTest/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerCloneTest.java
@@ -119,7 +119,7 @@ class CollectionInitializerCloneTest extends IntegrationServiceTestBase {
 
     // default collection should exist, with no tables in it
     UUID workspaceUuid = workspaceId.id();
-    assertTrue(collectionDao.collectionSchemaExists(CollectionId.of(workspaceUuid)));
+    assertTrue(collectionService.exists(CollectionId.of(workspaceUuid)));
     assertThat(recordDao.getAllRecordTypes(workspaceUuid)).isEmpty();
   }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/CollectionDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/CollectionDao.java
@@ -5,12 +5,12 @@ import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 
 @Deprecated(forRemoval = true, since = "v0.18.0")
 public interface CollectionDao {
-  // 23 usages
+  // 18 usages
   boolean collectionSchemaExists(CollectionId collectionId);
 
   // 1 usage
   void alterSchema(CollectionId oldCollectionId, CollectionId newCollectionId);
 
-  // 14 usages
+  // 10 usages
   WorkspaceId getWorkspaceId(CollectionId collectionId);
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/CollectionDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/CollectionDao.java
@@ -1,11 +1,10 @@
 package org.databiosphere.workspacedataservice.dao;
 
 import org.databiosphere.workspacedataservice.shared.model.CollectionId;
-import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 
 @Deprecated(forRemoval = true, since = "v0.18.0")
 public interface CollectionDao {
-  // 18 usages
+  // 9 usages
   boolean collectionSchemaExists(CollectionId collectionId);
 
   // 1 usage

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/CollectionDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/CollectionDao.java
@@ -4,8 +4,6 @@ import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 
 @Deprecated(forRemoval = true, since = "v0.18.0")
 public interface CollectionDao {
-  // 9 usages
-  boolean collectionSchemaExists(CollectionId collectionId);
 
   // 1 usage
   void alterSchema(CollectionId oldCollectionId, CollectionId newCollectionId);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/CollectionDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/CollectionDao.java
@@ -10,7 +10,4 @@ public interface CollectionDao {
 
   // 1 usage
   void alterSchema(CollectionId oldCollectionId, CollectionId newCollectionId);
-
-  // 10 usages
-  WorkspaceId getWorkspaceId(CollectionId collectionId);
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresCollectionDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresCollectionDao.java
@@ -38,15 +38,6 @@ public class PostgresCollectionDao implements CollectionDao {
   }
 
   @Override
-  public boolean collectionSchemaExists(CollectionId collectionId) {
-    return Boolean.TRUE.equals(
-        namedTemplate.queryForObject(
-            "select exists(select from sys_wds.collection WHERE id = :collectionId)",
-            new MapSqlParameterSource("collectionId", collectionId.id()),
-            Boolean.class));
-  }
-
-  @Override
   @WriteTransaction
   @SuppressWarnings("squid:S2077") // since collectionId must be a UUID, it is safe to use inline
   public void alterSchema(CollectionId oldCollectionId, CollectionId newCollectionId) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresCollectionDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/PostgresCollectionDao.java
@@ -76,16 +76,6 @@ public class PostgresCollectionDao implements CollectionDao {
     insertCollectionRow(newCollectionId, /* ignoreConflict= */ true);
   }
 
-  @Override
-  public WorkspaceId getWorkspaceId(CollectionId collectionId) {
-    UUID workspaceUuid =
-        namedTemplate.queryForObject(
-            "select workspace_id from sys_wds.collection where id = :collectionId",
-            new MapSqlParameterSource("collectionId", collectionId.id()),
-            UUID.class);
-    return WorkspaceId.of(workspaceUuid);
-  }
-
   private void insertCollectionRow(CollectionId collectionId, boolean ignoreConflict) {
     // if workspaceId as configured by the $WORKSPACE_ID is null, use
     // collectionId instead

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/CollectionService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/CollectionService.java
@@ -213,7 +213,7 @@ public class CollectionService {
    * @param collectionId the collection id to inspect
    * @return whether the collection exists
    */
-  public Boolean exists(CollectionId collectionId) {
+  public boolean exists(CollectionId collectionId) {
     return collectionRepository.existsById(collectionId);
   }
 
@@ -368,7 +368,6 @@ public class CollectionService {
    * @param collectionId the collection for which to look up the workspace
    * @return the workspace containing the given collection.
    */
-  // TODO AJ-1971: unit tests?
   public WorkspaceId getWorkspaceId(CollectionId collectionId) {
     // look up the workspaceId for this collection in the collection table
     WorkspaceId rowWorkspaceId = null;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/CollectionService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/CollectionService.java
@@ -14,7 +14,6 @@ import java.util.stream.StreamSupport;
 import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
 import org.databiosphere.workspacedataservice.config.TenancyProperties;
 import org.databiosphere.workspacedataservice.config.TwdsProperties;
-import org.databiosphere.workspacedataservice.dao.CollectionDao;
 import org.databiosphere.workspacedataservice.dao.CollectionRepository;
 import org.databiosphere.workspacedataservice.generated.CollectionRequestServerModel;
 import org.databiosphere.workspacedataservice.generated.CollectionServerModel;
@@ -36,7 +35,6 @@ import org.springframework.stereotype.Service;
 @Service
 public class CollectionService {
   private static final Logger LOGGER = LoggerFactory.getLogger(CollectionService.class);
-  private final CollectionDao collectionDao;
   private final ActivityLogger activityLogger;
   private final TenancyProperties tenancyProperties;
   private final TwdsProperties twdsProperties;
@@ -49,13 +47,11 @@ public class CollectionService {
   public static final String NAME_DEFAULT = "default";
 
   public CollectionService(
-      CollectionDao collectionDao,
       ActivityLogger activityLogger,
       TenancyProperties tenancyProperties,
       TwdsProperties twdsProperties,
       CollectionRepository collectionRepository,
       NamedParameterJdbcTemplate namedTemplate) {
-    this.collectionDao = collectionDao;
     this.activityLogger = activityLogger;
     this.tenancyProperties = tenancyProperties;
     this.twdsProperties = twdsProperties;
@@ -212,6 +208,16 @@ public class CollectionService {
   }
 
   /**
+   * Does a collection exist at the given id?
+   *
+   * @param collectionId the collection id to inspect
+   * @return whether the collection exists
+   */
+  public Boolean exists(CollectionId collectionId) {
+    return collectionRepository.existsById(collectionId);
+  }
+
+  /**
    * Retrieve a single collection by its workspaceId and collectionId, or empty Optional if not
    * found.
    *
@@ -340,7 +346,7 @@ public class CollectionService {
       return;
     }
     // else, check if this collection has a row in the collections table
-    if (!collectionDao.collectionSchemaExists(CollectionId.of(collectionId))) {
+    if (!exists(CollectionId.of(collectionId))) {
       throw new MissingObjectException(COLLECTION);
     }
   }
@@ -362,6 +368,7 @@ public class CollectionService {
    * @param collectionId the collection for which to look up the workspace
    * @return the workspace containing the given collection.
    */
+  // TODO AJ-1971: unit tests?
   public WorkspaceId getWorkspaceId(CollectionId collectionId) {
     // look up the workspaceId for this collection in the collection table
     WorkspaceId rowWorkspaceId = null;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerBean.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerBean.java
@@ -8,7 +8,6 @@ import java.util.concurrent.locks.Lock;
 import org.apache.commons.lang3.StringUtils;
 import org.databiosphere.workspacedataservice.annotations.SingleTenant;
 import org.databiosphere.workspacedataservice.dao.CloneDao;
-import org.databiosphere.workspacedataservice.dao.CollectionDao;
 import org.databiosphere.workspacedataservice.leonardo.LeonardoDao;
 import org.databiosphere.workspacedataservice.service.BackupRestoreService;
 import org.databiosphere.workspacedataservice.service.CollectionService;
@@ -34,7 +33,6 @@ import org.springframework.lang.Nullable;
 
 public class CollectionInitializerBean {
 
-  private final CollectionDao collectionDao;
   private final CollectionService collectionService;
   private final LeonardoDao leoDao;
   private final WorkspaceDataServiceDao wdsDao;
@@ -54,14 +52,13 @@ public class CollectionInitializerBean {
    * Constructor. Called by {@link CollectionInitializerConfig}.
    *
    * @see CollectionInitializerConfig
-   * @param collectionDao CollectionDao
+   * @param collectionService CollectionService
    * @param leoDao LeonardoDao
    * @param wdsDao WorkspaceDataServiceDao
    * @param cloneDao CloneDao
    * @param restoreService BackupRestoreService
    */
   public CollectionInitializerBean(
-      CollectionDao collectionDao,
       CollectionService collectionService,
       LeonardoDao leoDao,
       WorkspaceDataServiceDao wdsDao,
@@ -71,7 +68,6 @@ public class CollectionInitializerBean {
       @SingleTenant WorkspaceId workspaceId,
       @Nullable String sourceWorkspaceIdString,
       String startupToken) {
-    this.collectionDao = collectionDao;
     this.collectionService = collectionService;
     this.leoDao = leoDao;
     this.wdsDao = wdsDao;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerBean.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerBean.java
@@ -142,7 +142,7 @@ public class CollectionInitializerBean {
       // If there's a clone entry and a default schema there's nothing for us to do here.
       if (cloneDao.cloneExistsForWorkspace(sourceWorkspaceId)) {
         boolean collectionSchemaExists =
-            collectionDao.collectionSchemaExists(CollectionId.of(workspaceId.id()));
+            collectionService.exists(CollectionId.of(workspaceId.id()));
         LOGGER.info(
             "Previous clone entry found. Collection schema exists: {}.", collectionSchemaExists);
         return collectionSchemaExists;

--- a/service/src/main/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerConfig.java
@@ -3,7 +3,6 @@ package org.databiosphere.workspacedataservice.startup;
 import org.databiosphere.workspacedataservice.annotations.DeploymentMode.DataPlane;
 import org.databiosphere.workspacedataservice.annotations.SingleTenant;
 import org.databiosphere.workspacedataservice.dao.CloneDao;
-import org.databiosphere.workspacedataservice.dao.CollectionDao;
 import org.databiosphere.workspacedataservice.leonardo.LeonardoDao;
 import org.databiosphere.workspacedataservice.service.BackupRestoreService;
 import org.databiosphere.workspacedataservice.service.CollectionService;
@@ -20,7 +19,6 @@ public class CollectionInitializerConfig {
   @DataPlane
   @Bean
   public CollectionInitializerBean collectionInitializerBean(
-      CollectionDao collectionDao,
       CollectionService collectionService,
       LeonardoDao leoDao,
       WorkspaceDataServiceDao wdsDao,
@@ -31,7 +29,6 @@ public class CollectionInitializerConfig {
       @Value("${twds.instance.source-workspace-id}") String sourceWorkspaceIdString,
       @Value("${twds.startup-token}") String startupToken) {
     return new CollectionInitializerBean(
-        collectionDao,
         collectionService,
         leoDao,
         wdsDao,

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/JobControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/JobControllerMockMvcTest.java
@@ -13,9 +13,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import org.databiosphere.workspacedataservice.dao.CollectionDao;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
+import org.databiosphere.workspacedataservice.service.CollectionService;
 import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -25,7 +25,7 @@ import org.springframework.test.web.servlet.MvcResult;
 @ActiveProfiles(profiles = {"mock-sam"})
 class JobControllerMockMvcTest extends MockMvcTestBase {
   @MockBean private JobDao jobDao;
-  @MockBean private CollectionDao collectionDao;
+  @MockBean private CollectionService collectionService;
 
   @Test
   void smokeTestGetJob() throws Exception {
@@ -66,7 +66,7 @@ class JobControllerMockMvcTest extends MockMvcTestBase {
     // set created and updated to now, but in UTC because that's how Postgres stores it
     OffsetDateTime time = OffsetDateTime.now(ZoneId.of("Z"));
 
-    when(collectionDao.collectionSchemaExists(collectionId)).thenReturn(true);
+    when(collectionService.exists(collectionId)).thenReturn(true);
 
     List<GenericJobServerModel> expected = new ArrayList<GenericJobServerModel>(2);
     expected.add(

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/JobControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/JobControllerMockMvcTest.java
@@ -13,17 +13,20 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.databiosphere.workspacedataservice.config.TwdsProperties;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
 import org.databiosphere.workspacedataservice.service.CollectionService;
 import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MvcResult;
 
 @ActiveProfiles(profiles = {"mock-sam"})
 class JobControllerMockMvcTest extends MockMvcTestBase {
+  @Autowired TwdsProperties twdsProperties;
   @MockBean private JobDao jobDao;
   @MockBean private CollectionService collectionService;
 
@@ -42,6 +45,9 @@ class JobControllerMockMvcTest extends MockMvcTestBase {
             OffsetDateTime.now(ZoneId.of("Z")),
             OffsetDateTime.now(ZoneId.of("Z")));
     when(jobDao.getJob(jobId)).thenReturn(expected);
+
+    when(collectionService.getWorkspaceId(CollectionId.of(collectionId)))
+        .thenReturn(twdsProperties.workspaceId());
 
     // calling the API should result in 202 Accepted
     MvcResult mvcResult =
@@ -66,7 +72,7 @@ class JobControllerMockMvcTest extends MockMvcTestBase {
     // set created and updated to now, but in UTC because that's how Postgres stores it
     OffsetDateTime time = OffsetDateTime.now(ZoneId.of("Z"));
 
-    when(collectionService.exists(collectionId)).thenReturn(true);
+    when(collectionService.getWorkspaceId(collectionId)).thenReturn(twdsProperties.workspaceId());
 
     List<GenericJobServerModel> expected = new ArrayList<GenericJobServerModel>(2);
     expected.add(

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/JobControllerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/JobControllerTest.java
@@ -21,12 +21,12 @@ import java.util.UUID;
 import org.databiosphere.workspacedata.model.ErrorResponse;
 import org.databiosphere.workspacedata.model.ImportRequest.TypeEnum;
 import org.databiosphere.workspacedataservice.common.TestBase;
-import org.databiosphere.workspacedataservice.dao.CollectionDao;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.dataimport.ImportJobInput;
 import org.databiosphere.workspacedataservice.dataimport.pfb.PfbImportOptions;
 import org.databiosphere.workspacedataservice.dataimport.pfb.PfbJobInput;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
+import org.databiosphere.workspacedataservice.service.CollectionService;
 import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -58,7 +58,7 @@ class JobControllerTest extends TestBase {
   @Autowired private NamedParameterJdbcTemplate namedTemplate;
   @Autowired private TestRestTemplate restTemplate;
   @Autowired private JobDao jobDao;
-  @MockBean private CollectionDao collectionDao;
+  @MockBean private CollectionService collectionService;
 
   private final CollectionId collectionId = CollectionId.of(randomUUID());
   private UUID jobId;
@@ -88,7 +88,7 @@ class JobControllerTest extends TestBase {
   @ParameterizedTest(name = "Return all jobs with a querystring of {0}")
   @ValueSource(strings = {"", "?someOtherParam=whatever", "?statuses="})
   void instanceJobsReturnAll(String queryString) {
-    when(collectionDao.collectionSchemaExists(collectionId)).thenReturn(true);
+    when(collectionService.exists(collectionId)).thenReturn(true);
     HttpHeaders headers = new HttpHeaders();
     ResponseEntity<List<GenericJobServerModel>> result =
         restTemplate.exchange(
@@ -113,7 +113,7 @@ class JobControllerTest extends TestBase {
 
   @Test
   void instanceJobsWithMultipleStatuses() {
-    when(collectionDao.collectionSchemaExists(collectionId)).thenReturn(true);
+    when(collectionService.exists(collectionId)).thenReturn(true);
     assertDoesNotThrow(() -> jobDao.updateStatus(jobId, StatusEnum.CANCELLED));
     HttpHeaders headers = new HttpHeaders();
     ResponseEntity<List<GenericJobServerModel>> result =
@@ -135,7 +135,7 @@ class JobControllerTest extends TestBase {
 
   @Test
   void instanceJobsWithMultipleDelimitedStatuses() {
-    when(collectionDao.collectionSchemaExists(collectionId)).thenReturn(true);
+    when(collectionService.exists(collectionId)).thenReturn(true);
     assertDoesNotThrow(() -> jobDao.updateStatus(jobId, StatusEnum.CANCELLED));
     HttpHeaders headers = new HttpHeaders();
     ResponseEntity<List<GenericJobServerModel>> result =
@@ -158,7 +158,7 @@ class JobControllerTest extends TestBase {
   @ParameterizedTest(name = "Return Bad Request with ?statuses={0}")
   @ValueSource(strings = {"xasdaf", "QUEUED,bad,RUNNING"})
   void instanceJobsWithEmpStatuses(String statusValues) {
-    when(collectionDao.collectionSchemaExists(collectionId)).thenReturn(true);
+    when(collectionService.exists(collectionId)).thenReturn(true);
     HttpHeaders headers = new HttpHeaders();
     ResponseEntity<ErrorResponse> result =
         restTemplate.exchange(

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/JobControllerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/JobControllerTest.java
@@ -21,6 +21,7 @@ import java.util.UUID;
 import org.databiosphere.workspacedata.model.ErrorResponse;
 import org.databiosphere.workspacedata.model.ImportRequest.TypeEnum;
 import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.config.TwdsProperties;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.dataimport.ImportJobInput;
 import org.databiosphere.workspacedataservice.dataimport.pfb.PfbImportOptions;
@@ -58,6 +59,7 @@ class JobControllerTest extends TestBase {
   @Autowired private NamedParameterJdbcTemplate namedTemplate;
   @Autowired private TestRestTemplate restTemplate;
   @Autowired private JobDao jobDao;
+  @Autowired private TwdsProperties twdsProperties;
   @MockBean private CollectionService collectionService;
 
   private final CollectionId collectionId = CollectionId.of(randomUUID());
@@ -88,7 +90,7 @@ class JobControllerTest extends TestBase {
   @ParameterizedTest(name = "Return all jobs with a querystring of {0}")
   @ValueSource(strings = {"", "?someOtherParam=whatever", "?statuses="})
   void instanceJobsReturnAll(String queryString) {
-    when(collectionService.exists(collectionId)).thenReturn(true);
+    when(collectionService.getWorkspaceId(collectionId)).thenReturn(twdsProperties.workspaceId());
     HttpHeaders headers = new HttpHeaders();
     ResponseEntity<List<GenericJobServerModel>> result =
         restTemplate.exchange(
@@ -113,7 +115,7 @@ class JobControllerTest extends TestBase {
 
   @Test
   void instanceJobsWithMultipleStatuses() {
-    when(collectionService.exists(collectionId)).thenReturn(true);
+    when(collectionService.getWorkspaceId(collectionId)).thenReturn(twdsProperties.workspaceId());
     assertDoesNotThrow(() -> jobDao.updateStatus(jobId, StatusEnum.CANCELLED));
     HttpHeaders headers = new HttpHeaders();
     ResponseEntity<List<GenericJobServerModel>> result =
@@ -135,7 +137,9 @@ class JobControllerTest extends TestBase {
 
   @Test
   void instanceJobsWithMultipleDelimitedStatuses() {
-    when(collectionService.exists(collectionId)).thenReturn(true);
+
+    when(collectionService.getWorkspaceId(collectionId)).thenReturn(twdsProperties.workspaceId());
+
     assertDoesNotThrow(() -> jobDao.updateStatus(jobId, StatusEnum.CANCELLED));
     HttpHeaders headers = new HttpHeaders();
     ResponseEntity<List<GenericJobServerModel>> result =

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/MockCollectionDao.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/MockCollectionDao.java
@@ -35,15 +35,4 @@ public class MockCollectionDao implements CollectionDao {
     collections.remove(oldCollectionId);
     collections.add(newCollectionId);
   }
-
-  @Override
-  public WorkspaceId getWorkspaceId(CollectionId collectionId) {
-    return workspaceId;
-  }
-
-  // convenience for unit tests: removes all collections
-  public void clearAllCollections() {
-    Set<CollectionId> toRemove = Set.copyOf(collections);
-    collections.removeAll(toRemove);
-  }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/MockCollectionDao.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/MockCollectionDao.java
@@ -19,11 +19,6 @@ public class MockCollectionDao implements CollectionDao {
   }
 
   @Override
-  public boolean collectionSchemaExists(CollectionId collectionId) {
-    return collections.contains(collectionId);
-  }
-
-  @Override
   public void alterSchema(CollectionId oldCollectionId, CollectionId newCollectionId) {
     if (!collections.contains(oldCollectionId)) {
       ServerErrorMessage sqlMsg =

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceGetWorkspaceIdTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceGetWorkspaceIdTest.java
@@ -64,8 +64,7 @@ class CollectionServiceGetWorkspaceIdTest {
 
   @AfterAll
   void afterAll() {
-    TestUtils.cleanAllCollections(collectionService, namedTemplate);
-    TestUtils.cleanAllWorkspaces(namedTemplate);
+    beforeEach(); // execute the same cleanup after all as we do before each
   }
 
   // single-tenant; workspace and collection both exist; workspace matches env var; collection

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceGetWorkspaceIdTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceGetWorkspaceIdTest.java
@@ -1,61 +1,131 @@
 package org.databiosphere.workspacedataservice.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.databiosphere.workspacedataservice.workspace.WorkspaceDataTableType.WDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.util.UUID;
-import org.databiosphere.workspacedataservice.annotations.SingleTenant;
-import org.databiosphere.workspacedataservice.common.TestBase;
-import org.databiosphere.workspacedataservice.dao.CollectionDao;
+import org.databiosphere.workspacedataservice.TestUtils;
+import org.databiosphere.workspacedataservice.config.DataImportProperties;
+import org.databiosphere.workspacedataservice.config.TenancyProperties;
+import org.databiosphere.workspacedataservice.config.TwdsProperties;
+import org.databiosphere.workspacedataservice.dao.WorkspaceRepository;
+import org.databiosphere.workspacedataservice.dataimport.ImportValidator;
 import org.databiosphere.workspacedataservice.service.model.exception.CollectionException;
 import org.databiosphere.workspacedataservice.service.model.exception.MissingObjectException;
 import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
+import org.databiosphere.workspacedataservice.workspace.WorkspaceRecord;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
 
 /** Tests for CollectionService.getWorkspaceId() */
+@ActiveProfiles("control-plane")
 @DirtiesContext
-@SpringBootTest
-class CollectionServiceGetWorkspaceIdTest extends TestBase {
+@SpringBootTest(
+    properties = { // turn off pubsub autoconfiguration for tests
+      "spring.cloud.gcp.pubsub.enabled=false",
+      // aggressive retry settings so unit tests don't run too long
+      "rest.retry.maxAttempts=2",
+      "rest.retry.backoff.delay=3",
+      // Rawls url must be valid, else context initialization (Spring startup) will fail
+      "rawlsUrl=https://localhost/"
+    })
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class CollectionServiceGetWorkspaceIdTest {
 
   @Autowired private CollectionService collectionService;
-  @Autowired @SingleTenant WorkspaceId workspaceId;
-  @MockBean private CollectionDao mockCollectionDao;
+
+  @Autowired private NamedParameterJdbcTemplate namedTemplate;
+  @Autowired private WorkspaceRepository workspaceRepository;
+
+  @MockBean TenancyProperties tenancyProperties;
+  @MockBean TwdsProperties twdsProperties;
+
+  // mocks to satisfy bean dependencies, but unused
+  @MockBean ImportValidator importValidator;
+  @MockBean DataImportProperties dataImportProperties;
 
   @BeforeEach
   void beforeEach() {
-    Mockito.reset(mockCollectionDao);
+    TestUtils.cleanAllCollections(collectionService, namedTemplate);
+    TestUtils.cleanAllWorkspaces(namedTemplate);
   }
 
-  @Test
-  void expectedWorkspaceId() {
-    // collection dao returns the workspace id set in $WORKSPACE_ID
-    when(mockCollectionDao.getWorkspaceId(any(CollectionId.class))).thenReturn(workspaceId);
+  @AfterAll
+  void afterAll() {
+    TestUtils.cleanAllCollections(collectionService, namedTemplate);
+    TestUtils.cleanAllWorkspaces(namedTemplate);
+  }
 
-    CollectionId collectionId = CollectionId.of(UUID.randomUUID());
+  // single-tenant; workspace and collection both exist; workspace matches env var; collection
+  // belongs to workspace
+  @Test
+  void singleTenant() {
+    WorkspaceId workspaceId = WorkspaceId.of(UUID.randomUUID());
+
+    when(twdsProperties.workspaceId()).thenReturn(workspaceId);
+    when(tenancyProperties.getAllowVirtualCollections()).thenReturn(false);
+    when(tenancyProperties.getEnforceCollectionsMatchWorkspaceId()).thenReturn(true);
+
+    workspaceRepository.save(new WorkspaceRecord(workspaceId, WDS, true));
+    CollectionId collectionId =
+        CollectionId.of(collectionService.save(workspaceId, "name", "desc").getId());
+
     // expect getWorkspaceId to return the same workspace id that the dao returned
     assertEquals(workspaceId, collectionService.getWorkspaceId(collectionId));
   }
 
+  // single-tenant; workspace and collection both exist; collection belongs to workspace -
+  // but, workspaceId does not match env var
   @Test
-  void missingWorkspaceId() {
-    // collection dao doesn't find a row and therefore throws EmptyResultDataAccessException
-    when(mockCollectionDao.getWorkspaceId(any(CollectionId.class)))
-        .thenThrow(new EmptyResultDataAccessException("unit test intentional exception", 1));
+  void singleTenantMismatchedWorkspaceId() {
+    WorkspaceId workspaceId = WorkspaceId.of(UUID.randomUUID());
 
-    CollectionId collectionId = CollectionId.of(UUID.randomUUID());
+    // set a random env var that does not match
+    when(twdsProperties.workspaceId()).thenReturn(WorkspaceId.of(UUID.randomUUID()));
+    when(tenancyProperties.getAllowVirtualCollections()).thenReturn(false);
+    when(tenancyProperties.getEnforceCollectionsMatchWorkspaceId()).thenReturn(true); // see below
 
-    // Act / assert
+    workspaceRepository.save(new WorkspaceRecord(workspaceId, WDS, true));
+
+    // note: to save a collection into a workspace which does not match the env var, we need to
+    // disable validation. However, we later want to assert the validation works. So, we turn off
+    // validation, save, then turn it back on.
+    when(tenancyProperties.getEnforceCollectionsMatchWorkspaceId()).thenReturn(false);
+    CollectionId collectionId =
+        CollectionId.of(collectionService.save(workspaceId, "name", "desc").getId());
+    when(tenancyProperties.getEnforceCollectionsMatchWorkspaceId()).thenReturn(true);
+
+    // expect getWorkspaceId to throw, since it found an unexpected workspace id
+    assertThrows(CollectionException.class, () -> collectionService.getWorkspaceId(collectionId));
+  }
+
+  // single-tenant; collection does not exist
+  @Test
+  void singleTenantMissingWorkspaceId() {
+    WorkspaceId workspaceId = WorkspaceId.of(UUID.randomUUID());
+
+    when(twdsProperties.workspaceId()).thenReturn(workspaceId);
+    when(tenancyProperties.getAllowVirtualCollections()).thenReturn(false);
+    when(tenancyProperties.getEnforceCollectionsMatchWorkspaceId()).thenReturn(true);
+
+    workspaceRepository.save(new WorkspaceRecord(workspaceId, WDS, true));
+    // note: we do NOT insert a collection here; the collection doesn't exist
+
+    // attempt to retrieve the workspaceid for the default collection, even though the default
+    // collection doesn't exist
+    CollectionId collectionId = CollectionId.of(workspaceId.id());
     MissingObjectException actual =
         assertThrows(
             MissingObjectException.class, () -> collectionService.getWorkspaceId(collectionId));
@@ -64,15 +134,54 @@ class CollectionServiceGetWorkspaceIdTest extends TestBase {
     assertThat(actual).hasMessageContaining("Collection does not exist");
   }
 
+  // multi-tenant; workspace and collection both exist; no workspace env var; collection
+  // belongs to workspace
   @Test
-  void nonDefaultWorkspaceId() {
-    // collection dao returns a value not equal to the workspace id set in $WORKSPACE_ID
-    WorkspaceId mismatchingWorkspaceId = WorkspaceId.of(UUID.randomUUID());
-    when(mockCollectionDao.getWorkspaceId(any(CollectionId.class)))
-        .thenReturn(mismatchingWorkspaceId);
+  void multiTenant() {
+    WorkspaceId workspaceId = WorkspaceId.of(UUID.randomUUID());
 
-    CollectionId collectionId = CollectionId.of(UUID.randomUUID());
-    // expect getWorkspaceId to throw, since it found an unexpected workspace id
-    assertThrows(CollectionException.class, () -> collectionService.getWorkspaceId(collectionId));
+    when(twdsProperties.workspaceId()).thenReturn(null);
+    when(tenancyProperties.getAllowVirtualCollections()).thenReturn(true);
+    when(tenancyProperties.getEnforceCollectionsMatchWorkspaceId()).thenReturn(false);
+
+    workspaceRepository.save(new WorkspaceRecord(workspaceId, WDS, true));
+    CollectionId collectionId =
+        CollectionId.of(collectionService.save(workspaceId, "name", "desc").getId());
+
+    // expect getWorkspaceId to return the same workspace id that the dao returned
+    assertEquals(workspaceId, collectionService.getWorkspaceId(collectionId));
+  }
+
+  // multi-tenant; workspace exists but collection does not; since virtual collections are allowed,
+  // returns workspaceId=collectionId
+  @Test
+  void multiTenantVirtual() {
+    WorkspaceId workspaceId = WorkspaceId.of(UUID.randomUUID());
+
+    when(twdsProperties.workspaceId()).thenReturn(null);
+    when(tenancyProperties.getAllowVirtualCollections()).thenReturn(true);
+    when(tenancyProperties.getEnforceCollectionsMatchWorkspaceId()).thenReturn(false);
+
+    workspaceRepository.save(new WorkspaceRecord(workspaceId, WDS, true));
+
+    // request the collection whose id matches the known workspace
+    assertEquals(workspaceId, collectionService.getWorkspaceId(CollectionId.of(workspaceId.id())));
+  }
+
+  // multi-tenant; workspace virtual collections allowed; workspace does not exist
+  @Test
+  void multiTenantVirtualMissingWorkspace() {
+    WorkspaceId workspaceId = WorkspaceId.of(UUID.randomUUID());
+
+    when(twdsProperties.workspaceId()).thenReturn(null);
+    when(tenancyProperties.getAllowVirtualCollections()).thenReturn(true);
+    when(tenancyProperties.getEnforceCollectionsMatchWorkspaceId()).thenReturn(false);
+
+    // note we do not insert a workspace here
+
+    // request the collection whose id matches the known workspace
+    // this passes, even though the workspace doesn't exist; workspace validation happens at a
+    // higher layer
+    assertEquals(workspaceId, collectionService.getWorkspaceId(CollectionId.of(workspaceId.id())));
   }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceDataPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceDataPlaneTest.java
@@ -10,7 +10,6 @@ import java.util.Optional;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.annotations.SingleTenant;
 import org.databiosphere.workspacedataservice.common.TestBase;
-import org.databiosphere.workspacedataservice.dao.CollectionDao;
 import org.databiosphere.workspacedataservice.dao.CollectionRepository;
 import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
 import org.databiosphere.workspacedataservice.service.model.exception.CollectionException;
@@ -37,7 +36,7 @@ import org.springframework.test.context.ActiveProfiles;
 class ImportServiceDataPlaneTest extends TestBase {
   @Autowired ImportService importService;
   @Autowired @SingleTenant WorkspaceId workspaceId;
-  @MockBean CollectionDao collectionDao;
+  @MockBean CollectionService collectionService;
   @MockBean CollectionRepository collectionRepository;
 
   private final URI importUri =
@@ -52,7 +51,7 @@ class ImportServiceDataPlaneTest extends TestBase {
   void singleTenantWorkspaceId() {
     // ARRANGE
     // collection dao says the collection exists and returns the expected workspace id
-    when(collectionDao.collectionSchemaExists(collectionId)).thenReturn(true);
+    when(collectionService.exists(collectionId)).thenReturn(true);
     WdsCollection collection = new WdsCollection(workspaceId, collectionId, "name", "desc");
     when(collectionRepository.findById(collectionId)).thenReturn(Optional.of(collection));
 
@@ -70,7 +69,7 @@ class ImportServiceDataPlaneTest extends TestBase {
     // ARRANGE
     WorkspaceId nonMatchingWorkspaceId = WorkspaceId.of(UUID.randomUUID());
     // collection dao says the collection exists and returns an unexpected workspace id
-    when(collectionDao.collectionSchemaExists(collectionId)).thenReturn(true);
+    when(collectionService.exists(collectionId)).thenReturn(true);
     WdsCollection collection =
         new WdsCollection(nonMatchingWorkspaceId, collectionId, "name", "desc");
     when(collectionRepository.findById(collectionId)).thenReturn(Optional.of(collection));
@@ -89,7 +88,7 @@ class ImportServiceDataPlaneTest extends TestBase {
   void collectionDoesNotExist() {
     // ARRANGE
     // collection dao says the collection does not exist
-    when(collectionDao.collectionSchemaExists(collectionId)).thenReturn(false);
+    when(collectionService.exists(collectionId)).thenReturn(false);
     when(collectionRepository.findById(collectionId)).thenReturn(Optional.empty());
 
     // ACT/ASSERT

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceDataPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceDataPlaneTest.java
@@ -63,7 +63,6 @@ class ImportServiceDataPlaneTest extends TestBase {
   @Test
   void unexpectedWorkspaceId() {
     // ARRANGE
-    WorkspaceId nonMatchingWorkspaceId = WorkspaceId.of(UUID.randomUUID());
     // collection dao says the collection exists and returns an unexpected workspace id
     // collectionService.validateCollection() does not throw
     when(collectionService.getWorkspaceId(collectionId))

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/JobServiceControlPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/JobServiceControlPlaneTest.java
@@ -16,7 +16,7 @@ import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import org.databiosphere.workspacedataservice.dao.CollectionDao;
+import org.databiosphere.workspacedataservice.dao.CollectionRepository;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
 import org.databiosphere.workspacedataservice.pubsub.JobStatusUpdate;
@@ -46,7 +46,7 @@ class JobServiceControlPlaneTest extends JobServiceTestBase {
 
   @Autowired JobService jobService;
   @MockBean JobDao jobDao;
-  @MockBean CollectionDao collectionDao;
+  @MockBean CollectionRepository collectionRepository;
 
   /** requested job does not exist */
   @Test
@@ -74,8 +74,7 @@ class JobServiceControlPlaneTest extends JobServiceTestBase {
     // job exists
     when(jobDao.getJob(jobId)).thenReturn(expectedJob);
     // collection for this job does not exist
-    when(collectionDao.getWorkspaceId(collectionId))
-        .thenThrow(new EmptyResultDataAccessException("unit test intentional error", 1));
+    when(collectionRepository.findById(collectionId)).thenReturn(Optional.empty());
 
     // Act
     GenericJobServerModel actual = jobService.getJob(jobId);
@@ -94,8 +93,7 @@ class JobServiceControlPlaneTest extends JobServiceTestBase {
     // Arrange
     CollectionId collectionId = CollectionId.of(randomUUID());
     // collection for this job does not exist
-    when(collectionDao.getWorkspaceId(collectionId))
-        .thenThrow(new EmptyResultDataAccessException("unit test intentional error", 1));
+    when(collectionRepository.findById(collectionId)).thenReturn(Optional.empty());
     // return some jobs when listing this collection
     when(jobDao.getJobsForCollection(eq(collectionId), any()))
         .thenReturn(makeJobList(collectionId, 2));

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/JobServiceDataPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/JobServiceDataPlaneTest.java
@@ -16,7 +16,6 @@ import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
 import org.databiosphere.workspacedataservice.service.model.exception.MissingObjectException;
 import org.databiosphere.workspacedataservice.shared.model.CollectionId;
-import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/JobServiceDataPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/JobServiceDataPlaneTest.java
@@ -124,12 +124,4 @@ class JobServiceDataPlaneTest extends JobServiceTestBase {
     // this is verifying permissions only; only smoke-testing correctness of the result
     assertThat(actual).hasSize(2);
   }
-
-  // ==================================================
-  // ========== helpers ===============================
-  // ==================================================
-
-  private WorkspaceId getEnvWorkspaceId() {
-    return twdsProperties.workspaceId();
-  }
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerBeanTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerBeanTest.java
@@ -52,7 +52,6 @@ class CollectionInitializerBeanTest extends TestBase {
   @Autowired BackupRestoreService restoreService;
   @Autowired TwdsProperties twdsProperties;
   @MockBean JdbcLockRegistry registry;
-  @SpyBean CollectionDao collectionDao;
   @SpyBean CollectionRepository collectionRepository;
   @SpyBean CloneDao cloneDao;
 
@@ -197,7 +196,6 @@ class CollectionInitializerBeanTest extends TestBase {
 
   private CollectionInitializerBean getBean(@Nullable String sourceWorkspaceIdString) {
     return new CollectionInitializerBean(
-        collectionDao,
         collectionService,
         leoDao,
         wdsDao,

--- a/service/src/test/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerBeanTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerBeanTest.java
@@ -89,10 +89,10 @@ class CollectionInitializerBeanTest extends TestBase {
   void testSchemaAlreadyExists() {
     verify(collectionRepository, never()).save(any());
     // collection does not exist
-    assertFalse(collectionDao.collectionSchemaExists(collectionIdMatchingWorkspaceId()));
+    assertFalse(collectionService.exists(collectionIdMatchingWorkspaceId()));
     // create the collection outside the initializer
     collectionService.createDefaultCollection(twdsProperties.workspaceId());
-    assertTrue(collectionDao.collectionSchemaExists(collectionIdMatchingWorkspaceId()));
+    assertTrue(collectionService.exists(collectionIdMatchingWorkspaceId()));
     verify(collectionRepository, times(1)).save(any());
 
     // now run the initializer
@@ -101,14 +101,14 @@ class CollectionInitializerBeanTest extends TestBase {
     // verify that method to create collection was NOT called again. We expect one call from the
     // setup above.
     verify(collectionRepository, times(1)).save(any());
-    assertTrue(collectionDao.collectionSchemaExists(collectionIdMatchingWorkspaceId()));
+    assertTrue(collectionService.exists(collectionIdMatchingWorkspaceId()));
   }
 
   @Test
   // Cloning where we can get a lock and complete successfully.
   void cloneSuccessfully() {
     // collection does not exist
-    assertFalse(collectionDao.collectionSchemaExists(collectionIdMatchingWorkspaceId()));
+    assertFalse(collectionService.exists(collectionIdMatchingWorkspaceId()));
     // enter clone mode
     getBean().initCloneMode(sourceWorkspaceId);
     // confirm we have moved forward with cloning
@@ -120,7 +120,7 @@ class CollectionInitializerBeanTest extends TestBase {
   void cloneWithLockFail() throws InterruptedException {
     when(mockLock.tryLock(anyLong(), any())).thenReturn(false);
     // collection does not exist
-    assertFalse(collectionDao.collectionSchemaExists(collectionIdMatchingWorkspaceId()));
+    assertFalse(collectionService.exists(collectionIdMatchingWorkspaceId()));
     // enter clone mode
     boolean cleanExit = getBean().initCloneMode(sourceWorkspaceId);
     // initCloneMode() should have returned true since we did not enter a situation
@@ -151,7 +151,7 @@ class CollectionInitializerBeanTest extends TestBase {
     // start with clone entry
     cloneDao.createCloneEntry(randomUUID(), sourceWorkspaceId);
     // collection does not exist
-    assertFalse(collectionDao.collectionSchemaExists(collectionIdMatchingWorkspaceId()));
+    assertFalse(collectionService.exists(collectionIdMatchingWorkspaceId()));
     // enter clone mode
     boolean cleanExit = getBean().initCloneMode(sourceWorkspaceId);
     // initCloneMode() should have returned false since we encountered a situation


### PR DESCRIPTION
Deletes `CollectionDao.collectionSchemaExists()` and `CollectionDao. getWorkspaceId()`, as part of migrating fully to the multi-tenant CollectionRepository. Many unit test updates and some runtime changes to reflect these removals.

This PR has one Sonar warning, which I am ignoring; that code will be deleted shortly in the final follow-on PR, so I'm not bothering with it here.