### PR TITLE
AJ-1981: continue moving tests to control-plane profile

### DIFF
--- a/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/AvailabilityTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/AvailabilityTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
+import org.databiosphere.workspacedataservice.common.ControlPlaneTestBase;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.availability.ApplicationAvailability;
@@ -19,7 +19,7 @@ import org.springframework.test.web.servlet.ResultActions;
 
 @AutoConfigureMockMvc
 @SpringBootTest
-class AvailabilityTest extends DataPlaneTestBase {
+class AvailabilityTest extends ControlPlaneTestBase {
 
   @Autowired private MockMvc mvc;
   @Autowired private ApplicationContext context;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/annotations/AnnotatedApisTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/annotations/AnnotatedApisTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Optional;
 import org.databiosphere.workspacedataservice.annotations.DeploymentMode.ControlPlane;
 import org.databiosphere.workspacedataservice.annotations.DeploymentMode.DataPlane;
-import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
+import org.databiosphere.workspacedataservice.common.ControlPlaneTestBase;
 import org.databiosphere.workspacedataservice.dataimport.protecteddatasupport.ProtectedDataSupport;
 import org.databiosphere.workspacedataservice.dataimport.protecteddatasupport.WsmProtectedDataSupport;
 import org.databiosphere.workspacedataservice.workspace.DataTableTypeInspector;
@@ -34,7 +34,7 @@ import org.springframework.web.bind.annotation.RestController;
       // turn off pubsub autoconfiguration for tests
       "spring.cloud.gcp.pubsub.enabled=false"
     })
-class AnnotatedApisTest extends DataPlaneTestBase {
+class AnnotatedApisTest extends ControlPlaneTestBase {
 
   // Since we're running with both control-plane and data-plane profiles simultaneously, Spring
   // does not know what to do with beans which are satisfied by two different mutually exclusive

--- a/service/src/test/java/org/databiosphere/workspacedataservice/annotations/AnnotatedApisTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/annotations/AnnotatedApisTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Optional;
 import org.databiosphere.workspacedataservice.annotations.DeploymentMode.ControlPlane;
 import org.databiosphere.workspacedataservice.annotations.DeploymentMode.DataPlane;
-import org.databiosphere.workspacedataservice.common.ControlPlaneTestBase;
+import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
 import org.databiosphere.workspacedataservice.dataimport.protecteddatasupport.ProtectedDataSupport;
 import org.databiosphere.workspacedataservice.dataimport.protecteddatasupport.WsmProtectedDataSupport;
 import org.databiosphere.workspacedataservice.workspace.DataTableTypeInspector;
@@ -34,7 +34,7 @@ import org.springframework.web.bind.annotation.RestController;
       // turn off pubsub autoconfiguration for tests
       "spring.cloud.gcp.pubsub.enabled=false"
     })
-class AnnotatedApisTest extends ControlPlaneTestBase {
+class AnnotatedApisTest extends DataPlaneTestBase {
 
   // Since we're running with both control-plane and data-plane profiles simultaneously, Spring
   // does not know what to do with beans which are satisfied by two different mutually exclusive

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/GlobalExceptionHandlerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/GlobalExceptionHandlerTest.java
@@ -5,13 +5,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
+import org.databiosphere.workspacedataservice.common.ControlPlaneTestBase;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class GlobalExceptionHandlerTest extends DataPlaneTestBase {
+class GlobalExceptionHandlerTest extends ControlPlaneTestBase {
   @Autowired private GlobalExceptionHandler globalExceptionHandler;
 
   @Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/JobControllerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/JobControllerTest.java
@@ -20,8 +20,7 @@ import java.util.Map;
 import java.util.UUID;
 import org.databiosphere.workspacedata.model.ErrorResponse;
 import org.databiosphere.workspacedata.model.ImportRequest.TypeEnum;
-import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
-import org.databiosphere.workspacedataservice.config.TwdsProperties;
+import org.databiosphere.workspacedataservice.common.ControlPlaneTestBase;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.dataimport.ImportJobInput;
 import org.databiosphere.workspacedataservice.dataimport.pfb.PfbImportOptions;
@@ -29,6 +28,7 @@ import org.databiosphere.workspacedataservice.dataimport.pfb.PfbJobInput;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
 import org.databiosphere.workspacedataservice.service.CollectionService;
 import org.databiosphere.workspacedataservice.shared.model.CollectionId;
+import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -53,17 +53,18 @@ import org.springframework.test.context.ActiveProfiles;
 @DirtiesContext
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-class JobControllerTest extends DataPlaneTestBase {
+class JobControllerTest extends ControlPlaneTestBase {
   private static final String TEST_IMPORT_URI = "http://some/uri";
 
   @Autowired private NamedParameterJdbcTemplate namedTemplate;
   @Autowired private TestRestTemplate restTemplate;
   @Autowired private JobDao jobDao;
-  @Autowired private TwdsProperties twdsProperties;
+
   @MockBean private CollectionService collectionService;
 
   private final CollectionId collectionId = CollectionId.of(randomUUID());
   private UUID jobId;
+  private final WorkspaceId workspaceId = WorkspaceId.of(randomUUID());
 
   @BeforeAll
   void beforeAll() {
@@ -90,7 +91,7 @@ class JobControllerTest extends DataPlaneTestBase {
   @ParameterizedTest(name = "Return all jobs with a querystring of {0}")
   @ValueSource(strings = {"", "?someOtherParam=whatever", "?statuses="})
   void instanceJobsReturnAll(String queryString) {
-    when(collectionService.getWorkspaceId(collectionId)).thenReturn(twdsProperties.workspaceId());
+    when(collectionService.getWorkspaceId(collectionId)).thenReturn(workspaceId);
     HttpHeaders headers = new HttpHeaders();
     ResponseEntity<List<GenericJobServerModel>> result =
         restTemplate.exchange(
@@ -115,7 +116,7 @@ class JobControllerTest extends DataPlaneTestBase {
 
   @Test
   void instanceJobsWithMultipleStatuses() {
-    when(collectionService.getWorkspaceId(collectionId)).thenReturn(twdsProperties.workspaceId());
+    when(collectionService.getWorkspaceId(collectionId)).thenReturn(workspaceId);
     assertDoesNotThrow(() -> jobDao.updateStatus(jobId, StatusEnum.CANCELLED));
     HttpHeaders headers = new HttpHeaders();
     ResponseEntity<List<GenericJobServerModel>> result =
@@ -138,7 +139,7 @@ class JobControllerTest extends DataPlaneTestBase {
   @Test
   void instanceJobsWithMultipleDelimitedStatuses() {
 
-    when(collectionService.getWorkspaceId(collectionId)).thenReturn(twdsProperties.workspaceId());
+    when(collectionService.getWorkspaceId(collectionId)).thenReturn(workspaceId);
 
     assertDoesNotThrow(() -> jobDao.updateStatus(jobId, StatusEnum.CANCELLED));
     HttpHeaders headers = new HttpHeaders();

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/PostgresJobDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/PostgresJobDaoTest.java
@@ -22,7 +22,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
+import org.databiosphere.workspacedataservice.common.ControlPlaneTestBase;
 import org.databiosphere.workspacedataservice.common.MockInstantSource;
 import org.databiosphere.workspacedataservice.common.MockInstantSourceConfig;
 import org.databiosphere.workspacedataservice.dataimport.ImportJobInput;
@@ -50,7 +50,7 @@ import org.springframework.test.annotation.DirtiesContext;
 @DirtiesContext
 @SpringBootTest
 @Import(MockInstantSourceConfig.class)
-class PostgresJobDaoTest extends DataPlaneTestBase {
+class PostgresJobDaoTest extends ControlPlaneTestBase {
   private static final String TEST_IMPORT_URI = "http://some/uri";
 
   // createJob

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/QuartzSchedulerDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/QuartzSchedulerDaoTest.java
@@ -8,7 +8,7 @@ import java.io.Serializable;
 import java.util.Date;
 import java.util.Map;
 import java.util.Set;
-import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
+import org.databiosphere.workspacedataservice.common.ControlPlaneTestBase;
 import org.databiosphere.workspacedataservice.shared.model.Schedulable;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -25,7 +25,7 @@ import org.springframework.test.annotation.DirtiesContext;
 
 @DirtiesContext
 @SpringBootTest
-class QuartzSchedulerDaoTest extends DataPlaneTestBase {
+class QuartzSchedulerDaoTest extends ControlPlaneTestBase {
 
   @MockBean Scheduler scheduler;
   @Autowired SchedulerDao schedulerDao;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/FileDownloadHelperTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/FileDownloadHelperTest.java
@@ -3,14 +3,14 @@ package org.databiosphere.workspacedataservice.dataimport;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.io.IOException;
-import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
+import org.databiosphere.workspacedataservice.common.ControlPlaneTestBase;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.io.Resource;
 
 @SpringBootTest
-class FileDownloadHelperTest extends DataPlaneTestBase {
+class FileDownloadHelperTest extends ControlPlaneTestBase {
 
   @Value("classpath:parquet/empty.parquet")
   Resource emptyParquet;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/ImportJobInputTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/ImportJobInputTest.java
@@ -13,7 +13,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
+import org.databiosphere.workspacedataservice.common.ControlPlaneTestBase;
 import org.databiosphere.workspacedataservice.dataimport.pfb.PfbImportOptions;
 import org.databiosphere.workspacedataservice.dataimport.pfb.PfbJobInput;
 import org.databiosphere.workspacedataservice.dataimport.rawlsjson.RawlsJsonImportOptions;
@@ -29,7 +29,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class ImportJobInputTest extends DataPlaneTestBase {
+class ImportJobInputTest extends ControlPlaneTestBase {
   @Autowired ObjectMapper objectMapper;
 
   @ParameterizedTest(name = "with type {0}")

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/ImportRequirementsFactoryTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/ImportRequirementsFactoryTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.URI;
 import java.util.stream.Stream;
-import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
+import org.databiosphere.workspacedataservice.common.ControlPlaneTestBase;
 import org.databiosphere.workspacedataservice.config.DataImportProperties;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -13,7 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class ImportRequirementsFactoryTest extends DataPlaneTestBase {
+class ImportRequirementsFactoryTest extends ControlPlaneTestBase {
   @Autowired DataImportProperties dataImportProperties;
 
   @ParameterizedTest(name = "Imports from {0} should require a private workspace {1}")

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbRecordConverterTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbRecordConverterTest.java
@@ -25,7 +25,7 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
+import org.databiosphere.workspacedataservice.common.ControlPlaneTestBase;
 import org.databiosphere.workspacedataservice.recordsource.RecordSource.ImportMode;
 import org.databiosphere.workspacedataservice.service.JsonConfig;
 import org.databiosphere.workspacedataservice.shared.model.Record;
@@ -42,7 +42,7 @@ import org.springframework.test.annotation.DirtiesContext;
 
 @DirtiesContext
 @SpringBootTest(classes = {JsonConfig.class, PfbRecordConverter.class})
-class PfbRecordConverterTest extends DataPlaneTestBase {
+class PfbRecordConverterTest extends ControlPlaneTestBase {
 
   @Autowired private PfbRecordConverter converter;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/snapshotsupport/SnapshotSupportTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/snapshotsupport/SnapshotSupportTest.java
@@ -21,7 +21,7 @@ import java.util.UUID;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
+import org.databiosphere.workspacedataservice.common.ControlPlaneTestBase;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 import org.databiosphere.workspacedataservice.workspacemanager.WorkspaceManagerDao;
 import org.junit.jupiter.api.Test;
@@ -30,7 +30,7 @@ import org.springframework.test.annotation.DirtiesContext;
 
 @DirtiesContext
 @SpringBootTest
-class SnapshotSupportTest extends DataPlaneTestBase {
+class SnapshotSupportTest extends ControlPlaneTestBase {
 
   @Test
   void safeGetSnapshotId() {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/ParquetDataTypesTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/ParquetDataTypesTest.java
@@ -25,23 +25,20 @@ import org.apache.hadoop.fs.Path;
 import org.apache.parquet.hadoop.ParquetReader;
 import org.apache.parquet.hadoop.util.HadoopInputFile;
 import org.apache.parquet.io.InputFile;
-import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
+import org.databiosphere.workspacedataservice.common.ControlPlaneTestBase;
 import org.databiosphere.workspacedataservice.recordsource.RecordSource;
 import org.databiosphere.workspacedataservice.service.model.TdrManifestImportTable;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.io.Resource;
 
 @SpringBootTest
-class ParquetDataTypesTest extends DataPlaneTestBase {
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+class ParquetDataTypesTest extends ControlPlaneTestBase {
 
   @Autowired ObjectMapper mapper;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsModelTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsModelTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
+import org.databiosphere.workspacedataservice.common.ControlPlaneTestBase;
 import org.databiosphere.workspacedataservice.recordsink.RawlsModel.AddListMember;
 import org.databiosphere.workspacedataservice.recordsink.RawlsModel.AddUpdateAttribute;
 import org.databiosphere.workspacedataservice.recordsink.RawlsModel.AttributeValue;
@@ -20,7 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class RawlsModelTest extends DataPlaneTestBase {
+class RawlsModelTest extends ControlPlaneTestBase {
   @Autowired private ObjectMapper mapper;
 
   @Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/recordsource/JsonRecordSourceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/recordsource/JsonRecordSourceTest.java
@@ -9,7 +9,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.stream.Stream;
-import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
+import org.databiosphere.workspacedataservice.common.ControlPlaneTestBase;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -17,7 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class JsonRecordSourceTest extends DataPlaneTestBase {
+class JsonRecordSourceTest extends ControlPlaneTestBase {
   @Autowired ObjectMapper objectMapper; // as defined in JsonConfig
 
   private static Stream<Arguments> parserFeatures() {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/recordsource/PfbRecordSourceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/recordsource/PfbRecordSourceTest.java
@@ -15,7 +15,7 @@ import java.net.URL;
 import java.util.List;
 import org.apache.avro.file.DataFileStream;
 import org.apache.avro.generic.GenericRecord;
-import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
+import org.databiosphere.workspacedataservice.common.ControlPlaneTestBase;
 import org.databiosphere.workspacedataservice.recordsource.RecordSource.ImportMode;
 import org.databiosphere.workspacedataservice.recordsource.RecordSource.WriteStreamInfo;
 import org.databiosphere.workspacedataservice.shared.model.Record;
@@ -28,7 +28,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class PfbRecordSourceTest extends DataPlaneTestBase {
+class PfbRecordSourceTest extends ControlPlaneTestBase {
   @Autowired private ObjectMapper objectMapper;
 
   // does PfbRecordSource properly know how to page through a DataFileStream<GenericRecord>?

--- a/service/src/test/java/org/databiosphere/workspacedataservice/recordsource/StreamingTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/recordsource/StreamingTest.java
@@ -7,7 +7,7 @@ import static org.databiosphere.workspacedataservice.shared.model.OperationType.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.List;
-import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
+import org.databiosphere.workspacedataservice.common.ControlPlaneTestBase;
 import org.databiosphere.workspacedataservice.recordsource.RecordSource.WriteStreamInfo;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.junit.jupiter.api.Test;
@@ -15,7 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class StreamingTest extends DataPlaneTestBase {
+class StreamingTest extends ControlPlaneTestBase {
 
   @Autowired private ObjectMapper objectMapper;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerBeanTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerBeanTest.java
@@ -64,6 +64,8 @@ class CollectionInitializerBeanTest extends DataPlaneTestBase {
   void setUp() throws InterruptedException {
     when(mockLock.tryLock(anyLong(), any())).thenReturn(true);
     when(registry.obtain(anyString())).thenReturn(mockLock);
+    // start fresh
+    TestUtils.cleanAllCollections(collectionService, namedTemplate);
   }
 
   @AfterEach

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvBatchTypeDetectionTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvBatchTypeDetectionTest.java
@@ -12,8 +12,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.TestUtils;
-import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
-import org.databiosphere.workspacedataservice.config.TwdsProperties;
+import org.databiosphere.workspacedataservice.common.ControlPlaneTestBase;
+import org.databiosphere.workspacedataservice.dao.WorkspaceRepository;
 import org.databiosphere.workspacedataservice.recordsink.RecordSink;
 import org.databiosphere.workspacedataservice.recordsink.RecordSinkFactory;
 import org.databiosphere.workspacedataservice.recordsource.RecordSourceFactory;
@@ -29,6 +29,9 @@ import org.databiosphere.workspacedataservice.service.model.RecordTypeSchema;
 import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.databiosphere.workspacedataservice.shared.model.Record;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
+import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
+import org.databiosphere.workspacedataservice.workspace.WorkspaceDataTableType;
+import org.databiosphere.workspacedataservice.workspace.WorkspaceRecord;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -45,7 +48,7 @@ import org.springframework.test.context.TestPropertySource;
 @DirtiesContext
 @SpringBootTest
 @TestPropertySource(properties = {"twds.write.batch.size=2"})
-class TsvBatchTypeDetectionTest extends DataPlaneTestBase {
+class TsvBatchTypeDetectionTest extends ControlPlaneTestBase {
 
   @Autowired private RecordSourceFactory recordSourceFactory;
   @Autowired private RecordSinkFactory recordSinkFactory;
@@ -53,21 +56,28 @@ class TsvBatchTypeDetectionTest extends DataPlaneTestBase {
   @Autowired private RecordOrchestratorService recordOrchestratorService;
   @Autowired private CollectionService collectionService;
   @Autowired private NamedParameterJdbcTemplate namedTemplate;
-  @Autowired TwdsProperties twdsProperties;
+  @Autowired private WorkspaceRepository workspaceRepository;
   @SpyBean DataTypeInferer inferer;
   @SpyBean RecordService recordService;
 
   @Nullable private UUID collectionId;
+  @Nullable private WorkspaceId workspaceId;
   private static final RecordType THING_TYPE = RecordType.valueOf("thing");
 
   @BeforeEach
   void setUp() {
-    collectionId = collectionService.save(twdsProperties.workspaceId(), "name", "desc").getId();
+    workspaceId = WorkspaceId.of(UUID.randomUUID());
+
+    // create the workspace record
+    workspaceRepository.save(
+        new WorkspaceRecord(workspaceId, WorkspaceDataTableType.WDS, /* newFlag= */ true));
+    collectionId = collectionService.save(workspaceId, "name", "desc").getId();
   }
 
   @AfterEach
   void tearDown() {
     TestUtils.cleanAllCollections(collectionService, namedTemplate);
+    TestUtils.cleanAllWorkspaces(namedTemplate);
   }
 
   // when batchWriteTsvStream is called with a single specified RecordType, we should not fail if

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvBatchTypeDetectionTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvBatchTypeDetectionTest.java
@@ -61,12 +61,11 @@ class TsvBatchTypeDetectionTest extends ControlPlaneTestBase {
   @SpyBean RecordService recordService;
 
   @Nullable private UUID collectionId;
-  @Nullable private WorkspaceId workspaceId;
   private static final RecordType THING_TYPE = RecordType.valueOf("thing");
 
   @BeforeEach
   void setUp() {
-    workspaceId = WorkspaceId.of(UUID.randomUUID());
+    WorkspaceId workspaceId = WorkspaceId.of(UUID.randomUUID());
 
     // create the workspace record
     workspaceRepository.save(

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvDeserializerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvDeserializerTest.java
@@ -12,7 +12,7 @@ import java.math.BigInteger;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
-import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
+import org.databiosphere.workspacedataservice.common.ControlPlaneTestBase;
 import org.databiosphere.workspacedataservice.shared.model.attributes.JsonAttribute;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -30,7 +30,7 @@ import org.springframework.boot.test.context.SpringBootTest;
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @SpringBootTest
-class TsvDeserializerTest extends DataPlaneTestBase {
+class TsvDeserializerTest extends ControlPlaneTestBase {
 
   @Autowired TsvDeserializer tsvDeserializer;
   @Autowired ObjectMapper mapper;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvErrorMessageTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvErrorMessageTest.java
@@ -41,13 +41,12 @@ class TsvErrorMessageTest extends ControlPlaneTestBase {
   @Autowired private WorkspaceRepository workspaceRepository;
 
   private UUID collectionId;
-  private WorkspaceId workspaceId;
 
   private static final String VERSION = "v0.2";
 
   @BeforeEach
   void setUp() {
-    workspaceId = WorkspaceId.of(UUID.randomUUID());
+    WorkspaceId workspaceId = WorkspaceId.of(UUID.randomUUID());
 
     // create the workspace record
     workspaceRepository.save(

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvErrorMessageTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvErrorMessageTest.java
@@ -8,13 +8,16 @@ import java.io.InputStream;
 import java.util.Optional;
 import java.util.UUID;
 import org.databiosphere.workspacedataservice.TestUtils;
-import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
-import org.databiosphere.workspacedataservice.config.TwdsProperties;
+import org.databiosphere.workspacedataservice.common.ControlPlaneTestBase;
+import org.databiosphere.workspacedataservice.dao.WorkspaceRepository;
 import org.databiosphere.workspacedataservice.generated.CollectionServerModel;
 import org.databiosphere.workspacedataservice.service.CollectionService;
 import org.databiosphere.workspacedataservice.service.RecordOrchestratorService;
 import org.databiosphere.workspacedataservice.service.model.exception.InvalidTsvException;
 import org.databiosphere.workspacedataservice.shared.model.RecordType;
+import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
+import org.databiosphere.workspacedataservice.workspace.WorkspaceDataTableType;
+import org.databiosphere.workspacedataservice.workspace.WorkspaceRecord;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInstance;
@@ -30,27 +33,34 @@ import org.springframework.test.annotation.DirtiesContext;
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @DirtiesContext
-class TsvErrorMessageTest extends DataPlaneTestBase {
+class TsvErrorMessageTest extends ControlPlaneTestBase {
 
   @Autowired CollectionService collectionService;
   @Autowired RecordOrchestratorService recordOrchestratorService;
   @Autowired NamedParameterJdbcTemplate namedTemplate;
-  @Autowired TwdsProperties twdsProperties;
+  @Autowired private WorkspaceRepository workspaceRepository;
 
   private UUID collectionId;
+  private WorkspaceId workspaceId;
 
   private static final String VERSION = "v0.2";
 
   @BeforeEach
   void setUp() {
+    workspaceId = WorkspaceId.of(UUID.randomUUID());
+
+    // create the workspace record
+    workspaceRepository.save(
+        new WorkspaceRecord(workspaceId, WorkspaceDataTableType.WDS, /* newFlag= */ true));
     CollectionServerModel collectionServerModel =
-        TestUtils.createCollection(collectionService, twdsProperties.workspaceId());
+        TestUtils.createCollection(collectionService, workspaceId);
     collectionId = collectionServerModel.getId();
   }
 
   @AfterEach
   void tearDown() {
     TestUtils.cleanAllCollections(collectionService, namedTemplate);
+    TestUtils.cleanAllWorkspaces(namedTemplate);
   }
 
   @ParameterizedTest(name = "The malformed TSV file '{0}' should throw a helpful error")

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvJsonEquivalenceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvJsonEquivalenceTest.java
@@ -11,7 +11,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.List;
-import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
+import org.databiosphere.workspacedataservice.common.ControlPlaneTestBase;
 import org.databiosphere.workspacedataservice.shared.model.RecordAttributes;
 import org.databiosphere.workspacedataservice.shared.model.RecordRequest;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -26,7 +26,7 @@ import org.springframework.boot.test.context.SpringBootTest;
  * @see TsvJsonArgumentsProvider
  */
 @SpringBootTest
-class TsvJsonEquivalenceTest extends DataPlaneTestBase {
+class TsvJsonEquivalenceTest extends ControlPlaneTestBase {
 
   @Autowired private ObjectReader tsvReader;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/workspacemanager/WorkspaceManagerDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/workspacemanager/WorkspaceManagerDaoTest.java
@@ -23,8 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.databiosphere.workspacedataservice.annotations.SingleTenant;
-import org.databiosphere.workspacedataservice.common.DataPlaneTestBase;
+import org.databiosphere.workspacedataservice.common.ControlPlaneTestBase;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,13 +38,13 @@ import org.springframework.test.annotation.DirtiesContext;
 
 @SpringBootTest
 @DirtiesContext
-class WorkspaceManagerDaoTest extends DataPlaneTestBase {
+class WorkspaceManagerDaoTest extends ControlPlaneTestBase {
 
   @Autowired WorkspaceManagerDao workspaceManagerDao;
 
   @MockBean WorkspaceManagerClientFactory mockWorkspaceManagerClientFactory;
 
-  @Autowired @SingleTenant WorkspaceId workspaceId;
+  private WorkspaceId workspaceId;
 
   final ReferencedGcpResourceApi mockReferencedGcpResourceApi =
       Mockito.mock(ReferencedGcpResourceApi.class);
@@ -55,6 +54,8 @@ class WorkspaceManagerDaoTest extends DataPlaneTestBase {
 
   @BeforeEach
   void setUp() {
+    workspaceId = WorkspaceId.of(randomUUID());
+
     given(mockWorkspaceManagerClientFactory.getReferencedGcpResourceApi(nullable(String.class)))
         .willReturn(mockReferencedGcpResourceApi);
     given(mockWorkspaceManagerClientFactory.getResourceApi(nullable(String.class)))


### PR DESCRIPTION
Followup to #927.

This moves another 20 unit tests from the data-plane profile to the control-plane profile. There are still ~25 tests in the data-plane profile; this is incremental progress.

Some tests required relatively minor setup/teardown changes; some required no changes at all other than the profile switch.

The remaining tests will require the most attention, either because:
* they are actually testing data plane functionality and therefore we need to decide on keeping them or not
* they rely on controllers which are not yet enabled in the control plane