### PR TITLE
DDO-4131 read from google artifact registry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@ version: 2
 registries:
   broad-artifactory:
     type: maven-repository
-    url: https://broadinstitute.jfrog.io/artifactory/libs-release
+    url: https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-release/
 updates:
   - package-ecosystem: "gradle"
     registries:

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ following to your `build.gradle` file:
 ```
 repositories {
     maven {
-        url "https://broadinstitute.jfrog.io/broadinstitute/libs-snapshot-local/"
+        url "https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-snapshot/"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
 }
 
 repositories {
-    maven { url 'https://broadinstitute.jfrog.io/artifactory/maven-central' }
+    maven { url 'https://us-central1-maven.pkg.dev/dsp-artifact-registry/maven-central/' }
     mavenCentral()
 }
 

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 repositories {
-    maven { url 'https://broadinstitute.jfrog.io/artifactory/maven-central' }
+    maven { url 'https://us-central1-maven.pkg.dev/dsp-artifact-registry/maven-central/' }
     mavenCentral()
 }
 

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -18,10 +18,10 @@ springBoot {
 }
 
 repositories {
-    maven { url 'https://broadinstitute.jfrog.io/artifactory/maven-central' }
+    maven { url 'https://us-central1-maven.pkg.dev/dsp-artifact-registry/maven-central/' }
     mavenCentral()
-    maven { url 'https://broadinstitute.jfrog.io/artifactory/libs-snapshot' }
-    maven { url 'https://broadinstitute.jfrog.io/artifactory/libs-release' }
+    maven { url 'https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-snapshot/' }
+    maven { url 'https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-release/' }
 }
 
 gitProperties {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,7 @@
 pluginManagement {
     repositories {
         maven {
+            // todo: plugins-snapshot not provisioned yet in GAR
             url 'https://broadinstitute.jfrog.io/artifactory/plugins-snapshot'
         }
         gradlePluginPortal()

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,8 +1,7 @@
 pluginManagement {
     repositories {
         maven {
-            // todo: plugins-snapshot not provisioned yet in GAR
-            url 'https://broadinstitute.jfrog.io/artifactory/plugins-snapshot'
+            url 'https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-snapshot/'
         }
         gradlePluginPortal()
     }


### PR DESCRIPTION
Jira ticket: https://broadworkbench.atlassian.net/browse/DDO-4107

**Summary of changes**
Updated the artifact source for this service to read artifacts from Google Artifact Registry instead of JFrog.

**What**
Modified the config to pull artifacts from GAR. No publishing changes were made.

**Why**
This is part of Phase 2 of the artifact migration effort to deprecated JFrog and consolidate artifacts in GAR.

**Testing these changes**
Relied on passing CI checks and tests. Artifact reading-related issues are expected to surface as pipeline failures. For example these jobs [here](https://github.com/DataBiosphere/terra-scientific-pipelines-service/actions/runs/15309876591/job/43071753325?pr=222) and [here](https://github.com/DataBiosphere/leonardo/actions/runs/15324072477/job/43114134405?pr=4858) failed due to access issues (which have since been resolved).