### PR TITLE
CORE-577: AnVIL Data Explorer PFB imports get federal_data_lockdown

### DIFF
--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -155,7 +155,8 @@ twds:
           - ^https:\/\/gen3-biodatacatalyst-nhlbi-nih-gov-pfb-export\.s3\.amazonaws\.com\/
           - ^https:\/\/s3\.amazonaws.com\/gen3-biodatacatalyst-nhlbi-nih-gov-pfb-export\/
           - ^https:\/\/pic-sure-auth-prod-data-export\.s3\.amazonaws\.com\/
-          - ^https:\/\/s3\.amazonaws.com\/pic-sure-auth-prod-data-export\/
+          - ^https:\/\/s3\.amazonaws\.com\/pic-sure-auth-prod-data-export\/
+          - ^https:\/\/s3\.amazonaws\.com\/edu-ucsc-gi-platform-anvil-prod-storage-anvilprod\.us-east-1\/
           # anvil data is in TDR now, these are the old URLs
           - ^https:\/\/gen3-theanvil-io-pfb-export\.s3\.amazonaws\.com\/
           - ^https:\/\/s3\.amazonaws\.com\/gen3-theanvil-io-pfb-export\/


### PR DESCRIPTION
CORE-577

Imports from AnVIL Data Explorer now add the "federal_data_lockdown" auth domain.

We may be removing this functionality in the future if/when we have more precise knowledge about the auth domains for individual imports.

For previous art, see:
* https://github.com/DataBiosphere/terra-workspace-data-service/pull/1013
* https://github.com/DataBiosphere/terra-workspace-data-service/pull/1011