### PR TITLE
AJ-1981: rename TestBase to DataPlaneTestBase

### DIFF
--- a/service/src/test/java/org/databiosphere/workspacedataservice/GeneratedClientTests.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/GeneratedClientTests.java
@@ -29,7 +29,7 @@ import org.databiosphere.workspacedata.model.SearchFilter;
 import org.databiosphere.workspacedata.model.SearchRequest;
 import org.databiosphere.workspacedata.model.StatusResponse;
 import org.databiosphere.workspacedata.model.TsvUploadResponse;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.config.TwdsProperties;
 import org.databiosphere.workspacedataservice.service.CollectionService;
 import org.junit.jupiter.api.AfterEach;
@@ -49,7 +49,7 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles(profiles = "mock-sam")
 @DirtiesContext
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-class GeneratedClientTests extends TestBase {
+class GeneratedClientTests extends DataPlaneTestBase {
 
   private ApiClient apiClient;
   @LocalServerPort int port;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/ActivityEventBuilderTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/ActivityEventBuilderTest.java
@@ -12,7 +12,7 @@ import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.UsersApi;
 import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo;
 import org.databiosphere.workspacedataservice.TestUtils;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.config.TwdsProperties;
 import org.databiosphere.workspacedataservice.generated.CollectionServerModel;
 import org.databiosphere.workspacedataservice.sam.BearerTokenFilter;
@@ -37,7 +37,7 @@ import org.springframework.web.context.request.RequestContextHolder;
 @SpringBootTest
 @AutoConfigureMockMvc
 @ExtendWith(OutputCaptureExtension.class)
-class ActivityEventBuilderTest extends TestBase {
+class ActivityEventBuilderTest extends DataPlaneTestBase {
 
   @Autowired CollectionService collectionService;
   @Autowired TwdsProperties twdsProperties;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/AvailabilityTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/AvailabilityTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.availability.ApplicationAvailability;
@@ -19,7 +19,7 @@ import org.springframework.test.web.servlet.ResultActions;
 
 @AutoConfigureMockMvc
 @SpringBootTest
-class AvailabilityTest extends TestBase {
+class AvailabilityTest extends DataPlaneTestBase {
 
   @Autowired private MockMvc mvc;
   @Autowired private ApplicationContext context;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/LogStatementTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/LogStatementTest.java
@@ -10,7 +10,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Optional;
 import org.databiosphere.workspacedataservice.TestUtils;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.config.TwdsProperties;
 import org.databiosphere.workspacedataservice.datarepo.DataRepoClientFactory;
 import org.databiosphere.workspacedataservice.generated.CollectionRequestServerModel;
@@ -42,7 +42,7 @@ import org.springframework.web.multipart.MultipartFile;
 @SpringBootTest
 @ExtendWith(OutputCaptureExtension.class)
 @DirtiesContext
-class LogStatementTest extends TestBase {
+class LogStatementTest extends DataPlaneTestBase {
 
   private final String VERSION = "v0.2";
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/annotations/AnnotatedApisTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/annotations/AnnotatedApisTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Optional;
 import org.databiosphere.workspacedataservice.annotations.DeploymentMode.ControlPlane;
 import org.databiosphere.workspacedataservice.annotations.DeploymentMode.DataPlane;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.dataimport.protecteddatasupport.ProtectedDataSupport;
 import org.databiosphere.workspacedataservice.dataimport.protecteddatasupport.WsmProtectedDataSupport;
 import org.databiosphere.workspacedataservice.workspace.DataTableTypeInspector;
@@ -34,7 +34,7 @@ import org.springframework.web.bind.annotation.RestController;
       // turn off pubsub autoconfiguration for tests
       "spring.cloud.gcp.pubsub.enabled=false"
     })
-class AnnotatedApisTest extends TestBase {
+class AnnotatedApisTest extends DataPlaneTestBase {
 
   // Since we're running with both control-plane and data-plane profiles simultaneously, Spring
   // does not know what to do with beans which are satisfied by two different mutually exclusive

--- a/service/src/test/java/org/databiosphere/workspacedataservice/annotations/DeploymentModeTestBase.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/annotations/DeploymentModeTestBase.java
@@ -5,7 +5,7 @@ import static org.springframework.context.annotation.FilterType.ANNOTATION;
 import java.util.stream.Stream;
 import org.databiosphere.workspacedataservice.annotations.DeploymentMode.ControlPlane;
 import org.databiosphere.workspacedataservice.annotations.DeploymentMode.DataPlane;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -24,7 +24,7 @@ import org.springframework.test.annotation.DirtiesContext;
     })
 @DirtiesContext
 @SpringBootTest
-class DeploymentModeTestBase extends TestBase {
+class DeploymentModeTestBase extends DataPlaneTestBase {
 
   @Autowired protected ApplicationContext context;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/common/ConfigurationExceptionDetector.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/common/ConfigurationExceptionDetector.java
@@ -10,7 +10,7 @@ public class ConfigurationExceptionDetector implements TestWatcher {
 
   private static final String RESOLUTION_HINT =
       "You may need to specify @ActiveProfiles with \"data-plane\" or \"control-plane\" or extend %s"
-          .formatted(TestBase.class.getSimpleName());
+          .formatted(DataPlaneTestBase.class.getSimpleName());
 
   @Override
   public void testFailed(ExtensionContext context, Throwable cause) {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/common/DataPlaneTestBase.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/common/DataPlaneTestBase.java
@@ -28,7 +28,7 @@ import org.springframework.test.context.TestPropertySource;
     properties = {
       // data-plane mode requires a workspace-id to be set
       // example uuid from https://en.wikipedia.org/wiki/Universally_unique_identifier
-      "twds.instance.workspace-id=" + TestBase.HARDCODED_WORKSPACE_ID,
+      "twds.instance.workspace-id=" + DataPlaneTestBase.HARDCODED_WORKSPACE_ID,
       // turn off pubsub autoconfiguration for tests
       "spring.cloud.gcp.pubsub.enabled=false",
       // aggressive retry settings so unit tests don't run too long
@@ -38,6 +38,6 @@ import org.springframework.test.context.TestPropertySource;
       "rawlsUrl=https://localhost/"
     })
 @ExtendWith(ConfigurationExceptionDetector.class)
-public abstract class TestBase {
-  public static final String HARDCODED_WORKSPACE_ID = "123e4567-e89b-12d3-a456-426614174000";
+public abstract class DataPlaneTestBase {
+  public static final String HARDCODED_WORKSPACE_ID = "123e4567-e89b-12d3-a456-426614174000=";
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/common/DataPlaneTestBase.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/common/DataPlaneTestBase.java
@@ -39,5 +39,5 @@ import org.springframework.test.context.TestPropertySource;
     })
 @ExtendWith(ConfigurationExceptionDetector.class)
 public abstract class DataPlaneTestBase {
-  public static final String HARDCODED_WORKSPACE_ID = "123e4567-e89b-12d3-a456-426614174000=";
+  public static final String HARDCODED_WORKSPACE_ID = "123e4567-e89b-12d3-a456-426614174000";
 }

--- a/service/src/test/java/org/databiosphere/workspacedataservice/config/TwdsPropertiesDataPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/config/TwdsPropertiesDataPlaneTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -14,7 +14,7 @@ import org.springframework.test.context.ActiveProfiles;
 @SpringBootTest
 @DirtiesContext
 @ActiveProfiles("data-plane")
-class TwdsPropertiesDataPlaneTest extends TestBase {
+class TwdsPropertiesDataPlaneTest extends DataPlaneTestBase {
   @Autowired TwdsProperties twdsProperties;
   @Autowired DataImportProperties dataImportProperties;
   @Autowired InstanceProperties instanceProperties;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/ConcurrentDataTypeChangesTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/ConcurrentDataTypeChangesTest.java
@@ -13,7 +13,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.databiosphere.workspacedataservice.TestUtils;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.config.TwdsProperties;
 import org.databiosphere.workspacedataservice.generated.CollectionRequestServerModel;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
@@ -38,7 +38,7 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles(profiles = "mock-sam")
 @DirtiesContext
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-class ConcurrentDataTypeChangesTest extends TestBase {
+class ConcurrentDataTypeChangesTest extends DataPlaneTestBase {
   @Autowired private TestRestTemplate restTemplate;
   private HttpHeaders headers;
   private UUID instanceId;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackMDCRequestResponseTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackMDCRequestResponseTest.java
@@ -7,7 +7,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.util.List;
 import java.util.UUID;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.service.MDCServletRequestListener;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
@@ -26,7 +26,7 @@ import org.springframework.test.annotation.DirtiesContext;
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     properties = {"spring.main.allow-bean-definition-overriding=true"})
-class FullStackMDCRequestResponseTest extends TestBase {
+class FullStackMDCRequestResponseTest extends DataPlaneTestBase {
 
   // hmmmmm https://github.com/gradle/gradle/issues/5975
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
@@ -22,7 +22,7 @@ import java.util.UUID;
 import java.util.function.Supplier;
 import org.databiosphere.workspacedata.model.ErrorResponse;
 import org.databiosphere.workspacedataservice.TestUtils;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.config.TwdsProperties;
 import org.databiosphere.workspacedataservice.generated.CollectionRequestServerModel;
 import org.databiosphere.workspacedataservice.service.RelationUtils;
@@ -65,7 +65,7 @@ import org.springframework.transaction.annotation.Transactional;
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     properties = {"spring.main.allow-bean-definition-overriding=true"})
 @Import(SmallBatchWriteTestConfig.class)
-class FullStackRecordControllerTest extends TestBase {
+class FullStackRecordControllerTest extends DataPlaneTestBase {
   @Autowired private TestRestTemplate restTemplate;
   private HttpHeaders headers;
   private UUID instanceId;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/GlobalExceptionHandlerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/GlobalExceptionHandlerTest.java
@@ -5,13 +5,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class GlobalExceptionHandlerTest extends TestBase {
+class GlobalExceptionHandlerTest extends DataPlaneTestBase {
   @Autowired private GlobalExceptionHandler globalExceptionHandler;
 
   @Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/JobControllerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/JobControllerTest.java
@@ -20,7 +20,7 @@ import java.util.Map;
 import java.util.UUID;
 import org.databiosphere.workspacedata.model.ErrorResponse;
 import org.databiosphere.workspacedata.model.ImportRequest.TypeEnum;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.config.TwdsProperties;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.dataimport.ImportJobInput;
@@ -53,7 +53,7 @@ import org.springframework.test.context.ActiveProfiles;
 @DirtiesContext
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-class JobControllerTest extends TestBase {
+class JobControllerTest extends DataPlaneTestBase {
   private static final String TEST_IMPORT_URI = "http://some/uri";
 
   @Autowired private NamedParameterJdbcTemplate namedTemplate;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/MockMvcTestBase.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/MockMvcTestBase.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -14,7 +14,7 @@ import org.springframework.test.web.servlet.MvcResult;
 
 @AutoConfigureMockMvc
 @SpringBootTest
-class MockMvcTestBase extends TestBase {
+class MockMvcTestBase extends DataPlaneTestBase {
   @Autowired private ObjectMapper mapper;
   @Autowired protected MockMvc mockMvc;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvDownloadTest.java
@@ -23,7 +23,7 @@ import java.util.UUID;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.databiosphere.workspacedataservice.TestUtils;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.config.TwdsProperties;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.databiosphere.workspacedataservice.generated.CollectionRequestServerModel;
@@ -64,7 +64,7 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles(profiles = "mock-sam")
 @DirtiesContext
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-class TsvDownloadTest extends TestBase {
+class TsvDownloadTest extends DataPlaneTestBase {
 
   @Autowired private TestRestTemplate restTemplate;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvInputFormatsTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/TsvInputFormatsTest.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.databiosphere.workspacedataservice.TestUtils;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.config.TwdsProperties;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.databiosphere.workspacedataservice.generated.CollectionRequestServerModel;
@@ -42,7 +42,7 @@ import org.springframework.transaction.annotation.Transactional;
 @DirtiesContext
 @SpringBootTest
 @AutoConfigureMockMvc
-class TsvInputFormatsTest extends TestBase {
+class TsvInputFormatsTest extends DataPlaneTestBase {
 
   @Autowired private MockMvc mockMvc;
   @Autowired RecordDao recordDao;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/PostgresJobDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/PostgresJobDaoTest.java
@@ -22,9 +22,9 @@ import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.common.MockInstantSource;
 import org.databiosphere.workspacedataservice.common.MockInstantSourceConfig;
-import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.dataimport.ImportJobInput;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
 import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
@@ -50,7 +50,7 @@ import org.springframework.test.annotation.DirtiesContext;
 @DirtiesContext
 @SpringBootTest
 @Import(MockInstantSourceConfig.class)
-class PostgresJobDaoTest extends TestBase {
+class PostgresJobDaoTest extends DataPlaneTestBase {
   private static final String TEST_IMPORT_URI = "http://some/uri";
 
   // createJob

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/QuartzSchedulerDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/QuartzSchedulerDaoTest.java
@@ -8,7 +8,7 @@ import java.io.Serializable;
 import java.util.Date;
 import java.util.Map;
 import java.util.Set;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.shared.model.Schedulable;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -25,7 +25,7 @@ import org.springframework.test.annotation.DirtiesContext;
 
 @DirtiesContext
 @SpringBootTest
-class QuartzSchedulerDaoTest extends TestBase {
+class QuartzSchedulerDaoTest extends DataPlaneTestBase {
 
   @MockBean Scheduler scheduler;
   @Autowired SchedulerDao schedulerDao;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/RecordDaoTest.java
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.databiosphere.workspacedataservice.TestUtils;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.config.TwdsProperties;
 import org.databiosphere.workspacedataservice.service.CollectionService;
 import org.databiosphere.workspacedataservice.service.RelationUtils;
@@ -48,7 +48,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class RecordDaoTest extends TestBase {
+class RecordDaoTest extends DataPlaneTestBase {
 
   private static final String PRIMARY_KEY = "row_id";
   @Autowired RecordDao recordDao;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/DefaultImportValidatorTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/DefaultImportValidatorTest.java
@@ -15,7 +15,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import org.broadinstitute.dsde.workbench.client.sam.model.RolesAndActions;
 import org.broadinstitute.dsde.workbench.client.sam.model.UserResourcesResponse;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.config.DataImportProperties.ImportSourceConfig;
 import org.databiosphere.workspacedataservice.dataimport.protecteddatasupport.ProtectedDataSupport;
 import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
@@ -36,7 +36,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
 
 @SpringBootTest
-class DefaultImportValidatorTest extends TestBase {
+class DefaultImportValidatorTest extends DataPlaneTestBase {
 
   @TestConfiguration
   static class DefaultImportValidatorTestConfiguration {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/FileDownloadHelperTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/FileDownloadHelperTest.java
@@ -3,14 +3,14 @@ package org.databiosphere.workspacedataservice.dataimport;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.io.IOException;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.io.Resource;
 
 @SpringBootTest
-class FileDownloadHelperTest extends TestBase {
+class FileDownloadHelperTest extends DataPlaneTestBase {
 
   @Value("classpath:parquet/empty.parquet")
   Resource emptyParquet;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/ImportJobInputTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/ImportJobInputTest.java
@@ -13,7 +13,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.dataimport.pfb.PfbImportOptions;
 import org.databiosphere.workspacedataservice.dataimport.pfb.PfbJobInput;
 import org.databiosphere.workspacedataservice.dataimport.rawlsjson.RawlsJsonImportOptions;
@@ -29,7 +29,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class ImportJobInputTest extends TestBase {
+class ImportJobInputTest extends DataPlaneTestBase {
   @Autowired ObjectMapper objectMapper;
 
   @ParameterizedTest(name = "with type {0}")

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/ImportRequirementsFactoryTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/ImportRequirementsFactoryTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.URI;
 import java.util.stream.Stream;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.config.DataImportProperties;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -13,7 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class ImportRequirementsFactoryTest extends TestBase {
+class ImportRequirementsFactoryTest extends DataPlaneTestBase {
   @Autowired DataImportProperties dataImportProperties;
 
   @ParameterizedTest(name = "Imports from {0} should require a private workspace {1}")

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobTest.java
@@ -31,7 +31,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.service.BatchWriteService;
 import org.databiosphere.workspacedataservice.service.CollectionService;
@@ -56,7 +56,7 @@ import org.springframework.test.annotation.DirtiesContext;
 
 @DirtiesContext
 @SpringBootTest
-class PfbQuartzJobTest extends TestBase {
+class PfbQuartzJobTest extends DataPlaneTestBase {
   @MockBean JobDao jobDao;
   @MockBean WorkspaceManagerDao wsmDao;
   @MockBean BatchWriteService batchWriteService;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbRecordConverterTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbRecordConverterTest.java
@@ -25,7 +25,7 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.recordsource.RecordSource.ImportMode;
 import org.databiosphere.workspacedataservice.service.JsonConfig;
 import org.databiosphere.workspacedataservice.shared.model.Record;
@@ -42,7 +42,7 @@ import org.springframework.test.annotation.DirtiesContext;
 
 @DirtiesContext
 @SpringBootTest(classes = {JsonConfig.class, PfbRecordConverter.class})
-class PfbRecordConverterTest extends TestBase {
+class PfbRecordConverterTest extends DataPlaneTestBase {
 
   @Autowired private PfbRecordConverter converter;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/protecteddatasupport/RawlsProtectedDataSupportTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/protecteddatasupport/RawlsProtectedDataSupportTest.java
@@ -8,7 +8,7 @@ import bio.terra.workspace.model.WsmPolicyInput;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.rawls.RawlsClient;
 import org.databiosphere.workspacedataservice.rawls.RawlsWorkspaceDetails;
 import org.databiosphere.workspacedataservice.rawls.RawlsWorkspaceDetails.RawlsWorkspace.WorkspaceType;
@@ -23,7 +23,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles(profiles = "control-plane", inheritProfiles = false)
-class RawlsProtectedDataSupportTest extends TestBase {
+class RawlsProtectedDataSupportTest extends DataPlaneTestBase {
   @MockBean RawlsClient rawlsClient;
 
   @Autowired RawlsProtectedDataSupport rawlsProtectedDataSupport;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/protecteddatasupport/WsmProtectedDataSupportTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/protecteddatasupport/WsmProtectedDataSupportTest.java
@@ -8,7 +8,7 @@ import bio.terra.workspace.model.WsmPolicyInput;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.databiosphere.workspacedataservice.workspacemanager.WorkspaceManagerDao;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -19,7 +19,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
 @SpringBootTest
-class WsmProtectedDataSupportTest extends TestBase {
+class WsmProtectedDataSupportTest extends DataPlaneTestBase {
   @MockBean WorkspaceManagerDao wsmDao;
 
   @Autowired WsmProtectedDataSupport wsmProtectedDataSupport;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/rawlsjson/RawlsJsonQuartzJobTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/rawlsjson/RawlsJsonQuartzJobTest.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.TestUtils;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.pubsub.PubSub;
 import org.databiosphere.workspacedataservice.sam.MockSamUsersApi;
@@ -50,7 +50,7 @@ import org.springframework.test.context.TestPropertySource;
       "spring.cloud.gcp.pubsub.enabled=false",
       "rawlsUrl=https://localhost/",
     })
-class RawlsJsonQuartzJobTest extends TestBase {
+class RawlsJsonQuartzJobTest extends DataPlaneTestBase {
   @Autowired private CollectionService collectionService;
   @Autowired private NamedParameterJdbcTemplate namedTemplate;
   @Autowired private RawlsJsonTestSupport testSupport;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/snapshotsupport/RawlsSnapshotSupportTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/snapshotsupport/RawlsSnapshotSupportTest.java
@@ -14,7 +14,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.rawls.RawlsClient;
 import org.databiosphere.workspacedataservice.rawls.SnapshotListResponse;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
@@ -28,7 +28,7 @@ import org.springframework.test.context.ActiveProfiles;
 @DirtiesContext
 @ActiveProfiles(value = "control-plane", inheritProfiles = false)
 @SpringBootTest
-class RawlsSnapshotSupportTest extends TestBase {
+class RawlsSnapshotSupportTest extends DataPlaneTestBase {
 
   @MockBean RawlsClient rawlsClient;
   @MockBean ActivityLogger activityLogger;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/snapshotsupport/SnapshotSupportTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/snapshotsupport/SnapshotSupportTest.java
@@ -21,7 +21,7 @@ import java.util.UUID;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 import org.databiosphere.workspacedataservice.workspacemanager.WorkspaceManagerDao;
 import org.junit.jupiter.api.Test;
@@ -30,7 +30,7 @@ import org.springframework.test.annotation.DirtiesContext;
 
 @DirtiesContext
 @SpringBootTest
-class SnapshotSupportTest extends TestBase {
+class SnapshotSupportTest extends DataPlaneTestBase {
 
   @Test
   void safeGetSnapshotId() {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/snapshotsupport/WsmSnapshotSupportTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/snapshotsupport/WsmSnapshotSupportTest.java
@@ -15,7 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.retry.RestClientRetry;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
@@ -29,7 +29,7 @@ import org.springframework.test.annotation.DirtiesContext;
 
 @DirtiesContext
 @SpringBootTest
-class WsmSnapshotSupportTest extends TestBase {
+class WsmSnapshotSupportTest extends DataPlaneTestBase {
 
   @MockBean JobDao jobDao;
   @MockBean WorkspaceManagerDao wsmDao;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/ParquetDataTypesTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/ParquetDataTypesTest.java
@@ -25,7 +25,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.parquet.hadoop.ParquetReader;
 import org.apache.parquet.hadoop.util.HadoopInputFile;
 import org.apache.parquet.io.InputFile;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.recordsource.RecordSource;
 import org.databiosphere.workspacedataservice.service.model.TdrManifestImportTable;
 import org.databiosphere.workspacedataservice.shared.model.Record;
@@ -40,7 +40,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.io.Resource;
 
 @SpringBootTest
-class ParquetDataTypesTest extends TestBase {
+class ParquetDataTypesTest extends DataPlaneTestBase {
   private final Logger logger = LoggerFactory.getLogger(getClass());
 
   @Autowired ObjectMapper mapper;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobE2ETest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobE2ETest.java
@@ -20,7 +20,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.databiosphere.workspacedataservice.TestUtils;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.config.TwdsProperties;
 import org.databiosphere.workspacedataservice.dataimport.ImportValidator;
 import org.databiosphere.workspacedataservice.generated.CollectionServerModel;
@@ -64,7 +64,7 @@ import org.springframework.test.context.ActiveProfiles;
 @DirtiesContext
 @SpringBootTest
 @AutoConfigureMockMvc
-class TdrManifestQuartzJobE2ETest extends TestBase {
+class TdrManifestQuartzJobE2ETest extends DataPlaneTestBase {
   @Autowired private RecordOrchestratorService recordOrchestratorService;
   @Autowired private ImportService importService;
   @Autowired private CollectionService collectionService;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobMultipleBatchTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobMultipleBatchTest.java
@@ -16,7 +16,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.databiosphere.workspacedataservice.TestUtils;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.config.TwdsProperties;
 import org.databiosphere.workspacedataservice.dataimport.ImportValidator;
 import org.databiosphere.workspacedataservice.generated.CollectionServerModel;
@@ -59,7 +59,7 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest
 @AutoConfigureMockMvc
 @TestPropertySource(properties = {"twds.write.batch.size=2"})
-class TdrManifestQuartzJobMultipleBatchTest extends TestBase {
+class TdrManifestQuartzJobMultipleBatchTest extends DataPlaneTestBase {
   @Autowired private RecordOrchestratorService recordOrchestratorService;
   @Autowired private ImportService importService;
   @Autowired private CollectionService collectionService;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobTest.java
@@ -43,9 +43,9 @@ import org.apache.hadoop.fs.Path;
 import org.apache.parquet.hadoop.util.HadoopInputFile;
 import org.apache.parquet.io.InputFile;
 import org.databiosphere.workspacedataservice.activitylog.ActivityLogger;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.common.MockInstantSource;
 import org.databiosphere.workspacedataservice.common.MockInstantSourceConfig;
-import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.config.DataImportProperties;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
@@ -86,7 +86,7 @@ import org.springframework.test.annotation.DirtiesContext;
 @DirtiesContext
 @SpringBootTest
 @Import(MockInstantSourceConfig.class)
-class TdrManifestQuartzJobTest extends TestBase {
+class TdrManifestQuartzJobTest extends DataPlaneTestBase {
 
   @MockBean JobDao jobDao;
   @MockBean WorkspaceManagerDao wsmDao;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/datarepo/DataRepoDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/datarepo/DataRepoDaoTest.java
@@ -10,7 +10,7 @@ import bio.terra.datarepo.api.RepositoryApi;
 import bio.terra.datarepo.client.ApiException;
 import bio.terra.datarepo.model.SnapshotModel;
 import java.util.UUID;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -22,7 +22,7 @@ import org.springframework.test.annotation.DirtiesContext;
 
 @DirtiesContext
 @SpringBootTest
-class DataRepoDaoTest extends TestBase {
+class DataRepoDaoTest extends DataPlaneTestBase {
 
   @Autowired DataRepoDao dataRepoDao;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/jobexec/ImportJobUpdaterTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/jobexec/ImportJobUpdaterTest.java
@@ -6,9 +6,9 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Duration;
 import java.util.UUID;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.common.MockInstantSource;
 import org.databiosphere.workspacedataservice.common.MockInstantSourceConfig;
-import org.databiosphere.workspacedataservice.common.TestBase;
 import org.databiosphere.workspacedataservice.dao.PostgresJobDao;
 import org.databiosphere.workspacedataservice.dataimport.ImportJobInput;
 import org.databiosphere.workspacedataservice.dataimport.pfb.PfbImportOptions;
@@ -27,7 +27,7 @@ import org.springframework.context.annotation.Import;
 
 @SpringBootTest
 @Import(MockInstantSourceConfig.class)
-class ImportJobUpdaterTest extends TestBase {
+class ImportJobUpdaterTest extends DataPlaneTestBase {
 
   @Autowired PostgresJobDao jobDao;
   @Autowired MockInstantSource mockInstantSource;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/jobexec/QuartzJobTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/jobexec/QuartzJobTest.java
@@ -28,7 +28,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.databiosphere.workspacedataservice.annotations.WithTestObservationRegistry;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.config.DataImportProperties;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
@@ -51,7 +51,7 @@ import org.springframework.test.annotation.DirtiesContext;
 @DirtiesContext
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @WithTestObservationRegistry
-class QuartzJobTest extends TestBase {
+class QuartzJobTest extends DataPlaneTestBase {
 
   @MockBean JobDao jobDao;
   @MockBean DataImportProperties dataImportProperties;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/leonardo/LeonardoDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/leonardo/LeonardoDaoTest.java
@@ -17,7 +17,7 @@ import org.broadinstitute.dsde.workbench.client.leonardo.model.AppStatus;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.AppType;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.AuditInfo;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.ListAppResponse;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,7 +28,7 @@ import org.springframework.test.annotation.DirtiesContext;
 
 @DirtiesContext
 @SpringBootTest
-class LeonardoDaoTest extends TestBase {
+class LeonardoDaoTest extends DataPlaneTestBase {
   @Autowired LeonardoDao leonardoDao;
 
   @MockBean LeonardoClientFactory leonardoClientFactory;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/metrics/MetricsConfigTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/metrics/MetricsConfigTest.java
@@ -9,7 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Set;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -24,7 +24,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @DirtiesContext
 @SpringBootTest(properties = "management.prometheus.metrics.export.enabled=true")
 @AutoConfigureMockMvc
-class MetricsConfigTest extends TestBase {
+class MetricsConfigTest extends DataPlaneTestBase {
   @Autowired private BuildProperties buildProperties;
   @Autowired private MockMvc mockMvc;
   @Autowired private MeterRegistry metrics;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsModelTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsModelTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.recordsink.RawlsModel.AddListMember;
 import org.databiosphere.workspacedataservice.recordsink.RawlsModel.AddUpdateAttribute;
 import org.databiosphere.workspacedataservice.recordsink.RawlsModel.AttributeValue;
@@ -20,7 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class RawlsModelTest extends TestBase {
+class RawlsModelTest extends DataPlaneTestBase {
   @Autowired private ObjectMapper mapper;
 
   @Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkPrefixingTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkPrefixingTest.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.function.Supplier;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.dataimport.ImportDetails;
 import org.databiosphere.workspacedataservice.dataimport.rawlsjson.RawlsJsonImportOptions;
 import org.databiosphere.workspacedataservice.dataimport.rawlsjson.RawlsJsonJobInput;
@@ -48,7 +48,7 @@ import org.springframework.util.StreamUtils;
 @DirtiesContext
 @SpringBootTest
 @ActiveProfiles(value = "control-plane", inheritProfiles = false)
-class RawlsRecordSinkPrefixingTest extends TestBase {
+class RawlsRecordSinkPrefixingTest extends DataPlaneTestBase {
   @Autowired private ObjectMapper mapper;
   @MockBean private PubSub pubSub;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkTest.java
@@ -35,7 +35,7 @@ import java.util.UUID;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.dataimport.ImportDetails;
 import org.databiosphere.workspacedataservice.dataimport.ImportJobInput;
 import org.databiosphere.workspacedataservice.dataimport.rawlsjson.RawlsJsonImportOptions;
@@ -75,7 +75,7 @@ import org.springframework.util.StreamUtils;
 @DirtiesContext
 @SpringBootTest
 @ActiveProfiles(value = "control-plane", inheritProfiles = false)
-class RawlsRecordSinkTest extends TestBase {
+class RawlsRecordSinkTest extends DataPlaneTestBase {
   @Autowired private ObjectMapper mapper;
   @MockBean private PubSub pubSub;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/recordsource/JsonRecordSourceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/recordsource/JsonRecordSourceTest.java
@@ -9,7 +9,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.stream.Stream;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -17,7 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class JsonRecordSourceTest extends TestBase {
+class JsonRecordSourceTest extends DataPlaneTestBase {
   @Autowired ObjectMapper objectMapper; // as defined in JsonConfig
 
   private static Stream<Arguments> parserFeatures() {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/recordsource/PfbRecordSourceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/recordsource/PfbRecordSourceTest.java
@@ -15,7 +15,7 @@ import java.net.URL;
 import java.util.List;
 import org.apache.avro.file.DataFileStream;
 import org.apache.avro.generic.GenericRecord;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.recordsource.RecordSource.ImportMode;
 import org.databiosphere.workspacedataservice.recordsource.RecordSource.WriteStreamInfo;
 import org.databiosphere.workspacedataservice.shared.model.Record;
@@ -28,7 +28,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class PfbRecordSourceTest extends TestBase {
+class PfbRecordSourceTest extends DataPlaneTestBase {
   @Autowired private ObjectMapper objectMapper;
 
   // does PfbRecordSource properly know how to page through a DataFileStream<GenericRecord>?

--- a/service/src/test/java/org/databiosphere/workspacedataservice/recordsource/StreamingTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/recordsource/StreamingTest.java
@@ -7,7 +7,7 @@ import static org.databiosphere.workspacedataservice.shared.model.OperationType.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.List;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.recordsource.RecordSource.WriteStreamInfo;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.junit.jupiter.api.Test;
@@ -15,7 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class StreamingTest extends TestBase {
+class StreamingTest extends DataPlaneTestBase {
 
   @Autowired private ObjectMapper objectMapper;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/retry/RestClientRetryTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/retry/RestClientRetryTest.java
@@ -15,7 +15,7 @@ import java.lang.annotation.Target;
 import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.databiosphere.workspacedataservice.annotations.WithTestObservationRegistry;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.retry.RestClientRetry.RestCall;
 import org.databiosphere.workspacedataservice.retry.RestClientRetry.VoidRestCall;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthenticationException;
@@ -40,7 +40,7 @@ import org.springframework.test.annotation.DirtiesContext;
     }) // aggressive retry settings so unit test doesn't run too long
 @EnableRetry
 @WithTestObservationRegistry
-class RestClientRetryTest extends TestBase {
+class RestClientRetryTest extends DataPlaneTestBase {
 
   @Autowired private RestClientRetry restClientRetry;
   @Autowired private TestObservationRegistry observations;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/retry/TransactionRetryTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/retry/TransactionRetryTest.java
@@ -3,7 +3,7 @@ package org.databiosphere.workspacedataservice.retry;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.stream.Stream;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -26,7 +26,7 @@ import org.springframework.transaction.CannotCreateTransactionException;
       "terra.common.retry.transaction.slowRetryMultiplier=1.1",
       "terra.common.retry.transaction.fastRetryMaxAttempts=2"
     })
-class TransactionRetryTest extends TestBase {
+class TransactionRetryTest extends DataPlaneTestBase {
 
   @Autowired TransactionRetryTestBean transactionRetryTestBean;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/sam/BearerTokenFilterTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/sam/BearerTokenFilterTest.java
@@ -7,7 +7,7 @@ import static org.springframework.web.context.request.RequestAttributes.SCOPE_RE
 
 import java.util.stream.Stream;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -21,7 +21,7 @@ import org.springframework.web.context.request.RequestContextHolder;
 
 /** Tests for @see BearerTokenFilter */
 @SpringBootTest
-class BearerTokenFilterTest extends TestBase {
+class BearerTokenFilterTest extends DataPlaneTestBase {
 
   private static Stream<Arguments> provideAuthorizationHeaders() {
     /* Arguments are sets:

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/BackupRestoreServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/BackupRestoreServiceTest.java
@@ -13,7 +13,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.dao.BackupRestoreDao;
 import org.databiosphere.workspacedataservice.service.model.exception.LaunchProcessException;
 import org.databiosphere.workspacedataservice.shared.model.RestoreResponse;
@@ -30,7 +30,7 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(properties = "spring.cache.type=NONE")
 @TestPropertySource(
     properties = {"twds.pg_dump.path=/unit/test/pg_dump", "twds.pg_dump.psqlPath=/unit/test/psql"})
-class BackupRestoreServiceTest extends TestBase {
+class BackupRestoreServiceTest extends DataPlaneTestBase {
   @Autowired private BackupRestoreService backupRestoreService;
   @Autowired private NamedParameterJdbcTemplate namedTemplate;
   @Autowired private WorkspaceId workspaceId;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/BatchWriteServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/BatchWriteServiceTest.java
@@ -17,7 +17,7 @@ import java.util.Map;
 import org.apache.avro.file.DataFileStream;
 import org.apache.avro.generic.GenericRecord;
 import org.databiosphere.workspacedataservice.TestUtils;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.config.TwdsProperties;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.databiosphere.workspacedataservice.dataimport.pfb.PfbTestUtils;
@@ -44,7 +44,7 @@ import org.springframework.test.context.TestPropertySource;
 @DirtiesContext
 @SpringBootTest
 @TestPropertySource(properties = {"twds.write.batch.size=2"})
-class BatchWriteServiceTest extends TestBase {
+class BatchWriteServiceTest extends DataPlaneTestBase {
 
   @Autowired private RecordSourceFactory recordSourceFactory;
   @Autowired private RecordSinkFactory recordSinkFactory;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/DataTypeInfererTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/DataTypeInfererTest.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
 import org.databiosphere.workspacedataservice.service.model.Relation;
 import org.databiosphere.workspacedataservice.shared.model.Record;
@@ -27,7 +27,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class DataTypeInfererTest extends TestBase {
+class DataTypeInfererTest extends DataPlaneTestBase {
 
   @Autowired DataTypeInferer inferer;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceDataPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceDataPlaneTest.java
@@ -9,7 +9,7 @@ import static org.mockito.Mockito.when;
 import java.net.URI;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.annotations.SingleTenant;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.generated.ImportRequestServerModel;
 import org.databiosphere.workspacedataservice.service.model.exception.CollectionException;
 import org.databiosphere.workspacedataservice.service.model.exception.MissingObjectException;
@@ -31,7 +31,7 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles({"data-plane", "noop-scheduler-dao", "mock-sam"})
 @DirtiesContext
 @SpringBootTest
-class ImportServiceDataPlaneTest extends TestBase {
+class ImportServiceDataPlaneTest extends DataPlaneTestBase {
   @Autowired ImportService importService;
   @Autowired @SingleTenant WorkspaceId workspaceId;
   @MockBean CollectionService collectionService;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceTest.java
@@ -27,7 +27,7 @@ import org.broadinstitute.dsde.workbench.client.sam.ApiException;
 import org.broadinstitute.dsde.workbench.client.sam.api.GoogleApi;
 import org.databiosphere.workspacedataservice.TestUtils;
 import org.databiosphere.workspacedataservice.annotations.SingleTenant;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.dao.SchedulerDao;
 import org.databiosphere.workspacedataservice.dataimport.ImportJobInput;
@@ -67,7 +67,7 @@ import org.springframework.test.annotation.DirtiesContext;
 @DirtiesContext
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class ImportServiceTest extends TestBase {
+class ImportServiceTest extends DataPlaneTestBase {
 
   @Autowired ImportService importService;
   @Autowired CollectionService collectionService;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/NoCacheFilterTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/NoCacheFilterTest.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.text.StringSubstitutor;
 import org.databiosphere.workspacedataservice.TestUtils;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.config.TwdsProperties;
 import org.databiosphere.workspacedataservice.generated.CollectionRequestServerModel;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
@@ -35,7 +35,7 @@ import org.springframework.test.context.ActiveProfiles;
 @DirtiesContext
 @ActiveProfiles(profiles = "mock-sam")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-class NoCacheFilterTest extends TestBase {
+class NoCacheFilterTest extends DataPlaneTestBase {
   @Autowired private TwdsProperties twdsProperties;
 
   private static final String versionId = "v0.2";

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/PermissionServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/PermissionServiceTest.java
@@ -8,7 +8,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.util.UUID;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.sam.MockSamAuthorizationDao;
 import org.databiosphere.workspacedataservice.sam.SamAuthorizationDao;
 import org.databiosphere.workspacedataservice.sam.SamAuthorizationDaoFactory;
@@ -29,7 +29,7 @@ import org.springframework.test.annotation.DirtiesContext;
 
 @DirtiesContext
 @SpringBootTest
-class PermissionServiceTest extends TestBase {
+class PermissionServiceTest extends DataPlaneTestBase {
   @Autowired PermissionService permissionService;
   @MockBean SamAuthorizationDaoFactory samAuthorizationDaoFactory;
   @MockBean CollectionService collectionService;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/PermissionsStatusServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/PermissionsStatusServiceTest.java
@@ -5,7 +5,7 @@ import static org.mockito.Mockito.*;
 
 import org.broadinstitute.dsde.workbench.client.sam.api.StatusApi;
 import org.broadinstitute.dsde.workbench.client.sam.model.SystemStatus;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.sam.HttpSamDao;
 import org.databiosphere.workspacedataservice.sam.PermissionsStatusService;
 import org.databiosphere.workspacedataservice.sam.SamClientFactory;
@@ -24,7 +24,7 @@ import org.springframework.test.annotation.DirtiesContext;
 
 @DirtiesContext
 @SpringBootTest(properties = "spring.cache.type=NONE")
-class PermissionsStatusServiceTest extends TestBase {
+class PermissionsStatusServiceTest extends DataPlaneTestBase {
 
   @Autowired private PermissionsStatusService samStatusService;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceFilterQueryTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceFilterQueryTest.java
@@ -11,7 +11,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Stream;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.config.TwdsProperties;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.databiosphere.workspacedataservice.generated.CollectionRequestServerModel;
@@ -48,7 +48,7 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles(profiles = {"mock-sam"})
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class RecordOrchestratorServiceFilterQueryTest extends TestBase {
+class RecordOrchestratorServiceFilterQueryTest extends DataPlaneTestBase {
 
   @Autowired private CollectionService collectionService;
   @Autowired private RecordOrchestratorService recordOrchestratorService;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.databiosphere.workspacedataservice.TestUtils;
 import org.databiosphere.workspacedataservice.annotations.WithTestObservationRegistry;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.config.TwdsProperties;
 import org.databiosphere.workspacedataservice.service.model.AttributeSchema;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
@@ -54,7 +54,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 @SpringBootTest
 @WithTestObservationRegistry
-class RecordOrchestratorServiceTest extends TestBase {
+class RecordOrchestratorServiceTest extends DataPlaneTestBase {
 
   @Autowired private CollectionService collectionService;
   @Autowired private NamedParameterJdbcTemplate namedTemplate;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordServiceTest.java
@@ -16,7 +16,7 @@ import java.util.Optional;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.TestUtils;
 import org.databiosphere.workspacedataservice.annotations.WithTestObservationRegistry;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.config.TwdsProperties;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
 import org.databiosphere.workspacedataservice.generated.CollectionServerModel;
@@ -35,7 +35,7 @@ import org.springframework.test.annotation.DirtiesContext;
 @SpringBootTest
 @DirtiesContext
 @WithTestObservationRegistry
-class RecordServiceTest extends TestBase {
+class RecordServiceTest extends DataPlaneTestBase {
 
   @Autowired DataTypeInferer inferer;
   @Autowired CollectionService collectionService;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordRequestTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordRequestTest.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.math.BigInteger;
 import java.util.Map;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,7 +14,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class RecordRequestTest extends TestBase {
+class RecordRequestTest extends DataPlaneTestBase {
 
   @Autowired private ObjectMapper jacksonObjectMapper;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordResponseTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordResponseTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Map;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,7 +14,7 @@ import org.springframework.util.StringUtils;
 
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class RecordResponseTest extends TestBase {
+class RecordResponseTest extends DataPlaneTestBase {
 
   @Autowired private ObjectMapper jacksonObjectMapper;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordTest.java
@@ -9,7 +9,7 @@ import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.service.model.exception.InvalidNameException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -18,7 +18,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class RecordTest extends TestBase {
+class RecordTest extends DataPlaneTestBase {
 
   @Autowired private ObjectMapper jacksonObjectMapper;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/sourcewds/CloneOlderWdsTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/sourcewds/CloneOlderWdsTest.java
@@ -4,13 +4,13 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.databiosphere.workspacedata.model.BackupJob;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class CloneOlderWdsTest extends TestBase {
+class CloneOlderWdsTest extends DataPlaneTestBase {
 
   @Autowired ObjectMapper objectMapper;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/sourcewds/HttpWorkspaceDataServiceClientFactoryTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/sourcewds/HttpWorkspaceDataServiceClientFactoryTest.java
@@ -7,13 +7,13 @@ import java.util.Set;
 import org.databiosphere.workspacedata.client.ApiClient;
 import org.databiosphere.workspacedata.client.auth.Authentication;
 import org.databiosphere.workspacedata.client.auth.HttpBearerAuth;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class HttpWorkspaceDataServiceClientFactoryTest extends TestBase {
+class HttpWorkspaceDataServiceClientFactoryTest extends DataPlaneTestBase {
 
   @Autowired private WorkspaceDataServiceClientFactory workspaceDataServiceClientFactory;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerBeanTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerBeanTest.java
@@ -16,7 +16,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.locks.Lock;
 import org.databiosphere.workspacedataservice.TestUtils;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.config.TwdsProperties;
 import org.databiosphere.workspacedataservice.dao.*;
 import org.databiosphere.workspacedataservice.leonardo.LeonardoDao;
@@ -41,7 +41,7 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles({"mock-backup-dao", "mock-restore-dao", "mock-clone-dao", "local-cors"})
 @DirtiesContext
 @SpringBootTest
-class CollectionInitializerBeanTest extends TestBase {
+class CollectionInitializerBeanTest extends DataPlaneTestBase {
   // Don't run the CollectionInitializer on startup, so this test can start with a clean slate.
   // By making an (empty) mock bean to replace CollectionInitializer, we ensure it is a noop.
   @MockBean CollectionInitializer collectionInitializer;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/storage/GcsStorageTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/storage/GcsStorageTest.java
@@ -14,7 +14,7 @@ import com.google.cloud.storage.StorageException;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,9 +27,9 @@ import org.springframework.test.context.ActiveProfiles;
 @Component
 @DirtiesContext
 @SpringBootTest
-// inheritProfiles = false to make sure data-plane is not active from TestBase
+// inheritProfiles = false to make sure data-plane is not active from DataPlaneTestBase
 @ActiveProfiles(value = "control-plane", inheritProfiles = false)
-class GcsStorageTest extends TestBase {
+class GcsStorageTest extends DataPlaneTestBase {
   @Qualifier("mockGcsStorage")
   @Autowired
   private GcsStorage storage;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvBatchTypeDetectionTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvBatchTypeDetectionTest.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.TestUtils;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.config.TwdsProperties;
 import org.databiosphere.workspacedataservice.recordsink.RecordSink;
 import org.databiosphere.workspacedataservice.recordsink.RecordSinkFactory;
@@ -45,7 +45,7 @@ import org.springframework.test.context.TestPropertySource;
 @DirtiesContext
 @SpringBootTest
 @TestPropertySource(properties = {"twds.write.batch.size=2"})
-class TsvBatchTypeDetectionTest extends TestBase {
+class TsvBatchTypeDetectionTest extends DataPlaneTestBase {
 
   @Autowired private RecordSourceFactory recordSourceFactory;
   @Autowired private RecordSinkFactory recordSinkFactory;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvDeserializerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvDeserializerTest.java
@@ -12,7 +12,7 @@ import java.math.BigInteger;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.shared.model.attributes.JsonAttribute;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -30,7 +30,7 @@ import org.springframework.boot.test.context.SpringBootTest;
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @SpringBootTest
-class TsvDeserializerTest extends TestBase {
+class TsvDeserializerTest extends DataPlaneTestBase {
 
   @Autowired TsvDeserializer tsvDeserializer;
   @Autowired ObjectMapper mapper;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvErrorMessageTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvErrorMessageTest.java
@@ -8,7 +8,7 @@ import java.io.InputStream;
 import java.util.Optional;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.TestUtils;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.config.TwdsProperties;
 import org.databiosphere.workspacedataservice.generated.CollectionServerModel;
 import org.databiosphere.workspacedataservice.service.CollectionService;
@@ -30,7 +30,7 @@ import org.springframework.test.annotation.DirtiesContext;
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @DirtiesContext
-class TsvErrorMessageTest extends TestBase {
+class TsvErrorMessageTest extends DataPlaneTestBase {
 
   @Autowired CollectionService collectionService;
   @Autowired RecordOrchestratorService recordOrchestratorService;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvJsonEquivalenceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvJsonEquivalenceTest.java
@@ -11,7 +11,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.List;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
 import org.databiosphere.workspacedataservice.shared.model.RecordRequest;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -26,7 +26,7 @@ import org.springframework.boot.test.context.SpringBootTest;
  * @see TsvJsonArgumentsProvider
  */
 @SpringBootTest
-class TsvJsonEquivalenceTest extends TestBase {
+class TsvJsonEquivalenceTest extends DataPlaneTestBase {
 
   @Autowired private ObjectReader tsvReader;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/workspacemanager/WorkspaceManagerDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/workspacemanager/WorkspaceManagerDaoTest.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.UUID;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.databiosphere.workspacedataservice.annotations.SingleTenant;
-import org.databiosphere.workspacedataservice.common.TestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,7 +39,7 @@ import org.springframework.test.annotation.DirtiesContext;
 
 @SpringBootTest
 @DirtiesContext
-class WorkspaceManagerDaoTest extends TestBase {
+class WorkspaceManagerDaoTest extends DataPlaneTestBase {
 
   @Autowired WorkspaceManagerDao workspaceManagerDao;
 


### PR DESCRIPTION
pre-factoring for AJ-1981.

The only change in this PR is renaming `TestBase` to `DataPlaneTestBase`. However, this cascades changes to the 72 test files that extend this base class. There's a lot of files changed in this PR but the changes are all due to the renaming; no other changes.

This PR was all done through IntelliJ refactoring; nothing was coded by hand, except b273d350b7d1dc53d7e3724f8ed36998e9f2b29b … for some reason IntelliJ thought it needed to add an equals sign at the end of the UUID, so I fixed that.

Future PRs for AJ-1981 will:
* create and use a sibling `ControlPlaneTestBase` base class for tests
* gradually move tests away from `DataPlaneTestBase` and onto `ControlPlaneTestBase`