### PR TITLE
AJ-1981: some tests to the control plane

### DIFF
--- a/service/src/test/java/org/databiosphere/workspacedataservice/datarepo/DataRepoDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/datarepo/DataRepoDaoTest.java
@@ -10,7 +10,7 @@ import bio.terra.datarepo.api.RepositoryApi;
 import bio.terra.datarepo.client.ApiException;
 import bio.terra.datarepo.model.SnapshotModel;
 import java.util.UUID;
-import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
+import org.databiosphere.workspacedataservice.common.ControlPlaneTestBase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -22,7 +22,7 @@ import org.springframework.test.annotation.DirtiesContext;
 
 @DirtiesContext
 @SpringBootTest
-class DataRepoDaoTest extends DataPlaneTestBase {
+class DataRepoDaoTest extends ControlPlaneTestBase {
 
   @Autowired DataRepoDao dataRepoDao;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/jobexec/ImportJobUpdaterTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/jobexec/ImportJobUpdaterTest.java
@@ -6,7 +6,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Duration;
 import java.util.UUID;
-import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
+import org.databiosphere.workspacedataservice.common.ControlPlaneTestBase;
 import org.databiosphere.workspacedataservice.common.MockInstantSource;
 import org.databiosphere.workspacedataservice.common.MockInstantSourceConfig;
 import org.databiosphere.workspacedataservice.dao.PostgresJobDao;
@@ -27,7 +27,7 @@ import org.springframework.context.annotation.Import;
 
 @SpringBootTest
 @Import(MockInstantSourceConfig.class)
-class ImportJobUpdaterTest extends DataPlaneTestBase {
+class ImportJobUpdaterTest extends ControlPlaneTestBase {
 
   @Autowired PostgresJobDao jobDao;
   @Autowired MockInstantSource mockInstantSource;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/jobexec/QuartzJobTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/jobexec/QuartzJobTest.java
@@ -28,7 +28,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.databiosphere.workspacedataservice.annotations.WithTestObservationRegistry;
-import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
+import org.databiosphere.workspacedataservice.common.ControlPlaneTestBase;
 import org.databiosphere.workspacedataservice.config.DataImportProperties;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
@@ -51,7 +51,7 @@ import org.springframework.test.annotation.DirtiesContext;
 @DirtiesContext
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @WithTestObservationRegistry
-class QuartzJobTest extends DataPlaneTestBase {
+class QuartzJobTest extends ControlPlaneTestBase {
 
   @MockBean JobDao jobDao;
   @MockBean DataImportProperties dataImportProperties;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/leonardo/LeonardoDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/leonardo/LeonardoDaoTest.java
@@ -17,7 +17,7 @@ import org.broadinstitute.dsde.workbench.client.leonardo.model.AppStatus;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.AppType;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.AuditInfo;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.ListAppResponse;
-import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
+import org.databiosphere.workspacedataservice.common.ControlPlaneTestBase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,7 +28,7 @@ import org.springframework.test.annotation.DirtiesContext;
 
 @DirtiesContext
 @SpringBootTest
-class LeonardoDaoTest extends DataPlaneTestBase {
+class LeonardoDaoTest extends ControlPlaneTestBase {
   @Autowired LeonardoDao leonardoDao;
 
   @MockBean LeonardoClientFactory leonardoClientFactory;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/metrics/MetricsConfigTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/metrics/MetricsConfigTest.java
@@ -9,7 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Set;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
+import org.databiosphere.workspacedataservice.common.ControlPlaneTestBase;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -24,7 +24,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @DirtiesContext
 @SpringBootTest(properties = "management.prometheus.metrics.export.enabled=true")
 @AutoConfigureMockMvc
-class MetricsConfigTest extends DataPlaneTestBase {
+class MetricsConfigTest extends ControlPlaneTestBase {
   @Autowired private BuildProperties buildProperties;
   @Autowired private MockMvc mockMvc;
   @Autowired private MeterRegistry metrics;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/retry/RestClientRetryTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/retry/RestClientRetryTest.java
@@ -15,7 +15,7 @@ import java.lang.annotation.Target;
 import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.databiosphere.workspacedataservice.annotations.WithTestObservationRegistry;
-import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
+import org.databiosphere.workspacedataservice.common.ControlPlaneTestBase;
 import org.databiosphere.workspacedataservice.retry.RestClientRetry.RestCall;
 import org.databiosphere.workspacedataservice.retry.RestClientRetry.VoidRestCall;
 import org.databiosphere.workspacedataservice.service.model.exception.AuthenticationException;
@@ -40,7 +40,7 @@ import org.springframework.test.annotation.DirtiesContext;
     }) // aggressive retry settings so unit test doesn't run too long
 @EnableRetry
 @WithTestObservationRegistry
-class RestClientRetryTest extends DataPlaneTestBase {
+class RestClientRetryTest extends ControlPlaneTestBase {
 
   @Autowired private RestClientRetry restClientRetry;
   @Autowired private TestObservationRegistry observations;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/retry/TransactionRetryTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/retry/TransactionRetryTest.java
@@ -3,7 +3,7 @@ package org.databiosphere.workspacedataservice.retry;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.stream.Stream;
-import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
+import org.databiosphere.workspacedataservice.common.ControlPlaneTestBase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -26,7 +26,7 @@ import org.springframework.transaction.CannotCreateTransactionException;
       "terra.common.retry.transaction.slowRetryMultiplier=1.1",
       "terra.common.retry.transaction.fastRetryMaxAttempts=2"
     })
-class TransactionRetryTest extends DataPlaneTestBase {
+class TransactionRetryTest extends ControlPlaneTestBase {
 
   @Autowired TransactionRetryTestBean transactionRetryTestBean;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/sam/BearerTokenFilterTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/sam/BearerTokenFilterTest.java
@@ -7,7 +7,7 @@ import static org.springframework.web.context.request.RequestAttributes.SCOPE_RE
 
 import java.util.stream.Stream;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
+import org.databiosphere.workspacedataservice.common.ControlPlaneTestBase;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -21,7 +21,7 @@ import org.springframework.web.context.request.RequestContextHolder;
 
 /** Tests for @see BearerTokenFilter */
 @SpringBootTest
-class BearerTokenFilterTest extends DataPlaneTestBase {
+class BearerTokenFilterTest extends ControlPlaneTestBase {
 
   private static Stream<Arguments> provideAuthorizationHeaders() {
     /* Arguments are sets:

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/DataTypeInfererTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/DataTypeInfererTest.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
+import org.databiosphere.workspacedataservice.common.ControlPlaneTestBase;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
 import org.databiosphere.workspacedataservice.service.model.Relation;
 import org.databiosphere.workspacedataservice.shared.model.Record;
@@ -27,7 +27,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class DataTypeInfererTest extends DataPlaneTestBase {
+class DataTypeInfererTest extends ControlPlaneTestBase {
 
   @Autowired DataTypeInferer inferer;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/PermissionServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/PermissionServiceTest.java
@@ -8,7 +8,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.util.UUID;
-import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
+import org.databiosphere.workspacedataservice.common.ControlPlaneTestBase;
 import org.databiosphere.workspacedataservice.sam.MockSamAuthorizationDao;
 import org.databiosphere.workspacedataservice.sam.SamAuthorizationDao;
 import org.databiosphere.workspacedataservice.sam.SamAuthorizationDaoFactory;
@@ -29,7 +29,7 @@ import org.springframework.test.annotation.DirtiesContext;
 
 @DirtiesContext
 @SpringBootTest
-class PermissionServiceTest extends DataPlaneTestBase {
+class PermissionServiceTest extends ControlPlaneTestBase {
   @Autowired PermissionService permissionService;
   @MockBean SamAuthorizationDaoFactory samAuthorizationDaoFactory;
   @MockBean CollectionService collectionService;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/PermissionsStatusServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/PermissionsStatusServiceTest.java
@@ -5,7 +5,7 @@ import static org.mockito.Mockito.*;
 
 import org.broadinstitute.dsde.workbench.client.sam.api.StatusApi;
 import org.broadinstitute.dsde.workbench.client.sam.model.SystemStatus;
-import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
+import org.databiosphere.workspacedataservice.common.ControlPlaneTestBase;
 import org.databiosphere.workspacedataservice.sam.HttpSamDao;
 import org.databiosphere.workspacedataservice.sam.PermissionsStatusService;
 import org.databiosphere.workspacedataservice.sam.SamClientFactory;
@@ -24,7 +24,7 @@ import org.springframework.test.annotation.DirtiesContext;
 
 @DirtiesContext
 @SpringBootTest(properties = "spring.cache.type=NONE")
-class PermissionsStatusServiceTest extends DataPlaneTestBase {
+class PermissionsStatusServiceTest extends ControlPlaneTestBase {
 
   @Autowired private PermissionsStatusService samStatusService;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordOrchestratorServiceTest.java
@@ -20,8 +20,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.databiosphere.workspacedataservice.TestUtils;
 import org.databiosphere.workspacedataservice.annotations.WithTestObservationRegistry;
-import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
-import org.databiosphere.workspacedataservice.config.TwdsProperties;
+import org.databiosphere.workspacedataservice.common.ControlPlaneTestBase;
+import org.databiosphere.workspacedataservice.dao.WorkspaceRepository;
 import org.databiosphere.workspacedataservice.service.model.AttributeSchema;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
 import org.databiosphere.workspacedataservice.service.model.RecordTypeSchema;
@@ -38,6 +38,9 @@ import org.databiosphere.workspacedataservice.shared.model.RecordType;
 import org.databiosphere.workspacedataservice.shared.model.SearchFilter;
 import org.databiosphere.workspacedataservice.shared.model.SearchRequest;
 import org.databiosphere.workspacedataservice.shared.model.SortDirection;
+import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
+import org.databiosphere.workspacedataservice.workspace.WorkspaceDataTableType;
+import org.databiosphere.workspacedataservice.workspace.WorkspaceRecord;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -54,13 +57,13 @@ import org.springframework.web.server.ResponseStatusException;
 
 @SpringBootTest
 @WithTestObservationRegistry
-class RecordOrchestratorServiceTest extends DataPlaneTestBase {
+class RecordOrchestratorServiceTest extends ControlPlaneTestBase {
 
   @Autowired private CollectionService collectionService;
   @Autowired private NamedParameterJdbcTemplate namedTemplate;
   @Autowired private RecordOrchestratorService recordOrchestratorService;
   @Autowired private TestObservationRegistry observations;
-  @Autowired private TwdsProperties twdsProperties;
+  @Autowired private WorkspaceRepository workspaceRepository;
 
   @Nullable private UUID collectionId;
   private static final RecordType TEST_TYPE = RecordType.valueOf("test");
@@ -72,12 +75,17 @@ class RecordOrchestratorServiceTest extends DataPlaneTestBase {
 
   @BeforeEach
   void setUp() {
-    collectionId = collectionService.save(twdsProperties.workspaceId(), "name", "desc").getId();
+    // save a WDS-powered workspace
+    WorkspaceId workspaceId = WorkspaceId.of(UUID.randomUUID());
+    workspaceRepository.save(
+        new WorkspaceRecord(workspaceId, WorkspaceDataTableType.WDS, /* newFlag= */ true));
+    collectionId = collectionService.save(workspaceId, "name", "desc").getId();
   }
 
   @AfterEach
   void tearDown() {
     TestUtils.cleanAllCollections(collectionService, namedTemplate);
+    TestUtils.cleanAllWorkspaces(namedTemplate);
   }
 
   @Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/RecordServiceTest.java
@@ -16,14 +16,17 @@ import java.util.Optional;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.TestUtils;
 import org.databiosphere.workspacedataservice.annotations.WithTestObservationRegistry;
-import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
-import org.databiosphere.workspacedataservice.config.TwdsProperties;
+import org.databiosphere.workspacedataservice.common.ControlPlaneTestBase;
 import org.databiosphere.workspacedataservice.dao.RecordDao;
+import org.databiosphere.workspacedataservice.dao.WorkspaceRepository;
 import org.databiosphere.workspacedataservice.generated.CollectionServerModel;
 import org.databiosphere.workspacedataservice.service.model.DataTypeMapping;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
 import org.databiosphere.workspacedataservice.shared.model.RecordRequest;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
+import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
+import org.databiosphere.workspacedataservice.workspace.WorkspaceDataTableType;
+import org.databiosphere.workspacedataservice.workspace.WorkspaceRecord;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -35,27 +38,33 @@ import org.springframework.test.annotation.DirtiesContext;
 @SpringBootTest
 @DirtiesContext
 @WithTestObservationRegistry
-class RecordServiceTest extends DataPlaneTestBase {
+class RecordServiceTest extends ControlPlaneTestBase {
 
   @Autowired DataTypeInferer inferer;
   @Autowired CollectionService collectionService;
   @Autowired RecordDao recordDao;
   @Autowired TestObservationRegistry observationRegistry;
   @Autowired NamedParameterJdbcTemplate namedTemplate;
-  @Autowired TwdsProperties twdsProperties;
+  @Autowired WorkspaceRepository workspaceRepository;
 
   private UUID collectionId;
 
   @BeforeEach
   void beforeEach() {
+    // save a WDS-powered workspace
+    WorkspaceId workspaceId = WorkspaceId.of(UUID.randomUUID());
+    workspaceRepository.save(
+        new WorkspaceRecord(workspaceId, WorkspaceDataTableType.WDS, /* newFlag= */ true));
+    // create a collection in that workspace
     CollectionServerModel collectionServerModel =
-        TestUtils.createCollection(collectionService, twdsProperties.workspaceId());
+        TestUtils.createCollection(collectionService, workspaceId);
     collectionId = collectionServerModel.getId();
   }
 
   @AfterEach
   void afterEach() {
     TestUtils.cleanAllCollections(collectionService, namedTemplate);
+    TestUtils.cleanAllWorkspaces(namedTemplate);
   }
 
   @Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordRequestTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordRequestTest.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.math.BigInteger;
 import java.util.Map;
-import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
+import org.databiosphere.workspacedataservice.common.ControlPlaneTestBase;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,7 +14,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class RecordRequestTest extends DataPlaneTestBase {
+class RecordRequestTest extends ControlPlaneTestBase {
 
   @Autowired private ObjectMapper jacksonObjectMapper;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordResponseTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordResponseTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Map;
-import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
+import org.databiosphere.workspacedataservice.common.ControlPlaneTestBase;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,7 +14,7 @@ import org.springframework.util.StringUtils;
 
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class RecordResponseTest extends DataPlaneTestBase {
+class RecordResponseTest extends ControlPlaneTestBase {
 
   @Autowired private ObjectMapper jacksonObjectMapper;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/shared/model/RecordTest.java
@@ -9,7 +9,7 @@ import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
+import org.databiosphere.workspacedataservice.common.ControlPlaneTestBase;
 import org.databiosphere.workspacedataservice.service.model.exception.InvalidNameException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -18,7 +18,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class RecordTest extends DataPlaneTestBase {
+class RecordTest extends ControlPlaneTestBase {
 
   @Autowired private ObjectMapper jacksonObjectMapper;
 


### PR DESCRIPTION
This moves 20 unit tests from the data-plane profile to the control-plane profile. There are still ~45 tests in the data-plane profile; this is incremental progress.

Some tests required relatively minor setup/teardown changes; some required no changes at all other than the profile switch.