### PR TITLE
[AJ-1994] Turn off azure e2e tests

### DIFF
--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -1,8 +1,5 @@
 name: Run WDS e2e tests with BEE
 'on':
-  schedule:
-    # run twice a day at 10:00 and 22:00 UTC every day of the week
-    - cron: "0 10/12 * * 1-5"
   workflow_dispatch:
 env:
   BEE_NAME: 'wds-${{ github.run_id }}-${{ github.run_attempt}}-dev'


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1994
This PR stops running the azure e2e tests on a regular schedule.  They can still be run as needed.