### PR TITLE
CORE-69: bump tomcat-embed-core

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -148,6 +148,10 @@ dependencies {
         implementation('commons-beanutils:commons-beanutils:1.11.0') {
             because("CVE-2025-48734")
         }
+        // tomcat-embed-core is included by Spring Boot
+        implementation('org.apache.tomcat.embed:tomcat-embed-core:10.1.42') {
+            because("CVE-2025-48988")
+        }
     }
 }
 


### PR DESCRIPTION
addresses CVE-2025-48988.