### PR TITLE
CORE-692: more helpful error messages in PFB parsing failure

### DIFF
--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbRecordConverter.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbRecordConverter.java
@@ -29,16 +29,16 @@ public class PfbRecordConverter extends AvroRecordConverter {
     try {
       if (!genericRecord.hasField(fieldName)) {
         throw new PfbParsingException(
-            "Column [%s] is required, but was not found.".formatted(fieldName));
+            "Column [%s] is required, but was not found in the incoming PFB file.".formatted(fieldName));
       }
       Object fieldValue = genericRecord.get(fieldName);
       if (fieldValue == null) {
-        throw new PfbParsingException("Column [%s] cannot be null.".formatted(fieldName));
+        throw new PfbParsingException("Column [%s] cannot be null in the incoming PFB file.".formatted(fieldName));
       }
       return fieldValue.toString();
     } catch (Exception ex) {
       throw new PfbParsingException(
-          "Error parsing column [%s]: %s".formatted(fieldName, ex.getMessage()), ex);
+          "Error parsing column [%s] in the incoming PFB file: %s".formatted(fieldName, ex.getMessage()), ex);
     }
   }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbRecordConverter.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbRecordConverter.java
@@ -29,16 +29,20 @@ public class PfbRecordConverter extends AvroRecordConverter {
     try {
       if (!genericRecord.hasField(fieldName)) {
         throw new PfbParsingException(
-            "Column [%s] is required, but was not found in the incoming PFB file.".formatted(fieldName));
+            "Column [%s] is required, but was not found in the incoming PFB file."
+                .formatted(fieldName));
       }
       Object fieldValue = genericRecord.get(fieldName);
       if (fieldValue == null) {
-        throw new PfbParsingException("Column [%s] cannot be null in the incoming PFB file.".formatted(fieldName));
+        throw new PfbParsingException(
+            "Column [%s] cannot be null in the incoming PFB file.".formatted(fieldName));
       }
       return fieldValue.toString();
     } catch (Exception ex) {
       throw new PfbParsingException(
-          "Error parsing column [%s] in the incoming PFB file: %s".formatted(fieldName, ex.getMessage()), ex);
+          "Error parsing column [%s] in the incoming PFB file: %s"
+              .formatted(fieldName, ex.getMessage()),
+          ex);
     }
   }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbRecordConverter.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dataimport/pfb/PfbRecordConverter.java
@@ -28,7 +28,8 @@ public class PfbRecordConverter extends AvroRecordConverter {
   private String extractField(GenericRecord genericRecord, String fieldName) {
     try {
       if (!genericRecord.hasField(fieldName)) {
-        throw new PfbParsingException("Column [%s] is required, but was not found.".formatted(fieldName));
+        throw new PfbParsingException(
+            "Column [%s] is required, but was not found.".formatted(fieldName));
       }
       Object fieldValue = genericRecord.get(fieldName);
       if (fieldValue == null) {
@@ -36,7 +37,8 @@ public class PfbRecordConverter extends AvroRecordConverter {
       }
       return fieldValue.toString();
     } catch (Exception ex) {
-      throw new PfbParsingException("Error parsing column [%s]: %s".formatted(fieldName, ex.getMessage()), ex);
+      throw new PfbParsingException(
+          "Error parsing column [%s]: %s".formatted(fieldName, ex.getMessage()), ex);
     }
   }
 

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/PfbParsingException.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/model/exception/PfbParsingException.java
@@ -6,6 +6,10 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 @ResponseStatus(code = HttpStatus.BAD_REQUEST)
 public class PfbParsingException extends IllegalArgumentException {
 
+  public PfbParsingException(String message) {
+    super(message);
+  }
+
   public PfbParsingException(String message, Exception e) {
     super(message, e);
   }


### PR DESCRIPTION
CORE-692

If WDS cannot find an id or recordType when parsing a PFB, we now output a much more helpful error message.