### PR TITLE
CORE-69: remove deprecated MockBean/SpyBean

### DIFF
--- a/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/ActivityEventBuilderTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/ActivityEventBuilderTest.java
@@ -26,10 +26,10 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.context.request.RequestContextHolder;
 
@@ -41,7 +41,7 @@ class ActivityEventBuilderTest extends ControlPlaneTestBase {
 
   @Autowired CollectionService collectionService;
 
-  @MockBean SamClientFactory mockSamClientFactory;
+  @MockitoBean SamClientFactory mockSamClientFactory;
 
   final UsersApi mockUsersApi = Mockito.mock(UsersApi.class);
   final ResourcesApi mockResourcesApi = Mockito.mock(ResourcesApi.class);

--- a/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/LogStatementTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/activitylog/LogStatementTest.java
@@ -35,12 +35,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.web.multipart.MultipartFile;
 
 @SpringBootTest
@@ -56,14 +56,14 @@ class LogStatementTest extends ControlPlaneTestBase {
   @Autowired NamedParameterJdbcTemplate namedTemplate;
 
   // mocking for Workspace Manager
-  @MockBean WorkspaceManagerClientFactory mockWorkspaceManagerClientFactory;
+  @MockitoBean WorkspaceManagerClientFactory mockWorkspaceManagerClientFactory;
   final ReferencedGcpResourceApi mockReferencedGcpResourceApi =
       Mockito.mock(ReferencedGcpResourceApi.class);
 
   // mocking for data repo
   final RepositoryApi mockRepositoryApi = Mockito.mock(RepositoryApi.class);
 
-  @MockBean DataTableTypeInspector dataTableTypeInspector;
+  @MockitoBean DataTableTypeInspector dataTableTypeInspector;
 
   private WorkspaceId workspaceId;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/AllControllersPermissionsTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/AllControllersPermissionsTest.java
@@ -40,11 +40,11 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
@@ -55,12 +55,12 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 class AllControllersPermissionsTest extends DataPlaneTestBase {
   @Autowired private MockMvc mockMvc;
   @Autowired PermissionService permissionService;
-  @MockBean SamAuthorizationDaoFactory samAuthorizationDaoFactory;
-  @MockBean CollectionService collectionService;
-  @MockBean RecordDao recordDao;
-  @MockBean JobService jobService;
-  @MockBean BackupRestoreService backupRestoreService;
-  @MockBean RecordOrchestratorService recordOrchestratorService;
+  @MockitoBean SamAuthorizationDaoFactory samAuthorizationDaoFactory;
+  @MockitoBean CollectionService collectionService;
+  @MockitoBean RecordDao recordDao;
+  @MockitoBean JobService jobService;
+  @MockitoBean BackupRestoreService backupRestoreService;
+  @MockitoBean RecordOrchestratorService recordOrchestratorService;
   @Autowired TwdsProperties twdsProperties;
 
   private final SamAuthorizationDao samAuthorizationDao = spy(MockSamAuthorizationDao.allowAll());

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/CollectionControllerMockMvcSingleTenantTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/CollectionControllerMockMvcSingleTenantTest.java
@@ -35,7 +35,6 @@ import org.mockito.stubbing.OngoingStubbing;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -43,6 +42,7 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -64,7 +64,7 @@ class CollectionControllerMockMvcSingleTenantTest extends DataPlaneTestBase {
   @Autowired private ObjectMapper objectMapper;
   @Autowired private TwdsProperties twdsProperties;
 
-  @MockBean SamAuthorizationDaoFactory samAuthorizationDaoFactory;
+  @MockitoBean SamAuthorizationDaoFactory samAuthorizationDaoFactory;
 
   private final SamAuthorizationDao samAuthorizationDao = spy(MockSamAuthorizationDao.allowAll());
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/CollectionControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/CollectionControllerMockMvcTest.java
@@ -44,13 +44,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.mockito.stubbing.OngoingStubbing;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 
@@ -63,7 +63,7 @@ class CollectionControllerMockMvcTest extends MockMvcTestBase {
   @Autowired private NamedParameterJdbcTemplate namedTemplate;
   @Autowired private CollectionService collectionService;
 
-  @MockBean SamAuthorizationDaoFactory samAuthorizationDaoFactory;
+  @MockitoBean SamAuthorizationDaoFactory samAuthorizationDaoFactory;
 
   private final SamAuthorizationDao samAuthorizationDao = spy(MockSamAuthorizationDao.allowAll());
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/CorsLiveMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/CorsLiveMockMvcTest.java
@@ -9,8 +9,8 @@ import org.databiosphere.workspacedataservice.annotations.SingleTenant;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MvcResult;
 
 /**
@@ -26,7 +26,7 @@ import org.springframework.test.web.servlet.MvcResult;
 class CorsLiveMockMvcTest extends MockMvcTestBase {
   private static final String versionId = "v0.2";
 
-  @MockBean @SingleTenant WorkspaceId workspaceId;
+  @MockitoBean @SingleTenant WorkspaceId workspaceId;
 
   @ParameterizedTest(name = "CORS response headers for non-local profile to {0} should be correct")
   @ValueSource(

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/FullStackRecordControllerTest.java
@@ -47,7 +47,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpEntity;
@@ -59,6 +58,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 /**
  * This test spins up a web server and the full Spring Boot web stack. It was necessary to add it in
@@ -78,7 +78,7 @@ class FullStackRecordControllerTest extends ControlPlaneTestBase {
   @Autowired private TestRestTemplate restTemplate;
   @Autowired private WorkspaceRepository workspaceRepository;
 
-  @MockBean RawlsProtectedDataSupport rawlsProtectedDataSupport;
+  @MockitoBean RawlsProtectedDataSupport rawlsProtectedDataSupport;
 
   private HttpHeaders headers;
   private UUID instanceId;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/JobControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/JobControllerMockMvcTest.java
@@ -19,14 +19,14 @@ import org.databiosphere.workspacedataservice.service.CollectionService;
 import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MvcResult;
 
 @ActiveProfiles(profiles = {"mock-sam"})
 class JobControllerMockMvcTest extends MockMvcTestBase {
-  @MockBean private JobDao jobDao;
-  @MockBean private CollectionService collectionService;
+  @MockitoBean private JobDao jobDao;
+  @MockitoBean private CollectionService collectionService;
 
   @Test
   void smokeTestGetJob() throws Exception {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/JobControllerTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/JobControllerTest.java
@@ -37,7 +37,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
@@ -48,6 +47,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @ActiveProfiles(profiles = {"mock-sam"})
 @DirtiesContext
@@ -60,7 +60,7 @@ class JobControllerTest extends ControlPlaneTestBase {
   @Autowired private TestRestTemplate restTemplate;
   @Autowired private JobDao jobDao;
 
-  @MockBean private CollectionService collectionService;
+  @MockitoBean private CollectionService collectionService;
 
   private final CollectionId collectionId = CollectionId.of(randomUUID());
   private UUID jobId;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerExpressionsTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerExpressionsTest.java
@@ -28,13 +28,13 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class RecordControllerExpressionsTest extends MockMvcTestBase {
-  @MockBean private ExpressionService expressionService;
-  @MockBean private PermissionService permissionService;
+  @MockitoBean private ExpressionService expressionService;
+  @MockitoBean private PermissionService permissionService;
 
   public Stream<Arguments> testEvaluateExpressionValues() {
     return Stream.of(

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/WorkspaceControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/WorkspaceControllerMockMvcTest.java
@@ -37,11 +37,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.mockito.stubbing.OngoingStubbing;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MvcResult;
 
 @DirtiesContext
@@ -56,7 +56,7 @@ class WorkspaceControllerMockMvcTest extends MockMvcTestBase {
   @Autowired private NamedParameterJdbcTemplate namedTemplate;
   @Autowired private ObjectMapper objectMapper;
 
-  @MockBean SamAuthorizationDaoFactory samAuthorizationDaoFactory;
+  @MockitoBean SamAuthorizationDaoFactory samAuthorizationDaoFactory;
 
   private final SamAuthorizationDao samAuthorizationDao = spy(MockSamAuthorizationDao.allowAll());
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dao/QuartzSchedulerDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dao/QuartzSchedulerDaoTest.java
@@ -20,14 +20,14 @@ import org.quartz.SchedulerException;
 import org.quartz.Trigger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @DirtiesContext
 @SpringBootTest
 class QuartzSchedulerDaoTest extends ControlPlaneTestBase {
 
-  @MockBean Scheduler scheduler;
+  @MockitoBean Scheduler scheduler;
   @Autowired SchedulerDao schedulerDao;
 
   // this test needs a valid implementation of Job, so here's a noop one:

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/DefaultImportValidatorTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/DefaultImportValidatorTest.java
@@ -31,9 +31,9 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
 class DefaultImportValidatorTest extends ControlPlaneTestBase {
@@ -61,9 +61,9 @@ class DefaultImportValidatorTest extends ControlPlaneTestBase {
     }
   }
 
-  @MockBean ProtectedDataSupport protectedDataSupport;
+  @MockitoBean ProtectedDataSupport protectedDataSupport;
 
-  @MockBean SamDao samDao;
+  @MockitoBean SamDao samDao;
 
   @Autowired DefaultImportValidator importValidator;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobControlPlaneE2ETest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobControlPlaneE2ETest.java
@@ -75,12 +75,12 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.core.io.Resource;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.util.StreamUtils;
@@ -105,13 +105,13 @@ class PfbQuartzJobControlPlaneE2ETest extends ControlPlaneTestBase {
   @Qualifier("mockGcsStorage")
   GcsStorage storage;
 
-  @SpyBean PubSub pubSub;
-  @SpyBean SamDao samDao;
+  @MockitoSpyBean PubSub pubSub;
+  @MockitoSpyBean SamDao samDao;
   // Mock ImportValidator to allow importing test data from a file:// URL.
-  @MockBean ImportValidator importValidator;
-  @MockBean RawlsClient rawlsClient;
-  @MockBean WorkspaceService workspaceService;
-  @MockBean DataTableTypeInspector dataTableTypeInspector;
+  @MockitoBean ImportValidator importValidator;
+  @MockitoBean RawlsClient rawlsClient;
+  @MockitoBean WorkspaceService workspaceService;
+  @MockitoBean DataTableTypeInspector dataTableTypeInspector;
 
   /** ArgumentCaptor for the message passed to {@link PubSub#publishSync(Map)}. */
   @Captor private ArgumentCaptor<Map<String, String>> pubSubMessageCaptor;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobDataPlaneE2ETest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobDataPlaneE2ETest.java
@@ -41,12 +41,12 @@ import org.quartz.JobExecutionException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.core.io.Resource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 /**
  * Tests for PFB import that execute "end-to-end" - that is, they go through the whole process of
@@ -62,10 +62,10 @@ class PfbQuartzJobDataPlaneE2ETest extends DataPlaneTestBase {
   @Autowired CollectionService collectionService;
   @Autowired PfbTestSupport testSupport;
   @Autowired NamedParameterJdbcTemplate namedTemplate;
-  @MockBean WorkspaceManagerDao wsmDao;
+  @MockitoBean WorkspaceManagerDao wsmDao;
   // Mock ImportValidator to allow importing test data from a file:// URL.
-  @MockBean ImportValidator importValidator;
-  @SpyBean SamDao samDao;
+  @MockitoBean ImportValidator importValidator;
+  @MockitoSpyBean SamDao samDao;
 
   // test resources used below
   @Value("classpath:avro/four_rows.avro")

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbQuartzJobTest.java
@@ -50,9 +50,9 @@ import org.quartz.JobExecutionException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.core.io.Resource;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 /**
  * This test explicitly asserts on and mock calls to WSM as part of PFB import; it is explicitly a
@@ -61,11 +61,11 @@ import org.springframework.test.annotation.DirtiesContext;
 @DirtiesContext
 @SpringBootTest
 class PfbQuartzJobTest extends DataPlaneTestBase {
-  @MockBean JobDao jobDao;
-  @MockBean WorkspaceManagerDao wsmDao;
-  @MockBean BatchWriteService batchWriteService;
-  @MockBean CollectionService collectionService;
-  @MockBean ActivityLogger activityLogger;
+  @MockitoBean JobDao jobDao;
+  @MockitoBean WorkspaceManagerDao wsmDao;
+  @MockitoBean BatchWriteService batchWriteService;
+  @MockitoBean CollectionService collectionService;
+  @MockitoBean ActivityLogger activityLogger;
   @Autowired PfbTestSupport testSupport;
   @Autowired MeterRegistry meterRegistry;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/protecteddatasupport/RawlsProtectedDataSupportTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/protecteddatasupport/RawlsProtectedDataSupportTest.java
@@ -18,11 +18,11 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
 class RawlsProtectedDataSupportTest extends ControlPlaneTestBase {
-  @MockBean RawlsClient rawlsClient;
+  @MockitoBean RawlsClient rawlsClient;
 
   @Autowired RawlsProtectedDataSupport rawlsProtectedDataSupport;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/protecteddatasupport/WsmProtectedDataSupportTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/protecteddatasupport/WsmProtectedDataSupportTest.java
@@ -16,11 +16,11 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
 class WsmProtectedDataSupportTest extends DataPlaneTestBase {
-  @MockBean WorkspaceManagerDao wsmDao;
+  @MockitoBean WorkspaceManagerDao wsmDao;
 
   @Autowired WsmProtectedDataSupport wsmProtectedDataSupport;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/rawlsjson/RawlsJsonQuartzJobControlPlaneE2ETest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/rawlsjson/RawlsJsonQuartzJobControlPlaneE2ETest.java
@@ -35,10 +35,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 /**
  * Tests for RAWLSJSON import that execute "end-to-end" - which for this format is relatively
@@ -52,11 +52,11 @@ import org.springframework.test.context.ActiveProfiles;
 class RawlsJsonQuartzJobControlPlaneE2ETest extends ControlPlaneTestBase {
   @Autowired private ImportService importService;
   @Autowired private RawlsJsonTestSupport testSupport;
-  @SpyBean private PubSub pubSub;
+  @MockitoSpyBean private PubSub pubSub;
 
   // Mock ImportValidator to allow importing test data from a file:// URL.
-  @MockBean ImportValidator importValidator;
-  @MockBean DataTableTypeInspector dataTableTypeInspector;
+  @MockitoBean ImportValidator importValidator;
+  @MockitoBean DataTableTypeInspector dataTableTypeInspector;
 
   @Autowired
   @Qualifier("mockGcsStorage")

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/rawlsjson/RawlsJsonQuartzJobTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/rawlsjson/RawlsJsonQuartzJobTest.java
@@ -32,11 +32,11 @@ import org.quartz.JobExecutionException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 @DirtiesContext
 @SpringBootTest
@@ -45,10 +45,10 @@ class RawlsJsonQuartzJobTest extends ControlPlaneTestBase {
   @Autowired private CollectionService collectionService;
   @Autowired private NamedParameterJdbcTemplate namedTemplate;
   @Autowired private RawlsJsonTestSupport testSupport;
-  @SpyBean private PubSub pubSub;
+  @MockitoSpyBean private PubSub pubSub;
 
   // mock out JobDao to prevent Job state transitions from requiring a real entry in db
-  @MockBean private JobDao jobDao;
+  @MockitoBean private JobDao jobDao;
 
   @Autowired
   @Qualifier("mockGcsStorage")

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/snapshotsupport/RawlsSnapshotSupportTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/snapshotsupport/RawlsSnapshotSupportTest.java
@@ -21,15 +21,15 @@ import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @DirtiesContext
 @SpringBootTest
 class RawlsSnapshotSupportTest extends ControlPlaneTestBase {
 
-  @MockBean RawlsClient rawlsClient;
-  @MockBean ActivityLogger activityLogger;
+  @MockitoBean RawlsClient rawlsClient;
+  @MockitoBean ActivityLogger activityLogger;
 
   @ParameterizedTest(name = "paginates through results when Rawls has {0} references")
   @ValueSource(ints = {0, 1, 49, 50, 51, 99, 100, 101, 456})

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/snapshotsupport/WsmSnapshotSupportTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/snapshotsupport/WsmSnapshotSupportTest.java
@@ -24,16 +24,16 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @DirtiesContext
 @SpringBootTest
 class WsmSnapshotSupportTest extends DataPlaneTestBase {
 
-  @MockBean JobDao jobDao;
-  @MockBean WorkspaceManagerDao wsmDao;
-  @MockBean ActivityLogger activityLogger;
+  @MockitoBean JobDao jobDao;
+  @MockitoBean WorkspaceManagerDao wsmDao;
+  @MockitoBean ActivityLogger activityLogger;
   @Autowired RestClientRetry restClientRetry;
 
   @ParameterizedTest(name = "paginates through results when WSM has {0} references")

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobE2ETest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobE2ETest.java
@@ -44,11 +44,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.core.io.Resource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 /**
  * Tests for TdrManifest import that execute "end-to-end" - that is, they go through the whole
@@ -74,8 +74,8 @@ class TdrManifestQuartzJobE2ETest extends DataPlaneTestBase {
   @Autowired private TwdsProperties twdsProperties;
 
   // Mock ImportValidator to allow importing test data from a file:// URL.
-  @MockBean ImportValidator importValidator;
-  @MockBean WorkspaceManagerDao wsmDao;
+  @MockitoBean ImportValidator importValidator;
+  @MockitoBean WorkspaceManagerDao wsmDao;
 
   @Value("classpath:tdrmanifest/v2f.json")
   Resource v2fManifestResource;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobMultipleBatchTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobMultipleBatchTest.java
@@ -36,12 +36,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.core.io.Resource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 /**
  * Tests for TdrManifest import that execute "end-to-end" and involve multiple batches. These tests
@@ -69,8 +69,8 @@ class TdrManifestQuartzJobMultipleBatchTest extends DataPlaneTestBase {
   @Autowired private TwdsProperties twdsProperties;
 
   // Mock ImportValidator to allow importing test data from a file:// URL.
-  @MockBean ImportValidator importValidator;
-  @MockBean WorkspaceManagerDao wsmDao;
+  @MockitoBean ImportValidator importValidator;
+  @MockitoBean WorkspaceManagerDao wsmDao;
 
   @Value("classpath:tdrmanifest/with-entity-reference-lists.json")
   Resource withEntityReferenceListsResource;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/dataimport/tdr/TdrManifestQuartzJobTest.java
@@ -76,24 +76,24 @@ import org.quartz.JobExecutionContext;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.Resource;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @DirtiesContext
 @SpringBootTest
 @Import(MockInstantSourceConfig.class)
 class TdrManifestQuartzJobTest extends ControlPlaneTestBase {
 
-  @MockBean WorkspaceManagerDao wsmDao;
+  @MockitoBean WorkspaceManagerDao wsmDao;
 
-  @MockBean CollectionService collectionService;
-  @MockBean RecordService recordService;
-  @MockBean RecordDao recordDao;
-  @MockBean DataImportProperties dataImportProperties;
-  @MockBean SamDao samDao;
-  @MockBean DataTableTypeInspector dataTableTypeInspector;
+  @MockitoBean CollectionService collectionService;
+  @MockitoBean RecordService recordService;
+  @MockitoBean RecordDao recordDao;
+  @MockitoBean DataImportProperties dataImportProperties;
+  @MockitoBean SamDao samDao;
+  @MockitoBean DataTableTypeInspector dataTableTypeInspector;
   @Autowired RecordSinkFactory recordSinkFactory;
   @Autowired TdrTestSupport testSupport;
   @Autowired MockInstantSource mockInstantSource;

--- a/service/src/test/java/org/databiosphere/workspacedataservice/jobexec/QuartzJobTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/jobexec/QuartzJobTest.java
@@ -33,7 +33,7 @@ import org.databiosphere.workspacedataservice.config.DataImportProperties;
 import org.databiosphere.workspacedataservice.dao.JobDao;
 import org.databiosphere.workspacedataservice.generated.GenericJobServerModel;
 import org.databiosphere.workspacedataservice.sam.TokenContextUtil;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -44,8 +44,8 @@ import org.quartz.JobKey;
 import org.quartz.impl.JobDetailImpl;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
 @DirtiesContext
@@ -53,13 +53,13 @@ import org.springframework.test.annotation.DirtiesContext;
 @WithTestObservationRegistry
 class QuartzJobTest extends ControlPlaneTestBase {
 
-  @MockBean JobDao jobDao;
-  @MockBean DataImportProperties dataImportProperties;
+  @MockitoBean JobDao jobDao;
+  @MockitoBean DataImportProperties dataImportProperties;
   @Autowired MeterRegistry meterRegistry;
   @Autowired TestObservationRegistry observationRegistry;
 
-  @BeforeAll
-  void beforeAll() {
+  @BeforeEach
+  void beforeEach() {
     // set up the mock jobDao to return successfully on all calls except JobDao.fail()
     GenericJobServerModel genericJobServerModel =
         new GenericJobServerModel(

--- a/service/src/test/java/org/databiosphere/workspacedataservice/leonardo/LeonardoDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/leonardo/LeonardoDaoTest.java
@@ -22,16 +22,16 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @DirtiesContext
 @SpringBootTest
 class LeonardoDaoTest extends ControlPlaneTestBase {
   @Autowired LeonardoDao leonardoDao;
 
-  @MockBean LeonardoClientFactory leonardoClientFactory;
+  @MockitoBean LeonardoClientFactory leonardoClientFactory;
 
   final AppsApi mockAppsApi = mock(AppsApi.class);
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/pact/WsmPactTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/pact/WsmPactTest.java
@@ -37,10 +37,10 @@ import org.databiosphere.workspacedataservice.workspacemanager.WorkspaceManagerE
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
@@ -63,7 +63,7 @@ class WsmPactTest {
   private static final String USER_EMAIL = "fake.user@e.mail";
   private static final int NUM_SNAPSHOTS_THAT_EXIST = 3;
   private static final int NUM_SNAPSHOTS_REQUESTED = NUM_SNAPSHOTS_THAT_EXIST + 2;
-  @MockBean ActivityLogger activityLogger;
+  @MockitoBean ActivityLogger activityLogger;
 
   @BeforeEach
   void setUp() {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/rawls/RawlsClientRetryTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/rawls/RawlsClientRetryTest.java
@@ -19,11 +19,11 @@ import org.mockito.ArgumentMatcher;
 import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.web.client.HttpServerErrorException;
 
 @DirtiesContext
@@ -37,7 +37,7 @@ import org.springframework.web.client.HttpServerErrorException;
     })
 class RawlsClientRetryTest extends ControlPlaneTestBase {
   // create mock for RawlsApi
-  @MockBean RawlsApi mockRawlsApi;
+  @MockitoBean RawlsApi mockRawlsApi;
 
   @Autowired RawlsClient rawlsClient;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/rawls/RawlsClientTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/rawls/RawlsClientTest.java
@@ -20,13 +20,13 @@ import org.mockito.Captor;
 import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @DirtiesContext
 @SpringBootTest
 class RawlsClientTest extends ControlPlaneTestBase {
-  @MockBean RawlsApi mockRawlsApi;
+  @MockitoBean RawlsApi mockRawlsApi;
 
   @Autowired RawlsClient rawlsClient;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkPrefixingTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkPrefixingTest.java
@@ -34,8 +34,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.util.StreamUtils;
 
 /**
@@ -48,7 +48,7 @@ import org.springframework.util.StreamUtils;
 @SpringBootTest
 class RawlsRecordSinkPrefixingTest extends ControlPlaneTestBase {
   @Autowired private ObjectMapper mapper;
-  @MockBean private PubSub pubSub;
+  @MockitoBean private PubSub pubSub;
 
   @Qualifier("mockGcsStorage")
   @Autowired

--- a/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/recordsink/RawlsRecordSinkTest.java
@@ -67,15 +67,15 @@ import org.mockito.Captor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.util.StreamUtils;
 
 @DirtiesContext
 @SpringBootTest
 class RawlsRecordSinkTest extends ControlPlaneTestBase {
   @Autowired private ObjectMapper mapper;
-  @MockBean private PubSub pubSub;
+  @MockitoBean private PubSub pubSub;
 
   @Qualifier("mockGcsStorage")
   @Autowired

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/BackupRestoreServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/BackupRestoreServiceTest.java
@@ -21,10 +21,10 @@ import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @DirtiesContext
 @SpringBootTest(properties = "spring.cache.type=NONE")
@@ -35,7 +35,7 @@ class BackupRestoreServiceTest extends DataPlaneTestBase {
   @Autowired private NamedParameterJdbcTemplate namedTemplate;
   @Autowired private WorkspaceId workspaceId;
 
-  @MockBean BackupRestoreDao<RestoreResponse> mockRestoreDao;
+  @MockitoBean BackupRestoreDao<RestoreResponse> mockRestoreDao;
 
   @Test
   void CheckBackupCommandLine() {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/BatchWriteServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/BatchWriteServiceTest.java
@@ -40,10 +40,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @DirtiesContext
 @SpringBootTest
@@ -56,7 +56,7 @@ class BatchWriteServiceTest extends ControlPlaneTestBase {
   @Autowired private CollectionService collectionService;
   @Autowired private NamedParameterJdbcTemplate namedTemplate;
   @Autowired private WorkspaceRepository workspaceRepository;
-  @MockBean RecordDao recordDao; // prevents actual calls to the db
+  @MockitoBean RecordDao recordDao; // prevents actual calls to the db
 
   @Nullable private CollectionId collectionId;
   private static final RecordType THING_TYPE = RecordType.valueOf("thing");

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceGetWorkspaceIdTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/CollectionServiceGetWorkspaceIdTest.java
@@ -28,10 +28,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 /** Tests for CollectionService.getWorkspaceId() */
 @DirtiesContext
@@ -44,13 +44,13 @@ class CollectionServiceGetWorkspaceIdTest extends ControlPlaneTestBase {
   @Autowired private NamedParameterJdbcTemplate namedTemplate;
   @Autowired private WorkspaceRepository workspaceRepository;
 
-  @MockBean RawlsClient rawlsClient;
-  @MockBean TenancyProperties tenancyProperties;
-  @MockBean TwdsProperties twdsProperties;
+  @MockitoBean RawlsClient rawlsClient;
+  @MockitoBean TenancyProperties tenancyProperties;
+  @MockitoBean TwdsProperties twdsProperties;
 
   // mocks to satisfy bean dependencies, but unused
-  @MockBean ImportValidator importValidator;
-  @MockBean DataImportProperties dataImportProperties;
+  @MockitoBean ImportValidator importValidator;
+  @MockitoBean DataImportProperties dataImportProperties;
 
   @BeforeEach
   void beforeEach() {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceControlPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceControlPlaneTest.java
@@ -15,9 +15,9 @@ import org.databiosphere.workspacedataservice.workspace.WorkspaceDataTableType;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 /**
  * Tests for permission behaviors in the control plane. See also {@link ImportServiceTest} for tests
@@ -32,7 +32,7 @@ class ImportServiceControlPlaneTest extends ControlPlaneTestBase {
 
   @Autowired ImportService importService;
 
-  @MockBean DataTableTypeInspector dataTableTypeInspector;
+  @MockitoBean DataTableTypeInspector dataTableTypeInspector;
 
   private final URI importUri =
       URI.create("https://teststorageaccount.blob.core.windows.net/testcontainer/file");

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceDataPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceDataPlaneTest.java
@@ -18,9 +18,9 @@ import org.databiosphere.workspacedataservice.shared.model.WorkspaceId;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 /**
  * Tests for permission behaviors in the data plane. See also {@link ImportServiceTest} for tests of
@@ -34,7 +34,7 @@ import org.springframework.test.context.ActiveProfiles;
 class ImportServiceDataPlaneTest extends DataPlaneTestBase {
   @Autowired ImportService importService;
   @Autowired @SingleTenant WorkspaceId workspaceId;
-  @MockBean CollectionService collectionService;
+  @MockitoBean CollectionService collectionService;
 
   private final URI importUri =
       URI.create("https://teststorageaccount.blob.core.windows.net/testcontainer/file");

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/ImportServiceTest.java
@@ -61,10 +61,10 @@ import org.quartz.Job;
 import org.quartz.JobDataMap;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 @DirtiesContext
 @SpringBootTest
@@ -73,9 +73,9 @@ class ImportServiceTest extends ControlPlaneTestBase {
 
   @Autowired ImportService importService;
   @Autowired CollectionService collectionService;
-  @SpyBean JobDao jobDao;
-  @MockBean SchedulerDao schedulerDao;
-  @MockBean SamClientFactory mockSamClientFactory;
+  @MockitoSpyBean JobDao jobDao;
+  @MockitoBean SchedulerDao schedulerDao;
+  @MockitoBean SamClientFactory mockSamClientFactory;
   @Autowired NamedParameterJdbcTemplate namedTemplate;
   @Autowired WorkspaceRepository workspaceRepository;
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/JobServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/JobServiceTest.java
@@ -25,11 +25,11 @@ import org.databiosphere.workspacedataservice.shared.model.CollectionId;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @ActiveProfiles(profiles = {"control-plane"})
 @DirtiesContext
@@ -44,7 +44,7 @@ import org.springframework.test.context.TestPropertySource;
 class JobServiceTest extends JobServiceTestBase {
 
   @Autowired JobService jobService;
-  @MockBean JobDao jobDao;
+  @MockitoBean JobDao jobDao;
 
   /** requested job does not exist */
   @Test

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/PermissionServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/PermissionServiceTest.java
@@ -23,16 +23,16 @@ import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.OngoingStubbing;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @DirtiesContext
 @SpringBootTest
 class PermissionServiceTest extends ControlPlaneTestBase {
   @Autowired PermissionService permissionService;
-  @MockBean SamAuthorizationDaoFactory samAuthorizationDaoFactory;
-  @MockBean CollectionService collectionService;
+  @MockitoBean SamAuthorizationDaoFactory samAuthorizationDaoFactory;
+  @MockitoBean CollectionService collectionService;
 
   private final SamAuthorizationDao samAuthorizationDao = spy(MockSamAuthorizationDao.allowAll());
 

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/PermissionsStatusServiceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/PermissionsStatusServiceTest.java
@@ -19,8 +19,8 @@ import org.mockito.exceptions.base.MockitoException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @DirtiesContext
 @SpringBootTest(properties = "spring.cache.type=NONE")
@@ -28,9 +28,9 @@ class PermissionsStatusServiceTest extends ControlPlaneTestBase {
 
   @Autowired private PermissionsStatusService samStatusService;
 
-  @MockBean HttpSamDao httpSamDao;
+  @MockitoBean HttpSamDao httpSamDao;
 
-  @MockBean SamClientFactory mockSamClientFactory;
+  @MockitoBean SamClientFactory mockSamClientFactory;
 
   // mock for the StatusApi class inside the Sam client; since this is not a Spring bean we have to
   // mock it manually

--- a/service/src/test/java/org/databiosphere/workspacedataservice/service/WorkspaceServiceControlPlaneTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/service/WorkspaceServiceControlPlaneTest.java
@@ -16,14 +16,14 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @DirtiesContext
 @SpringBootTest
 class WorkspaceServiceControlPlaneTest extends ControlPlaneTestBase {
 
-  @MockBean RawlsClient rawlsClient;
+  @MockitoBean RawlsClient rawlsClient;
   @Autowired WorkspaceService workspaceService;
 
   static Stream<Arguments> workspaceTypeArguments() {

--- a/service/src/test/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerBeanTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/startup/CollectionInitializerBeanTest.java
@@ -30,13 +30,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.integration.jdbc.lock.JdbcLockRegistry;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.lang.Nullable;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 @ActiveProfiles({"mock-backup-dao", "mock-restore-dao", "mock-clone-dao", "local-cors"})
 @DirtiesContext
@@ -44,16 +44,16 @@ import org.springframework.test.context.ActiveProfiles;
 class CollectionInitializerBeanTest extends DataPlaneTestBase {
   // Don't run the CollectionInitializer on startup, so this test can start with a clean slate.
   // By making an (empty) mock bean to replace CollectionInitializer, we ensure it is a noop.
-  @MockBean CollectionInitializer collectionInitializer;
+  @MockitoBean CollectionInitializer collectionInitializer;
   @Autowired CollectionService collectionService;
   @Autowired LeonardoDao leoDao;
   @Autowired NamedParameterJdbcTemplate namedTemplate;
   @Autowired WorkspaceDataServiceDao wdsDao;
   @Autowired BackupRestoreService restoreService;
   @Autowired TwdsProperties twdsProperties;
-  @MockBean JdbcLockRegistry registry;
-  @SpyBean CollectionRepository collectionRepository;
-  @SpyBean CloneDao cloneDao;
+  @MockitoBean JdbcLockRegistry registry;
+  @MockitoSpyBean CollectionRepository collectionRepository;
+  @MockitoSpyBean CloneDao cloneDao;
 
   // sourceWorkspaceId when we need one
   final WorkspaceId sourceWorkspaceId = WorkspaceId.of(randomUUID());

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvBatchTypeDetectionTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvBatchTypeDetectionTest.java
@@ -38,12 +38,12 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.http.MediaType;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 @DirtiesContext
 @SpringBootTest
@@ -57,8 +57,8 @@ class TsvBatchTypeDetectionTest extends ControlPlaneTestBase {
   @Autowired private CollectionService collectionService;
   @Autowired private NamedParameterJdbcTemplate namedTemplate;
   @Autowired private WorkspaceRepository workspaceRepository;
-  @SpyBean DataTypeInferer inferer;
-  @SpyBean RecordService recordService;
+  @MockitoSpyBean DataTypeInferer inferer;
+  @MockitoSpyBean RecordService recordService;
 
   @Nullable private UUID collectionId;
   private static final RecordType THING_TYPE = RecordType.valueOf("thing");

--- a/service/src/test/java/org/databiosphere/workspacedataservice/workspacemanager/WorkspaceManagerDaoTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/workspacemanager/WorkspaceManagerDaoTest.java
@@ -31,10 +31,10 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.lang.Nullable;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
 @DirtiesContext
@@ -42,7 +42,7 @@ class WorkspaceManagerDaoTest extends ControlPlaneTestBase {
 
   @Autowired WorkspaceManagerDao workspaceManagerDao;
 
-  @MockBean WorkspaceManagerClientFactory mockWorkspaceManagerClientFactory;
+  @MockitoBean WorkspaceManagerClientFactory mockWorkspaceManagerClientFactory;
 
   private WorkspaceId workspaceId;
 


### PR DESCRIPTION
In #956, we upgraded to Spring Boot 3.4. 

Spring Boot 3.4 deprecated `@MockBean` and `@SpyBean`. This PR removes all usages of those annotations and replaces them with the newly-recommended `@MockitoBean` and `@MockitoSpyBean`.

This is almost completely a find/replace. There is one single test - `QuartzJobTest` - which needed a slight syntax change; I'll add a comment inline to call that out.