### PR TITLE
CORE-551: dont cancel github actions for pushes to main

### DIFF
--- a/.github/workflows/build-test-tag-and-publish.yml
+++ b/.github/workflows/build-test-tag-and-publish.yml
@@ -8,7 +8,8 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  # don't cancel in-progress workflows for pushes to main
+  cancel-in-progress: ${{ !(github.event_name == 'push' && github.ref_name == 'main') }}
 
 jobs:
   build:


### PR DESCRIPTION
Found during CORE-551; does not compete that ticket.

Some merges to main are not getting deployed to dev. In my recent PRs this is happening because the workflow that should release cWDS gets canceled. It created a new release tag and then went on to deploy ... but other workflows kicked off on the tag and canceled the deploy.

This PR adjusts the GHA workflow concurrency such that it will not cancel workflows on pushes to main.