### PR TITLE
AJ-2022: add Content-Security-Policy meta header for swagger-ui

### DIFF
--- a/service/src/main/resources/swagger-ui-control-plane-preview.html
+++ b/service/src/main/resources/swagger-ui-control-plane-preview.html
@@ -4,6 +4,8 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy"
+        content="default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self'; form-action 'none';">
   <title>cWDS API</title>
   <!-- *** next 4 lines updated to reference /webjars/swagger-ui-dist/ instead of ./ -->
   <link rel="stylesheet" type="text/css" href="/webjars/swagger-ui-dist/swagger-ui.css"/>

--- a/service/src/main/resources/swagger-ui-control-plane-preview.html
+++ b/service/src/main/resources/swagger-ui-control-plane-preview.html
@@ -5,7 +5,7 @@
 <head>
   <meta charset="UTF-8">
   <meta http-equiv="Content-Security-Policy"
-        content="default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self'; form-action 'none';">
+        content="default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self'; form-action 'none'; frame-ancestors 'none';">
   <title>cWDS API</title>
   <!-- *** next 4 lines updated to reference /webjars/swagger-ui-dist/ instead of ./ -->
   <link rel="stylesheet" type="text/css" href="/webjars/swagger-ui-dist/swagger-ui.css"/>

--- a/service/src/main/resources/swagger-ui-control-plane-preview.html
+++ b/service/src/main/resources/swagger-ui-control-plane-preview.html
@@ -5,7 +5,7 @@
 <head>
   <meta charset="UTF-8">
   <meta http-equiv="Content-Security-Policy"
-        content="default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self'; form-action 'none'; frame-ancestors 'none';">
+        content="default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self'; form-action 'none';">
   <title>cWDS API</title>
   <!-- *** next 4 lines updated to reference /webjars/swagger-ui-dist/ instead of ./ -->
   <link rel="stylesheet" type="text/css" href="/webjars/swagger-ui-dist/swagger-ui.css"/>

--- a/service/src/main/resources/swagger-ui-control-plane.html
+++ b/service/src/main/resources/swagger-ui-control-plane.html
@@ -4,6 +4,8 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy"
+        content="default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self'; form-action 'none';">
   <title>cWDS API</title>
   <!-- *** next 4 lines updated to reference /webjars/swagger-ui-dist/ instead of ./ -->
   <link rel="stylesheet" type="text/css" href="/webjars/swagger-ui-dist/swagger-ui.css"/>

--- a/service/src/main/resources/swagger-ui-control-plane.html
+++ b/service/src/main/resources/swagger-ui-control-plane.html
@@ -5,7 +5,7 @@
 <head>
   <meta charset="UTF-8">
   <meta http-equiv="Content-Security-Policy"
-        content="default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self'; form-action 'none';">
+        content="default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self'; form-action 'none'; frame-ancestors 'none';">
   <title>cWDS API</title>
   <!-- *** next 4 lines updated to reference /webjars/swagger-ui-dist/ instead of ./ -->
   <link rel="stylesheet" type="text/css" href="/webjars/swagger-ui-dist/swagger-ui.css"/>

--- a/service/src/main/resources/swagger-ui-control-plane.html
+++ b/service/src/main/resources/swagger-ui-control-plane.html
@@ -5,7 +5,7 @@
 <head>
   <meta charset="UTF-8">
   <meta http-equiv="Content-Security-Policy"
-        content="default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self'; form-action 'none'; frame-ancestors 'none';">
+        content="default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self'; form-action 'none';">
   <title>cWDS API</title>
   <!-- *** next 4 lines updated to reference /webjars/swagger-ui-dist/ instead of ./ -->
   <link rel="stylesheet" type="text/css" href="/webjars/swagger-ui-dist/swagger-ui.css"/>

--- a/service/src/main/resources/swagger-ui-data-plane.html
+++ b/service/src/main/resources/swagger-ui-data-plane.html
@@ -5,7 +5,7 @@
 <head>
   <meta charset="UTF-8">
   <meta http-equiv="Content-Security-Policy"
-        content="default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self'; form-action 'none'; frame-ancestors 'none';">
+        content="default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self'; form-action 'none';">
   <title>WDS API</title>
   <!-- *** next 4 lines updated to reference /webjars/swagger-ui-dist/ instead of ./ -->
   <link rel="stylesheet" type="text/css" href="/webjars/swagger-ui-dist/swagger-ui.css"/>

--- a/service/src/main/resources/swagger-ui-data-plane.html
+++ b/service/src/main/resources/swagger-ui-data-plane.html
@@ -5,7 +5,7 @@
 <head>
   <meta charset="UTF-8">
   <meta http-equiv="Content-Security-Policy"
-        content="default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self'; form-action 'none';">
+        content="default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self'; form-action 'none'; frame-ancestors 'none';">
   <title>WDS API</title>
   <!-- *** next 4 lines updated to reference /webjars/swagger-ui-dist/ instead of ./ -->
   <link rel="stylesheet" type="text/css" href="/webjars/swagger-ui-dist/swagger-ui.css"/>

--- a/service/src/main/resources/swagger-ui-data-plane.html
+++ b/service/src/main/resources/swagger-ui-data-plane.html
@@ -4,6 +4,8 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy"
+        content="default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self'; form-action 'none';">
   <title>WDS API</title>
   <!-- *** next 4 lines updated to reference /webjars/swagger-ui-dist/ instead of ./ -->
   <link rel="stylesheet" type="text/css" href="/webjars/swagger-ui-dist/swagger-ui.css"/>


### PR DESCRIPTION
Basing these changes on https://github.com/DataBiosphere/terra-landing-zone-service/pull/502

This PR adds a `Content-Security-Policy` to swagger-ui via `<meta http-equiv …` tags.

