### PR TITLE
[CORE-661] allow test fixture bucket on staging

### DIFF
--- a/service/src/main/resources/application-staging.yml
+++ b/service/src/main/resources/application-staging.yml
@@ -7,10 +7,3 @@ drshubUrl: https://drshub.dsde-staging.broadinstitute.org/
 drs:
   allowed-hosts:
     - jade\.datarepo-.*\.broadinstitute\.org
-  sources:
-    - urls:
-        - ^https:\/\/storage\.googleapis\.com\/datarepo-.*-snapshot-export-bucket
-        - ^https:\/\/storage\.googleapis\.com\/fixtures-for-tests
-      requirePrivateWorkspace: false
-      requireProtectedDataPolicy: false
-      requiredAuthDomainGroups:

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -156,6 +156,7 @@ twds:
       - urls:
           - ^https:\/\/storage\.googleapis\.com\/datarepo-.*-snapshot-export-bucket
           - ^https:\/\/s3\.amazonaws\.com\/edu-ucsc-gi-platform-hca-prod-storage-prod\.us-east-1
+          - ^https:\/\/storage\.googleapis\.com\/fixtures-for-tests
         requirePrivateWorkspace: false
         requireProtectedDataPolicy: false
         requiredAuthDomainGroups:


### PR DESCRIPTION
---
https://broadworkbench.atlassian.net/browse/CORE-661 
https://github.com/DataBiosphere/terra-workspace-data-service/pull/1052 restricted which URLS can be imported, but failed to allow-list the buckets that are used for files in ui integration tests.  This PR adds that bucket to all environments

### Reminder:

#### Keeping Docs Up To Date ####
If you make changes to the github actions or workflows, particularly when they are run or which other workflows they call, please update [the GHA wiki page](https://github.com/DataBiosphere/terra-workspace-data-service/wiki/GHA-structure-in-WDS) to stay up to date.
