### PR TITLE
AJ-2005 remove mention of datarepo url from readme

### DIFF
--- a/.github/workflows/release-python-client.yml
+++ b/.github/workflows/release-python-client.yml
@@ -84,7 +84,6 @@ jobs:
       - name: Run WDS service and tests
         run: |
           export SAM_URL=http://localhost:9889
-          export DATA_REPO_URL=http://localhost:9889
           export WORKSPACE_MANAGER_URL=http://localhost:9889
           export WORKSPACE_ID=123e4567-e89b-12d3-a456-426614174000
           export SPRING_PROFILES_ACTIVE=data-plane,local

--- a/README.md
+++ b/README.md
@@ -106,15 +106,6 @@ environment variable, such as:
 export SAM_URL=https://sam.dsde-dev.broadinstitute.org/
 ```
 
-##### DATA_REPO_URL
-
-For importing snapshots from the Terra Data Repo, WDS will need the TDR URL configured as an
-environment variable, such as:
-
-```
-export DATA_REPO_URL=https://jade.datarepo-dev.broadinstitute.org/
-```
-
 ##### WORKSPACE_MANAGER_URL
 
 Importing snapshots from the Terra Data Repo also requires the Workspace Manager configured as an
@@ -240,7 +231,7 @@ To run a single test, run
 
 ## Troubleshooting
 
-Some problems during build and test may be solved by running the Gradle `clean` task: 
+Some problems during build and test may be solved by running the Gradle `clean` task:
 
 ```bash
 ./gradlew clean

--- a/service/src/main/resources/application-bee.yml
+++ b/service/src/main/resources/application-bee.yml
@@ -1,7 +1,6 @@
 beename: ${BEE_NAME}
 
 samurl: https://sam.${beename}.bee.envs-terra.bio
-datarepourl: https://data.${beename}.bee.envs-terra.bio
 workspacemanagerurl: https://workspace.${beename}.bee.envs-terra.bio
 leoUrl: https://leonardo.${beename}.bee.envs-terra.bio
 rawlsUrl: https://rawls.${beename}.bee.envs-terra.bio

--- a/service/src/main/resources/application-dev.yml
+++ b/service/src/main/resources/application-dev.yml
@@ -1,5 +1,4 @@
 samurl: https://sam.dsde-dev.broadinstitute.org/
-datarepourl: https://jade.datarepo-dev.broadinstitute.org/
 workspacemanagerurl: https://workspace.dsde-dev.broadinstitute.org/
 leoUrl: https://leonardo.dsde-dev.broadinstitute.org/
 rawlsUrl: https://rawls.dsde-dev.broadinstitute.org/

--- a/service/src/main/resources/application-local.yml
+++ b/service/src/main/resources/application-local.yml
@@ -19,5 +19,4 @@ spring:
 logging:
   pattern:
     correlation: "%X{requestId} "
-
-controlPlanePreview: "on"
+    

--- a/service/src/main/resources/application-local.yml
+++ b/service/src/main/resources/application-local.yml
@@ -1,5 +1,4 @@
 samurl: ${SAM_URL:https://sam.dsde-dev.broadinstitute.org/}
-datarepourl: ${DATA_REPO_URL:https://jade.datarepo-dev.broadinstitute.org/}
 workspacemanagerurl: ${WORKSPACE_MANAGER_URL:https://workspace.dsde-dev.broadinstitute.org/}
 leoUrl: ${LEONARDO_URL:https://leonardo.dsde-dev.broadinstitute.org/}
 rawlsUrl: ${RAWLS_URL:https://rawls.dsde-dev.broadinstitute.org/}
@@ -20,3 +19,5 @@ spring:
 logging:
   pattern:
     correlation: "%X{requestId} "
+
+controlPlanePreview: "on"

--- a/service/src/main/resources/application-prod.yml
+++ b/service/src/main/resources/application-prod.yml
@@ -1,5 +1,4 @@
 samurl: https://sam.dsde-prod.broadinstitute.org/
-datarepourl: https://data.terra.bio/
 workspacemanagerurl: https://workspace.dsde-prod.broadinstitute.org/
 leoUrl: https://leonardo.dsde-prod.broadinstitute.org/
 rawlsUrl: https://rawls.dsde-prod.broadinstitute.org/

--- a/service/src/main/resources/application-staging.yml
+++ b/service/src/main/resources/application-staging.yml
@@ -1,5 +1,4 @@
 samurl: https://sam.dsde-staging.broadinstitute.org/
-datarepourl: https://data.staging.envs-terra.bio/
 workspacemanagerurl: https://workspace.dsde-staging.broadinstitute.org/
 leoUrl: https://leonardo.dsde-staging.broadinstitute.org/
 rawlsUrl: https://rawls.dsde-staging.broadinstitute.org/


### PR DESCRIPTION
After https://github.com/DataBiosphere/terra-workspace-data-service/pull/774 we don't need the data repo url anymore; this PR removes its mention from the README and its use from `.yml` files.