### PR TITLE
CORE-551: set longer timeouts for Rawls REST client

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/rawls/RawlsClientConfig.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/rawls/RawlsClientConfig.java
@@ -3,11 +3,14 @@ package org.databiosphere.workspacedataservice.rawls;
 import io.micrometer.observation.ObservationRegistry;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.Duration;
 import org.databiosphere.workspacedataservice.retry.RestClientRetry;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.JettyClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.support.RestClientAdapter;
 import org.springframework.web.service.invoker.HttpServiceProxyFactory;
@@ -17,6 +20,12 @@ public class RawlsClientConfig {
 
   @Value("${rawlsurl:}")
   private String rawlsUrl;
+
+  @Value("${rawls.connectTimeout:10}")
+  private Integer connectTimeout;
+
+  @Value("${rawls.readTimeout:45}")
+  private Integer readTimeout;
 
   @Bean
   public RawlsClient rawlsClient(RawlsApi rawlsApi, RestClientRetry restClientRetry) {
@@ -30,6 +39,13 @@ public class RawlsClientConfig {
         HttpServiceProxyFactory.builderFor(RestClientAdapter.create(restClient)).build();
 
     return httpServiceProxyFactory.createClient(RawlsApi.class);
+  }
+
+  ClientHttpRequestFactory customRequestFactory() {
+    JettyClientHttpRequestFactory factory = new JettyClientHttpRequestFactory();
+    factory.setReadTimeout(Duration.ofSeconds(readTimeout));
+    factory.setConnectTimeout(Duration.ofSeconds(connectTimeout));
+    return factory;
   }
 
   // fluent RestClient, initialized with Rawls' base url, auth from TokenContextUtil, and the
@@ -46,6 +62,7 @@ public class RawlsClientConfig {
         .observationRegistry(observationRegistry)
         .baseUrl(rawlsUrl)
         .requestInitializer(new BearerAuthRequestInitializer())
+        .requestFactory(customRequestFactory())
         .build();
   }
 }

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -191,3 +191,8 @@ api:
     backoff:
       delay: 150
       multiplier: 1.5
+
+# configuration for the Rawls REST client
+rawls:
+  connectTimeout: 10
+  readTimeout: 45


### PR DESCRIPTION
Every so often we see timeouts in the Terra UI integration tests, which run in the staging environment. These tests hit a 10-second timeout.

The actual Rawls APIs being called DO succeed - but they take longer than 10 seconds. Thanks to the additional logging in https://github.com/broadinstitute/rawls/pull/3387, I can see that in the last 5 instances of this timeout, it was the step to add a group to an auth domain that eats up the majority of the time.

This PR increases the timeout for the Rawls REST client to see if that helps with the test failures. I've changed the timeouts for all environments because it seems like a good idea anyway, but since it is driven from config we could have different timeouts for each environment if we wanted to.

---

This reimplements #1032, which was reverted. #1032 used `SimpleClientHttpRequestFactory`, which does not support PATCH requests - which we need to call `PATCH /api/workspaces/v2/{workspaceNamespace}/{workspaceName}/authDomain`.

In this PR, we use `JettyClientHttpRequestFactory` instead. Our options are:
  * JettyClientHttpRequestFactory - used in this PR
  * OkHttp3ClientHttpRequestFactory - this should work, but is deprecated by Spring
  * JdkClientHttpRequestFactory - doesn't support connect timeouts
  * HttpComponentsClientHttpRequestFactory - fails to start WDS, requires a new Apache dependency
  * ReactorClientHttpRequestFactory - fails to start WDS, not sure why, I assume it needs a Reactor dependency
  * SimpleClientHttpRequestFactory - does not support PATCH