### PR TITLE
[CORE-335] Add Sage BioNetworks Allowed DRS Hostnames

### DIFF
--- a/service/src/main/resources/application-bee.yml
+++ b/service/src/main/resources/application-bee.yml
@@ -13,3 +13,4 @@ controlPlanePreview: "off"
 drs:
   allowed-hosts:
     - data\.[^.]+\.bee\.envs-terra\.bio # This is a regex that matches tdr bee environments
+    - repo-dev\.dev\.sagebase\.org

--- a/service/src/main/resources/application-dev.yml
+++ b/service/src/main/resources/application-dev.yml
@@ -11,3 +11,4 @@ controlPlanePreview: "off"
 drs:
   allowed-hosts:
     - jade\.datarepo-.*\.broadinstitute\.org
+    - repo-dev\.dev\.sagebase\.org

--- a/service/src/main/resources/application-local.yml
+++ b/service/src/main/resources/application-local.yml
@@ -24,3 +24,4 @@ logging:
 drs:
   allowed-hosts:
     - jade\.datarepo-.*\.broadinstitute\.org
+    - repo-dev\.dev\.sagebase\.org

--- a/service/src/main/resources/application-prod.yml
+++ b/service/src/main/resources/application-prod.yml
@@ -16,4 +16,4 @@ twds:
 # Set the allowed hosts for drs pfb imports
 drs:
   allowed-hosts:
-    - # TODO: add allowed sage drs hostnames
+    - repo-prod\.prod\.sagebase\.org


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CORE-335

#### What ####
As a followup to https://broadworkbench.atlassian.net/browse/CORE-264, this PR updates the WDS config to allow DRS URI resolution by adding valid hostnames for Sage BioNetworks:
- Prod: `repo-prod.prod.sagebase.org`
- Dev/BEE/Local: `repo-dev.dev.sagebase.org`

#### Releasing WDS ####
PRs merged into main will not automatically generate a PR in https://github.com/broadinstitute/terra-helmfile to update the WDS image deployed to kubernetes - this action will need to be triggered manually by running the following github action: https://github.com/DataBiosphere/terra-workspace-data-service/actions/workflows/tag-and-publish.yml. Dont forget to provide a Jira Id when triggering the manual action, if no Jira ID is provided the action will not fully succeed. 

After you manually trigger the github action (and it completes with no errors), you must go to [the terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo and verify that this generated a PR that merged successfully.

The terra-helmfile PR merge will then generate a PR in [leonardo](https://github.com/DataBiosphere/leonardo).  This will automerge if all tests pass, but if jenkins tests fail it will not; be sure to watch it to ensure it merges. To trigger jenkins retest simply comment on PR with "jenkins retest". 

#### Keeping Docs Up To Date ####
If you make changes to the github actions or workflows, particularly when they are run or which other workflows they call, please update [the GHA wiki page](https://github.com/DataBiosphere/terra-workspace-data-service/wiki/GHA-structure-in-WDS) to stay up to date.
