### PR TITLE
CORE-302: stop publishing docker images to ACR

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -108,13 +108,10 @@ jobs:
     needs: [ build, unit-tests, bump-check ]
     secrets: inherit
 
-  # Publish Docker image to Google and Azure Container Registries, also reports to sherlock
+  # Publish Docker image to Google Container Registry, also reports to Sherlock
   docker-image-job:
     if: always() && needs.bump-check.outputs.is-bump == 'no' && github.event_name == 'push'
-    needs: [build, bump-check, tag]
+    needs: [ build, bump-check, tag ]
     uses: ./.github/workflows/publish-docker.yml
     with:
       new-tag: ${{ needs.tag.outputs.new-tag }}
-    secrets:
-      ACR_SP_PASSWORD: ${{ secrets.ACR_SP_PASSWORD }}
-      ACR_SP_USER: ${{ secrets.ACR_SP_USER }}

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,20 +1,14 @@
-name: Publish Docker Images to GCR and ACR
+name: Publish Docker Images to GCR
 on:
   workflow_call:
     inputs:
       new-tag:
         required: true
         type: string
-    secrets:
-      ACR_SP_PASSWORD:
-        required: true
-      ACR_SP_USER:
-        required: true
 
 env:
   SERVICE_NAME: ${{ github.event.repository.name }}
   GCR_REGISTRY: us.gcr.io
-  ACR_REGISTRY: terradevacrpublic.azurecr.io
   GOOGLE_PROJECT: broad-dsp-gcr-public
 
 jobs:
@@ -67,10 +61,6 @@ jobs:
         id: gcr-image-name
         run: echo "name=${GCR_REGISTRY}/${GOOGLE_PROJECT}/${SERVICE_NAME}" >> $GITHUB_OUTPUT
 
-      - name: Construct ACR docker image name
-        id: acr-image-name
-        run: echo "name=${ACR_REGISTRY}/${SERVICE_NAME}" >> $GITHUB_OUTPUT
-
       - name: Build image locally with jib
         run: |
           ./gradlew --build-cache jibDockerBuild \
@@ -88,19 +78,6 @@ jobs:
 
       - name: Push GCR image
         run: docker push --all-tags ${{ steps.gcr-image-name.outputs.name }}
-
-      - name: Re-tag image for ACR
-        run: docker tag ${{ steps.gcr-image-name.outputs.name }}:${{ steps.setHash.outputs.git_short_sha }} ${{ steps.acr-image-name.outputs.name }}:${{ steps.setHash.outputs.git_short_sha }}
-
-      - name: Add version tag to ACR
-        run: docker image tag ${{ steps.acr-image-name.outputs.name }}:${{ steps.setHash.outputs.git_short_sha }} ${{ steps.acr-image-name.outputs.name }}:${{ inputs.new-tag }}
-
-      - name: Push image to Azure
-        run: |
-          echo ${{ secrets.ACR_SP_PASSWORD }} | docker login ${ACR_REGISTRY} \
-          --username ${{ secrets.ACR_SP_USER }} \
-          --password-stdin
-          docker push --all-tags ${{ steps.acr-image-name.outputs.name }}
 
   # Report the new version of cWDS to Sherlock.
   # This enables Sherlock to gather metrics and generate changelogs for deployments.

--- a/.github/workflows/tag-and-publish.yml
+++ b/.github/workflows/tag-and-publish.yml
@@ -51,15 +51,12 @@ jobs:
     secrets:
       ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
       ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-  # Publish Docker image to Google and Azure Container Registries
+  # Publish Docker image to Google Container Registry
   docker-image-job:
     needs: tag-job
     uses: ./.github/workflows/publish-docker.yml
     with:
       new-tag: ${{ needs.tag-job.outputs.new_tag }}
-    secrets:
-      ACR_SP_PASSWORD: ${{ secrets.ACR_SP_PASSWORD }}
-      ACR_SP_USER: ${{ secrets.ACR_SP_USER }}
   # Publish GitHub Release
   release-job:
     needs: tag-job
@@ -82,7 +79,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   # Publish new version to DSP infrastructure
   publish-app-version-job:
-    needs: [tag-job, docker-image-job]
+    needs: [ tag-job, docker-image-job ]
     uses: ./.github/workflows/publish-app-version.yml
     with:
       new-tag: ${{ needs.tag-job.outputs.new_tag }}


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CORE-302

Adjusts github actions so we stop publishing new docker images to ACR. We continue publishing to GCR, and the images already in ACR will stay there.
