### PR TITLE
CORE-301: disable control-plane preview APIs

### DIFF
--- a/service/src/main/resources/application-bee.yml
+++ b/service/src/main/resources/application-bee.yml
@@ -5,5 +5,6 @@ workspacemanagerurl: https://workspace.${beename}.bee.envs-terra.bio
 leoUrl: https://leonardo.${beename}.bee.envs-terra.bio
 rawlsUrl: https://rawls.${beename}.bee.envs-terra.bio
 
-# Enable preview of control plane apis
-controlPlanePreview: "on"
+# Disable preview of control plane apis
+# This is the default; leaving this property here for easy overriding later
+controlPlanePreview: "off"

--- a/service/src/main/resources/application-data-plane.yml
+++ b/service/src/main/resources/application-data-plane.yml
@@ -23,5 +23,6 @@ sentry:
   deploymentMode: data-plane
   dsn: https://e59ecdd940784bd2922f25a0f3197ffd@o54426.ingest.sentry.io/4504299946835968
 
-# Enable preview of control plane apis
-controlPlanePreview: "on"
+# Disable preview of control plane apis
+# This is the default; leaving this property here for easy overriding later
+controlPlanePreview: "off"

--- a/service/src/main/resources/application-data-plane.yml
+++ b/service/src/main/resources/application-data-plane.yml
@@ -23,6 +23,5 @@ sentry:
   deploymentMode: data-plane
   dsn: https://e59ecdd940784bd2922f25a0f3197ffd@o54426.ingest.sentry.io/4504299946835968
 
-# Disable preview of control plane apis
-# This is the default; leaving this property here for easy overriding later
-controlPlanePreview: "off"
+# Enable preview of control plane apis
+controlPlanePreview: "on"

--- a/service/src/main/resources/application-dev.yml
+++ b/service/src/main/resources/application-dev.yml
@@ -3,5 +3,6 @@ workspacemanagerurl: https://workspace.dsde-dev.broadinstitute.org/
 leoUrl: https://leonardo.dsde-dev.broadinstitute.org/
 rawlsUrl: https://rawls.dsde-dev.broadinstitute.org/
 
-# Enable preview of control plane apis
-controlPlanePreview: "on"
+# Disable preview of control plane apis
+# This is the default; leaving this property here for easy overriding later
+controlPlanePreview: "off"


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CORE-301

Disable the data-table-specific APIs in the control plane. We had previously enabled these APIs in dev and bees only to enable pentests and security approval towards eventually migrating GCP/control-plane workspaces to WDS. That effort is on hold, so these APIs are only cluttering things.

Verified by running this PR version in a BEE that the APIs disappear from swagger-ui.