### PR TITLE
CORE-551: use isEmpty instead of size()

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -656,7 +656,7 @@ public class RecordDao {
 
   private String genColumnDefs(Map<String, DataTypeMapping> tableInfo, String primaryKeyCol) {
     return getPrimaryKeyDef(primaryKeyCol)
-        + (tableInfo.size() > 0
+        + (!tableInfo.isEmpty()
             ? ", "
                 + tableInfo.entrySet().stream()
                     .map(


### PR DESCRIPTION
Found during CORE-551, does not fix that ticket.

Use !.isEmpty instead of .size() >0