### PR TITLE
CORE-69: bump git properties plugin to 2.5.0, with compatibility fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
     id 'idea'
     id "org.openapi.generator" version "7.12.0" apply false
     id 'java'
-    id 'com.gorylenko.gradle-git-properties' version '2.4.2'
+    id 'com.gorylenko.gradle-git-properties' version '2.5.0'
     id 'jacoco'
     id 'com.diffplug.spotless' version '7.0.2' apply false
 }

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -24,6 +24,10 @@ repositories {
     maven { url 'https://broadinstitute.jfrog.io/artifactory/libs-release' }
 }
 
+gitProperties {
+    dotGitDirectory = project.rootProject.layout.projectDirectory.dir(".git")
+}
+
 jib {
     from {
         // see https://github.com/broadinstitute/dsp-appsec-blessed-images/tree/main/jre


### PR DESCRIPTION
partially supersedes #1001 .

That other PR attempts to bump the git properties plugin, but causes gradle errors. This PR has the same bump, but also includes the appropriate gradle fix from `https://github.com/n0mer/gradle-git-properties/pull/235`.

