### PR TITLE
AJ-1782 address security vulnerability

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -151,6 +151,9 @@ dependencies {
         implementation('org.apache.commons:commons-configuration2:2.11.0') {
             because("CVE-2024-29131, CVE-2024-29133")
         }
+        implementation('org.springframework:spring-webmvc:6.1.13') {
+            because("CVE-2024-38816")
+        }
     }
 }
 


### PR DESCRIPTION
Bumps spring-webmvc to address [security vulnerability](https://github.com/DataBiosphere/terra-workspace-data-service/security/dependabot/98).  Can be removed once `spring-boot-starter-web`, which is what pulls in spring-webmvc, releases an update that includes the patch.

Reminder:

#### Releasing WDS ####
PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag-and-publish.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 

#### Keeping Docs Up To Date ####
If you make changes to the github actions or workflows, particularly when they are run or which other workflows they call, please update [the GHA wiki page](https://github.com/DataBiosphere/terra-workspace-data-service/wiki/GHA-structure-in-WDS) to stay up to date.
