### PR TITLE
CORE-69: update spotless and google-java-format

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -3,3 +3,6 @@
 
 # AJ-1289: Reformat code using spotless to match Google style guide.
 c795c46f2ce4bf30fce829979bcfc40ec12eef0c
+
+# Reformat code with an updated version of google-java-format
+c9348741a676497a7bfae123293c243c018e38e0

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
     id 'java'
     id 'com.gorylenko.gradle-git-properties' version '2.5.2'
     id 'jacoco'
-    id 'com.diffplug.spotless' version '7.2.1' apply false
+    id 'com.diffplug.spotless' version '8.0.0' apply false
 }
 
 repositories {

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -193,7 +193,7 @@ spotless {
         targetExclude "${layout.buildDirectory.asFile}/**"
         targetExclude "**/swagger-code/**"
         targetExclude "**/generated*/**"
-        googleJavaFormat('1.18.1')
+        googleJavaFormat() // let spotless choose which version to use
         toggleOffOn() // allow spotless:off & spotless:on to protect code from formatting
     }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/dao/RecordDao.java
@@ -1097,30 +1097,32 @@ public class RecordDao {
           ARRAY_OF_DATE,
           ARRAY_OF_DATE_TIME,
           ARRAY_OF_NUMBER,
-          EMPTY_ARRAY -> attVal.stream()
-          .map(e -> Objects.toString(e, null)) // .toString() non-nulls, else return null
-          .toList()
-          .toArray(new String[0]);
+          EMPTY_ARRAY ->
+          attVal.stream()
+              .map(e -> Objects.toString(e, null)) // .toString() non-nulls, else return null
+              .toList()
+              .toArray(new String[0]);
       case ARRAY_OF_BOOLEAN ->
-      // accept all casings of True and False if they're strings
-      attVal.stream()
-          .map(Object::toString)
-          .map(String::toLowerCase)
-          .map(Boolean::parseBoolean)
-          .toList()
-          .toArray(new Boolean[0]);
-      case ARRAY_OF_JSON -> attVal.stream()
-          .map(
-              el -> {
-                try {
-                  return objectMapper.writeValueAsString(el);
-                } catch (JsonProcessingException e) {
-                  throw new SerializationException(
-                      "Could not serialize array element to json string", e);
-                }
-              })
-          .toList()
-          .toArray(new String[0]);
+          // accept all casings of True and False if they're strings
+          attVal.stream()
+              .map(Object::toString)
+              .map(String::toLowerCase)
+              .map(Boolean::parseBoolean)
+              .toList()
+              .toArray(new Boolean[0]);
+      case ARRAY_OF_JSON ->
+          attVal.stream()
+              .map(
+                  el -> {
+                    try {
+                      return objectMapper.writeValueAsString(el);
+                    } catch (JsonProcessingException e) {
+                      throw new SerializationException(
+                          "Could not serialize array element to json string", e);
+                    }
+                  })
+              .toList()
+              .toArray(new String[0]);
       default -> throw new IllegalArgumentException("Unhandled array type " + typeMapping);
     };
   }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/pubsub/JobStatusUpdate.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/pubsub/JobStatusUpdate.java
@@ -36,8 +36,9 @@ public record JobStatusUpdate(
       case "Upserting" -> StatusEnum.RUNNING;
       case "Done" -> StatusEnum.SUCCEEDED;
       case "Error" -> StatusEnum.ERROR;
-      default -> throw new IllegalArgumentException(
-          "Unknown Rawls import status: %s".formatted(rawlsStatus));
+      default ->
+          throw new IllegalArgumentException(
+              "Unknown Rawls import status: %s".formatted(rawlsStatus));
     };
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/MultiCloudRecordSinkFactory.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/MultiCloudRecordSinkFactory.java
@@ -56,8 +56,9 @@ public class MultiCloudRecordSinkFactory implements RecordSinkFactory {
   public RecordSink buildRecordSink(ImportDetails importDetails) {
     return switch (workspaceService.getDataTableType(importDetails.workspaceId())) {
       case RAWLS -> RawlsRecordSink.create(mapper, storage, pubSub, importDetails);
-      case WDS -> new WdsRecordSink(
-          recordService, recordDao, dataTypeInferer, importDetails.collectionId());
+      case WDS ->
+          new WdsRecordSink(
+              recordService, recordDao, dataTypeInferer, importDetails.collectionId());
     };
   }
 
@@ -71,8 +72,9 @@ public class MultiCloudRecordSinkFactory implements RecordSinkFactory {
   public RecordSink buildRecordSink(CollectionId collectionId) {
     WorkspaceId workspaceId = collectionService.getWorkspaceId(collectionId);
     return switch (workspaceService.getDataTableType(workspaceId)) {
-      case RAWLS -> throw new NotImplementedException(
-          "MultiCloudRecordSinkFactory does not support building a RawlsRecordSink from a CollectionId");
+      case RAWLS ->
+          throw new NotImplementedException(
+              "MultiCloudRecordSinkFactory does not support building a RawlsRecordSink from a CollectionId");
       case WDS -> new WdsRecordSink(recordService, recordDao, dataTypeInferer, collectionId);
     };
   }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RawlsModel.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/recordsink/RawlsModel.java
@@ -222,8 +222,8 @@ public class RawlsModel {
             yield AttributeValue.of(node.toString());
           }
         }
-        default -> throw new RawlsDeserializationException(
-            "Unexpected JSON token: " + currentToken) {};
+        default ->
+            throw new RawlsDeserializationException("Unexpected JSON token: " + currentToken) {};
       };
     }
   }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/retry/RestClientRetry.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/retry/RestClientRetry.java
@@ -71,7 +71,7 @@ public class RestClientRetry {
           .lowCardinalityKeyValue("outcome", "ERROR");
       observation.error(e);
       switch (exceptionHttpCode) {
-          // retryable http codes
+        // retryable http codes
         case 0:
           LOGGER.warn(loggerHint + " REST request resulted in connection failure", e);
           throw new RestConnectionException();
@@ -84,7 +84,7 @@ public class RestClientRetry {
           throw new RestServerException(
               requireNonNull(HttpStatus.resolve(exceptionHttpCode)), e.getMessage()); // retryable
 
-          // non-retryable http codes
+        // non-retryable http codes
         case 401:
           throw new AuthenticationException(e.getMessage());
         case 403:

--- a/service/src/main/java/org/databiosphere/workspacedataservice/search/QueryParser.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/search/QueryParser.java
@@ -119,9 +119,9 @@ public class QueryParser {
           values.put(paramName, parseDateTime(value));
         }
         case NULL, EMPTY_ARRAY ->
-        // results in a `where false` clause. These columns are nonsensical to filter on, as
-        // they cannot contain anything. Would it be better to throw InvalidQueryException?
-        clauses.add("false");
+            // results in a `where false` clause. These columns are nonsensical to filter on, as
+            // they cannot contain anything. Would it be better to throw InvalidQueryException?
+            clauses.add("false");
         case ARRAY_OF_RELATION -> {
           // 'mysearchterm' IN (select split_part(unnest, '/', 3) from unnest("mycolumn")
           /* values in the column will be of the form "terra-wds:/${targetType}/${targetId}".
@@ -153,9 +153,10 @@ public class QueryParser {
           values.put(paramName, value);
         }
         default ->
-        // this shouldn't happen, since all datatypes are covered above. Leaving this in place
-        // as a safety net in case we add datatypes
-        throw new InvalidQueryException("Column specified in query is of an unsupported datatype");
+            // this shouldn't happen, since all datatypes are covered above. Leaving this in place
+            // as a safety net in case we add datatypes
+            throw new InvalidQueryException(
+                "Column specified in query is of an unsupported datatype");
       }
 
       return new WhereClausePart(clauses, values);

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/BatchWriteService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/BatchWriteService.java
@@ -122,8 +122,9 @@ public class BatchWriteService {
               recordSink.upsertBatch(recType, schema, recordsToWrite, primaryKey);
             }
             case DELETE -> recordSink.deleteBatch(recType, recordsToWrite);
-            default -> throw new UnsupportedOperationException(
-                "OperationType " + opType + " is not supported");
+            default ->
+                throw new UnsupportedOperationException(
+                    "OperationType " + opType + " is not supported");
           }
           // update the result counts
           result.increaseCount(recType, recordsToWrite.size());

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/CollectionService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/CollectionService.java
@@ -412,10 +412,10 @@ public class CollectionService {
     try {
       return switch (dataTableTypeInspector.getWorkspaceDataTableType(virtualWorkspaceId)) {
         case RAWLS -> // this is a known, Rawls-powered workspace. It's a virtual collection.
-        virtualWorkspaceId;
+            virtualWorkspaceId;
         case WDS -> // this is a known, WDS-powered workspace. Virtual collections are not allowed
-        // for WDS-powered workspaces. This is an error.
-        throw new MissingObjectException(COLLECTION);
+            // for WDS-powered workspaces. This is an error.
+            throw new MissingObjectException(COLLECTION);
       };
     } catch (RawlsException rawlsException) {
       if (HttpStatus.NOT_FOUND.equals(rawlsException.getStatusCode())) {

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/ImportService.java
@@ -128,8 +128,8 @@ public class ImportService {
     return switch (importType) {
       case PFB -> new PfbSchedulable(jobId.toString(), "PFB import", arguments);
       case RAWLSJSON -> new RawlsJsonSchedulable(jobId.toString(), "RAWLSJSON import", arguments);
-      case TDRMANIFEST -> new TdrManifestSchedulable(
-          jobId.toString(), "TDR manifest import", arguments);
+      case TDRMANIFEST ->
+          new TdrManifestSchedulable(jobId.toString(), "TDR manifest import", arguments);
     };
   }
 }

--- a/service/src/main/java/org/databiosphere/workspacedataservice/service/JobService.java
+++ b/service/src/main/java/org/databiosphere/workspacedataservice/service/JobService.java
@@ -75,10 +75,11 @@ public class JobService {
 
       switch (newStatus) {
         case SUCCEEDED -> jobDao.succeeded(jobId);
-        case ERROR -> jobDao.fail(
-            jobId, requireNonNullElse(update.errorMessage(), "Unknown error"));
-        default -> throw new ValidationException(
-            "Unexpected status from Rawls for job %s: %s".formatted(jobId, newStatus));
+        case ERROR ->
+            jobDao.fail(jobId, requireNonNullElse(update.errorMessage(), "Unknown error"));
+        default ->
+            throw new ValidationException(
+                "Unexpected status from Rawls for job %s: %s".formatted(jobId, newStatus));
       }
     } catch (EmptyResultDataAccessException e) {
       throw new MissingObjectException("Job");

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerMockMvcTest.java
@@ -614,7 +614,8 @@ class RecordControllerMockMvcTest extends MockMvcTestBase {
 					value
 					foo
 					bar
-					baz		""".getBytes());
+					baz		"""
+                .getBytes());
 
     String recordType = "null-headers";
     mockMvc

--- a/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerSearchFilterTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/controller/RecordControllerSearchFilterTest.java
@@ -86,7 +86,8 @@ class RecordControllerSearchFilterTest extends MockMvcTestBase {
   @Test
   void nullFilter() {
     String testCase = "when filter is entirely omitted";
-    String searchRequestPayload = """
+    String searchRequestPayload =
+"""
 {"limit": 5, "sortAttribute": "sortByMe"}
 """;
     List<String> expected = List.of("000", "001", "002", "003", "004");
@@ -96,7 +97,8 @@ class RecordControllerSearchFilterTest extends MockMvcTestBase {
   @Test
   void nullIds() {
     String testCase = "when filter is specified but filter.ids is not";
-    String searchRequestPayload = """
+    String searchRequestPayload =
+"""
 {"limit": 5, "sortAttribute": "sortByMe", "filter": {}}
 """;
     List<String> expected = List.of("000", "001", "002", "003", "004");
@@ -107,7 +109,7 @@ class RecordControllerSearchFilterTest extends MockMvcTestBase {
   void emptyIds() {
     String testCase = "when filter.ids is specified but empty";
     String searchRequestPayload =
-        """
+"""
 {"limit": 5, "sortAttribute": "sortByMe", "filter": {"ids": []}}
 """;
     List<String> expected = List.of();
@@ -118,7 +120,7 @@ class RecordControllerSearchFilterTest extends MockMvcTestBase {
   void oneId() {
     String testCase = "when filter.ids contains a single matching id";
     String searchRequestPayload =
-        """
+"""
 {"limit": 5, "sortAttribute": "sortByMe", "filter": {"ids": ["012"]}}
 """;
     List<String> expected = List.of("012");
@@ -129,7 +131,7 @@ class RecordControllerSearchFilterTest extends MockMvcTestBase {
   void multipleIds() {
     String testCase = "when filter.ids contains multiple matching ids";
     String searchRequestPayload =
-        """
+"""
 {"limit": 5, "sortAttribute": "sortByMe", "filter": {"ids": ["003", "009", "012"]}}
 """;
     List<String> expected = List.of("003", "009", "012");
@@ -140,7 +142,7 @@ class RecordControllerSearchFilterTest extends MockMvcTestBase {
   void someMatch() {
     String testCase = "when filter.ids contains some known and some unknown ids";
     String searchRequestPayload =
-        """
+"""
 {"limit": 5, "sortAttribute": "sortByMe", "filter": {"ids": ["003", "unknown", "012"]}}
 """;
     List<String> expected = List.of("003", "012");
@@ -151,7 +153,7 @@ class RecordControllerSearchFilterTest extends MockMvcTestBase {
   void unknownIds() {
     String testCase = "when filter.ids contains ids that match nothing";
     String searchRequestPayload =
-        """
+"""
 {"limit": 5, "sortAttribute": "sortByMe", "filter": {"ids": ["unknown1", "unknown2"]}}
 """;
     List<String> expected = List.of();
@@ -162,7 +164,7 @@ class RecordControllerSearchFilterTest extends MockMvcTestBase {
   void moreIdsThanLimit() {
     String testCase = "when filter.ids contains more matching ids than the query limit";
     String searchRequestPayload =
-        """
+"""
 {"limit": 2, "sortAttribute": "sortByMe", "filter": {"ids": ["002", "004", "006", "008"]}}
 """;
     List<String> expected = List.of("002", "004");
@@ -173,7 +175,7 @@ class RecordControllerSearchFilterTest extends MockMvcTestBase {
   void offsetRespected() {
     String testCase = "when filter.ids is over limit, offset is still respected";
     String searchRequestPayload =
-        """
+"""
 {"limit": 2, "offset": 2, "sortAttribute": "sortByMe", "filter": {"ids": ["002", "004", "006", "008"]}}
 """;
     List<String> expected = List.of("006", "008");
@@ -184,7 +186,7 @@ class RecordControllerSearchFilterTest extends MockMvcTestBase {
   void idOrderIsIgnored() {
     String testCase = "when filter.ids order conflicts with sortAttribute, sortAttribute wins";
     String searchRequestPayload =
-        """
+"""
 {"limit": 3, "sortAttribute": "sortByMe", "sort": "DESC", "filter": {"ids": ["004", "006", "008"]}}
 """;
     List<String> expected = List.of("008", "006", "004");

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvBatchTypeDetectionTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvBatchTypeDetectionTest.java
@@ -85,7 +85,8 @@ class TsvBatchTypeDetectionTest extends ControlPlaneTestBase {
   void schemaSafeAcrossBatches() throws IOException {
     // generate a TSV input with one column. The first batch of rows has numerics for this column,
     // but the second batch has a string. This should not fail the import.
-    String tsvContent = """
+    String tsvContent =
+"""
 id\tmyColumn
 1\t1
 2\t2

--- a/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvJsonEquivalenceTest.java
+++ b/service/src/test/java/org/databiosphere/workspacedataservice/tsv/TsvJsonEquivalenceTest.java
@@ -63,7 +63,8 @@ class TsvJsonEquivalenceTest extends ControlPlaneTestBase {
     String json =
         """
                 {"attributes":{"col1":%s}}
-                """.formatted(jsonValue);
+                """
+            .formatted(jsonValue);
 
     RecordAttributes tsvAttributes = readTsv(tsv);
     RecordAttributes jsonAttributes =


### PR DESCRIPTION
Supersedes #1060

* Bumps com.diffplug.spotless from 7.2.1 to 8.0.0.
* Uses the default version of `google-java-format` inside Spotless, instead of pinning to 1.18.1
* Reformats files with the default version of `google-java-format`
* Ignores the reformatting for `git blame`

Once this merges, if the commit hashes change, I will follow up to revise the `.git-blame-ignore-revs`