### PR TITLE
[CORE-69] Move dependabot updates from AJ to CORE

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,7 @@ updates:
     reviewers:
       - "@DataBiosphere/broad-core-services"
     commit-message:
-      prefix: "[CORE-70]"
+      prefix: "[CORE-69]"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -41,7 +41,7 @@ updates:
     reviewers:
       - "@DataBiosphere/broad-core-services"
     commit-message:
-      prefix: "[CORE-70]"
+      prefix: "[CORE-69]"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,9 +18,9 @@ updates:
       - "gradle"
     open-pull-requests-limit: 10
     reviewers:
-      - "@DataBiosphere/analysisjourneys"
+      - "@DataBiosphere/broad-core-services"
     commit-message:
-      prefix: "[AJ-1782]"
+      prefix: "[CORE-70]"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -39,9 +39,9 @@ updates:
       - "github-actions"
     open-pull-requests-limit: 10
     reviewers:
-      - "@DataBiosphere/analysisjourneys"
+      - "@DataBiosphere/broad-core-services"
     commit-message:
-      prefix: "[AJ-1782]"
+      prefix: "[CORE-70]"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
Dependabot automatically tags an associated ticket and the AJ team. The ticket was moved from AJ to CORE; this PR updates the ticket and which team is tagged on dependabot updates.