### PR TITLE
[CORE-69]: Bump spring_cloud_gcp_version from 5.10.0 to 6.0.1

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -39,7 +39,7 @@ jib {
 ext {
     parquet_mr_version = "1.15.0"
     hadoop_version = "3.4.1"
-    spring_cloud_gcp_version = "5.10.0"
+    spring_cloud_gcp_version = "6.0.1"
 }
 
 dependencies {

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -72,6 +72,10 @@ spring:
         enabled: false
       storage:
         enabled: false
+      secretmanager:
+        # WDS does not use secret manager, but GCP starter libraries attempt to autoconfigure it.
+        # Explicitly disable it here to avoid problems with autoconfig.
+        enabled: false
 
   datasource:
     hikari:


### PR DESCRIPTION
CORE-69

supersedes #999.

The new 6.x Spring Cloud GCP starters have added features for secret manager. Even though WDS does not include the secret manager starter, the common Spring autoconfig attempts to configure secret manager, and fails. This PR explicitly disables secret manager autoconfig.

---

Bumps `spring_cloud_gcp_version` from 5.10.0 to 6.0.1.
Updates `com.google.cloud:spring-cloud-gcp-starter-storage` from 5.10.0 to 6.0.1
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/releases">com.google.cloud:spring-cloud-gcp-starter-storage's releases</a>.</em></p>
<blockquote>
<h2>v6.0.1</h2>
<h2><a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/compare/v6.0.0...v6.0.1">6.0.1</a> (2025-02-24)</h2>
<h3>Bug Fixes</h3>
<ul>
<li><strong>deps:</strong> update dependency com.google.api:gapic-generator-java-bom to v2.53.0 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3543">#3543</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/abaca12899b2c5ec0aea1a409e199fb169f04888">abaca12</a>)</li>
<li><strong>deps:</strong> update dependency com.google.cloud:libraries-bom to v26.55.0 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3588">#3588</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/7dfb67656b047a85924c42f4314cba5a81a3cfcf">7dfb676</a>)</li>
</ul>
<h3>Dependencies</h3>
<ul>
<li>bump cloud-sql-socket-factory.version from 1.23.0 to 1.23.1 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3555">#3555</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/576c8d294ab91be928a72b0206dfc01e24d3dfed">576c8d2</a>)</li>
<li>bump com.google.cloud:alloydb-jdbc-connector from 1.1.8 to 1.2.0 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3552">#3552</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/c412facefb1ee80b40242501be951faf9c2ae035">c412fac</a>)</li>
<li>bump io.micrometer:micrometer-tracing-bom from 1.4.2 to 1.4.3 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3547">#3547</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/4a6b7a5e781053674d6d9251e3a794ca71d43ec7">4a6b7a5</a>)</li>
<li>bump io.opentelemetry:opentelemetry-api from 1.46.0 to 1.47.0 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3540">#3540</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/3d4d8c6b9bd8253cf9c40724bb98d6fc7fbab5a4">3d4d8c6</a>)</li>
<li>bump org.awaitility:awaitility from 4.2.2 to 4.3.0 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3575">#3575</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/8087e1e7be46ff6d5c66dfb91b071f878ea5efef">8087e1e</a>)</li>
<li>bump org.graalvm.buildtools:native-maven-plugin (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3530">#3530</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/0688e0b5b47e873238cf0bb42a2f35aece5c4ff0">0688e0b</a>)</li>
<li>bump org.springframework.boot:spring-boot-starter-parent (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3571">#3571</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/7ab75a312bc2eccb5afca923870961b5dae5dd2b">7ab75a3</a>)</li>
<li>bump zipkin-gcp.version from 2.2.6 to 2.3.0 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3561">#3561</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/9c080620534fa458ee77466e7fa2d602d0a9068d">9c08062</a>)</li>
</ul>
<h3>Documentation</h3>
<ul>
<li>add clarification for <code>spring.cloud.gcp.core.enabled</code> (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3572">#3572</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/8af632589c09d7e0029d07a2d4d90882d9567d5d">8af6325</a>)</li>
<li>Update README.adoc with latest released versions (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3535">#3535</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/76101e5c5432093c12af6d40f9bf1582fff70599">76101e5</a>)</li>
<li>update secret manager documentation (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3534">#3534</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/11f862efd1626f4d814533366fd267a9f07d8bb0">11f862e</a>)</li>
</ul>
<h2>v6.0.0</h2>
<h2><a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/compare/v5.10.0...v6.0.0">6.0.0</a> (2025-02-04)</h2>
<h3>⚠ BREAKING CHANGES</h3>
<ul>
<li><strong>pubsub:</strong> set default max ack extension period to 60 minutes (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3501">#3501</a>)</li>
<li>Spring Cloud 2024.0 and Spring Boot 3.4.2 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3500">#3500</a>)
<ul>
<li><strong>spring-cloud-gcp-secretmanager</strong>: We will introduce support for resolving values of the form <code>sm@secret_id</code> in addition to the already existing <code>sm://secret_id</code> format. Users should move away from <code>sm://</code> and use <code>sm@</code> instead. Usage of <code>sm://</code> will raise a warning about this being removed in the future. This has been tested using <code>spring-framework:6.2.2-SNAPSHOT</code>.</li>
<li><strong>spring-cloud-gcp-config-sample (breaking change)</strong>: removed autoconfiguration and sample code. This is to adjust to what's stated in <a href="https://googlecloudplatform.github.io/spring-cloud-gcp/5.9.0/reference/html/index.html#cloud-runtime-configuration-api">the docs</a>.</li>
<li><strong>spring-cloud-gcp-kotlin-sample (breaking change)</strong>: Adjust to <a href="https://redirect.github.com/spring-projects/spring-boot/issues/43100">hibernate upgrade</a> which <a href="https://github.com/hibernate/hibernate-orm/commit/522269e9a93f71af593f1d94039df5ade4f93617">introduced</a> a change in default value handling (see <a href="https://hibernate.atlassian.net/browse/HHH-1661">tracker</a>). (More info in <a href="https://stackoverflow.com/questions/79228209/spring-boot-3-4-0-lets-integration-tests-with-jpa-hibernate-fail">SO</a>)</li>
<li>Internal changes
<ul>
<li><strong>spring-cloud-gcp-pubsub-stream</strong>: Adjust unit tests to prevent duplicate bean detection (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/actions/runs/12542129567/job/34971518975">example logs</a>).</li>
<li><strong>spring-cloud-gcp-data-datastore</strong>: Upgrade <a href="https://github.com/spring-projects/spring-data-commons/commit/096836ee808d2cf82caf2efd48cb56271e6ee7c8">deprecated</a> <code>QueryMethodEvaluationContextProvider</code> to <code>ValueExpressionDelegate</code></li>
<li><strong>spring-cloud-gcp-data-spanner</strong>: Upgrade <a href="https://github.com/spring-projects/spring-data-commons/commit/096836ee808d2cf82caf2efd48cb56271e6ee7c8">deprecated</a> <code>QueryMethodEvaluationContextProvider</code> to <code>ValueExpressionDelegate</code></li>
</ul>
</li>
</ul>
</li>
</ul>
<h3>Features</h3>
<ul>
<li><strong>pubsub:</strong> set default max ack extension period to 60 minutes (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3501">#3501</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/9245031042054efc2ab52cdffad75298922a5a79">9245031</a>)</li>
<li>Spring Cloud 2024.0 and Spring Boot 3.4.1 (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/a72a86b6091ffbc208e2aa4bbb02273b94ae32fc">a72a86b</a>)</li>
<li>Spring Cloud 2024.0 and Spring Boot 3.4.2 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3500">#3500</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/01080543e9133850ecb60d1d41120356a8af18fc">0108054</a>)</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/blob/main/CHANGELOG.md">com.google.cloud:spring-cloud-gcp-starter-storage's changelog</a>.</em></p>
<blockquote>
<h2><a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/compare/v6.0.0...v6.0.1">6.0.1</a> (2025-02-24)</h2>
<h3>Bug Fixes</h3>
<ul>
<li><strong>deps:</strong> update dependency com.google.api:gapic-generator-java-bom to v2.53.0 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3543">#3543</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/abaca12899b2c5ec0aea1a409e199fb169f04888">abaca12</a>)</li>
<li><strong>deps:</strong> update dependency com.google.cloud:libraries-bom to v26.55.0 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3588">#3588</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/7dfb67656b047a85924c42f4314cba5a81a3cfcf">7dfb676</a>)</li>
</ul>
<h3>Dependencies</h3>
<ul>
<li>bump cloud-sql-socket-factory.version from 1.23.0 to 1.23.1 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3555">#3555</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/576c8d294ab91be928a72b0206dfc01e24d3dfed">576c8d2</a>)</li>
<li>bump com.google.cloud:alloydb-jdbc-connector from 1.1.8 to 1.2.0 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3552">#3552</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/c412facefb1ee80b40242501be951faf9c2ae035">c412fac</a>)</li>
<li>bump io.micrometer:micrometer-tracing-bom from 1.4.2 to 1.4.3 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3547">#3547</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/4a6b7a5e781053674d6d9251e3a794ca71d43ec7">4a6b7a5</a>)</li>
<li>bump io.opentelemetry:opentelemetry-api from 1.46.0 to 1.47.0 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3540">#3540</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/3d4d8c6b9bd8253cf9c40724bb98d6fc7fbab5a4">3d4d8c6</a>)</li>
<li>bump org.awaitility:awaitility from 4.2.2 to 4.3.0 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3575">#3575</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/8087e1e7be46ff6d5c66dfb91b071f878ea5efef">8087e1e</a>)</li>
<li>bump org.graalvm.buildtools:native-maven-plugin (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3530">#3530</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/0688e0b5b47e873238cf0bb42a2f35aece5c4ff0">0688e0b</a>)</li>
<li>bump org.springframework.boot:spring-boot-starter-parent (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3571">#3571</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/7ab75a312bc2eccb5afca923870961b5dae5dd2b">7ab75a3</a>)</li>
<li>bump zipkin-gcp.version from 2.2.6 to 2.3.0 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3561">#3561</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/9c080620534fa458ee77466e7fa2d602d0a9068d">9c08062</a>)</li>
</ul>
<h3>Documentation</h3>
<ul>
<li>add clarification for <code>spring.cloud.gcp.core.enabled</code> (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3572">#3572</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/8af632589c09d7e0029d07a2d4d90882d9567d5d">8af6325</a>)</li>
<li>Update README.adoc with latest released versions (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3535">#3535</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/76101e5c5432093c12af6d40f9bf1582fff70599">76101e5</a>)</li>
<li>update secret manager documentation (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3534">#3534</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/11f862efd1626f4d814533366fd267a9f07d8bb0">11f862e</a>)</li>
</ul>
<h2><a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/compare/v5.10.0...v6.0.0">6.0.0</a> (2025-02-04)</h2>
<h3>⚠ BREAKING CHANGES</h3>
<ul>
<li><strong>pubsub:</strong> set default max ack extension period to 60 minutes (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3501">#3501</a>)</li>
<li>Spring Cloud 2024.0 and Spring Boot 3.4.2 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3500">#3500</a>)</li>
</ul>
<h3>Features</h3>
<ul>
<li><strong>pubsub:</strong> set default max ack extension period to 60 minutes (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3501">#3501</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/9245031042054efc2ab52cdffad75298922a5a79">9245031</a>)</li>
<li>Spring Cloud 2024.0 and Spring Boot 3.4.1 (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/a72a86b6091ffbc208e2aa4bbb02273b94ae32fc">a72a86b</a>)</li>
<li>Spring Cloud 2024.0 and Spring Boot 3.4.2 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3500">#3500</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/01080543e9133850ecb60d1d41120356a8af18fc">0108054</a>)</li>
</ul>
<h3>Bug Fixes</h3>
<ul>
<li><strong>deps:</strong> update gapic-generator-java-bom.version to v2.52.0 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3512">#3512</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/c184e6993898a6f9be8f00a2e6ef5e12deb39bb5">c184e69</a>)</li>
</ul>
<h3>Dependencies</h3>
<ul>
<li>bump cloud-sql-socket-factory.version from 1.21.2 to 1.23.0 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3502">#3502</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/7760474ffd74897bcf67631157a100e2bc329569">7760474</a>)</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/005ad98cfdf60ead025490efd3a3c26f3783445f"><code>005ad98</code></a> chore(main): release 6.0.1 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3538">#3538</a>)</li>
<li><a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/0ff48fbcb541f8d3172b7168c6106d740b0473b5"><code>0ff48fb</code></a> chore(main): release 6.0.1-SNAPSHOT (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3528">#3528</a>)</li>
<li><a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/84706c7add68ed013be7a8ed537b5b9726ac22be"><code>84706c7</code></a> chore(main): release 6.0.0 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3498">#3498</a>)</li>
<li><a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/1b64d1ff915cff463175376c581b1bfab99b7e57"><code>1b64d1f</code></a> chore(main): release 5.10.1-SNAPSHOT (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3473">#3473</a>)</li>
<li>See full diff in <a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/compare/v5.10.0...v6.0.1">compare view</a></li>
</ul>
</details>
<br />

Updates `com.google.cloud:spring-cloud-gcp-starter-pubsub` from 5.10.0 to 6.0.1
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/releases">com.google.cloud:spring-cloud-gcp-starter-pubsub's releases</a>.</em></p>
<blockquote>
<h2>v6.0.1</h2>
<h2><a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/compare/v6.0.0...v6.0.1">6.0.1</a> (2025-02-24)</h2>
<h3>Bug Fixes</h3>
<ul>
<li><strong>deps:</strong> update dependency com.google.api:gapic-generator-java-bom to v2.53.0 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3543">#3543</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/abaca12899b2c5ec0aea1a409e199fb169f04888">abaca12</a>)</li>
<li><strong>deps:</strong> update dependency com.google.cloud:libraries-bom to v26.55.0 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3588">#3588</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/7dfb67656b047a85924c42f4314cba5a81a3cfcf">7dfb676</a>)</li>
</ul>
<h3>Dependencies</h3>
<ul>
<li>bump cloud-sql-socket-factory.version from 1.23.0 to 1.23.1 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3555">#3555</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/576c8d294ab91be928a72b0206dfc01e24d3dfed">576c8d2</a>)</li>
<li>bump com.google.cloud:alloydb-jdbc-connector from 1.1.8 to 1.2.0 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3552">#3552</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/c412facefb1ee80b40242501be951faf9c2ae035">c412fac</a>)</li>
<li>bump io.micrometer:micrometer-tracing-bom from 1.4.2 to 1.4.3 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3547">#3547</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/4a6b7a5e781053674d6d9251e3a794ca71d43ec7">4a6b7a5</a>)</li>
<li>bump io.opentelemetry:opentelemetry-api from 1.46.0 to 1.47.0 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3540">#3540</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/3d4d8c6b9bd8253cf9c40724bb98d6fc7fbab5a4">3d4d8c6</a>)</li>
<li>bump org.awaitility:awaitility from 4.2.2 to 4.3.0 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3575">#3575</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/8087e1e7be46ff6d5c66dfb91b071f878ea5efef">8087e1e</a>)</li>
<li>bump org.graalvm.buildtools:native-maven-plugin (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3530">#3530</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/0688e0b5b47e873238cf0bb42a2f35aece5c4ff0">0688e0b</a>)</li>
<li>bump org.springframework.boot:spring-boot-starter-parent (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3571">#3571</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/7ab75a312bc2eccb5afca923870961b5dae5dd2b">7ab75a3</a>)</li>
<li>bump zipkin-gcp.version from 2.2.6 to 2.3.0 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3561">#3561</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/9c080620534fa458ee77466e7fa2d602d0a9068d">9c08062</a>)</li>
</ul>
<h3>Documentation</h3>
<ul>
<li>add clarification for <code>spring.cloud.gcp.core.enabled</code> (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3572">#3572</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/8af632589c09d7e0029d07a2d4d90882d9567d5d">8af6325</a>)</li>
<li>Update README.adoc with latest released versions (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3535">#3535</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/76101e5c5432093c12af6d40f9bf1582fff70599">76101e5</a>)</li>
<li>update secret manager documentation (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3534">#3534</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/11f862efd1626f4d814533366fd267a9f07d8bb0">11f862e</a>)</li>
</ul>
<h2>v6.0.0</h2>
<h2><a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/compare/v5.10.0...v6.0.0">6.0.0</a> (2025-02-04)</h2>
<h3>⚠ BREAKING CHANGES</h3>
<ul>
<li><strong>pubsub:</strong> set default max ack extension period to 60 minutes (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3501">#3501</a>)</li>
<li>Spring Cloud 2024.0 and Spring Boot 3.4.2 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3500">#3500</a>)
<ul>
<li><strong>spring-cloud-gcp-secretmanager</strong>: We will introduce support for resolving values of the form <code>sm@secret_id</code> in addition to the already existing <code>sm://secret_id</code> format. Users should move away from <code>sm://</code> and use <code>sm@</code> instead. Usage of <code>sm://</code> will raise a warning about this being removed in the future. This has been tested using <code>spring-framework:6.2.2-SNAPSHOT</code>.</li>
<li><strong>spring-cloud-gcp-config-sample (breaking change)</strong>: removed autoconfiguration and sample code. This is to adjust to what's stated in <a href="https://googlecloudplatform.github.io/spring-cloud-gcp/5.9.0/reference/html/index.html#cloud-runtime-configuration-api">the docs</a>.</li>
<li><strong>spring-cloud-gcp-kotlin-sample (breaking change)</strong>: Adjust to <a href="https://redirect.github.com/spring-projects/spring-boot/issues/43100">hibernate upgrade</a> which <a href="https://github.com/hibernate/hibernate-orm/commit/522269e9a93f71af593f1d94039df5ade4f93617">introduced</a> a change in default value handling (see <a href="https://hibernate.atlassian.net/browse/HHH-1661">tracker</a>). (More info in <a href="https://stackoverflow.com/questions/79228209/spring-boot-3-4-0-lets-integration-tests-with-jpa-hibernate-fail">SO</a>)</li>
<li>Internal changes
<ul>
<li><strong>spring-cloud-gcp-pubsub-stream</strong>: Adjust unit tests to prevent duplicate bean detection (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/actions/runs/12542129567/job/34971518975">example logs</a>).</li>
<li><strong>spring-cloud-gcp-data-datastore</strong>: Upgrade <a href="https://github.com/spring-projects/spring-data-commons/commit/096836ee808d2cf82caf2efd48cb56271e6ee7c8">deprecated</a> <code>QueryMethodEvaluationContextProvider</code> to <code>ValueExpressionDelegate</code></li>
<li><strong>spring-cloud-gcp-data-spanner</strong>: Upgrade <a href="https://github.com/spring-projects/spring-data-commons/commit/096836ee808d2cf82caf2efd48cb56271e6ee7c8">deprecated</a> <code>QueryMethodEvaluationContextProvider</code> to <code>ValueExpressionDelegate</code></li>
</ul>
</li>
</ul>
</li>
</ul>
<h3>Features</h3>
<ul>
<li><strong>pubsub:</strong> set default max ack extension period to 60 minutes (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3501">#3501</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/9245031042054efc2ab52cdffad75298922a5a79">9245031</a>)</li>
<li>Spring Cloud 2024.0 and Spring Boot 3.4.1 (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/a72a86b6091ffbc208e2aa4bbb02273b94ae32fc">a72a86b</a>)</li>
<li>Spring Cloud 2024.0 and Spring Boot 3.4.2 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3500">#3500</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/01080543e9133850ecb60d1d41120356a8af18fc">0108054</a>)</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/blob/main/CHANGELOG.md">com.google.cloud:spring-cloud-gcp-starter-pubsub's changelog</a>.</em></p>
<blockquote>
<h2><a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/compare/v6.0.0...v6.0.1">6.0.1</a> (2025-02-24)</h2>
<h3>Bug Fixes</h3>
<ul>
<li><strong>deps:</strong> update dependency com.google.api:gapic-generator-java-bom to v2.53.0 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3543">#3543</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/abaca12899b2c5ec0aea1a409e199fb169f04888">abaca12</a>)</li>
<li><strong>deps:</strong> update dependency com.google.cloud:libraries-bom to v26.55.0 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3588">#3588</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/7dfb67656b047a85924c42f4314cba5a81a3cfcf">7dfb676</a>)</li>
</ul>
<h3>Dependencies</h3>
<ul>
<li>bump cloud-sql-socket-factory.version from 1.23.0 to 1.23.1 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3555">#3555</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/576c8d294ab91be928a72b0206dfc01e24d3dfed">576c8d2</a>)</li>
<li>bump com.google.cloud:alloydb-jdbc-connector from 1.1.8 to 1.2.0 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3552">#3552</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/c412facefb1ee80b40242501be951faf9c2ae035">c412fac</a>)</li>
<li>bump io.micrometer:micrometer-tracing-bom from 1.4.2 to 1.4.3 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3547">#3547</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/4a6b7a5e781053674d6d9251e3a794ca71d43ec7">4a6b7a5</a>)</li>
<li>bump io.opentelemetry:opentelemetry-api from 1.46.0 to 1.47.0 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3540">#3540</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/3d4d8c6b9bd8253cf9c40724bb98d6fc7fbab5a4">3d4d8c6</a>)</li>
<li>bump org.awaitility:awaitility from 4.2.2 to 4.3.0 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3575">#3575</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/8087e1e7be46ff6d5c66dfb91b071f878ea5efef">8087e1e</a>)</li>
<li>bump org.graalvm.buildtools:native-maven-plugin (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3530">#3530</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/0688e0b5b47e873238cf0bb42a2f35aece5c4ff0">0688e0b</a>)</li>
<li>bump org.springframework.boot:spring-boot-starter-parent (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3571">#3571</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/7ab75a312bc2eccb5afca923870961b5dae5dd2b">7ab75a3</a>)</li>
<li>bump zipkin-gcp.version from 2.2.6 to 2.3.0 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3561">#3561</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/9c080620534fa458ee77466e7fa2d602d0a9068d">9c08062</a>)</li>
</ul>
<h3>Documentation</h3>
<ul>
<li>add clarification for <code>spring.cloud.gcp.core.enabled</code> (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3572">#3572</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/8af632589c09d7e0029d07a2d4d90882d9567d5d">8af6325</a>)</li>
<li>Update README.adoc with latest released versions (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3535">#3535</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/76101e5c5432093c12af6d40f9bf1582fff70599">76101e5</a>)</li>
<li>update secret manager documentation (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3534">#3534</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/11f862efd1626f4d814533366fd267a9f07d8bb0">11f862e</a>)</li>
</ul>
<h2><a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/compare/v5.10.0...v6.0.0">6.0.0</a> (2025-02-04)</h2>
<h3>⚠ BREAKING CHANGES</h3>
<ul>
<li><strong>pubsub:</strong> set default max ack extension period to 60 minutes (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3501">#3501</a>)</li>
<li>Spring Cloud 2024.0 and Spring Boot 3.4.2 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3500">#3500</a>)</li>
</ul>
<h3>Features</h3>
<ul>
<li><strong>pubsub:</strong> set default max ack extension period to 60 minutes (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3501">#3501</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/9245031042054efc2ab52cdffad75298922a5a79">9245031</a>)</li>
<li>Spring Cloud 2024.0 and Spring Boot 3.4.1 (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/a72a86b6091ffbc208e2aa4bbb02273b94ae32fc">a72a86b</a>)</li>
<li>Spring Cloud 2024.0 and Spring Boot 3.4.2 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3500">#3500</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/01080543e9133850ecb60d1d41120356a8af18fc">0108054</a>)</li>
</ul>
<h3>Bug Fixes</h3>
<ul>
<li><strong>deps:</strong> update gapic-generator-java-bom.version to v2.52.0 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3512">#3512</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/c184e6993898a6f9be8f00a2e6ef5e12deb39bb5">c184e69</a>)</li>
</ul>
<h3>Dependencies</h3>
<ul>
<li>bump cloud-sql-socket-factory.version from 1.21.2 to 1.23.0 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3502">#3502</a>) (<a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/7760474ffd74897bcf67631157a100e2bc329569">7760474</a>)</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/005ad98cfdf60ead025490efd3a3c26f3783445f"><code>005ad98</code></a> chore(main): release 6.0.1 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3538">#3538</a>)</li>
<li><a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/0ff48fbcb541f8d3172b7168c6106d740b0473b5"><code>0ff48fb</code></a> chore(main): release 6.0.1-SNAPSHOT (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3528">#3528</a>)</li>
<li><a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/84706c7add68ed013be7a8ed537b5b9726ac22be"><code>84706c7</code></a> chore(main): release 6.0.0 (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3498">#3498</a>)</li>
<li><a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/1b64d1ff915cff463175376c581b1bfab99b7e57"><code>1b64d1f</code></a> chore(main): release 5.10.1-SNAPSHOT (<a href="https://redirect.github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3473">#3473</a>)</li>
<li>See full diff in <a href="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/compare/v5.10.0...v6.0.1">compare view</a></li>
</ul>
</details>
<br />
