### PR TITLE
AJ-1782: sam-client and spring-webmvc dependency cleanup

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -49,7 +49,6 @@ dependencies {
     implementation 'org.zalando:logbook-spring-boot-starter:3.9.0'
 
     // Azure libraries
-    // do not upgrade app insights past 3.5.1 until AJ-1897 is resolved
     implementation 'com.microsoft.azure:applicationinsights-runtime-attach:3.5.3'
     implementation 'com.azure:azure-storage-blob:12.28.0'
     implementation 'com.azure:azure-identity-extensions:1.1.19' // postgres password plugin
@@ -86,7 +85,7 @@ dependencies {
     implementation 'io.swagger.core.v3:swagger-annotations:2.2.23'
 
     // Terra libraries
-    implementation group: 'org.broadinstitute.dsde.workbench', name: 'sam-client_2.13', version: '0.1-752b4f3'
+    implementation group: 'org.broadinstitute.dsde.workbench', name: 'sam-client_2.13', version: 'v0.0.282'
     implementation group: 'org.broadinstitute.dsde.workbench', name: 'leonardo-client_2.13', version: '1.3.6-22ee00b'
     implementation 'com.squareup.okhttp3:okhttp' // required by Sam client
     implementation "bio.terra:datarepo-client:2.13.0-SNAPSHOT"
@@ -153,9 +152,6 @@ dependencies {
         }
         implementation('org.apache.commons:commons-configuration2:2.11.0') {
             because("CVE-2024-29131, CVE-2024-29133")
-        }
-        implementation('org.springframework:spring-webmvc:6.1.13') {
-            because("CVE-2024-38816")
         }
     }
 }


### PR DESCRIPTION
Some minor dependency cleanup:
* remove an obsolete comment
* remove the `constraint` on `spring-webmvc`, since the Spring Boot upgrade in #936 makes that constraint obsolete
* update to a recent version of `sam-client` and move to its "v"-based semantic versioning