### PR TITLE
CORE-551: use .isEmpty

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -1313,7 +1313,7 @@ public class RecordDao {
             attributes.putAttribute(primaryKeyColumn, rs.getString(columnIndex));
             continue;
           }
-          if (referenceColToTable.size() > 0
+          if (!referenceColToTable.isEmpty()
               && referenceColToTable.containsKey(columnName)
               && rs.getString(columnName) != null) {
             attributes.putAttribute(


### PR DESCRIPTION
Found during CORE-551, does not fix that ticket.

Use !.isEmpty instead of .size() >0