### PR TITLE
[CORE-539] Upgrade commons-beanutils to 1.11.0

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -144,6 +144,10 @@ dependencies {
         implementation('org.apache.commons:commons-configuration2:2.12.0') {
             because("CVE-2024-29131, CVE-2024-29133")
         }
+        // required by org.apache.hadoop:hadoop-common:3.4.1
+        implementation('commons-beanutils:commons-beanutils:1.11.0') {
+            because("CVE-2025-48734")
+        }
     }
 }
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-539

We have to upgrade `commons-beanutils` to `1.11.0` which a dependency for `org.apache.hadoop:hadoop-common:3.4.1`
because of [CVE-2025-48734](https://nvd.nist.gov/vuln/detail/cve-2025-48734)

---

### Reminder:

#### Keeping Docs Up To Date ####
If you make changes to the github actions or workflows, particularly when they are run or which other workflows they call, please update [the GHA wiki page](https://github.com/DataBiosphere/terra-workspace-data-service/wiki/GHA-structure-in-WDS) to stay up to date.
